### PR TITLE
chore(demo): fix typo at dialog service docs

### DIFF
--- a/projects/demo/src/modules/services/dialogs/dialogs.template.html
+++ b/projects/demo/src/modules/services/dialogs/dialogs.template.html
@@ -248,7 +248,7 @@
             </li>
             <li>
                 <p i18n>
-                    Use <code>open</code> mothod to show a dialog, subscribe to
+                    Use <code>open</code> method to show a dialog, subscribe to
                     an <code>Observable</code>:
                 </p>
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

-   [x] The commit message follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0-beta.4/)
-   [ ] Tests for the changes have been added (for bug fixes / features)
-   [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

-   [ ] Bugfix
-   [ ] Feature
-   [x] Refactoring (no functional changes, no api changes)
-   [ ] Other... Please describe:

## What is the current behavior?

Docs have a typo - `Use open mothod to show a dialog, subscribe to an Observable:`

Closes #

## What is the new behavior?
Typo is fixed

## Does this PR introduce a breaking change?

-   [ ] Yes
-   [x] No

## Other information
Before: 
![dialog-service-typo_before](https://user-images.githubusercontent.com/43645356/130996813-960d2d83-cea7-45fe-8f10-9a6da60b0e60.png)

After:
![dialog-service-typo_after](https://user-images.githubusercontent.com/43645356/130996846-59960ac6-ef99-465d-8766-bb496b58b4ec.png)
