### PR TITLE
ci: drop redundant `E2E / addon-charts` job (Cypress)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -37,8 +37,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        project:
-          [addon-doc, addon-charts, addon-commerce, addon-mobile, addon-table, addon-tablebars, icons, core, deep, kit]
+        project: [addon-doc, addon-commerce, addon-mobile, addon-table, addon-tablebars, icons, core, deep, kit]
     name: ${{ matrix.project }}
     steps:
       - uses: taiga-family/ci/actions/setup/checkout@v1.32.0


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring
- [ ] Build or CI related changes
- [X] Tests related changes
- [ ] Documentation content changes

## What is the current behavior?
See https://github.com/taiga-family/taiga-ui/actions/runs/6471836415/job/17575507890

```
> nx run demo-cypress:e2e --folder addon-charts

It looks like this is your first time using Cypress: 13.3.0
[STARTED] Task without title.
[SUCCESS] Task without title.
Opening Cypress...
DevTools listening on ws://127.0.0.1:39273/devtools/browser/be250f9e-a0ac-[43](https://github.com/taiga-family/taiga-ui/actions/runs/6469026495/job/17562735941?pr=5588#step:7:44)6d-b11d-b76c4ca65d71
Can't run because no spec files were found.

We searched for specs matching this glob pattern:

  > /home/runner/work/taiga-ui/taiga-ui/**/addon-charts/**/*.cy.ts
Warning: run-commands command "npx cypress run --env ci=true --browser chrome --headless --project ./projects/demo-cypress --spec '**/addon-charts/**/*.cy.ts'" exited with non-zero status code

 

 >  NX   Running target e2e for project demo-cypress failed

   Failed tasks:
   
   - demo-cypress:e2e
   
   Hint: run the command with --verbose for more details.

Error: Process completed with exit code 1.
```

Relates to https://github.com/taiga-family/taiga-ui/pull/5584