### PR TITLE
fix(addon-mobile): remove shadow background in mobile calendar header

### DIFF
--- a/projects/addon-mobile/components/mobile-calendar/mobile-calendar.style.less
+++ b/projects/addon-mobile/components/mobile-calendar/mobile-calendar.style.less
@@ -70,7 +70,6 @@
 }
 
 .t-label {
-    .text-overflow-with-fade();
     flex-grow: 1;
     margin: 0;
     font-size: 1.25rem;
@@ -78,32 +77,18 @@
     font-weight: 500;
     letter-spacing: -0.0125rem;
     white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+
+    & + .t-link {
+        padding-left: 1rem;
+    }
 
     :host._ios & {
         font-size: 1.0625rem;
         font-weight: 600;
         letter-spacing: -0.025625rem;
         text-align: center;
-    }
-
-    &:after {
-        background-image: linear-gradient(
-            to right,
-            // --tui-base-01 in rgb
-            rgba(255, 255, 255, 0) 0%,
-            var(--tui-base-01) 80%,
-            var(--tui-base-01) 100%
-        );
-    }
-
-    :host-context([data-mode='onDark']) &:after {
-        background-image: linear-gradient(
-            to right,
-            // --tui-base-01 in rgb
-            rgba(34, 34, 34, 0) 0%,
-            var(--tui-base-01) 80%,
-            var(--tui-base-01) 100%
-        );
     }
 }
 


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring
- [ ] Build or CI related changes
- [ ] Tests related changes
- [ ] Documentation content changes

## What is the current behavior?

Closes #4025

![image](https://github.com/taiga-family/taiga-ui/assets/12021443/07e73877-520a-43de-bd23-4d418070957c)


## What is the new behavior?

<img width="271" alt="image" src="https://github.com/taiga-family/taiga-ui/assets/12021443/b0af4edc-b859-46ec-a9f3-60d812994e85">
<img width="432" alt="image" src="https://github.com/taiga-family/taiga-ui/assets/12021443/9d1cd80e-6c10-4eef-9091-ea79500cba8f">

