### PR TITLE
fix(addon-doc): unexpected expanding subitems

### DIFF
--- a/projects/addon-doc/src/components/navigation/navigation.component.ts
+++ b/projects/addon-doc/src/components/navigation/navigation.component.ts
@@ -176,7 +176,7 @@ export class TuiDocNavigationComponent {
                     page.subPages.forEach(subPage => {
                         if (this.isActiveRoute(subPage.route)) {
                             this.openPagesArr[pagesIndex] = true;
-                            this.openPagesGroupsArr[pagesIndex + pageIndex] = true;
+                            this.openPagesGroupsArr[pagesIndex * 100 + pageIndex] = true;
                             this.active = subPage.route;
                         }
                     });

--- a/projects/addon-doc/src/components/navigation/navigation.template.html
+++ b/projects/addon-doc/src/components/navigation/navigation.template.html
@@ -57,7 +57,7 @@
                             *ngFor="let item of items[index]; index as subIndex"
                         >
                             <ng-container
-                                *ngTemplateOutlet="pages; context: {item: item, index: index + subIndex}"
+                                *ngTemplateOutlet="pages; context: {item: item, index: (index * 100) + subIndex}"
                             >
                             </ng-container>
                         </ng-container>


### PR DESCRIPTION
This is caused by a non-unique index in the array holding expanding state.

## PR Checklist

Please check if your PR fulfills the following requirements:

-   [X] The commit message follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0-beta.4/)
-   [X] Tests for the changes have been added (for bug fixes / features)
-   [X] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

-   [X] Bugfix
-   [ ] Feature
-   [ ] Refactoring (no functional changes, no api changes)
-   [ ] Other... Please describe:

## What is the current behavior?

1. open 'Common' and 'Components' Accordion on page 'https://taiga-ui.dev/getting-started'
2. click 'Badges' in Components
3. SubItem 'Styles' is also expanded

Closes #933

## What is the new behavior?

Only opens clicked expanded Group in the doc navigation.

## Does this PR introduce a breaking change?

-   [ ] Yes
-   [X] No

## Other information
