### PR TITLE
fix(addon-doc): icon should be paste from subPage

### DIFF
--- a/projects/addon-doc/components/navigation/navigation.template.html
+++ b/projects/addon-doc/components/navigation/navigation.template.html
@@ -135,7 +135,7 @@
                             >
                                 {{ subPage.title }}
                                 <tui-svg
-                                    *polymorpheusOutlet="item.icon as icon"
+                                    *polymorpheusOutlet="subPage.icon as icon"
                                     class="t-icon"
                                     [src]="icon"
                                 ></tui-svg>


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring
- [ ] Build or CI related changes
- [ ] Tests related changes
- [ ] Documentation content changes

## What is the current behavior?

<img width="266" alt="image" src="https://github.com/taiga-family/taiga-ui/assets/12021443/e70a739f-4fca-45c1-b6e5-ba874bbd539e">


## What is the new behavior?

<img width="296" alt="image" src="https://github.com/taiga-family/taiga-ui/assets/12021443/97b78587-12bd-4e13-8ce4-2f558f39dc47">
