### PR TITLE
fix(kit): scroll to active tab when views are ready

### DIFF
--- a/projects/kit/components/tabs/tabs.directive.ts
+++ b/projects/kit/components/tabs/tabs.directive.ts
@@ -8,7 +8,8 @@ import {
     Input,
     Output,
 } from '@angular/core';
-import {tuiMoveFocus} from '@taiga-ui/cdk';
+import {tuiIsHTMLElement, tuiMoveFocus} from '@taiga-ui/cdk';
+import {Subject} from 'rxjs';
 
 import {TUI_TAB_ACTIVATE} from './tab/tab.providers';
 
@@ -16,11 +17,17 @@ import {TUI_TAB_ACTIVATE} from './tab/tab.providers';
     selector: 'tui-tabs, nav[tuiTabs]',
 })
 export class TuiTabsDirective implements AfterViewChecked {
-    @Input()
-    activeItemIndex = 0;
+    @Input('activeItemIndex')
+    set activeIndex(index: number) {
+        this.activeItemIndex = index;
+    }
 
     @Output()
     readonly activeItemIndexChange = new EventEmitter<number>();
+
+    readonly checked = new Subject<void>();
+
+    activeItemIndex = 0;
 
     constructor(@Inject(ElementRef) private readonly el: ElementRef<HTMLElement>) {}
 
@@ -63,5 +70,24 @@ export class TuiTabsDirective implements AfterViewChecked {
             nativeElement.classList.toggle('_active', active);
             nativeElement.setAttribute('tabIndex', active ? '0' : '-1');
         });
+
+        this.checked.next();
+    }
+
+    scrollToActiveItem(): void {
+        const tab = this.activeElement;
+
+        if (!tuiIsHTMLElement(tab)) {
+            return;
+        }
+
+        const tabs = this.el.nativeElement;
+        const horizontal =
+            tab.offsetLeft + tab.offsetWidth > tabs.scrollLeft + tabs.offsetWidth ||
+            tabs.scrollLeft > tab.offsetLeft;
+
+        if (horizontal) {
+            tabs.scrollLeft = tab.offsetLeft;
+        }
     }
 }


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring
- [ ] Build or CI related changes
- [ ] Tests related changes
- [ ] Documentation content changes

## What is the current behavior?

Closes #2182

## What is the new behavior?

<img width="635" alt="image" src="https://github.com/taiga-family/taiga-ui/assets/12021443/3de82ebf-9021-4e78-affc-892582fb8b7d">
