### PR TITLE
fix(core): onmouseout events don't trigger when objects move under mouse in Safari

### DIFF
--- a/projects/cdk/directives/hovered/hovered.service.ts
+++ b/projects/cdk/directives/hovered/hovered.service.ts
@@ -3,7 +3,7 @@ import {ALWAYS_FALSE_HANDLER, ALWAYS_TRUE_HANDLER} from '@taiga-ui/cdk/constants
 import {tuiTypedFromEvent, tuiZoneOptimized} from '@taiga-ui/cdk/observables';
 import {tuiIsElement} from '@taiga-ui/cdk/utils';
 import {merge, Observable} from 'rxjs';
-import {distinctUntilChanged, filter, map} from 'rxjs/operators';
+import {delay, distinctUntilChanged, filter, map} from 'rxjs/operators';
 
 function movedOut({currentTarget, relatedTarget}: MouseEvent): boolean {
     return (
@@ -26,6 +26,14 @@ export class TuiHoveredService extends Observable<boolean> {
         tuiTypedFromEvent(this.el.nativeElement, `mouseout`).pipe(
             filter(movedOut),
             map(ALWAYS_FALSE_HANDLER),
+        ),
+        /**
+         * NOTE: onmouseout events don't trigger when objects move under mouse in Safari
+         * https://bugs.webkit.org/show_bug.cgi?id=4117
+         */
+        tuiTypedFromEvent(this.el.nativeElement, `click`).pipe(
+            delay(0),
+            map(() => this.el.nativeElement.matches(`:hover`)),
         ),
     ).pipe(distinctUntilChanged(), tuiZoneOptimized(this.zone));
 

--- a/projects/demo/src/modules/components/dialog/examples/6/index.html
+++ b/projects/demo/src/modules/components/dialog/examples/6/index.html
@@ -1,6 +1,8 @@
 <button
     size="m"
     tuiButton
+    tuiHint="Some text"
+    tuiHintDirection="top"
     type="button"
     (click)="showDialog()"
 >


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring
- [ ] Build or CI related changes
- [ ] Tests related changes
- [ ] Documentation content changes

## What is the current behavior?

Closes #5197

## What is the new behavior?


https://github.com/taiga-family/taiga-ui/assets/12021443/394a9808-4838-40cf-8388-9d964e3bbccc

