### PR TITLE
fix(core): expand component changing height when clicking inside wrapper

### DIFF
--- a/projects/core/components/expand/expand.component.ts
+++ b/projects/core/components/expand/expand.component.ts
@@ -126,6 +126,11 @@ export class TuiExpandComponent {
         }
     }
 
+    @HostListener('click.silent')
+    checkInsideClick(): void {
+        this.retrigger(this.state);
+    }
+
     private retrigger(state: TuiValuesOf<typeof State>): void {
         this.state = State.Prepared;
 


### PR DESCRIPTION
## PR Type

expand component changing height when clicking inside wrapper

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring
- [ ] Build or CI related changes
- [ ] Tests related changes
- [ ] Documentation content changes

## При раскрытии вложенного в аккордеон а аккордеона контент дочернего обрезался

Closes #5625

## Контент не обрезается. При клике внутри раскрытого контента запускается проверка изменений.

Возможно не самое лучшее решение, но я хотя бы PR сделал 😅
