### PR TITLE
fix(core): break words in notification

### DIFF
--- a/projects/core/components/notification/notification.style.less
+++ b/projects/core/components/notification/notification.style.less
@@ -81,4 +81,6 @@
     flex: 1;
     word-wrap: break-word;
     color: var(--tui-text-01);
+    overflow: hidden;
+    hyphens: auto;
 }


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring
- [ ] Build or CI related changes
- [ ] Tests related changes
- [ ] Documentation content changes

## What is the current behavior?

Closes #5000

![image](https://github.com/taiga-family/taiga-ui/assets/12021443/29864d90-91cc-47d9-b746-2ea93ef2a105)


## What is the new behavior?

<img width="417" alt="image" src="https://github.com/taiga-family/taiga-ui/assets/12021443/8aa8502e-3bd5-4465-850c-ba8e5118887f">

