### PR TITLE
ci: reuse node_modules cache between branches

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,16 +36,33 @@ jobs:
               uses: actions/setup-node@v1
               with:
                   node-version: '12.x'
-            - name: Cache Node.js modules
+            # Setup cache
+            - name: Restore node_modules from cache
+              id: cache-node-modules
+              uses: actions/cache@v2
+              with:
+                  path: |
+                      node_modules
+                      !node_modules/.cache/
+                  key: node-modules-cache-${{ hashFiles('**/package-lock.json') }}
+            - name: Restore from global NPM cache
+              if: steps.cache-node-modules.outputs.cache-hit != 'true'
               uses: actions/cache@v2
               with:
                   path: ~/.npm
-                  key: ${{ runner.OS }}-node-${{ hashFiles('**/package-lock.json') }}
-                  restore-keys: |
-                      ${{ runner.OS }}-node-
-                      ${{ runner.OS }}-
-            - name: Install dependencies
+                  key: npm-cache-${{ hashFiles('**/package-lock.json') }}
+                  restore-keys: npm-cache-
+            - name: Restore from cache of builds
+              id: build-cache
+              uses: actions/cache@v2
+              with:
+                  path: node_modules/.cache
+                  key: builds-cache-${{ hashFiles('**/package-lock.json') }}-${{ github.ref }}
+                  restore-keys: builds-cache-${{ hashFiles('**/package-lock.json') }}
+            - name: Clean install dependencies
+              if: steps.cache-node-modules.outputs.cache-hit != 'true'
               run: npm ci
+            # End of setup cache
             # End of setup
             - name: Run affected builds for libraries based on main branch
               if: ${{ env.IS_MAIN_BRANCH == 'false' }}

--- a/.github/workflows/demo-integrations.yml
+++ b/.github/workflows/demo-integrations.yml
@@ -10,6 +10,7 @@ on:
             - 'angular.json'
             - 'package.json'
             - 'tsconfig*'
+            - '**/demo-integrations.yml'
     push:
         branches:
             - '!main'
@@ -25,14 +26,42 @@ jobs:
         env:
             NX_CLOUD_AUTH_TOKEN: ${{ secrets.NX_CLOUD_AUTH_TOKEN }}
         steps:
-            - name: Checkout
-              uses: actions/checkout@v2
-
-            - name: Run screenshot tests
-              uses: cypress-io/github-action@v2
+            - uses: actions/checkout@v2
+            - name: Use Node.js
+              uses: actions/setup-node@v1
               with:
-                  build: npm run build:demo
-                  command: npm run demo:integrations:ci
+                  node-version: '12.x'
+            # Setup cache
+            - name: Restore node_modules from cache
+              id: cache-node-modules
+              uses: actions/cache@v2
+              with:
+                  path: |
+                      node_modules
+                      !node_modules/.cache/
+                  key: node-modules-cache-${{ hashFiles('**/package-lock.json') }}
+            - name: Restore from global NPM cache
+              if: steps.cache-node-modules.outputs.cache-hit != 'true'
+              uses: actions/cache@v2
+              with:
+                  path: ~/.npm
+                  key: npm-cache-${{ hashFiles('**/package-lock.json') }}
+                  restore-keys: npm-cache-
+            - name: Restore from cache of builds
+              id: build-cache
+              uses: actions/cache@v2
+              with:
+                  path: node_modules/.cache
+                  key: builds-cache-${{ hashFiles('**/package-lock.json') }}-${{ github.ref }}
+                  restore-keys: builds-cache-${{ hashFiles('**/package-lock.json') }}
+            - name: Clean install dependencies
+              if: steps.cache-node-modules.outputs.cache-hit != 'true'
+              run: npm ci
+            # End of setup cache
+            - name: Run screenshot tests
+              run: |
+                  npm run build:demo
+                  npm run demo:integrations:ci
 
             - name: Upload artifact
               uses: actions/upload-artifact@v1

--- a/.github/workflows/deploy-next.yml
+++ b/.github/workflows/deploy-next.yml
@@ -8,6 +8,7 @@ on:
             - 'projects/**'
             - 'angular.json'
             - 'package.json'
+            - '**/deploy-next.yml'
     workflow_dispatch:
 
 env:
@@ -25,18 +26,35 @@ jobs:
               uses: actions/setup-node@v1
               with:
                   node-version: '12.x'
-            - name: Cache Node.js modules
+            # Setup cache
+            - name: Restore node_modules from cache
+              id: cache-node-modules
+              uses: actions/cache@v2
+              with:
+                  path: |
+                      node_modules
+                      !node_modules/.cache/
+                  key: node-modules-cache-${{ hashFiles('**/package-lock.json') }}
+            - name: Restore from global NPM cache
+              if: steps.cache-node-modules.outputs.cache-hit != 'true'
               uses: actions/cache@v2
               with:
                   path: ~/.npm
-                  key: ${{ runner.OS }}-node-${{ hashFiles('**/package-lock.json') }}
-                  restore-keys: |
-                      ${{ runner.OS }}-node-
-                      ${{ runner.OS }}-
-            - name: npm ci and build demo
-              run: |
-                  npm ci
-                  npm run build:demo:next
+                  key: npm-cache-${{ hashFiles('**/package-lock.json') }}
+                  restore-keys: npm-cache-
+            - name: Restore from cache of builds
+              id: build-cache
+              uses: actions/cache@v2
+              with:
+                  path: node_modules/.cache
+                  key: builds-cache-${{ hashFiles('**/package-lock.json') }}-${{ github.ref }}
+                  restore-keys: builds-cache-${{ hashFiles('**/package-lock.json') }}
+            - name: Clean install dependencies
+              if: steps.cache-node-modules.outputs.cache-hit != 'true'
+              run: npm ci
+            # End of setup cache
+            - name: npm build demo
+              run: npm run build:demo:next
             - name: Deploy
               uses: JamesIves/github-pages-deploy-action@4.1.4
               with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,17 +21,35 @@ jobs:
               uses: actions/setup-node@v1
               with:
                   node-version: '12.x'
-            - name: Cache Node.js modules
+            # Setup cache
+            - name: Restore node_modules from cache
+              id: cache-node-modules
+              uses: actions/cache@v2
+              with:
+                  path: |
+                      node_modules
+                      !node_modules/.cache/
+                  key: node-modules-cache-${{ hashFiles('**/package-lock.json') }}
+            - name: Restore from global NPM cache
+              if: steps.cache-node-modules.outputs.cache-hit != 'true'
               uses: actions/cache@v2
               with:
                   path: ~/.npm
-                  key: ${{ runner.OS }}-node-${{ hashFiles('**/package-lock.json') }}
-                  restore-keys: |
-                      ${{ runner.OS }}-node-
-                      ${{ runner.OS }}-
-            - name: npm ci and build demo
+                  key: npm-cache-${{ hashFiles('**/package-lock.json') }}
+                  restore-keys: npm-cache-
+            - name: Restore from cache of builds
+              id: build-cache
+              uses: actions/cache@v2
+              with:
+                  path: node_modules/.cache
+                  key: builds-cache-${{ hashFiles('**/package-lock.json') }}-${{ github.ref }}
+                  restore-keys: builds-cache-${{ hashFiles('**/package-lock.json') }}
+            - name: Clean install dependencies
+              if: steps.cache-node-modules.outputs.cache-hit != 'true'
+              run: npm ci
+            # End of setup cache
+            - name: npm build demo
               run: |
-                  npm ci
                   npm run build:demo
                   npm run build:demo:next
             - name: Deploy

--- a/.github/workflows/firebase-hosting-pull-request.yml
+++ b/.github/workflows/firebase-hosting-pull-request.yml
@@ -10,9 +10,38 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v2
-            - run: |
-                  npm ci
-                  npm run build:demo
+            - name: Use Node.js
+              uses: actions/setup-node@v1
+              with:
+                  node-version: '12.x'
+            # Setup cache
+            - name: Restore node_modules from cache
+              id: cache-node-modules
+              uses: actions/cache@v2
+              with:
+                  path: |
+                      node_modules
+                      !node_modules/.cache/
+                  key: node-modules-cache-${{ hashFiles('**/package-lock.json') }}
+            - name: Restore from global NPM cache
+              if: steps.cache-node-modules.outputs.cache-hit != 'true'
+              uses: actions/cache@v2
+              with:
+                  path: ~/.npm
+                  key: npm-cache-${{ hashFiles('**/package-lock.json') }}
+                  restore-keys: npm-cache-
+            - name: Restore from cache of builds
+              id: build-cache
+              uses: actions/cache@v2
+              with:
+                  path: node_modules/.cache
+                  key: builds-cache-${{ hashFiles('**/package-lock.json') }}-${{ github.ref }}
+                  restore-keys: builds-cache-${{ hashFiles('**/package-lock.json') }}
+            - name: Clean install dependencies
+              if: steps.cache-node-modules.outputs.cache-hit != 'true'
+              run: npm ci
+            # End of setup cache
+            - run: npm run build:demo
             - uses: FirebaseExtended/action-hosting-deploy@v0
               if: ${{ env.IS_FORK == 'false' }}
               with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -38,16 +38,33 @@ jobs:
               uses: actions/setup-node@v1
               with:
                   node-version: '12.x'
-            - name: Cache Node.js modules
+            # Setup cache
+            - name: Restore node_modules from cache
+              id: cache-node-modules
+              uses: actions/cache@v2
+              with:
+                  path: |
+                      node_modules
+                      !node_modules/.cache/
+                  key: node-modules-cache-${{ hashFiles('**/package-lock.json') }}
+            - name: Restore from global NPM cache
+              if: steps.cache-node-modules.outputs.cache-hit != 'true'
               uses: actions/cache@v2
               with:
                   path: ~/.npm
-                  key: ${{ runner.OS }}-node-${{ hashFiles('**/package-lock.json') }}
-                  restore-keys: |
-                      ${{ runner.OS }}-node-
-                      ${{ runner.OS }}-
-            - name: Install dependencies
+                  key: npm-cache-${{ hashFiles('**/package-lock.json') }}
+                  restore-keys: npm-cache-
+            - name: Restore from cache of builds
+              id: build-cache
+              uses: actions/cache@v2
+              with:
+                  path: node_modules/.cache
+                  key: builds-cache-${{ hashFiles('**/package-lock.json') }}-${{ github.ref }}
+                  restore-keys: builds-cache-${{ hashFiles('**/package-lock.json') }}
+            - name: Clean install dependencies
+              if: steps.cache-node-modules.outputs.cache-hit != 'true'
               run: npm ci
+            # End of setup cache
             # End of setup
 
             - name: Typecheck

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,16 +21,33 @@ jobs:
               with:
                   node-version: '12.x'
                   registry-url: 'https://registry.npmjs.org'
-            - name: Cache Node.js modules
+            # Setup cache
+            - name: Restore node_modules from cache
+              id: cache-node-modules
+              uses: actions/cache@v2
+              with:
+                  path: |
+                      node_modules
+                      !node_modules/.cache/
+                  key: node-modules-cache-${{ hashFiles('**/package-lock.json') }}
+            - name: Restore from global NPM cache
+              if: steps.cache-node-modules.outputs.cache-hit != 'true'
               uses: actions/cache@v2
               with:
                   path: ~/.npm
-                  key: ${{ runner.OS }}-node-${{ hashFiles('**/package-lock.json') }}
-                  restore-keys: |
-                      ${{ runner.OS }}-node-
-                      ${{ runner.OS }}-
-            - name: Install dependencies
+                  key: npm-cache-${{ hashFiles('**/package-lock.json') }}
+                  restore-keys: npm-cache-
+            - name: Restore from cache of builds
+              id: build-cache
+              uses: actions/cache@v2
+              with:
+                  path: node_modules/.cache
+                  key: builds-cache-${{ hashFiles('**/package-lock.json') }}-${{ github.ref }}
+                  restore-keys: builds-cache-${{ hashFiles('**/package-lock.json') }}
+            - name: Clean install dependencies
+              if: steps.cache-node-modules.outputs.cache-hit != 'true'
               run: npm ci
+            # End of setup cache
             # End of setup
             - name: Build publishable libraries
               run: npm run run-many:build:libs

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,16 +34,33 @@ jobs:
               uses: actions/setup-node@v1
               with:
                   node-version: '12.x'
-            - name: Cache Node.js modules
+            # Setup cache
+            - name: Restore node_modules from cache
+              id: cache-node-modules
+              uses: actions/cache@v2
+              with:
+                  path: |
+                      node_modules
+                      !node_modules/.cache/
+                  key: node-modules-cache-${{ hashFiles('**/package-lock.json') }}
+            - name: Restore from global NPM cache
+              if: steps.cache-node-modules.outputs.cache-hit != 'true'
               uses: actions/cache@v2
               with:
                   path: ~/.npm
-                  key: ${{ runner.OS }}-node-${{ hashFiles('**/package-lock.json') }}
-                  restore-keys: |
-                      ${{ runner.OS }}-node-
-                      ${{ runner.OS }}-
-            - name: Install dependencies
+                  key: npm-cache-${{ hashFiles('**/package-lock.json') }}
+                  restore-keys: npm-cache-
+            - name: Restore from cache of builds
+              id: build-cache
+              uses: actions/cache@v2
+              with:
+                  path: node_modules/.cache
+                  key: builds-cache-${{ hashFiles('**/package-lock.json') }}-${{ github.ref }}
+                  restore-keys: builds-cache-${{ hashFiles('**/package-lock.json') }}
+            - name: Clean install dependencies
+              if: steps.cache-node-modules.outputs.cache-hit != 'true'
               run: npm ci
+            # End of setup cache
             # End of setup
             - name: Run affected tests for libraries based on main branch
               if: ${{ env.IS_MAIN_BRANCH == 'false' }}

--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,5 @@
 node-options="--max-old-space-size=8192"
+prefer-offline=true
+cache=~/.npm/
 FORCE_COLOR=1
+CYPRESS_CACHE_FOLDER=node_modules/.cache-cypress

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "version": "2.21.0",
     "description": "Taiga UI by Tinkoff is a set of components, services, directives and other tools to build high quality UI using modern Angular framework",
     "scripts": {
-        "postinstall": "husky install",
+        "postinstall": "husky install && ngcc --async",
         "start": "nx serve",
         "start:ssl": "nx serve --ssl",
         "start:ru": "nx serve --configuration ru",


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

-   [x] The commit message follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0-beta.4/)
-   [ ] Tests for the changes have been added (for bug fixes / features)
-   [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

-   [ ] Bugfix
-   [ ] Feature
-   [ ] Refactoring (no functional changes, no api changes)
-   [x] Other... Please describe: CI

## What is the current behavior?

Now clean install starts and runs about 1-3 minutes

![image](https://user-images.githubusercontent.com/12021443/139050254-12850d78-b1c7-40a6-8514-c1676a64ad7e.png)

Also, the cache for Nx is not reused in branches between pushes, which takes additional time.

## What is the new behavior?

Increases the speed of installing dependencies and reuses the cache for global npm modules and nx

## Does this PR introduce a breaking change?

-   [ ] Yes
-   [x] No
