### PR TITLE
fix(addon-doc): `Example` should not show tabs if there is only default one (preview)

### DIFF
--- a/projects/addon-doc/components/example/example.template.html
+++ b/projects/addon-doc/components/example/example.template.html
@@ -32,7 +32,10 @@
     class="t-example"
 >
     <ng-container *ngIf="files | tuiDocExampleGetTabs: defaultTab as tabs">
-        <div class="t-tabs-wrapper">
+        <div
+            *ngIf="tabs.length > 1"
+            class="t-tabs-wrapper"
+        >
             <tui-tabs-with-more
                 class="t-tabs"
                 [(activeItemIndex)]="activeItemIndex"


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring
- [ ] Build or CI related changes
- [ ] Tests related changes
- [ ] Documentation content changes

## What is the current behavior?
<img height="400" alt="before" src="https://github.com/taiga-family/taiga-ui/assets/35179038/8d854b64-07e2-46a8-b675-0274d8775832">

https://maskito.dev/frameworks/vue#example


## What is the new behavior?
<img height="400" alt="after" src="https://github.com/taiga-family/taiga-ui/assets/35179038/71eac629-3e4b-4882-8119-cc7e5d444c55">
