### PR TITLE
fix(cdk): mask value may be different instead of real input value

### DIFF
--- a/projects/cdk/abstract/control.ts
+++ b/projects/cdk/abstract/control.ts
@@ -215,6 +215,8 @@ export abstract class AbstractTuiControl<T>
      */
     protected updateValue(value: T): void {
         if (this.disabled || this.valueIdenticalComparator(this.value, value)) {
+            this.checkControlUpdate();
+
             return;
         }
 


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring
- [ ] Build or CI related changes
- [ ] Tests related changes
- [ ] Documentation content changes

## What is the current behavior?

Closes #5098

<img width="1351" alt="Screenshot 2023-09-20 at 21 36 13" src="https://github.com/taiga-family/taiga-ui/assets/12021443/8296628d-b097-46d3-bab2-b2d81b874fea">

`this.valueIdenticalComparator(this.value, value)` returned `true` when if the value does not match the mask

## What is the new behavior?


