### PR TITLE
fix(kit): `Textarea` has character descenders problems

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -79,6 +79,11 @@
             "languageId": "ts",
             "filename": ["**/tests/schematic-migrate-sliders.spec.ts"],
             "ignoreWords": ["Maxxxxx"]
+        },
+        {
+            "languageId": "ts",
+            "filename": ["**/textarea.spec.ts"],
+            "ignoreWords": ["qwertypgj_"]
         }
     ]
 }

--- a/projects/core/styles/mixins/mixins.less
+++ b/projects/core/styles/mixins/mixins.less
@@ -80,7 +80,7 @@
     .autofill(@mode);
     padding: 0;
     margin: 0;
-    border: 0;
+    border-width: 0;
     border-radius: inherit;
     background: none;
     font-size: inherit;

--- a/projects/core/styles/mixins/textfield.less
+++ b/projects/core/styles/mixins/textfield.less
@@ -48,7 +48,8 @@
     .text-basic();
     .clearinput();
     .fullsize();
-    border: solid transparent;
+    border-style: solid;
+    border-color: transparent;
     border-inline-start-width: var(--border-start, 0);
     border-inline-end-width: var(--border-end, 0);
     text-indent: var(--text-indent);

--- a/projects/demo-playwright/tests/kit/textarea/textarea.spec.ts
+++ b/projects/demo-playwright/tests/kit/textarea/textarea.spec.ts
@@ -13,7 +13,7 @@ describe(`Textarea`, () => {
     }) => {
         const placeholder = `qwertypgj_`;
 
-        await tuiGoto(page, `components/textarea/API?placehoder=${placeholder}`);
+        await tuiGoto(page, `components/textarea/API?placeholder=${placeholder}`);
 
         const {apiPageExample} = new TuiDocumentationPagePO(page);
         const textarea = apiPageExample.getByPlaceholder(placeholder);

--- a/projects/demo-playwright/tests/kit/textarea/textarea.spec.ts
+++ b/projects/demo-playwright/tests/kit/textarea/textarea.spec.ts
@@ -1,0 +1,27 @@
+import {TuiDocumentationPagePO, tuiGoto} from '@demo-playwright/utils';
+import {expect, test} from '@playwright/test';
+
+const {describe} = test;
+
+describe(`Textarea`, () => {
+    test.use({
+        viewport: {width: 400, height: 500},
+    });
+
+    test(`correctly shows character with descenders inside placeholder`, async ({
+        page,
+    }) => {
+        const placeholder = `qwertypgj_`;
+
+        await tuiGoto(page, `components/textarea/API?placehoder=${placeholder}`);
+
+        const {apiPageExample} = new TuiDocumentationPagePO(page);
+        const textarea = apiPageExample.getByPlaceholder(placeholder);
+
+        await textarea.click();
+
+        await expect(apiPageExample).toHaveScreenshot(
+            `01-character-with-descenders-inside-placeholder.png`,
+        );
+    });
+});

--- a/projects/demo/src/modules/components/textarea/textarea.component.ts
+++ b/projects/demo/src/modules/components/textarea/textarea.component.ts
@@ -80,4 +80,6 @@ export class ExampleTuiTextareaComponent extends AbstractExampleTuiControl {
     override readonly sizeVariants: ReadonlyArray<TuiSizeL | TuiSizeM> = ['m', 'l'];
 
     override size: TuiSizeL | TuiSizeM = this.sizeVariants[1];
+
+    placeholder = 'Placeholder';
 }

--- a/projects/demo/src/modules/components/textarea/textarea.template.html
+++ b/projects/demo/src/modules/components/textarea/textarea.template.html
@@ -87,8 +87,8 @@
             >
                 Textfield for multiline input. It can grow with its content.
                 <textarea
-                    placeholder="Placeholder"
                     tuiTextfield
+                    [placeholder]="placeholder"
                 ></textarea>
             </tui-textarea>
         </tui-doc-demo>
@@ -142,6 +142,27 @@
             </ng-template>
         </tui-doc-documentation>
         <inherited-documentation></inherited-documentation>
+        <tui-doc-documentation heading="Native <textarea> inside TuiTextarea">
+            <p>
+                Learn more how to set some attributes or listen to events on native textarea in this
+                <a
+                    fragment="native"
+                    routerLink="/components/textarea"
+                    tuiLink
+                >
+                    example
+                </a>
+            </p>
+
+            <ng-template
+                documentationPropertyMode="input"
+                documentationPropertyName="placehoder"
+                documentationPropertyType="string"
+                [(documentationPropertyValue)]="placeholder"
+            >
+                Text displayed in a text field when the it has no value
+            </ng-template>
+        </tui-doc-documentation>
     </ng-template>
 
     <ng-template pageTab>

--- a/projects/demo/src/modules/components/textarea/textarea.template.html
+++ b/projects/demo/src/modules/components/textarea/textarea.template.html
@@ -156,7 +156,7 @@
 
             <ng-template
                 documentationPropertyMode="input"
-                documentationPropertyName="placehoder"
+                documentationPropertyName="placeholder"
                 documentationPropertyType="string"
                 [(documentationPropertyValue)]="placeholder"
             >

--- a/projects/kit/components/textarea/textarea.style.less
+++ b/projects/kit/components/textarea/textarea.style.less
@@ -183,7 +183,8 @@
     resize: none;
     overflow: hidden;
     outline: none;
-    border: solid transparent;
+    border-style: solid;
+    border-color: transparent;
     border-inline-start-width: var(--border-start, 0);
     border-inline-end-width: var(--border-end, 0);
 


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- [X] Bugfix
- [ ] Feature
- [ ] Refactoring
- [ ] Build or CI related changes
- [ ] Tests related changes
- [ ] Documentation content changes

## What is the current behavior?
![01-character-with-descenders-inside-placeholder](https://github.com/taiga-family/taiga-ui/assets/35179038/e5f1cddc-c2ca-49fc-b53e-9c43d9d828e8)


Closes #5211
Closes #5271

## What is the new behavior?
![01-character-with-descenders-inside-placeholder-expected](https://github.com/taiga-family/taiga-ui/assets/35179038/9a8fbc2b-87ef-47bb-967b-8e234d7b9c75)


