### PR TITLE
feat(core): add neutral notification status

### DIFF
--- a/projects/core/components/notification/notification.style.less
+++ b/projects/core/components/notification/notification.style.less
@@ -70,6 +70,11 @@
         color: var(--tui-warning-fill);
         background: linear-gradient(var(--tui-warning-bg), var(--tui-warning-bg)), var(--tui-base-01);
     }
+
+    &[data-status='neutral'] {
+        color: var(--tui-neutral-fill);
+        background: linear-gradient(var(--tui-neutral-bg), var(--tui-neutral-bg)), var(--tui-base-01);
+    }
 }
 
 .t-content {

--- a/projects/core/tokens/notification-options.ts
+++ b/projects/core/tokens/notification-options.ts
@@ -14,6 +14,7 @@ export const STATUS_ICON = {
     success: `tuiIconCheckCircle`,
     error: `tuiIconXCircle`,
     warning: `tuiIconAlertCircle`,
+    neutral: `tuiIconInfo`,
 } as const;
 
 /** Default values for the notification options. */

--- a/projects/core/types/notification.ts
+++ b/projects/core/types/notification.ts
@@ -1,1 +1,1 @@
-export type TuiNotificationT = 'error' | 'info' | 'success' | 'warning';
+export type TuiNotificationT = 'error' | 'info' | 'neutral' | 'success' | 'warning';

--- a/projects/demo/src/modules/components/notification/notification.component.ts
+++ b/projects/demo/src/modules/components/notification/notification.component.ts
@@ -31,7 +31,13 @@ export class ExampleTuiNotificationComponent {
 
     hasIcon = true;
 
-    readonly statusVariants: TuiNotificationT[] = ['info', 'error', 'warning', 'success'];
+    readonly statusVariants: TuiNotificationT[] = [
+        'info',
+        'error',
+        'warning',
+        'success',
+        'neutral',
+    ];
 
     status = this.statusVariants[0];
 }


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ x ] Feature
- [ ] Refactoring
- [ ] Build or CI related changes
- [ ] Tests related changes
- [ ] Documentation content changes

## What is the current behavior?

There is no neutral status in `tui-notification`

Closes https://github.com/taiga-family/taiga-ui/issues/5222

## What is the new behavior?

Added neutral status for `tui-notification` component
