### PR TITLE
fix(experimental): `Avatar` with image has redundant gap below itself

### DIFF
--- a/projects/experimental/components/avatar/avatar.style.less
+++ b/projects/experimental/components/avatar/avatar.style.less
@@ -95,6 +95,8 @@
 
     &._img {
         background: transparent;
+        line-height: 0;
+        vertical-align: middle;
     }
 }
 


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- [X] Bugfix
- [ ] Feature
- [ ] Refactoring
- [ ] Build or CI related changes
- [ ] Tests related changes
- [ ] Documentation content changes

## What is the current behavior?
Open
* https://taiga-ui.dev/experimental/avatar/API?src=https:%2F%2Favatars.githubusercontent.com%2Fu%2F11832552&round=true&size=s

<img width="1790" alt="40" src="https://github.com/taiga-family/taiga-ui/assets/35179038/5bd3725d-4be7-4bc5-b338-24f8d4a38b38">
<img width="1790" alt="45" src="https://github.com/taiga-family/taiga-ui/assets/35179038/ee3a82ac-39af-4928-b559-646baacadfb1">

Parent container (with no styles) has more height than `<tui-avatar />`.

**Learn more:**
* https://dev.to/christiankaindl/the-strange-img-gap-in-html
* https://stackoverflow.com/questions/5804256/image-inside-div-has-extra-space-below-the-image
* https://stackblitz.com/edit/img-inside-div-angular?file=src%2Fglobal_styles.css,src%2Fmain.ts

## What is the new behavior?
<img width="1790" alt="40" src="https://github.com/taiga-family/taiga-ui/assets/35179038/793f9b61-480a-4e4b-868f-f728b0101613">
<img width="1790" alt="again-40" src="https://github.com/taiga-family/taiga-ui/assets/35179038/5ae401e4-5e57-435a-a04c-e897b6b7ef3f">

