### PR TITLE
fix(core): `DropdownHover` fix dropdown closing after child transition

### DIFF
--- a/projects/cdk/directives/hovered/hovered.service.ts
+++ b/projects/cdk/directives/hovered/hovered.service.ts
@@ -27,13 +27,6 @@ export class TuiHoveredService extends Observable<boolean> {
             filter(movedOut),
             map(ALWAYS_FALSE_HANDLER),
         ),
-        /**
-         * NOTE: onmouseout events don't trigger when objects move under mouse in Safari
-         * https://bugs.webkit.org/show_bug.cgi?id=4117
-         */
-        tuiTypedFromEvent(this.el.nativeElement, `transitionend`).pipe(
-            map(() => this.el.nativeElement.matches(`:hover`)),
-        ),
     ).pipe(distinctUntilChanged(), tuiZoneOptimized(this.zone));
 
     constructor(

--- a/projects/core/directives/dropdown/dropdown-hover.directive.ts
+++ b/projects/core/directives/dropdown/dropdown-hover.directive.ts
@@ -48,10 +48,7 @@ export class TuiDropdownHoverDirective extends TuiDriver {
     }
 
     toggle(visible: boolean): void {
-        if (this.parentHover) {
-            this.parentHover.toggle(visible);
-        }
-
+        this.parentHover?.toggle(visible);
         this.toggle$.next(visible);
     }
 }

--- a/projects/core/directives/hint/hint-hover.directive.ts
+++ b/projects/core/directives/hint/hint-hover.directive.ts
@@ -29,8 +29,8 @@ export class TuiHintHoverDirective extends TuiDriver {
             repeat(),
         ),
     ).pipe(
-        map(value => !tuiGetElementObscures(this.el.nativeElement)?.length && value),
         filter(() => this.enabled),
+        map(value => value && !tuiGetElementObscures(this.el.nativeElement)?.length),
         tap(visible => {
             this.visible = visible;
         }),

--- a/projects/core/directives/hint/hint-hover.directive.ts
+++ b/projects/core/directives/hint/hint-hover.directive.ts
@@ -1,9 +1,9 @@
 /* eslint-disable rxjs/no-unsafe-takeuntil */
 import {Directive, ElementRef, Inject, Input} from '@angular/core';
-import {TuiHoveredService} from '@taiga-ui/cdk';
+import {tuiGetElementObscures, TuiHoveredService} from '@taiga-ui/cdk';
 import {tuiAsDriver, TuiDriver} from '@taiga-ui/core/abstract';
 import {merge, Observable, of, Subject} from 'rxjs';
-import {delay, filter, repeat, switchMap, takeUntil, tap} from 'rxjs/operators';
+import {delay, filter, map, repeat, switchMap, takeUntil, tap} from 'rxjs/operators';
 
 import {TUI_HINT_OPTIONS, TuiHintOptions} from './hint-options.directive';
 
@@ -29,6 +29,7 @@ export class TuiHintHoverDirective extends TuiDriver {
             repeat(),
         ),
     ).pipe(
+        map(value => !tuiGetElementObscures(this.el.nativeElement)?.length && value),
         filter(() => this.enabled),
         tap(visible => {
             this.visible = visible;

--- a/projects/core/directives/hint/hint.component.ts
+++ b/projects/core/directives/hint/hint.component.ts
@@ -14,6 +14,7 @@ import {
     tuiClamp,
     TuiContextWithImplicit,
     TuiDestroyService,
+    tuiGetElementObscures,
     TuiHoveredService,
     tuiPure,
     tuiPx,
@@ -108,8 +109,9 @@ export class TuiHintComponent<C = any> {
     @HostListener('document:click', ['$event.target'])
     onClick(target: HTMLElement): void {
         if (
-            !this.el.nativeElement.contains(target) &&
-            !this.hover.el.nativeElement.contains(target)
+            (!this.el.nativeElement.contains(target) &&
+                !this.hover.el.nativeElement.contains(target)) ||
+            tuiGetElementObscures(this.hover.el.nativeElement)?.length
         ) {
             this.hover.toggle(false);
         }


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring
- [ ] Build or CI related changes
- [ ] Tests related changes
- [ ] Documentation content changes

## What is the current behavior?

https://github.com/taiga-family/taiga-ui/issues/5395#issuecomment-1743010657

closes #5197

## What is the new behavior?
