### PR TITLE
fix(addon-doc): downgrade dependency `ngx-highlightjs` (v6 => v5)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -798,11 +798,12 @@
             "dev": true
         },
         "node_modules/@babel/code-frame": {
-            "version": "7.22.5",
-            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.22.5.tgz",
-            "integrity": "sha512-Xmwn266vad+6DAqEB2A6V/CcZVp62BbwVmcOJc2RPuwih1kw02TjQvWVWlcKGbBPd+8/0V5DEkOcizRGYsspYQ==",
+            "version": "7.22.10",
+            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.22.10.tgz",
+            "integrity": "sha512-/KKIMG4UEL35WmI9OlvMhurwtytjvXoFcGNrOvyG9zIzA8YmPjVtIZUf7b05+TPO7G7/GEmLHDaoCgACHl9hhA==",
             "dependencies": {
-                "@babel/highlight": "^7.22.5"
+                "@babel/highlight": "^7.22.10",
+                "chalk": "^2.4.2"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -866,9 +867,9 @@
             }
         },
         "node_modules/@babel/eslint-parser": {
-            "version": "7.22.9",
-            "resolved": "https://registry.npmjs.org/@babel/eslint-parser/-/eslint-parser-7.22.9.tgz",
-            "integrity": "sha512-xdMkt39/nviO/4vpVdrEYPwXCsYIXSSAr6mC7WQsNIlGnuxKyKE7GZjalcnbSWiC4OXGNNN3UQPeHfjSC6sTDA==",
+            "version": "7.22.10",
+            "resolved": "https://registry.npmjs.org/@babel/eslint-parser/-/eslint-parser-7.22.10.tgz",
+            "integrity": "sha512-0J8DNPRXQRLeR9rPaUMM3fA+RbixjnVLe/MRMYCkp3hzgsSuxCHQ8NN8xQG1wIHKJ4a1DTROTvFJdW+B5/eOsg==",
             "dev": true,
             "dependencies": {
                 "@nicolo-ribaudo/eslint-scope-5-internals": "5.1.1-v1",
@@ -879,7 +880,7 @@
                 "node": "^10.13.0 || ^12.13.0 || >=14.0.0"
             },
             "peerDependencies": {
-                "@babel/core": ">=7.11.0",
+                "@babel/core": "^7.11.0",
                 "eslint": "^7.5.0 || ^8.0.0"
             }
         },
@@ -902,9 +903,9 @@
             }
         },
         "node_modules/@babel/eslint-plugin": {
-            "version": "7.22.5",
-            "resolved": "https://registry.npmjs.org/@babel/eslint-plugin/-/eslint-plugin-7.22.5.tgz",
-            "integrity": "sha512-lDXW06rf1sXywWWw+UdS/iYxRjrqhH4AXdPeKE4+fEgEoGBXcdIDQ+uCJOUcvCb0jCTvfwHOSXkwnfd24EAkLQ==",
+            "version": "7.22.10",
+            "resolved": "https://registry.npmjs.org/@babel/eslint-plugin/-/eslint-plugin-7.22.10.tgz",
+            "integrity": "sha512-SRZcvo3fnO5h79B9DZSV6LG2vHH7OWsSNp1huFLHsXKyytRG413byQk9zxW1VcPOhnzfx2VIUz+8aGbiE7fOkA==",
             "dev": true,
             "dependencies": {
                 "eslint-rule-composer": "^0.3.0"
@@ -913,8 +914,8 @@
                 "node": "^10.13.0 || ^12.13.0 || >=14.0.0"
             },
             "peerDependencies": {
-                "@babel/eslint-parser": ">=7.11.0",
-                "eslint": ">=7.5.0"
+                "@babel/eslint-parser": "^7.11.0",
+                "eslint": "^7.5.0 || ^8.0.0"
             }
         },
         "node_modules/@babel/generator": {
@@ -951,21 +952,21 @@
             }
         },
         "node_modules/@babel/helper-builder-binary-assignment-operator-visitor": {
-            "version": "7.22.5",
-            "resolved": "https://registry.npmjs.org/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.22.5.tgz",
-            "integrity": "sha512-m1EP3lVOPptR+2DwD125gziZNcmoNSHGmJROKoy87loWUQyJaVXDgpmruWqDARZSmtYQ+Dl25okU8+qhVzuykw==",
+            "version": "7.22.10",
+            "resolved": "https://registry.npmjs.org/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.22.10.tgz",
+            "integrity": "sha512-Av0qubwDQxC56DoUReVDeLfMEjYYSN1nZrTUrWkXd7hpU73ymRANkbuDm3yni9npkn+RXy9nNbEJZEzXr7xrfQ==",
             "dev": true,
             "dependencies": {
-                "@babel/types": "^7.22.5"
+                "@babel/types": "^7.22.10"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-compilation-targets": {
-            "version": "7.22.9",
-            "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.22.9.tgz",
-            "integrity": "sha512-7qYrNM6HjpnPHJbopxmb8hSPoZ0gsX8IvUS32JGVoy+pU9e5N0nLr1VjJoR6kA4d9dmGLxNYOjeB8sUDal2WMw==",
+            "version": "7.22.10",
+            "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.22.10.tgz",
+            "integrity": "sha512-JMSwHD4J7SLod0idLq5PKgI+6g/hLD/iuWBq08ZX49xE14VpVEojJ5rHWptpirV2j020MvypRLAXAO50igCJ5Q==",
             "dev": true,
             "dependencies": {
                 "@babel/compat-data": "^7.22.9",
@@ -976,9 +977,6 @@
             },
             "engines": {
                 "node": ">=6.9.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0"
             }
         },
         "node_modules/@babel/helper-compilation-targets/node_modules/semver": {
@@ -991,9 +989,9 @@
             }
         },
         "node_modules/@babel/helper-create-class-features-plugin": {
-            "version": "7.22.9",
-            "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.22.9.tgz",
-            "integrity": "sha512-Pwyi89uO4YrGKxL/eNJ8lfEH55DnRloGPOseaA8NFNL6jAUnn+KccaISiFazCj5IolPPDjGSdzQzXVzODVRqUQ==",
+            "version": "7.22.10",
+            "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.22.10.tgz",
+            "integrity": "sha512-5IBb77txKYQPpOEdUdIhBx8VrZyDCQ+H82H0+5dX1TmuscP5vJKEE3cKurjtIw/vFwzbVH48VweE78kVDBrqjA==",
             "dev": true,
             "dependencies": {
                 "@babel/helper-annotate-as-pure": "^7.22.5",
@@ -1315,14 +1313,14 @@
             }
         },
         "node_modules/@babel/helper-wrap-function": {
-            "version": "7.22.9",
-            "resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.22.9.tgz",
-            "integrity": "sha512-sZ+QzfauuUEfxSEjKFmi3qDSHgLsTPK/pEpoD/qonZKOtTPTLbf59oabPQ4rKekt9lFcj/hTZaOhWwFYrgjk+Q==",
+            "version": "7.22.10",
+            "resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.22.10.tgz",
+            "integrity": "sha512-OnMhjWjuGYtdoO3FmsEFWvBStBAe2QOgwOLsLNDjN+aaiMD8InJk1/O3HSD8lkqTjCgg5YI34Tz15KNNA3p+nQ==",
             "dev": true,
             "dependencies": {
                 "@babel/helper-function-name": "^7.22.5",
                 "@babel/template": "^7.22.5",
-                "@babel/types": "^7.22.5"
+                "@babel/types": "^7.22.10"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1343,13 +1341,13 @@
             }
         },
         "node_modules/@babel/helpers": {
-            "version": "7.22.6",
-            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.22.6.tgz",
-            "integrity": "sha512-YjDs6y/fVOYFV8hAf1rxd1QvR9wJe1pDBZ2AREKq/SDayfPzgk0PBnVuTCE5X1acEpMMNOVUqoe+OwiZGJ+OaA==",
+            "version": "7.22.10",
+            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.22.10.tgz",
+            "integrity": "sha512-a41J4NW8HyZa1I1vAndrraTlPZ/eZoga2ZgS7fEr0tZJGVU4xqdE80CEm0CcNjha5EZ8fTBYLKHF0kqDUuAwQw==",
             "dependencies": {
                 "@babel/template": "^7.22.5",
-                "@babel/traverse": "^7.22.6",
-                "@babel/types": "^7.22.5"
+                "@babel/traverse": "^7.22.10",
+                "@babel/types": "^7.22.10"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1369,12 +1367,12 @@
             }
         },
         "node_modules/@babel/highlight": {
-            "version": "7.22.5",
-            "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.22.5.tgz",
-            "integrity": "sha512-BSKlD1hgnedS5XRnGOljZawtag7H1yPfQp0tdNJCHoH6AZ+Pcm9VvkrK59/Yy593Ypg0zMxH2BxD1VPYUQ7UIw==",
+            "version": "7.22.10",
+            "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.22.10.tgz",
+            "integrity": "sha512-78aUtVcT7MUscr0K5mIEnkwxPE0MaxkR5RxRwuHaQ+JuU5AmTPhY+do2mdzVTnIJJpyBglql2pehuBIWHug+WQ==",
             "dependencies": {
                 "@babel/helper-validator-identifier": "^7.22.5",
-                "chalk": "^2.0.0",
+                "chalk": "^2.4.2",
                 "js-tokens": "^4.0.0"
             },
             "engines": {
@@ -1382,9 +1380,9 @@
             }
         },
         "node_modules/@babel/parser": {
-            "version": "7.22.7",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.22.7.tgz",
-            "integrity": "sha512-7NF8pOkHP5o2vpmGgNGcfAeCvOYhGLyA3Z4eBQkT1RJlWu47n63bCs93QfJ2hIAFCil7L5P2IWhs1oToVgrL0Q==",
+            "version": "7.22.10",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.22.10.tgz",
+            "integrity": "sha512-lNbdGsQb9ekfsnjFGhEiF4hfFqGgfOP3H3d27re3n+CGhNuTSUEQdfWk556sTLNTloczcdM5TYF2LhzmDQKyvQ==",
             "bin": {
                 "parser": "bin/babel-parser.js"
             },
@@ -1475,16 +1473,16 @@
             }
         },
         "node_modules/@babel/plugin-proposal-decorators": {
-            "version": "7.22.7",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-decorators/-/plugin-proposal-decorators-7.22.7.tgz",
-            "integrity": "sha512-omXqPF7Onq4Bb7wHxXjM3jSMSJvUUbvDvmmds7KI5n9Cq6Ln5I05I1W2nRlRof1rGdiUxJrxwe285WF96XlBXQ==",
+            "version": "7.22.10",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-decorators/-/plugin-proposal-decorators-7.22.10.tgz",
+            "integrity": "sha512-KxN6TqZzcFi4uD3UifqXElBTBNLAEH1l3vzMQj6JwJZbL2sZlThxSViOKCYY+4Ah4V4JhQ95IVB7s/Y6SJSlMQ==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-create-class-features-plugin": "^7.22.6",
+                "@babel/helper-create-class-features-plugin": "^7.22.10",
                 "@babel/helper-plugin-utils": "^7.22.5",
-                "@babel/helper-replace-supers": "^7.22.5",
+                "@babel/helper-replace-supers": "^7.22.9",
                 "@babel/helper-split-export-declaration": "^7.22.6",
-                "@babel/plugin-syntax-decorators": "^7.22.5"
+                "@babel/plugin-syntax-decorators": "^7.22.10"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1755,9 +1753,9 @@
             }
         },
         "node_modules/@babel/plugin-syntax-decorators": {
-            "version": "7.22.5",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-decorators/-/plugin-syntax-decorators-7.22.5.tgz",
-            "integrity": "sha512-avpUOBS7IU6al8MmF1XpAyj9QYeLPuSDJI5D4pVMSMdL7xQokKqJPYQC67RCT0aCTashUXPiGwMJ0DEXXCEmMA==",
+            "version": "7.22.10",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-decorators/-/plugin-syntax-decorators-7.22.10.tgz",
+            "integrity": "sha512-z1KTVemBjnz+kSEilAsI4lbkPOl5TvJH7YDSY1CTIzvLWJ+KHXp+mRe8VPmfnyvqOPqar1V2gid2PleKzRUstQ==",
             "dev": true,
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.22.5"
@@ -2011,14 +2009,14 @@
             }
         },
         "node_modules/@babel/plugin-transform-async-generator-functions": {
-            "version": "7.22.7",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-generator-functions/-/plugin-transform-async-generator-functions-7.22.7.tgz",
-            "integrity": "sha512-7HmE7pk/Fmke45TODvxvkxRMV9RazV+ZZzhOL9AG8G29TLrr3jkjwF7uJfxZ30EoXpO+LJkq4oA8NjO2DTnEDg==",
+            "version": "7.22.10",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-generator-functions/-/plugin-transform-async-generator-functions-7.22.10.tgz",
+            "integrity": "sha512-eueE8lvKVzq5wIObKK/7dvoeKJ+xc6TvRn6aysIjS6pSCeLy7S/eVi7pEQknZqyqvzaNKdDtem8nUNTBgDVR2g==",
             "dev": true,
             "dependencies": {
                 "@babel/helper-environment-visitor": "^7.22.5",
                 "@babel/helper-plugin-utils": "^7.22.5",
-                "@babel/helper-remap-async-to-generator": "^7.22.5",
+                "@babel/helper-remap-async-to-generator": "^7.22.9",
                 "@babel/plugin-syntax-async-generators": "^7.8.4"
             },
             "engines": {
@@ -2061,9 +2059,9 @@
             }
         },
         "node_modules/@babel/plugin-transform-block-scoping": {
-            "version": "7.22.5",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.22.5.tgz",
-            "integrity": "sha512-EcACl1i5fSQ6bt+YGuU/XGCeZKStLmyVGytWkpyhCLeQVA0eu6Wtiw92V+I1T/hnezUv7j74dA/Ro69gWcU+hg==",
+            "version": "7.22.10",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.22.10.tgz",
+            "integrity": "sha512-1+kVpGAOOI1Albt6Vse7c8pHzcZQdQKW+wJH+g8mCaszOdDVwRXa/slHPqIw+oJAJANTKDMuM2cBdV0Dg618Vg==",
             "dev": true,
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.22.5"
@@ -2174,9 +2172,9 @@
             }
         },
         "node_modules/@babel/plugin-transform-destructuring": {
-            "version": "7.22.5",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.22.5.tgz",
-            "integrity": "sha512-GfqcFuGW8vnEqTUBM7UtPd5A4q797LTvvwKxXTgRsFjoqaJiEg9deBG6kWeQYkVEL569NpnmpC0Pkr/8BLKGnQ==",
+            "version": "7.22.10",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.22.10.tgz",
+            "integrity": "sha512-dPJrL0VOyxqLM9sritNbMSGx/teueHF/htMKrPT7DNxccXxRDPYqlgPFFdr8u+F+qUZOkZoXue/6rL5O5GduEw==",
             "dev": true,
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.22.5"
@@ -2543,9 +2541,9 @@
             }
         },
         "node_modules/@babel/plugin-transform-optional-chaining": {
-            "version": "7.22.6",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-chaining/-/plugin-transform-optional-chaining-7.22.6.tgz",
-            "integrity": "sha512-Vd5HiWml0mDVtcLHIoEU5sw6HOUW/Zk0acLs/SAeuLzkGNOPc9DB4nkUajemhCmTIz3eiaKREZn2hQQqF79YTg==",
+            "version": "7.22.10",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-chaining/-/plugin-transform-optional-chaining-7.22.10.tgz",
+            "integrity": "sha512-MMkQqZAZ+MGj+jGTG3OTuhKeBpNcO+0oCEbrGNEaOmiEn+1MzRyQlYsruGiU8RTK3zV6XwrVJTmwiDOyYK6J9g==",
             "dev": true,
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.22.5",
@@ -2636,13 +2634,13 @@
             }
         },
         "node_modules/@babel/plugin-transform-regenerator": {
-            "version": "7.22.5",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.22.5.tgz",
-            "integrity": "sha512-rR7KePOE7gfEtNTh9Qw+iO3Q/e4DEsoQ+hdvM6QUDH7JRJ5qxq5AA52ZzBWbI5i9lfNuvySgOGP8ZN7LAmaiPw==",
+            "version": "7.22.10",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.22.10.tgz",
+            "integrity": "sha512-F28b1mDt8KcT5bUyJc/U9nwzw6cV+UmTeRlXYIl2TNqMMJif0Jeey9/RQ3C4NOd2zp0/TRsDns9ttj2L523rsw==",
             "dev": true,
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.22.5",
-                "regenerator-transform": "^0.15.1"
+                "regenerator-transform": "^0.15.2"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -2772,13 +2770,13 @@
             }
         },
         "node_modules/@babel/plugin-transform-typescript": {
-            "version": "7.22.9",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.22.9.tgz",
-            "integrity": "sha512-BnVR1CpKiuD0iobHPaM1iLvcwPYN2uVFAqoLVSpEDKWuOikoCv5HbKLxclhKYUXlWkX86DoZGtqI4XhbOsyrMg==",
+            "version": "7.22.10",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.22.10.tgz",
+            "integrity": "sha512-7++c8I/ymsDo4QQBAgbraXLzIM6jmfao11KgIBEYZRReWzNWH9NtNgJcyrZiXsOPh523FQm6LfpLyy/U5fn46A==",
             "dev": true,
             "dependencies": {
                 "@babel/helper-annotate-as-pure": "^7.22.5",
-                "@babel/helper-create-class-features-plugin": "^7.22.9",
+                "@babel/helper-create-class-features-plugin": "^7.22.10",
                 "@babel/helper-plugin-utils": "^7.22.5",
                 "@babel/plugin-syntax-typescript": "^7.22.5"
             },
@@ -2802,9 +2800,9 @@
             }
         },
         "node_modules/@babel/plugin-transform-unicode-escapes": {
-            "version": "7.22.5",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-escapes/-/plugin-transform-unicode-escapes-7.22.5.tgz",
-            "integrity": "sha512-biEmVg1IYB/raUO5wT1tgfacCef15Fbzhkx493D3urBI++6hpJ+RFG4SrWMn0NEZLfvilqKf3QDrRVZHo08FYg==",
+            "version": "7.22.10",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-escapes/-/plugin-transform-unicode-escapes-7.22.10.tgz",
+            "integrity": "sha512-lRfaRKGZCBqDlRU3UIFovdp9c9mEvlylmpod0/OatICsSfuQ9YFthRo1tpTkGsklEefZdqlEFdY4A2dwTb6ohg==",
             "dev": true,
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.22.5"
@@ -3027,18 +3025,18 @@
             }
         },
         "node_modules/@babel/traverse": {
-            "version": "7.22.8",
-            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.22.8.tgz",
-            "integrity": "sha512-y6LPR+wpM2I3qJrsheCTwhIinzkETbplIgPBbwvqPKc+uljeA5gP+3nP8irdYt1mjQaDnlIcG+dw8OjAco4GXw==",
+            "version": "7.22.10",
+            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.22.10.tgz",
+            "integrity": "sha512-Q/urqV4pRByiNNpb/f5OSv28ZlGJiFiiTh+GAHktbIrkPhPbl90+uW6SmpoLyZqutrg9AEaEf3Q/ZBRHBXgxig==",
             "dependencies": {
-                "@babel/code-frame": "^7.22.5",
-                "@babel/generator": "^7.22.7",
+                "@babel/code-frame": "^7.22.10",
+                "@babel/generator": "^7.22.10",
                 "@babel/helper-environment-visitor": "^7.22.5",
                 "@babel/helper-function-name": "^7.22.5",
                 "@babel/helper-hoist-variables": "^7.22.5",
                 "@babel/helper-split-export-declaration": "^7.22.6",
-                "@babel/parser": "^7.22.7",
-                "@babel/types": "^7.22.5",
+                "@babel/parser": "^7.22.10",
+                "@babel/types": "^7.22.10",
                 "debug": "^4.1.0",
                 "globals": "^11.1.0"
             },
@@ -3047,11 +3045,11 @@
             }
         },
         "node_modules/@babel/traverse/node_modules/@babel/generator": {
-            "version": "7.22.9",
-            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.22.9.tgz",
-            "integrity": "sha512-KtLMbmicyuK2Ak/FTCJVbDnkN1SlT8/kceFTiuDiiRUUSMnHMidxSCdG4ndkTOHHpoomWe/4xkvHkEOncwjYIw==",
+            "version": "7.22.10",
+            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.22.10.tgz",
+            "integrity": "sha512-79KIf7YiWjjdZ81JnLujDRApWtl7BxTqWD88+FFdQEIOG8LJ0etDOM7CXuIgGJa55sGOwZVwuEsaLEm0PJ5/+A==",
             "dependencies": {
-                "@babel/types": "^7.22.5",
+                "@babel/types": "^7.22.10",
                 "@jridgewell/gen-mapping": "^0.3.2",
                 "@jridgewell/trace-mapping": "^0.3.17",
                 "jsesc": "^2.5.1"
@@ -3061,9 +3059,9 @@
             }
         },
         "node_modules/@babel/types": {
-            "version": "7.22.5",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.22.5.tgz",
-            "integrity": "sha512-zo3MIHGOkPOfoRXitsgHLjEXmlDaD/5KU1Uzuc9GNiZPhSqVxVRtxuPaSBZDsYZ9qV88AjtMtWW7ww98loJ9KA==",
+            "version": "7.22.10",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.22.10.tgz",
+            "integrity": "sha512-obaoigiLrlDZ7TUQln/8m4mSqIW2QFeOrCQc9r+xsaHGNoplVNYlRVpsfE8Vj35GEm2ZH4ZhrNYogs/3fj85kg==",
             "dependencies": {
                 "@babel/helper-string-parser": "^7.22.5",
                 "@babel/helper-validator-identifier": "^7.22.5",
@@ -3459,36 +3457,6 @@
             },
             "engines": {
                 "node": ">=v14"
-            }
-        },
-        "node_modules/@commitlint/parse/node_modules/conventional-changelog-angular": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-6.0.0.tgz",
-            "integrity": "sha512-6qLgrBF4gueoC7AFVHu51nHL9pF9FRjXrH+ceVf7WmAfH3gs+gEYOkvxhjMPjZu57I4AGUGoNTY8V7Hrgf1uqg==",
-            "dev": true,
-            "dependencies": {
-                "compare-func": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=14"
-            }
-        },
-        "node_modules/@commitlint/parse/node_modules/conventional-commits-parser": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-4.0.0.tgz",
-            "integrity": "sha512-WRv5j1FsVM5FISJkoYMR6tPk07fkKT0UodruX4je86V4owk451yjXAKzKAPOs9l7y59E2viHUS9eQ+dfUA9NSg==",
-            "dev": true,
-            "dependencies": {
-                "is-text-path": "^1.0.1",
-                "JSONStream": "^1.3.5",
-                "meow": "^8.1.2",
-                "split2": "^3.2.2"
-            },
-            "bin": {
-                "conventional-commits-parser": "cli.js"
-            },
-            "engines": {
-                "node": ">=14"
             }
         },
         "node_modules/@commitlint/read": {
@@ -4266,9 +4234,9 @@
             "dev": true
         },
         "node_modules/@eslint/eslintrc/node_modules/globals": {
-            "version": "13.20.0",
-            "resolved": "https://registry.npmjs.org/globals/-/globals-13.20.0.tgz",
-            "integrity": "sha512-Qg5QtVkCy/kv3FUSlu4ukeZDVf9ee0iXLAUYX13gbR17bnejFTzr4iS9bY7kwCf1NztRNm1t91fjOiyx4CSwPQ==",
+            "version": "13.21.0",
+            "resolved": "https://registry.npmjs.org/globals/-/globals-13.21.0.tgz",
+            "integrity": "sha512-ybyme3s4yy/t/3s35bewwXKOf7cvzfreG2lH0lZl0JB7I4GxRP2ghxOK/Nb9EkRXdbBXZLfq/p/0W2JUONB/Gg==",
             "dev": true,
             "dependencies": {
                 "type-fest": "^0.20.2"
@@ -4330,6 +4298,12 @@
             "engines": {
                 "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
             }
+        },
+        "node_modules/@fastify/deepmerge": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/@fastify/deepmerge/-/deepmerge-1.3.0.tgz",
+            "integrity": "sha512-J8TOSBq3SoZbDhM9+R/u77hP93gz/rajSA+K2kGyijPpORPWUXHUpTaleoj+92As0S9uPRP7Oi8IqMf0u+ro6A==",
+            "dev": true
         },
         "node_modules/@hapi/hoek": {
             "version": "9.3.0",
@@ -5260,23 +5234,23 @@
             }
         },
         "node_modules/@jridgewell/sourcemap-codec": {
-            "version": "1.4.14",
-            "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
-            "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw=="
+            "version": "1.4.15",
+            "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
+            "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg=="
         },
         "node_modules/@jridgewell/trace-mapping": {
-            "version": "0.3.18",
-            "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.18.tgz",
-            "integrity": "sha512-w+niJYzMHdd7USdiH2U6869nqhD2nbfZXND5Yp93qIbEmnDNk7PD48o+YchRVpzMU7M6jVCbenTR7PA1FLQ9pA==",
+            "version": "0.3.19",
+            "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.19.tgz",
+            "integrity": "sha512-kf37QtfW+Hwx/buWGMPcR60iF9ziHa6r/CZJIHbmcm4+0qrXiVdxegAH0F6yddEVQ7zdkjcGCgCzUu+BcbhQxw==",
             "dependencies": {
-                "@jridgewell/resolve-uri": "3.1.0",
-                "@jridgewell/sourcemap-codec": "1.4.14"
+                "@jridgewell/resolve-uri": "^3.1.0",
+                "@jridgewell/sourcemap-codec": "^1.4.14"
             }
         },
         "node_modules/@jridgewell/trace-mapping/node_modules/@jridgewell/resolve-uri": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz",
-            "integrity": "sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==",
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.1.tgz",
+            "integrity": "sha512-dSYZh7HhCDtCKm4QakX0xFpsRDqjjtZf/kjI/v3T3Nwt5r8/qz/M19F9ySyOqU94SXBmeG9ttTul+YnR4LOxFA==",
             "engines": {
                 "node": ">=6.0.0"
             }
@@ -5892,21 +5866,21 @@
             }
         },
         "node_modules/@nx/js/node_modules/@babel/core": {
-            "version": "7.22.9",
-            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.22.9.tgz",
-            "integrity": "sha512-G2EgeufBcYw27U4hhoIwFcgc1XU7TlXJ3mv04oOv1WCuo900U/anZSPzEqNjwdjgffkk2Gs0AN0dW1CKVLcG7w==",
+            "version": "7.22.10",
+            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.22.10.tgz",
+            "integrity": "sha512-fTmqbbUBAwCcre6zPzNngvsI0aNrPZe77AeqvDxWM9Nm+04RrJ3CAmGHA9f7lJQY6ZMhRztNemy4uslDxTX4Qw==",
             "dev": true,
             "dependencies": {
                 "@ampproject/remapping": "^2.2.0",
-                "@babel/code-frame": "^7.22.5",
-                "@babel/generator": "^7.22.9",
-                "@babel/helper-compilation-targets": "^7.22.9",
+                "@babel/code-frame": "^7.22.10",
+                "@babel/generator": "^7.22.10",
+                "@babel/helper-compilation-targets": "^7.22.10",
                 "@babel/helper-module-transforms": "^7.22.9",
-                "@babel/helpers": "^7.22.6",
-                "@babel/parser": "^7.22.7",
+                "@babel/helpers": "^7.22.10",
+                "@babel/parser": "^7.22.10",
                 "@babel/template": "^7.22.5",
-                "@babel/traverse": "^7.22.8",
-                "@babel/types": "^7.22.5",
+                "@babel/traverse": "^7.22.10",
+                "@babel/types": "^7.22.10",
                 "convert-source-map": "^1.7.0",
                 "debug": "^4.1.0",
                 "gensync": "^1.0.0-beta.2",
@@ -5931,12 +5905,12 @@
             }
         },
         "node_modules/@nx/js/node_modules/@babel/generator": {
-            "version": "7.22.9",
-            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.22.9.tgz",
-            "integrity": "sha512-KtLMbmicyuK2Ak/FTCJVbDnkN1SlT8/kceFTiuDiiRUUSMnHMidxSCdG4ndkTOHHpoomWe/4xkvHkEOncwjYIw==",
+            "version": "7.22.10",
+            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.22.10.tgz",
+            "integrity": "sha512-79KIf7YiWjjdZ81JnLujDRApWtl7BxTqWD88+FFdQEIOG8LJ0etDOM7CXuIgGJa55sGOwZVwuEsaLEm0PJ5/+A==",
             "dev": true,
             "dependencies": {
-                "@babel/types": "^7.22.5",
+                "@babel/types": "^7.22.10",
                 "@jridgewell/gen-mapping": "^0.3.2",
                 "@jridgewell/trace-mapping": "^0.3.17",
                 "jsesc": "^2.5.1"
@@ -5991,16 +5965,16 @@
             }
         },
         "node_modules/@nx/js/node_modules/@babel/plugin-transform-runtime": {
-            "version": "7.22.9",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.22.9.tgz",
-            "integrity": "sha512-9KjBH61AGJetCPYp/IEyLEp47SyybZb0nDRpBvmtEkm+rUIwxdlKpyNHI1TmsGkeuLclJdleQHRZ8XLBnnh8CQ==",
+            "version": "7.22.10",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.22.10.tgz",
+            "integrity": "sha512-RchI7HePu1eu0CYNKHHHQdfenZcM4nz8rew5B1VWqeRKdcwW5aQ5HeG9eTUbWiAS1UrmHVLmoxTWHt3iLD/NhA==",
             "dev": true,
             "dependencies": {
                 "@babel/helper-module-imports": "^7.22.5",
                 "@babel/helper-plugin-utils": "^7.22.5",
-                "babel-plugin-polyfill-corejs2": "^0.4.4",
-                "babel-plugin-polyfill-corejs3": "^0.8.2",
-                "babel-plugin-polyfill-regenerator": "^0.5.1",
+                "babel-plugin-polyfill-corejs2": "^0.4.5",
+                "babel-plugin-polyfill-corejs3": "^0.8.3",
+                "babel-plugin-polyfill-regenerator": "^0.5.2",
                 "semver": "^6.3.1"
             },
             "engines": {
@@ -6020,13 +5994,13 @@
             }
         },
         "node_modules/@nx/js/node_modules/@babel/preset-env": {
-            "version": "7.22.9",
-            "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.22.9.tgz",
-            "integrity": "sha512-wNi5H/Emkhll/bqPjsjQorSykrlfY5OWakd6AulLvMEytpKasMVUpVy8RL4qBIBs5Ac6/5i0/Rv0b/Fg6Eag/g==",
+            "version": "7.22.10",
+            "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.22.10.tgz",
+            "integrity": "sha512-riHpLb1drNkpLlocmSyEg4oYJIQFeXAK/d7rI6mbD0XsvoTOOweXDmQPG/ErxsEhWk3rl3Q/3F6RFQlVFS8m0A==",
             "dev": true,
             "dependencies": {
                 "@babel/compat-data": "^7.22.9",
-                "@babel/helper-compilation-targets": "^7.22.9",
+                "@babel/helper-compilation-targets": "^7.22.10",
                 "@babel/helper-plugin-utils": "^7.22.5",
                 "@babel/helper-validator-option": "^7.22.5",
                 "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": "^7.22.5",
@@ -6051,15 +6025,15 @@
                 "@babel/plugin-syntax-top-level-await": "^7.14.5",
                 "@babel/plugin-syntax-unicode-sets-regex": "^7.18.6",
                 "@babel/plugin-transform-arrow-functions": "^7.22.5",
-                "@babel/plugin-transform-async-generator-functions": "^7.22.7",
+                "@babel/plugin-transform-async-generator-functions": "^7.22.10",
                 "@babel/plugin-transform-async-to-generator": "^7.22.5",
                 "@babel/plugin-transform-block-scoped-functions": "^7.22.5",
-                "@babel/plugin-transform-block-scoping": "^7.22.5",
+                "@babel/plugin-transform-block-scoping": "^7.22.10",
                 "@babel/plugin-transform-class-properties": "^7.22.5",
                 "@babel/plugin-transform-class-static-block": "^7.22.5",
                 "@babel/plugin-transform-classes": "^7.22.6",
                 "@babel/plugin-transform-computed-properties": "^7.22.5",
-                "@babel/plugin-transform-destructuring": "^7.22.5",
+                "@babel/plugin-transform-destructuring": "^7.22.10",
                 "@babel/plugin-transform-dotall-regex": "^7.22.5",
                 "@babel/plugin-transform-duplicate-keys": "^7.22.5",
                 "@babel/plugin-transform-dynamic-import": "^7.22.5",
@@ -6082,27 +6056,27 @@
                 "@babel/plugin-transform-object-rest-spread": "^7.22.5",
                 "@babel/plugin-transform-object-super": "^7.22.5",
                 "@babel/plugin-transform-optional-catch-binding": "^7.22.5",
-                "@babel/plugin-transform-optional-chaining": "^7.22.6",
+                "@babel/plugin-transform-optional-chaining": "^7.22.10",
                 "@babel/plugin-transform-parameters": "^7.22.5",
                 "@babel/plugin-transform-private-methods": "^7.22.5",
                 "@babel/plugin-transform-private-property-in-object": "^7.22.5",
                 "@babel/plugin-transform-property-literals": "^7.22.5",
-                "@babel/plugin-transform-regenerator": "^7.22.5",
+                "@babel/plugin-transform-regenerator": "^7.22.10",
                 "@babel/plugin-transform-reserved-words": "^7.22.5",
                 "@babel/plugin-transform-shorthand-properties": "^7.22.5",
                 "@babel/plugin-transform-spread": "^7.22.5",
                 "@babel/plugin-transform-sticky-regex": "^7.22.5",
                 "@babel/plugin-transform-template-literals": "^7.22.5",
                 "@babel/plugin-transform-typeof-symbol": "^7.22.5",
-                "@babel/plugin-transform-unicode-escapes": "^7.22.5",
+                "@babel/plugin-transform-unicode-escapes": "^7.22.10",
                 "@babel/plugin-transform-unicode-property-regex": "^7.22.5",
                 "@babel/plugin-transform-unicode-regex": "^7.22.5",
                 "@babel/plugin-transform-unicode-sets-regex": "^7.22.5",
-                "@babel/preset-modules": "^0.1.5",
-                "@babel/types": "^7.22.5",
-                "babel-plugin-polyfill-corejs2": "^0.4.4",
-                "babel-plugin-polyfill-corejs3": "^0.8.2",
-                "babel-plugin-polyfill-regenerator": "^0.5.1",
+                "@babel/preset-modules": "0.1.6-no-external-plugins",
+                "@babel/types": "^7.22.10",
+                "babel-plugin-polyfill-corejs2": "^0.4.5",
+                "babel-plugin-polyfill-corejs3": "^0.8.3",
+                "babel-plugin-polyfill-regenerator": "^0.5.2",
                 "core-js-compat": "^3.31.0",
                 "semver": "^6.3.1"
             },
@@ -6122,13 +6096,27 @@
                 "semver": "bin/semver.js"
             }
         },
-        "node_modules/@nx/js/node_modules/@babel/runtime": {
-            "version": "7.22.6",
-            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.22.6.tgz",
-            "integrity": "sha512-wDb5pWm4WDdF6LFUde3Jl8WzPA+3ZbxYqkC6xAXuD3irdEHN1k0NfTRrJD8ZD378SJ61miMLCqIOXYhd8x+AJQ==",
+        "node_modules/@nx/js/node_modules/@babel/preset-modules": {
+            "version": "0.1.6-no-external-plugins",
+            "resolved": "https://registry.npmjs.org/@babel/preset-modules/-/preset-modules-0.1.6-no-external-plugins.tgz",
+            "integrity": "sha512-HrcgcIESLm9aIR842yhJ5RWan/gebQUJ6E/E5+rf0y9o6oj7w0Br+sWuL6kEQ/o/AdfvR1Je9jG18/gnpwjEyA==",
             "dev": true,
             "dependencies": {
-                "regenerator-runtime": "^0.13.11"
+                "@babel/helper-plugin-utils": "^7.0.0",
+                "@babel/types": "^7.4.4",
+                "esutils": "^2.0.2"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0 || ^8.0.0-0 <8.0.0"
+            }
+        },
+        "node_modules/@nx/js/node_modules/@babel/runtime": {
+            "version": "7.22.10",
+            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.22.10.tgz",
+            "integrity": "sha512-21t/fkKLMZI4pqP2wlmsQAWnYW1PDyKyyUV4vCi+B25ydmdaYTKXPwCj0BzSUnZf4seIiYvSA3jcZ3gdsMFkLQ==",
+            "dev": true,
+            "dependencies": {
+                "regenerator-runtime": "^0.14.0"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -6279,9 +6267,9 @@
             }
         },
         "node_modules/@nx/js/node_modules/regenerator-runtime": {
-            "version": "0.13.11",
-            "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
-            "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
+            "version": "0.14.0",
+            "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.0.tgz",
+            "integrity": "sha512-srw17NI0TUWHuGa5CFGGmhfNIeja30WMBfbslPNhf6JrqQlLN5gcrvig1oqPxiVaXb0oW0XRKtH6Nngs5lKCIA==",
             "dev": true
         },
         "node_modules/@nx/js/node_modules/semver": {
@@ -7568,9 +7556,9 @@
             }
         },
         "node_modules/@tinkoff/eslint-config/node_modules/globals": {
-            "version": "13.20.0",
-            "resolved": "https://registry.npmjs.org/globals/-/globals-13.20.0.tgz",
-            "integrity": "sha512-Qg5QtVkCy/kv3FUSlu4ukeZDVf9ee0iXLAUYX13gbR17bnejFTzr4iS9bY7kwCf1NztRNm1t91fjOiyx4CSwPQ==",
+            "version": "13.21.0",
+            "resolved": "https://registry.npmjs.org/globals/-/globals-13.21.0.tgz",
+            "integrity": "sha512-ybyme3s4yy/t/3s35bewwXKOf7cvzfreG2lH0lZl0JB7I4GxRP2ghxOK/Nb9EkRXdbBXZLfq/p/0W2JUONB/Gg==",
             "dev": true,
             "dependencies": {
                 "type-fest": "^0.20.2"
@@ -8505,9 +8493,9 @@
             }
         },
         "node_modules/@types/eslint": {
-            "version": "8.44.1",
-            "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.44.1.tgz",
-            "integrity": "sha512-XpNDc4Z5Tb4x+SW1MriMVeIsMoONHCkWFMkR/aPJbzEsxqHy+4Glu/BqTdPrApfDeMaXbtNh6bseNgl5KaWrSg==",
+            "version": "8.44.2",
+            "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.44.2.tgz",
+            "integrity": "sha512-sdPRb9K6iL5XZOmBubg8yiFp5yS/JdUDQsq5e6h95km91MCYMuvp7mh1fjPEYUhvHepKpZOjnEaMBR4PxjWDzg==",
             "dev": true,
             "dependencies": {
                 "@types/estree": "*",
@@ -8690,9 +8678,9 @@
             "dev": true
         },
         "node_modules/@types/lodash": {
-            "version": "4.14.196",
-            "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.196.tgz",
-            "integrity": "sha512-22y3o88f4a94mKljsZcanlNWPzO0uBsBdzLAngf2tp533LzZcQzb6+eZPJ+vCTt+bqF2XnvT9gejTLsAcJAJyQ==",
+            "version": "4.14.197",
+            "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.197.tgz",
+            "integrity": "sha512-BMVOiWs0uNxHVlHBgzTIqJYmj+PgCo4euloGF+5m4okL3rEYzM2EEv78mw8zWSMM57dM7kVIgJ2QDvwHSoCI5g==",
             "dev": true
         },
         "node_modules/@types/markdown-it": {
@@ -10103,13 +10091,11 @@
             }
         },
         "node_modules/agentkeepalive": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.3.0.tgz",
-            "integrity": "sha512-7Epl1Blf4Sy37j4v9f9FjICCh4+KAQOyXgHEwlyBiAQLbhKdq/i2QQU3amQalS/wPhdPzDXPL5DMR5bkn+YeWg==",
+            "version": "4.5.0",
+            "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.5.0.tgz",
+            "integrity": "sha512-5GG/5IbQQpC9FpkRGsSvZI5QYeSCzlJHdpBQntCsuTOxhKD8lqKhrleg2Yi7yvMIf82Ycmmqln9U8V9qwEiJew==",
             "dev": true,
             "dependencies": {
-                "debug": "^4.1.0",
-                "depd": "^2.0.0",
                 "humanize-ms": "^1.2.1"
             },
             "engines": {
@@ -10877,21 +10863,21 @@
             }
         },
         "node_modules/axios-retry/node_modules/@babel/runtime": {
-            "version": "7.22.6",
-            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.22.6.tgz",
-            "integrity": "sha512-wDb5pWm4WDdF6LFUde3Jl8WzPA+3ZbxYqkC6xAXuD3irdEHN1k0NfTRrJD8ZD378SJ61miMLCqIOXYhd8x+AJQ==",
+            "version": "7.22.10",
+            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.22.10.tgz",
+            "integrity": "sha512-21t/fkKLMZI4pqP2wlmsQAWnYW1PDyKyyUV4vCi+B25ydmdaYTKXPwCj0BzSUnZf4seIiYvSA3jcZ3gdsMFkLQ==",
             "dev": true,
             "dependencies": {
-                "regenerator-runtime": "^0.13.11"
+                "regenerator-runtime": "^0.14.0"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/axios-retry/node_modules/regenerator-runtime": {
-            "version": "0.13.11",
-            "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
-            "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
+            "version": "0.14.0",
+            "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.0.tgz",
+            "integrity": "sha512-srw17NI0TUWHuGa5CFGGmhfNIeja30WMBfbslPNhf6JrqQlLN5gcrvig1oqPxiVaXb0oW0XRKtH6Nngs5lKCIA==",
             "dev": true
         },
         "node_modules/axobject-query": {
@@ -12372,9 +12358,9 @@
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001518",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001518.tgz",
-            "integrity": "sha512-rup09/e3I0BKjncL+FesTayKtPrdwKhUufQFd3riFw1hHg8JmIFoInYfB102cFcY/pPgGmdyl/iy+jgiDi2vdA==",
+            "version": "1.0.30001520",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001520.tgz",
+            "integrity": "sha512-tahF5O9EiiTzwTUqAeFjIZbn4Dnqxzz7ktrgGlMYNLH43Ul26IgTMH/zvL3DG0lZxBYnlT04axvInszUsZULdA==",
             "dev": true,
             "funding": [
                 {
@@ -12642,69 +12628,19 @@
             }
         },
         "node_modules/cli-truncate": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-3.1.0.tgz",
-            "integrity": "sha512-wfOBkjXteqSnI59oPcJkcPl/ZmwvMMOj340qUIY1SKZCv0B9Cf4D4fAucRkIKQmsIuYK3x1rrgU7MeGRruiuiA==",
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-2.1.0.tgz",
+            "integrity": "sha512-n8fOixwDD6b/ObinzTrp1ZKFzbgvKZvuz/TvejnLn1aQfC6r52XEx85FmuC+3HI+JM7coBRXUvNqEU2PHVrHpg==",
             "dev": true,
             "dependencies": {
-                "slice-ansi": "^5.0.0",
-                "string-width": "^5.0.0"
+                "slice-ansi": "^3.0.0",
+                "string-width": "^4.2.0"
             },
             "engines": {
-                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+                "node": ">=8"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/cli-truncate/node_modules/ansi-regex": {
-            "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
-            "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
-            "dev": true,
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/ansi-regex?sponsor=1"
-            }
-        },
-        "node_modules/cli-truncate/node_modules/emoji-regex": {
-            "version": "9.2.2",
-            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
-            "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
-            "dev": true
-        },
-        "node_modules/cli-truncate/node_modules/string-width": {
-            "version": "5.1.2",
-            "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
-            "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
-            "dev": true,
-            "dependencies": {
-                "eastasianwidth": "^0.2.0",
-                "emoji-regex": "^9.2.2",
-                "strip-ansi": "^7.0.1"
-            },
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/cli-truncate/node_modules/strip-ansi": {
-            "version": "7.1.0",
-            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
-            "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
-            "dev": true,
-            "dependencies": {
-                "ansi-regex": "^6.0.1"
-            },
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/strip-ansi?sponsor=1"
             }
         },
         "node_modules/cli-width": {
@@ -13111,16 +13047,15 @@
             }
         },
         "node_modules/conventional-changelog-angular": {
-            "version": "5.0.13",
-            "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-5.0.13.tgz",
-            "integrity": "sha512-i/gipMxs7s8L/QeuavPF2hLnJgH6pEZAttySB6aiQLWcX3puWDL3ACVmvBhJGxnAy52Qc15ua26BufY6KpmrVA==",
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-6.0.0.tgz",
+            "integrity": "sha512-6qLgrBF4gueoC7AFVHu51nHL9pF9FRjXrH+ceVf7WmAfH3gs+gEYOkvxhjMPjZu57I4AGUGoNTY8V7Hrgf1uqg==",
             "dev": true,
             "dependencies": {
-                "compare-func": "^2.0.0",
-                "q": "^1.5.1"
+                "compare-func": "^2.0.0"
             },
             "engines": {
-                "node": ">=10"
+                "node": ">=14"
             }
         },
         "node_modules/conventional-changelog-atom": {
@@ -13185,6 +13120,26 @@
                 "read-pkg": "^3.0.0",
                 "read-pkg-up": "^3.0.0",
                 "through2": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/conventional-changelog-core/node_modules/conventional-commits-parser": {
+            "version": "3.2.4",
+            "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-3.2.4.tgz",
+            "integrity": "sha512-nK7sAtfi+QXbxHCYfhpZsfRtaitZLIA6889kFIouLvz6repszQDgxBu7wf2WbU+Dco7sAnNCJYERCwt54WPC2Q==",
+            "dev": true,
+            "dependencies": {
+                "is-text-path": "^1.0.1",
+                "JSONStream": "^1.0.4",
+                "lodash": "^4.17.15",
+                "meow": "^8.0.0",
+                "split2": "^3.0.0",
+                "through2": "^4.0.0"
+            },
+            "bin": {
+                "conventional-commits-parser": "cli.js"
             },
             "engines": {
                 "node": ">=10"
@@ -13434,6 +13389,19 @@
                 "semver": "bin/semver.js"
             }
         },
+        "node_modules/conventional-changelog/node_modules/conventional-changelog-angular": {
+            "version": "5.0.13",
+            "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-5.0.13.tgz",
+            "integrity": "sha512-i/gipMxs7s8L/QeuavPF2hLnJgH6pEZAttySB6aiQLWcX3puWDL3ACVmvBhJGxnAy52Qc15ua26BufY6KpmrVA==",
+            "dev": true,
+            "dependencies": {
+                "compare-func": "^2.0.0",
+                "q": "^1.5.1"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
         "node_modules/conventional-changelog/node_modules/conventional-changelog-conventionalcommits": {
             "version": "4.6.3",
             "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-4.6.3.tgz",
@@ -13462,23 +13430,21 @@
             }
         },
         "node_modules/conventional-commits-parser": {
-            "version": "3.2.4",
-            "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-3.2.4.tgz",
-            "integrity": "sha512-nK7sAtfi+QXbxHCYfhpZsfRtaitZLIA6889kFIouLvz6repszQDgxBu7wf2WbU+Dco7sAnNCJYERCwt54WPC2Q==",
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-4.0.0.tgz",
+            "integrity": "sha512-WRv5j1FsVM5FISJkoYMR6tPk07fkKT0UodruX4je86V4owk451yjXAKzKAPOs9l7y59E2viHUS9eQ+dfUA9NSg==",
             "dev": true,
             "dependencies": {
                 "is-text-path": "^1.0.1",
-                "JSONStream": "^1.0.4",
-                "lodash": "^4.17.15",
-                "meow": "^8.0.0",
-                "split2": "^3.0.0",
-                "through2": "^4.0.0"
+                "JSONStream": "^1.3.5",
+                "meow": "^8.1.2",
+                "split2": "^3.2.2"
             },
             "bin": {
                 "conventional-commits-parser": "cli.js"
             },
             "engines": {
-                "node": ">=10"
+                "node": ">=14"
             }
         },
         "node_modules/conventional-recommended-bump": {
@@ -13510,6 +13476,72 @@
             "dev": true,
             "engines": {
                 "node": ">=0.10.0"
+            }
+        },
+        "node_modules/conventional-recommended-bump/node_modules/conventional-commits-parser": {
+            "version": "3.2.4",
+            "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-3.2.4.tgz",
+            "integrity": "sha512-nK7sAtfi+QXbxHCYfhpZsfRtaitZLIA6889kFIouLvz6repszQDgxBu7wf2WbU+Dco7sAnNCJYERCwt54WPC2Q==",
+            "dev": true,
+            "dependencies": {
+                "is-text-path": "^1.0.1",
+                "JSONStream": "^1.0.4",
+                "lodash": "^4.17.15",
+                "meow": "^8.0.0",
+                "split2": "^3.0.0",
+                "through2": "^4.0.0"
+            },
+            "bin": {
+                "conventional-commits-parser": "cli.js"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/conventional-recommended-bump/node_modules/conventional-commits-parser/node_modules/meow": {
+            "version": "8.1.2",
+            "resolved": "https://registry.npmjs.org/meow/-/meow-8.1.2.tgz",
+            "integrity": "sha512-r85E3NdZ+mpYk1C6RjPFEMSE+s1iZMuHtsHAqY0DT3jZczl0diWUZ8g6oU7h0M9cD2EL+PzaYghhCLzR0ZNn5Q==",
+            "dev": true,
+            "dependencies": {
+                "@types/minimist": "^1.2.0",
+                "camelcase-keys": "^6.2.2",
+                "decamelize-keys": "^1.1.0",
+                "hard-rejection": "^2.1.0",
+                "minimist-options": "4.1.0",
+                "normalize-package-data": "^3.0.0",
+                "read-pkg-up": "^7.0.1",
+                "redent": "^3.0.0",
+                "trim-newlines": "^3.0.0",
+                "type-fest": "^0.18.0",
+                "yargs-parser": "^20.2.3"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/conventional-recommended-bump/node_modules/conventional-commits-parser/node_modules/type-fest": {
+            "version": "0.18.1",
+            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.18.1.tgz",
+            "integrity": "sha512-OIAYXk8+ISY+qTOwkHtKqzAuxchoMiD9Udx+FSGQDuiRR+PJKJHc2NJAXlbhkGwTt/4/nKZxELY1w3ReWOL8mw==",
+            "dev": true,
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/conventional-recommended-bump/node_modules/conventional-commits-parser/node_modules/yargs-parser": {
+            "version": "20.2.9",
+            "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
+            "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
+            "dev": true,
+            "engines": {
+                "node": ">=10"
             }
         },
         "node_modules/conventional-recommended-bump/node_modules/dargs": {
@@ -13611,6 +13643,18 @@
                 "node": ">= 4"
             }
         },
+        "node_modules/conventional-recommended-bump/node_modules/git-raw-commits/node_modules/normalize-package-data": {
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
+            "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
+            "dev": true,
+            "dependencies": {
+                "hosted-git-info": "^2.1.4",
+                "resolve": "^1.10.0",
+                "semver": "2 || 3 || 4 || 5",
+                "validate-npm-package-license": "^3.0.1"
+            }
+        },
         "node_modules/conventional-recommended-bump/node_modules/git-raw-commits/node_modules/read-pkg-up": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-3.0.0.tgz",
@@ -13635,6 +13679,25 @@
             },
             "engines": {
                 "node": ">=4"
+            }
+        },
+        "node_modules/conventional-recommended-bump/node_modules/git-raw-commits/node_modules/split2": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/split2/-/split2-2.2.0.tgz",
+            "integrity": "sha512-RAb22TG39LhI31MbreBgIuKiIKhVsawfTgEGqKHTK87aG+ul/PB8Sqoi3I7kVdRWiCfrKxK3uo4/YUkpNvhPbw==",
+            "dev": true,
+            "dependencies": {
+                "through2": "^2.0.2"
+            }
+        },
+        "node_modules/conventional-recommended-bump/node_modules/git-raw-commits/node_modules/through2": {
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
+            "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
+            "dev": true,
+            "dependencies": {
+                "readable-stream": "~2.3.6",
+                "xtend": "~4.0.1"
             }
         },
         "node_modules/conventional-recommended-bump/node_modules/git-raw-commits/node_modules/trim-newlines": {
@@ -13723,7 +13786,7 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/conventional-recommended-bump/node_modules/normalize-package-data": {
+        "node_modules/conventional-recommended-bump/node_modules/meow/node_modules/normalize-package-data": {
             "version": "2.5.0",
             "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
             "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
@@ -13821,6 +13884,18 @@
                 "node": ">=4"
             }
         },
+        "node_modules/conventional-recommended-bump/node_modules/read-pkg/node_modules/normalize-package-data": {
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
+            "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
+            "dev": true,
+            "dependencies": {
+                "hosted-git-info": "^2.1.4",
+                "resolve": "^1.10.0",
+                "semver": "2 || 3 || 4 || 5",
+                "validate-npm-package-license": "^3.0.1"
+            }
+        },
         "node_modules/conventional-recommended-bump/node_modules/readable-stream": {
             "version": "2.3.8",
             "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
@@ -13851,15 +13926,6 @@
                 "semver": "bin/semver"
             }
         },
-        "node_modules/conventional-recommended-bump/node_modules/split2": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/split2/-/split2-2.2.0.tgz",
-            "integrity": "sha512-RAb22TG39LhI31MbreBgIuKiIKhVsawfTgEGqKHTK87aG+ul/PB8Sqoi3I7kVdRWiCfrKxK3uo4/YUkpNvhPbw==",
-            "dev": true,
-            "dependencies": {
-                "through2": "^2.0.2"
-            }
-        },
         "node_modules/conventional-recommended-bump/node_modules/string_decoder": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
@@ -13876,16 +13942,6 @@
             "dev": true,
             "engines": {
                 "node": ">=4"
-            }
-        },
-        "node_modules/conventional-recommended-bump/node_modules/through2": {
-            "version": "2.0.5",
-            "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
-            "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
-            "dev": true,
-            "dependencies": {
-                "readable-stream": "~2.3.6",
-                "xtend": "~4.0.1"
             }
         },
         "node_modules/conventional-recommended-bump/node_modules/type-fest": {
@@ -15783,9 +15839,9 @@
             }
         },
         "node_modules/cypress-real-events/node_modules/prettier": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.0.0.tgz",
-            "integrity": "sha512-zBf5eHpwHOGPC47h0zrPyNn+eAEIdEzfywMoYn2XPi0P44Zp0tSq64rq0xAREh4auw2cJZHo9QUob+NqCQky4g==",
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.0.1.tgz",
+            "integrity": "sha512-fcOWSnnpCrovBsmFZIGIy9UqK2FaI7Hqax+DIO0A9UxeVoY4iweyaFjS5TavZN97Hfehph0nhsZnjlVKzEQSrQ==",
             "dev": true,
             "bin": {
                 "prettier": "bin/prettier.cjs"
@@ -15798,9 +15854,9 @@
             }
         },
         "node_modules/cypress/node_modules/@types/node": {
-            "version": "16.18.39",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.39.tgz",
-            "integrity": "sha512-8q9ZexmdYYyc5/cfujaXb4YOucpQxAV4RMG0himLyDUOEr8Mr79VrqsFI+cQ2M2h89YIuy95lbxuYjxT4Hk4kQ==",
+            "version": "16.18.40",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.40.tgz",
+            "integrity": "sha512-+yno3ItTEwGxXiS/75Q/aHaa5srkpnJaH+kdkTVJ3DtJEwv92itpKbxU+FjPoh2m/5G9zmUQfrL4A4C13c+iGA==",
             "dev": true
         },
         "node_modules/cypress/node_modules/ansi-styles": {
@@ -16070,20 +16126,20 @@
             }
         },
         "node_modules/date-fns/node_modules/@babel/runtime": {
-            "version": "7.22.6",
-            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.22.6.tgz",
-            "integrity": "sha512-wDb5pWm4WDdF6LFUde3Jl8WzPA+3ZbxYqkC6xAXuD3irdEHN1k0NfTRrJD8ZD378SJ61miMLCqIOXYhd8x+AJQ==",
+            "version": "7.22.10",
+            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.22.10.tgz",
+            "integrity": "sha512-21t/fkKLMZI4pqP2wlmsQAWnYW1PDyKyyUV4vCi+B25ydmdaYTKXPwCj0BzSUnZf4seIiYvSA3jcZ3gdsMFkLQ==",
             "dependencies": {
-                "regenerator-runtime": "^0.13.11"
+                "regenerator-runtime": "^0.14.0"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/date-fns/node_modules/regenerator-runtime": {
-            "version": "0.13.11",
-            "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
-            "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg=="
+            "version": "0.14.0",
+            "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.0.tgz",
+            "integrity": "sha512-srw17NI0TUWHuGa5CFGGmhfNIeja30WMBfbslPNhf6JrqQlLN5gcrvig1oqPxiVaXb0oW0XRKtH6Nngs5lKCIA=="
         },
         "node_modules/dateformat": {
             "version": "3.0.3",
@@ -16999,9 +17055,9 @@
             }
         },
         "node_modules/electron-to-chromium": {
-            "version": "1.4.480",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.480.tgz",
-            "integrity": "sha512-IXTgg+bITkQv/FLP9FjX6f9KFCs5hQWeh5uNSKxB9mqYj/JXhHDbu+ekS43LVvbkL3eW6/oZy4+r9Om6lan1Uw==",
+            "version": "1.4.490",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.490.tgz",
+            "integrity": "sha512-6s7NVJz+sATdYnIwhdshx/N/9O6rvMxmhVoDSDFdj6iA45gHR8EQje70+RYsF4GeB+k0IeNSBnP7yG9ZXJFr7A==",
             "dev": true
         },
         "node_modules/ember-rfc176-data": {
@@ -17805,14 +17861,14 @@
             }
         },
         "node_modules/eslint-import-resolver-node": {
-            "version": "0.3.7",
-            "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.7.tgz",
-            "integrity": "sha512-gozW2blMLJCeFpBwugLTGyvVjNoeo1knonXAcatC6bjPBZitotxdWf7Gimr25N4c0AAOo4eOUfaG82IJPDpqCA==",
+            "version": "0.3.9",
+            "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.9.tgz",
+            "integrity": "sha512-WFj2isz22JahUv+B788TlO3N6zL3nNJGU8CcZbPZvVEkBPaJdCV4vy5wyghty5ROFbCRnm132v8BScu5/1BQ8g==",
             "dev": true,
             "dependencies": {
                 "debug": "^3.2.7",
-                "is-core-module": "^2.11.0",
-                "resolve": "^1.22.1"
+                "is-core-module": "^2.13.0",
+                "resolve": "^1.22.4"
             }
         },
         "node_modules/eslint-import-resolver-node/node_modules/debug": {
@@ -17825,12 +17881,12 @@
             }
         },
         "node_modules/eslint-import-resolver-node/node_modules/resolve": {
-            "version": "1.22.2",
-            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.2.tgz",
-            "integrity": "sha512-Sb+mjNHOULsBv818T40qSPeRiuWLyaGMa5ewydRLFimneixmVy2zdivRl+AF6jaYPC8ERxGDmFSiqui6SfPd+g==",
+            "version": "1.22.4",
+            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.4.tgz",
+            "integrity": "sha512-PXNdCiPqDqeUou+w1C2eTQbNfxKSuMxqTCuvlmmMsk1NWHL5fRrhY6Pl0qEYYc6+QqGClco1Qj8XnjPego4wfg==",
             "dev": true,
             "dependencies": {
-                "is-core-module": "^2.11.0",
+                "is-core-module": "^2.13.0",
                 "path-parse": "^1.0.7",
                 "supports-preserve-symlinks-flag": "^1.0.0"
             },
@@ -17911,12 +17967,12 @@
             }
         },
         "node_modules/eslint-import-resolver-typescript/node_modules/resolve": {
-            "version": "1.22.2",
-            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.2.tgz",
-            "integrity": "sha512-Sb+mjNHOULsBv818T40qSPeRiuWLyaGMa5ewydRLFimneixmVy2zdivRl+AF6jaYPC8ERxGDmFSiqui6SfPd+g==",
+            "version": "1.22.4",
+            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.4.tgz",
+            "integrity": "sha512-PXNdCiPqDqeUou+w1C2eTQbNfxKSuMxqTCuvlmmMsk1NWHL5fRrhY6Pl0qEYYc6+QqGClco1Qj8XnjPego4wfg==",
             "dev": true,
             "dependencies": {
-                "is-core-module": "^2.11.0",
+                "is-core-module": "^2.13.0",
                 "path-parse": "^1.0.7",
                 "supports-preserve-symlinks-flag": "^1.0.0"
             },
@@ -17928,9 +17984,9 @@
             }
         },
         "node_modules/eslint-import-resolver-webpack": {
-            "version": "0.13.2",
-            "resolved": "https://registry.npmjs.org/eslint-import-resolver-webpack/-/eslint-import-resolver-webpack-0.13.2.tgz",
-            "integrity": "sha512-XodIPyg1OgE2h5BDErz3WJoK7lawxKTJNhgPNafRST6csC/MZC+L5P6kKqsZGRInpbgc02s/WZMrb4uGJzcuRg==",
+            "version": "0.13.4",
+            "resolved": "https://registry.npmjs.org/eslint-import-resolver-webpack/-/eslint-import-resolver-webpack-0.13.4.tgz",
+            "integrity": "sha512-6RN3DFoOu8J05VAjuclAquTiLou/JYZx4x7qoL2rC96LmNqYyIwszSqb+Ys1Q+eA6qvQhXYKDaHnEpHmDA0qBw==",
             "dev": true,
             "dependencies": {
                 "array-find": "^1.0.0",
@@ -17939,11 +17995,11 @@
                 "find-root": "^1.1.0",
                 "has": "^1.0.3",
                 "interpret": "^1.4.0",
-                "is-core-module": "^2.7.0",
+                "is-core-module": "^2.13.0",
                 "is-regex": "^1.1.4",
                 "lodash": "^4.17.21",
-                "resolve": "^1.20.0",
-                "semver": "^5.7.1"
+                "resolve": "^1.22.4",
+                "semver": "^5.7.2"
             },
             "engines": {
                 "node": ">= 6"
@@ -17981,6 +18037,23 @@
             "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.2.0.tgz",
             "integrity": "sha512-+y4mDxU4rvXXu5UDSGCGNiesFmwCHuefGMoPCO1WYucNYj7DsLqrFaa2fXVI0H+NNiPTwwzKwspn9yTZqUGqng==",
             "dev": true
+        },
+        "node_modules/eslint-import-resolver-webpack/node_modules/resolve": {
+            "version": "1.22.4",
+            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.4.tgz",
+            "integrity": "sha512-PXNdCiPqDqeUou+w1C2eTQbNfxKSuMxqTCuvlmmMsk1NWHL5fRrhY6Pl0qEYYc6+QqGClco1Qj8XnjPego4wfg==",
+            "dev": true,
+            "dependencies": {
+                "is-core-module": "^2.13.0",
+                "path-parse": "^1.0.7",
+                "supports-preserve-symlinks-flag": "^1.0.0"
+            },
+            "bin": {
+                "resolve": "bin/resolve"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
         },
         "node_modules/eslint-import-resolver-webpack/node_modules/semver": {
             "version": "5.7.2",
@@ -18065,21 +18138,21 @@
             }
         },
         "node_modules/eslint-plugin-decorator-position/node_modules/@babel/core": {
-            "version": "7.22.9",
-            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.22.9.tgz",
-            "integrity": "sha512-G2EgeufBcYw27U4hhoIwFcgc1XU7TlXJ3mv04oOv1WCuo900U/anZSPzEqNjwdjgffkk2Gs0AN0dW1CKVLcG7w==",
+            "version": "7.22.10",
+            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.22.10.tgz",
+            "integrity": "sha512-fTmqbbUBAwCcre6zPzNngvsI0aNrPZe77AeqvDxWM9Nm+04RrJ3CAmGHA9f7lJQY6ZMhRztNemy4uslDxTX4Qw==",
             "dev": true,
             "dependencies": {
                 "@ampproject/remapping": "^2.2.0",
-                "@babel/code-frame": "^7.22.5",
-                "@babel/generator": "^7.22.9",
-                "@babel/helper-compilation-targets": "^7.22.9",
+                "@babel/code-frame": "^7.22.10",
+                "@babel/generator": "^7.22.10",
+                "@babel/helper-compilation-targets": "^7.22.10",
                 "@babel/helper-module-transforms": "^7.22.9",
-                "@babel/helpers": "^7.22.6",
-                "@babel/parser": "^7.22.7",
+                "@babel/helpers": "^7.22.10",
+                "@babel/parser": "^7.22.10",
                 "@babel/template": "^7.22.5",
-                "@babel/traverse": "^7.22.8",
-                "@babel/types": "^7.22.5",
+                "@babel/traverse": "^7.22.10",
+                "@babel/types": "^7.22.10",
                 "convert-source-map": "^1.7.0",
                 "debug": "^4.1.0",
                 "gensync": "^1.0.0-beta.2",
@@ -18095,12 +18168,12 @@
             }
         },
         "node_modules/eslint-plugin-decorator-position/node_modules/@babel/generator": {
-            "version": "7.22.9",
-            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.22.9.tgz",
-            "integrity": "sha512-KtLMbmicyuK2Ak/FTCJVbDnkN1SlT8/kceFTiuDiiRUUSMnHMidxSCdG4ndkTOHHpoomWe/4xkvHkEOncwjYIw==",
+            "version": "7.22.10",
+            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.22.10.tgz",
+            "integrity": "sha512-79KIf7YiWjjdZ81JnLujDRApWtl7BxTqWD88+FFdQEIOG8LJ0etDOM7CXuIgGJa55sGOwZVwuEsaLEm0PJ5/+A==",
             "dev": true,
             "dependencies": {
-                "@babel/types": "^7.22.5",
+                "@babel/types": "^7.22.10",
                 "@jridgewell/gen-mapping": "^0.3.2",
                 "@jridgewell/trace-mapping": "^0.3.17",
                 "jsesc": "^2.5.1"
@@ -18309,12 +18382,12 @@
             }
         },
         "node_modules/eslint-plugin-import/node_modules/resolve": {
-            "version": "1.22.3",
-            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.3.tgz",
-            "integrity": "sha512-P8ur/gp/AmbEzjr729bZnLjXK5Z+4P0zhIJgBgzqRih7hL7BOukHGtSTA3ACMY467GRFz3duQsi0bDZdR7DKdw==",
+            "version": "1.22.4",
+            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.4.tgz",
+            "integrity": "sha512-PXNdCiPqDqeUou+w1C2eTQbNfxKSuMxqTCuvlmmMsk1NWHL5fRrhY6Pl0qEYYc6+QqGClco1Qj8XnjPego4wfg==",
             "dev": true,
             "dependencies": {
-                "is-core-module": "^2.12.0",
+                "is-core-module": "^2.13.0",
                 "path-parse": "^1.0.7",
                 "supports-preserve-symlinks-flag": "^1.0.0"
             },
@@ -19337,29 +19410,28 @@
             "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
         },
         "node_modules/fast-json-stringify": {
-            "version": "2.7.13",
-            "resolved": "https://registry.npmjs.org/fast-json-stringify/-/fast-json-stringify-2.7.13.tgz",
-            "integrity": "sha512-ar+hQ4+OIurUGjSJD1anvYSDcUflywhKjfxnsW4TBTD7+u0tJufv6DKRWoQk3vI6YBOWMoz0TQtfbe7dxbQmvA==",
+            "version": "5.8.0",
+            "resolved": "https://registry.npmjs.org/fast-json-stringify/-/fast-json-stringify-5.8.0.tgz",
+            "integrity": "sha512-VVwK8CFMSALIvt14U8AvrSzQAwN/0vaVRiFFUVlpnXSnDGrSkOAO5MtzyN8oQNjLd5AqTW5OZRgyjoNuAuR3jQ==",
             "dev": true,
             "dependencies": {
-                "ajv": "^6.11.0",
-                "deepmerge": "^4.2.2",
-                "rfdc": "^1.2.0",
-                "string-similarity": "^4.0.1"
-            },
-            "engines": {
-                "node": ">= 10.0.0"
+                "@fastify/deepmerge": "^1.0.0",
+                "ajv": "^8.10.0",
+                "ajv-formats": "^2.1.1",
+                "fast-deep-equal": "^3.1.3",
+                "fast-uri": "^2.1.0",
+                "rfdc": "^1.2.0"
             }
         },
         "node_modules/fast-json-stringify/node_modules/ajv": {
-            "version": "6.12.6",
-            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-            "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+            "version": "8.12.0",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
+            "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
             "dev": true,
             "dependencies": {
                 "fast-deep-equal": "^3.1.1",
-                "fast-json-stable-stringify": "^2.0.0",
-                "json-schema-traverse": "^0.4.1",
+                "json-schema-traverse": "^1.0.0",
+                "require-from-string": "^2.0.2",
                 "uri-js": "^4.2.2"
             },
             "funding": {
@@ -19367,11 +19439,22 @@
                 "url": "https://github.com/sponsors/epoberezkin"
             }
         },
-        "node_modules/fast-json-stringify/node_modules/json-schema-traverse": {
-            "version": "0.4.1",
-            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-            "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-            "dev": true
+        "node_modules/fast-json-stringify/node_modules/ajv-formats": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
+            "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
+            "dev": true,
+            "dependencies": {
+                "ajv": "^8.0.0"
+            },
+            "peerDependencies": {
+                "ajv": "^8.0.0"
+            },
+            "peerDependenciesMeta": {
+                "ajv": {
+                    "optional": true
+                }
+            }
         },
         "node_modules/fast-levenshtein": {
             "version": "2.0.6",
@@ -19390,6 +19473,12 @@
             "engines": {
                 "node": ">=10.0"
             }
+        },
+        "node_modules/fast-uri": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-2.2.0.tgz",
+            "integrity": "sha512-cIusKBIt/R/oI6z/1nyfe2FvGKVTohVRfvkOhvx0nCEW+xf5NoCXjAHcWp93uOUBchzYcsvPlrapAdX1uW+YGg==",
+            "dev": true
         },
         "node_modules/fastest-levenshtein": {
             "version": "1.0.16",
@@ -21738,9 +21827,9 @@
             }
         },
         "node_modules/is-core-module": {
-            "version": "2.12.1",
-            "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.12.1.tgz",
-            "integrity": "sha512-Q4ZuBAe2FUsKtyQJoQHlvP8OvBERxO3jEmy1I7hcRXcJBGGHFh/aJBswbXuS9sgrDH2QUO8ilkwNPHvHMd8clg==",
+            "version": "2.13.0",
+            "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.13.0.tgz",
+            "integrity": "sha512-Z7dk6Qo8pOCp3l4tsX2C5ZVas4V+UxwQodwZhLopL91TX8UyyHEXafPcyoeeWuLrwzHcr3igO78wNLwHJHsMCQ==",
             "dependencies": {
                 "has": "^1.0.3"
             },
@@ -21841,15 +21930,11 @@
             }
         },
         "node_modules/is-fullwidth-code-point": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-4.0.0.tgz",
-            "integrity": "sha512-O4L094N2/dZ7xqVdrXhh9r1KODPJpFms8B5sGdJLPy664AgvXsreZUyCQQNItZRDlYug4xStLjNp/sz3HvBowQ==",
-            "dev": true,
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+            "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
             "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
+                "node": ">=8"
             }
         },
         "node_modules/is-generator-fn": {
@@ -26020,6 +26105,22 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/lint-staged/node_modules/cli-truncate": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-3.1.0.tgz",
+            "integrity": "sha512-wfOBkjXteqSnI59oPcJkcPl/ZmwvMMOj340qUIY1SKZCv0B9Cf4D4fAucRkIKQmsIuYK3x1rrgU7MeGRruiuiA==",
+            "dev": true,
+            "dependencies": {
+                "slice-ansi": "^5.0.0",
+                "string-width": "^5.0.0"
+            },
+            "engines": {
+                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/lint-staged/node_modules/commander": {
             "version": "11.0.0",
             "resolved": "https://registry.npmjs.org/commander/-/commander-11.0.0.tgz",
@@ -26088,6 +26189,18 @@
             "dev": true,
             "engines": {
                 "node": ">=14.18.0"
+            }
+        },
+        "node_modules/lint-staged/node_modules/is-fullwidth-code-point": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-4.0.0.tgz",
+            "integrity": "sha512-O4L094N2/dZ7xqVdrXhh9r1KODPJpFms8B5sGdJLPy664AgvXsreZUyCQQNItZRDlYug4xStLjNp/sz3HvBowQ==",
+            "dev": true,
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/lint-staged/node_modules/is-stream": {
@@ -26240,6 +26353,22 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/lint-staged/node_modules/slice-ansi": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-5.0.0.tgz",
+            "integrity": "sha512-FC+lgizVPfie0kkhqUScwRu1O/lF6NOgJmlCgK+/LYxDCTk8sGelYaHDhFcDN+Sn3Cv+3VSa4Byeo+IMCzpMgQ==",
+            "dev": true,
+            "dependencies": {
+                "ansi-styles": "^6.0.0",
+                "is-fullwidth-code-point": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+            }
+        },
         "node_modules/lint-staged/node_modules/string-width": {
             "version": "5.1.2",
             "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
@@ -26349,64 +26478,6 @@
                 }
             }
         },
-        "node_modules/listr2/node_modules/ansi-styles": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-            "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-            "dev": true,
-            "dependencies": {
-                "color-convert": "^2.0.1"
-            },
-            "engines": {
-                "node": ">=8"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-            }
-        },
-        "node_modules/listr2/node_modules/cli-truncate": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-2.1.0.tgz",
-            "integrity": "sha512-n8fOixwDD6b/ObinzTrp1ZKFzbgvKZvuz/TvejnLn1aQfC6r52XEx85FmuC+3HI+JM7coBRXUvNqEU2PHVrHpg==",
-            "dev": true,
-            "dependencies": {
-                "slice-ansi": "^3.0.0",
-                "string-width": "^4.2.0"
-            },
-            "engines": {
-                "node": ">=8"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/listr2/node_modules/color-convert": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-            "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-            "dev": true,
-            "dependencies": {
-                "color-name": "~1.1.4"
-            },
-            "engines": {
-                "node": ">=7.0.0"
-            }
-        },
-        "node_modules/listr2/node_modules/color-name": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-            "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-            "dev": true
-        },
-        "node_modules/listr2/node_modules/is-fullwidth-code-point": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-            "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-            "dev": true,
-            "engines": {
-                "node": ">=8"
-            }
-        },
         "node_modules/listr2/node_modules/rxjs": {
             "version": "7.8.1",
             "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
@@ -26414,20 +26485,6 @@
             "dev": true,
             "dependencies": {
                 "tslib": "^2.1.0"
-            }
-        },
-        "node_modules/listr2/node_modules/slice-ansi": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-3.0.0.tgz",
-            "integrity": "sha512-pSyv7bSTC7ig9Dcgbw9AuRNUb5k5V6oDudjZoMBSr13qpLBG7tB+zgCkARjq7xIUgdz5P1Qe8u+rSGdouOOIyQ==",
-            "dev": true,
-            "dependencies": {
-                "ansi-styles": "^4.0.0",
-                "astral-regex": "^2.0.0",
-                "is-fullwidth-code-point": "^3.0.0"
-            },
-            "engines": {
-                "node": ">=8"
             }
         },
         "node_modules/load-json-file": {
@@ -26828,15 +26885,6 @@
             "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
             "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
             "dev": true
-        },
-        "node_modules/log-update/node_modules/is-fullwidth-code-point": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-            "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-            "dev": true,
-            "engines": {
-                "node": ">=8"
-            }
         },
         "node_modules/log-update/node_modules/slice-ansi": {
             "version": "4.0.0",
@@ -27977,17 +28025,17 @@
             }
         },
         "node_modules/ngx-highlightjs": {
-            "version": "6.1.3",
-            "resolved": "https://registry.npmjs.org/ngx-highlightjs/-/ngx-highlightjs-6.1.3.tgz",
-            "integrity": "sha512-QF91hKhD75HpuJOgCGL3M7UyZommAqIgzubpZN2/At7OqBZ3G6NX9n/r6ksezSur34wjYOYQunNJhIvsXQzu6Q==",
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/ngx-highlightjs/-/ngx-highlightjs-5.0.0.tgz",
+            "integrity": "sha512-EZ390iBJdjHcyD7659pJcEcbAARWyt4c7/Oru6SEDgAC9nz8TQOFmgDCvGuYHpwEORcw3g4adZOUf7COrsuTOw==",
             "dependencies": {
-                "highlight.js": "^11.0.0",
+                "highlight.js": ">=11.0.0",
                 "highlightjs-line-numbers.js": "^2.8.0",
                 "tslib": "^2.0.0"
             },
             "peerDependencies": {
-                "@angular/common": ">=13.0.0",
-                "@angular/core": ">=13.0.0",
+                "@angular/common": ">=12.0.0",
+                "@angular/core": ">=12.0.0",
                 "rxjs": ">=6.0.0"
             }
         },
@@ -32805,9 +32853,9 @@
             }
         },
         "node_modules/prosemirror-markdown": {
-            "version": "1.11.1",
-            "resolved": "https://registry.npmjs.org/prosemirror-markdown/-/prosemirror-markdown-1.11.1.tgz",
-            "integrity": "sha512-CLOieKoaSSEusKyYcXIj8v2qHGLW+tnuffci+8678Sen48NEFQE7M3o0Nx0gj9v63iVDj+yLibj2gCe8eb3jIw==",
+            "version": "1.11.2",
+            "resolved": "https://registry.npmjs.org/prosemirror-markdown/-/prosemirror-markdown-1.11.2.tgz",
+            "integrity": "sha512-Eu5g4WPiCdqDTGhdSsG9N6ZjACQRYrsAkrF9KYfdMaCmjIApH75aVncsWYOJvEk2i1B3i8jZppv3J/tnuHGiUQ==",
             "dev": true,
             "dependencies": {
                 "markdown-it": "^13.0.1",
@@ -33319,9 +33367,9 @@
             "dev": true
         },
         "node_modules/regenerator-transform": {
-            "version": "0.15.1",
-            "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.15.1.tgz",
-            "integrity": "sha512-knzmNAcuyxV+gQCufkYcvOqX/qIIfHLv0u5x79kRxuGojfYVky1f15TzZEu2Avte8QGepvUNTnLskf8E6X6Vyg==",
+            "version": "0.15.2",
+            "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.15.2.tgz",
+            "integrity": "sha512-hfMp2BoF0qOk3uc5V20ALGDS2ddjQaLrdl7xrGXvAIow7qeWRM2VA2HuCHkUKk9slq3VwEwLNK3DFBqDfPGYtg==",
             "dev": true,
             "dependencies": {
                 "@babel/runtime": "^7.8.4"
@@ -33842,16 +33890,16 @@
             }
         },
         "node_modules/roarr": {
-            "version": "7.15.0",
-            "resolved": "https://registry.npmjs.org/roarr/-/roarr-7.15.0.tgz",
-            "integrity": "sha512-CV9WefQfUXTX6wr8CrEMhfNef3sjIt9wNhE/5PNu4tNWsaoDNDXqq+OGn/RW9A1UPb0qc7FQlswXRaJJJsqn8A==",
+            "version": "7.15.1",
+            "resolved": "https://registry.npmjs.org/roarr/-/roarr-7.15.1.tgz",
+            "integrity": "sha512-0ExL9rjOXeQPvQvQo8IcV8SR2GTXmDr1FQFlY2HiAV+gdVQjaVZNOx9d4FI2RqFFsd0sNsiw2TRS/8RU9g0ZfA==",
             "dev": true,
             "dependencies": {
                 "boolean": "^3.1.4",
-                "fast-json-stringify": "^2.7.10",
+                "fast-json-stringify": "^5.8.0",
                 "fast-printf": "^1.6.9",
                 "globalthis": "^1.0.2",
-                "safe-stable-stringify": "^2.4.1",
+                "safe-stable-stringify": "^2.4.3",
                 "semver-compare": "^1.0.0"
             },
             "engines": {
@@ -35180,32 +35228,51 @@
             }
         },
         "node_modules/slice-ansi": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-5.0.0.tgz",
-            "integrity": "sha512-FC+lgizVPfie0kkhqUScwRu1O/lF6NOgJmlCgK+/LYxDCTk8sGelYaHDhFcDN+Sn3Cv+3VSa4Byeo+IMCzpMgQ==",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-3.0.0.tgz",
+            "integrity": "sha512-pSyv7bSTC7ig9Dcgbw9AuRNUb5k5V6oDudjZoMBSr13qpLBG7tB+zgCkARjq7xIUgdz5P1Qe8u+rSGdouOOIyQ==",
             "dev": true,
             "dependencies": {
-                "ansi-styles": "^6.0.0",
-                "is-fullwidth-code-point": "^4.0.0"
+                "ansi-styles": "^4.0.0",
+                "astral-regex": "^2.0.0",
+                "is-fullwidth-code-point": "^3.0.0"
             },
             "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+                "node": ">=8"
             }
         },
         "node_modules/slice-ansi/node_modules/ansi-styles": {
-            "version": "6.2.1",
-            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
-            "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+            "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
             "dev": true,
+            "dependencies": {
+                "color-convert": "^2.0.1"
+            },
             "engines": {
-                "node": ">=12"
+                "node": ">=8"
             },
             "funding": {
                 "url": "https://github.com/chalk/ansi-styles?sponsor=1"
             }
+        },
+        "node_modules/slice-ansi/node_modules/color-convert": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+            "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+            "dev": true,
+            "dependencies": {
+                "color-name": "~1.1.4"
+            },
+            "engines": {
+                "node": ">=7.0.0"
+            }
+        },
+        "node_modules/slice-ansi/node_modules/color-name": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+            "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+            "dev": true
         },
         "node_modules/slide": {
             "version": "1.1.6",
@@ -35369,21 +35436,21 @@
             }
         },
         "node_modules/socket.io": {
-            "version": "4.7.1",
-            "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-4.7.1.tgz",
-            "integrity": "sha512-W+utHys2w//dhFjy7iQQu9sGd3eokCjGbl2r59tyLqNiJJBdIebn3GAKEXBr3osqHTObJi2die/25bCx2zsaaw==",
+            "version": "4.7.2",
+            "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-4.7.2.tgz",
+            "integrity": "sha512-bvKVS29/I5fl2FGLNHuXlQaUH/BlzX1IN6S+NKLNZpBsPZIDH+90eQmCs2Railn4YUiww4SzUedJ6+uzwFnKLw==",
             "dev": true,
             "dependencies": {
                 "accepts": "~1.3.4",
                 "base64id": "~2.0.0",
                 "cors": "~2.8.5",
                 "debug": "~4.3.2",
-                "engine.io": "~6.5.0",
+                "engine.io": "~6.5.2",
                 "socket.io-adapter": "~2.5.2",
                 "socket.io-parser": "~4.2.4"
             },
             "engines": {
-                "node": ">=10.0.0"
+                "node": ">=10.2.0"
             }
         },
         "node_modules/socket.io-adapter": {
@@ -35417,14 +35484,14 @@
             }
         },
         "node_modules/socket.io-client": {
-            "version": "4.7.1",
-            "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.7.1.tgz",
-            "integrity": "sha512-Qk3Xj8ekbnzKu3faejo4wk2MzXA029XppiXtTF/PkbTg+fcwaTw1PlDrTrrrU4mKoYC4dvlApOnSeyLCKwek2w==",
+            "version": "4.7.2",
+            "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.7.2.tgz",
+            "integrity": "sha512-vtA0uD4ibrYD793SOIAwlo8cj6haOeMHrGvwPxJsxH7CeIksqJ+3Zc06RvWTIFgiSqx4A3sOnTXpfAEE2Zyz6w==",
             "dev": true,
             "dependencies": {
                 "@socket.io/component-emitter": "~3.1.0",
                 "debug": "~4.3.2",
-                "engine.io-client": "~6.5.1",
+                "engine.io-client": "~6.5.2",
                 "socket.io-parser": "~4.2.4"
             },
             "engines": {
@@ -36189,13 +36256,6 @@
                 "node": ">=10"
             }
         },
-        "node_modules/string-similarity": {
-            "version": "4.0.4",
-            "resolved": "https://registry.npmjs.org/string-similarity/-/string-similarity-4.0.4.tgz",
-            "integrity": "sha512-/q/8Q4Bl4ZKAPjj8WerIBJWALKkaPRfrvhfF8k/B23i4nzrlRj2/go1m90In7nG/3XDSbOo0+pu6RvCTM9RGMQ==",
-            "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
-            "dev": true
-        },
         "node_modules/string-width": {
             "version": "4.2.3",
             "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
@@ -36205,14 +36265,6 @@
                 "is-fullwidth-code-point": "^3.0.0",
                 "strip-ansi": "^6.0.1"
             },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/string-width/node_modules/is-fullwidth-code-point": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-            "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
             "engines": {
                 "node": ">=8"
             }
@@ -36837,15 +36889,6 @@
             "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
             "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
             "dev": true
-        },
-        "node_modules/table/node_modules/is-fullwidth-code-point": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-            "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-            "dev": true,
-            "engines": {
-                "node": ">=8"
-            }
         },
         "node_modules/table/node_modules/slice-ansi": {
             "version": "4.0.0",
@@ -39874,21 +39917,21 @@
             }
         },
         "node_modules/yup/node_modules/@babel/runtime": {
-            "version": "7.22.6",
-            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.22.6.tgz",
-            "integrity": "sha512-wDb5pWm4WDdF6LFUde3Jl8WzPA+3ZbxYqkC6xAXuD3irdEHN1k0NfTRrJD8ZD378SJ61miMLCqIOXYhd8x+AJQ==",
+            "version": "7.22.10",
+            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.22.10.tgz",
+            "integrity": "sha512-21t/fkKLMZI4pqP2wlmsQAWnYW1PDyKyyUV4vCi+B25ydmdaYTKXPwCj0BzSUnZf4seIiYvSA3jcZ3gdsMFkLQ==",
             "dev": true,
             "dependencies": {
-                "regenerator-runtime": "^0.13.11"
+                "regenerator-runtime": "^0.14.0"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/yup/node_modules/regenerator-runtime": {
-            "version": "0.13.11",
-            "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
-            "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
+            "version": "0.14.0",
+            "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.0.tgz",
+            "integrity": "sha512-srw17NI0TUWHuGa5CFGGmhfNIeja30WMBfbslPNhf6JrqQlLN5gcrvig1oqPxiVaXb0oW0XRKtH6Nngs5lKCIA==",
             "dev": true
         },
         "node_modules/zone.js": {
@@ -39941,7 +39984,7 @@
             "dependencies": {
                 "@angular-devkit/schematics": "12.2.18",
                 "markdown-it": "13.0.1",
-                "ngx-highlightjs": "6.1.3",
+                "ngx-highlightjs": "5.0.0",
                 "schematics-utilities": "1.1.3"
             },
             "devDependencies": {

--- a/projects/addon-doc/package.json
+++ b/projects/addon-doc/package.json
@@ -16,7 +16,7 @@
     "dependencies": {
         "@angular-devkit/schematics": "12.2.18",
         "markdown-it": "13.0.1",
-        "ngx-highlightjs": "6.1.3",
+        "ngx-highlightjs": "5.0.0",
         "schematics-utilities": "1.1.3"
     },
     "devDependencies": {


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring
- [X] Build or CI related changes
- [ ] Tests related changes
- [ ] Documentation content changes

## What is the current behavior?
`@taiga-ui/addon-doc` uses `ngx-highlightjs@6.1.3`.

`ngx-highlightjs@6.1.3` is:
* compatible with Angular 16 (it is published using `Ivy` engine) ✅
* not compatible with Angular 12 ([peerDeps require Angular >= 13](https://github.com/MurhafSousli/ngx-highlightjs/blob/v6.1.3/projects/ngx-highlightjs/package.json#L33-L34)). ❌
It causes [the following error](https://github.com/taiga-family/maskito/actions/runs/5853471264/job/15867544365?pr=416):
```
/home/runner/work/maskito/maskito/node_modules/ngx-highlightjs/fesm2020/ngx-highlightjs.mjs:1
    ({"Object.<anonymous>":function(module,exports,require,__dirname,__filename,jest){import * as i0 from '@angular/core';
                                                                                      ^^^^^^

    SyntaxError: Cannot use import statement outside a module
```

## What is the new behavior?
`@taiga-ui/addon-doc` uses `ngx-highlightjs@5.0.0`.

`ngx-highlightjs@5.0.0` is:
* compatible with Angular 16 (it is published using `Ivy` engine) ✅
* compatible with Angular 12 ([peerDeps require Angular >= 12](https://github.com/MurhafSousli/ngx-highlightjs/blob/v5.0.0/projects/ngx-highlightjs/package.json#L33-L34)). ✅ 

## See also
* https://github.com/taiga-family/taiga-ui/issues/4606
* https://github.com/taiga-family/taiga-ui/pull/4608
* https://github.com/taiga-family/maskito/actions/runs/5853471264/job/15867544365?pr=416
