### PR TITLE
chore(demo-playwright): `TuiPrimitiveTextfield` spec has flaky test

### DIFF
--- a/projects/demo-playwright/tests/core/primitive-textfield/primitive-textfield.spec.ts
+++ b/projects/demo-playwright/tests/core/primitive-textfield/primitive-textfield.spec.ts
@@ -27,9 +27,15 @@ test.describe(`TuiPrimitiveTextfield`, () => {
             `components/primitive-textfield/API?value=TEXT&postfix=__!&prefix=!__`,
         );
 
-        await expect(new TuiDocumentationPagePO(page).apiPageExample).toHaveScreenshot(
-            `02-prefix-postfix.png`,
+        const {apiPageExample} = new TuiDocumentationPagePO(page);
+
+        await expect(apiPageExample.getByRole(`textbox`)).toHaveCSS(
+            `text-indent`,
+            /\d+px/, // Auto-retrying assertions for test stability
         );
+        await page.waitForTimeout(50);
+
+        await expect(apiPageExample).toHaveScreenshot(`02-prefix-postfix.png`);
     });
 
     test(`label should not be visible in focused state with filler`, async ({page}) => {


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring
- [ ] Build or CI related changes
- [X] Tests related changes
- [ ] Documentation content changes

## What is the current behavior?

![flaky-test](https://github.com/taiga-family/taiga-ui/assets/35179038/e89e32e7-386f-453d-912e-53deb2cb111a)

## What is the new behavior?
I've tried to reproduce this flaky behaviour locally via
```ts
const client = await (page.context() as ChromiumBrowserContext).newCDPSession(
            page,
        );

await client.send(`Emulation.setCPUThrottlingRate`, {rate: 5});
```
and 
```
nx e2e demo-playwright -- primitive-textfield.spec.ts --repeat-each=50
```

Unfortunately, I can't achieve it on my local machine :(
This PR is **an attempt** to improve test stability.
