### PR TITLE
fix(cdk): schematic error `Attempted to get information from a node that was removed or forgotten`

### DIFF
--- a/projects/cdk/schematics/ng-update/steps/remove-module.ts
+++ b/projects/cdk/schematics/ng-update/steps/remove-module.ts
@@ -29,6 +29,10 @@ export function removeModule(name: string, moduleSpecifier: string): void {
     const references = getNamedImportReferences(name, moduleSpecifier);
 
     references.forEach(ref => {
+        if (ref.wasForgotten()) {
+            return;
+        }
+
         const parent = ref.getParent();
 
         if (Node.isImportSpecifier(parent)) {

--- a/projects/cdk/schematics/ng-update/steps/rename-types.ts
+++ b/projects/cdk/schematics/ng-update/steps/rename-types.ts
@@ -34,6 +34,10 @@ function renameType(
     const references = getNamedImportReferences(from, moduleSpecifier);
 
     references.forEach(ref => {
+        if (ref.wasForgotten()) {
+            return;
+        }
+
         const parent = ref.getParent();
 
         if (Node.isImportSpecifier(parent)) {

--- a/projects/cdk/schematics/ng-update/steps/replace-enums.ts
+++ b/projects/cdk/schematics/ng-update/steps/replace-enums.ts
@@ -32,6 +32,10 @@ function replaceEnumWithString(
     const references = getNamedImportReferences(enumName);
 
     for (const ref of references) {
+        if (ref.wasForgotten()) {
+            continue;
+        }
+
         const parent = ref.getParent();
 
         if (Node.isImportSpecifier(parent) && !(keepAsType && containTypeRef(parent))) {

--- a/projects/cdk/schematics/ng-update/steps/replace-services.ts
+++ b/projects/cdk/schematics/ng-update/steps/replace-services.ts
@@ -40,6 +40,10 @@ function replaceService(
     const references = getNamedImportReferences(from.name, from.moduleSpecifier);
 
     references.forEach(ref => {
+        if (ref.wasForgotten()) {
+            return;
+        }
+
         const parent = ref.getParent();
 
         if (Node.isImportSpecifier(parent)) {


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- [X] Bugfix
- [ ] Feature
- [ ] Refactoring
- [ ] Build or CI related changes
- [ ] Tests related changes
- [ ] Documentation content changes

## What is the current behavior?
```
🚀 Your packages will be updated to @taiga-ui/*@^3.42.1

[...]

  ⚡️ replacing services...
    > replacing TuiPortalService...
    > replacing TuiNotificationsService...
Attempted to get information from a node that was removed or forgotten.

Node text: TuiNotificationsService
/Users/n.barsukov/WebstormProjects/sme-deposits-front/node_modules/@nrwl/workspace/node_modules/yargs/build/lib/yargs.js:1132
                throw err;
```
