### PR TITLE
ci: add auto assign author for PR

### DIFF
--- a/.github/workflows/auto-author-assign.yml
+++ b/.github/workflows/auto-author-assign.yml
@@ -1,0 +1,16 @@
+name: Auto author assign for PR
+
+on:
+    # for forks or origin pull requests
+    pull_request_target:
+        types: [opened, reopened]
+
+permissions:
+    pull-requests: write
+
+jobs:
+    assign-author:
+        runs-on: ubuntu-latest
+        steps:
+            # This action automatically assigns PR author as an assignee.
+            - uses: toshimaru/auto-author-assign@v1.3.7


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

-   [x] The commit message follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0-beta.4/)
-   [ ] Tests for the changes have been added (for bug fixes / features)
-   [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

-   [ ] Bugfix
-   [ ] Feature
-   [ ] Refactoring (no functional changes, no api changes)
-   [x] Other... Please describe: CI

## What is the current behavior?

![image](https://user-images.githubusercontent.com/12021443/137140158-7c7afcdc-e90f-4500-9c14-aa8a89f28a23.png)

## What is the new behavior?

![image](https://user-images.githubusercontent.com/12021443/137140203-76ebea82-f936-4b21-86ba-ee2397f41db3.png)

In most cases, pull request author should be assigned an assignee of the pull request.

This action automatically assigns PR author as an assignee.

## Does this PR introduce a breaking change?

-   [ ] Yes
-   [x] No
