### PR TITLE
ci: fix `combine-playwright-failed-screenshots.ts` script for nested folders

### DIFF
--- a/projects/demo/src/modules/components/mobile-calendar/examples/1/index.ts
+++ b/projects/demo/src/modules/components/mobile-calendar/examples/1/index.ts
@@ -18,7 +18,7 @@ import {map} from 'rxjs/operators';
     encapsulation,
 })
 export class TuiMobileCalendarExample1 {
-    private readonly control = new FormControl(new TuiDay(2024, 8, 3));
+    private readonly control = new FormControl(new TuiDay(2024, 11, 3));
 
     private readonly dialog$: Observable<TuiDay>;
 

--- a/scripts/combine-playwright-failed-screenshots.ts
+++ b/scripts/combine-playwright-failed-screenshots.ts
@@ -4,37 +4,41 @@ import {readdirSync, writeFileSync} from 'fs';
 const FAILED_SCREENSHOTS_PATH = `projects/demo-playwright/tests-results`;
 const DIFF_IMAGE_POSTFIX = `-diff.png`;
 
-(async function main(): Promise<void> {
-    const testsDirs: string[] = readdirSync(FAILED_SCREENSHOTS_PATH).map(
-        (dirName: string) => `${FAILED_SCREENSHOTS_PATH}/${dirName}`,
-    );
+(async function combinePlaywrightFailedScreenshots(
+    rootPath = FAILED_SCREENSHOTS_PATH,
+): Promise<void> {
+    const filesOrDirs = readdirSync(rootPath, {
+        withFileTypes: true,
+    });
 
-    for (const dir of testsDirs) {
-        const imagesPaths: string[] = readdirSync(dir).map(
-            (fileName: string) => `${dir}/${fileName}`,
-        );
-        const diffImage = imagesPaths.find(path => path.endsWith(DIFF_IMAGE_POSTFIX));
-
-        if (!diffImage) {
-            continue;
-        }
-
-        const images = await Promise.all(imagesPaths.map(loadImage));
-        const totalWidth = images.reduce((acc, {width}) => acc + width, 0);
-        const maxHeight = Math.max(...images.map(({height}) => height));
-        const canvas = createCanvas(totalWidth, maxHeight);
-        const ctx = canvas.getContext(`2d`);
-
-        let prevWidth = 0;
-
-        images.forEach(image => {
-            ctx.drawImage(image, prevWidth, 0);
-            prevWidth += image.width;
-        });
-
-        const buffer = canvas.toBuffer(`image/png`);
-        const diffImageName = diffImage.split(`/`).pop()!.replace(DIFF_IMAGE_POSTFIX, ``);
-
-        writeFileSync(`${dir}/${diffImageName}.diff.png`, buffer);
+    for (const {name} of filesOrDirs.filter(x => x.isDirectory())) {
+        await combinePlaywrightFailedScreenshots(`${rootPath}/${name}`);
     }
+
+    const imagesPaths: string[] = filesOrDirs
+        .filter(x => x.isFile())
+        .map(({name}) => `${rootPath}/${name}`);
+    const diffImage = imagesPaths.find(path => path.endsWith(DIFF_IMAGE_POSTFIX));
+
+    if (!diffImage) {
+        return;
+    }
+
+    const images = await Promise.all(imagesPaths.map(loadImage));
+    const totalWidth = images.reduce((acc, {width}) => acc + width, 0);
+    const maxHeight = Math.max(...images.map(({height}) => height));
+    const canvas = createCanvas(totalWidth, maxHeight);
+    const ctx = canvas.getContext(`2d`);
+
+    let prevWidth = 0;
+
+    images.forEach(image => {
+        ctx.drawImage(image, prevWidth, 0);
+        prevWidth += image.width;
+    });
+
+    const buffer = canvas.toBuffer(`image/png`);
+    const diffImageName = diffImage.split(`/`).pop()!.replace(DIFF_IMAGE_POSTFIX, ``);
+
+    writeFileSync(`${rootPath}/${diffImageName}.diff.png`, buffer);
 })();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -31,7 +31,7 @@
         "module": "es2020",
         "lib": ["es2017", "es2018.asynciterable", "dom"],
         "typeRoots": ["node_modules/@types", "scripts/types"],
-        "types": ["ng-dev-mode"],
+        "types": ["ng-dev-mode", "node"],
         "skipLibCheck": true,
         "downlevelIteration": true,
         "skipDefaultLibCheck": true,


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring
- [ ] Build or CI related changes
- [ ] Tests related changes
- [ ] Documentation content changes

## What is the current behavior?
Possible file structure of `projects/demo-playwright/tests-results`:

```
├── tests-demo-demo-Demo-charts-line-days-chart-chromium
│   └── charts-line-days-chart
│       ├── 1-actual.png
│       ├── 1-diff.png
│       └── 1-expected.png
├── tests-demo-demo-Demo-charts-line-days-chart-chromium-retry1
│   ├── charts-line-days-chart
│   │   ├── 1-actual.png
│   │   ├── 1-diff.png
│   │   └── 1-expected.png
│   └── trace.zip
├── tests-demo-demo-Demo-components-input-files-chromium
│   └── components-input-files
│       ├── 3-actual.png
│       ├── 3-diff.png
│       └── 3-expected.png
├── tests-demo-demo-Demo-components-input-files-chromium-retry1
│   ├── components-input-files
│   │   ├── 3-actual.png
│   │   ├── 3-diff.png
│   │   └── 3-expected.png
│   └── trace.zip
```
