### PR TITLE
fix: migrate styles-components from using selectors

### DIFF
--- a/projects/addon-mobile/directives/mobile-tabs/mobile-tabs.component.ts
+++ b/projects/addon-mobile/directives/mobile-tabs/mobile-tabs.component.ts
@@ -1,7 +1,9 @@
 import {ChangeDetectionStrategy, Component, ViewEncapsulation} from '@angular/core';
 
 @Component({
-    selector: 'tui-mobile-tabs',
+    host: {
+        class: 'tui-mobile-tabs-styles',
+    },
     template: '',
     styleUrls: ['./mobile-tabs.style.less'],
     encapsulation: ViewEncapsulation.None,

--- a/projects/addon-mobile/directives/ripple/ripple-styles.component.ts
+++ b/projects/addon-mobile/directives/ripple/ripple-styles.component.ts
@@ -1,7 +1,9 @@
 import {ChangeDetectionStrategy, Component, ViewEncapsulation} from '@angular/core';
 
 @Component({
-    selector: 'tui-ripple',
+    host: {
+        class: 'tui-ripple-styles',
+    },
     template: '',
     styleUrls: ['./ripple.style.less'],
     encapsulation: ViewEncapsulation.None,

--- a/projects/cdk/directives/autofilled/autofilled-style.component.ts
+++ b/projects/cdk/directives/autofilled/autofilled-style.component.ts
@@ -1,7 +1,9 @@
 import {ChangeDetectionStrategy, Component, ViewEncapsulation} from '@angular/core';
 
 @Component({
-    selector: 'tui-autofilled-style',
+    host: {
+        class: 'tui-autofilled-styles',
+    },
     template: '',
     styleUrls: ['./autofilled.style.less'],
     encapsulation: ViewEncapsulation.None,

--- a/projects/core/components/group/group-styles.component.ts
+++ b/projects/core/components/group/group-styles.component.ts
@@ -1,7 +1,9 @@
 import {ChangeDetectionStrategy, Component, ViewEncapsulation} from '@angular/core';
 
 @Component({
-    selector: 'tui-group-style',
+    host: {
+        class: 'tui-group-styles',
+    },
     template: '',
     styleUrls: ['./group.style.less'],
     encapsulation: ViewEncapsulation.None,

--- a/projects/experimental/components/button/button.directive.ts
+++ b/projects/experimental/components/button/button.directive.ts
@@ -13,6 +13,9 @@ import {Observable} from 'rxjs';
 import {TUI_BUTTON_OPTIONS, TuiButtonOptions} from './button.options';
 
 @Component({
+    host: {
+        class: 'tui-button-styles',
+    },
     template: '',
     styleUrls: ['./button.style.less'],
     changeDetection: ChangeDetectionStrategy.OnPush,

--- a/projects/experimental/directives/fade/fade.component.ts
+++ b/projects/experimental/directives/fade/fade.component.ts
@@ -1,6 +1,9 @@
 import {ChangeDetectionStrategy, Component, ViewEncapsulation} from '@angular/core';
 
 @Component({
+    host: {
+        class: 'tui-fade-styles',
+    },
     template: '',
     styleUrls: ['./fade.style.less'],
     changeDetection: ChangeDetectionStrategy.OnPush,

--- a/projects/experimental/directives/sensitive/sensitive.component.ts
+++ b/projects/experimental/directives/sensitive/sensitive.component.ts
@@ -1,6 +1,9 @@
 import {ChangeDetectionStrategy, Component, ViewEncapsulation} from '@angular/core';
 
 @Component({
+    host: {
+        class: 'tui-sensitive-styles',
+    },
     changeDetection: ChangeDetectionStrategy.OnPush,
     template: '',
     styleUrls: ['./sensitive.style.less'],

--- a/projects/experimental/directives/surface/surface.component.ts
+++ b/projects/experimental/directives/surface/surface.component.ts
@@ -1,6 +1,9 @@
 import {ChangeDetectionStrategy, Component, ViewEncapsulation} from '@angular/core';
 
 @Component({
+    host: {
+        class: 'tui-surface-styles',
+    },
     template: '',
     styleUrls: ['./surface.style.less'],
     changeDetection: ChangeDetectionStrategy.OnPush,


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring
- [ ] Build or CI related changes
- [ ] Tests related changes
- [ ] Documentation content changes

## What is the current behaviour?
Developers that are using Angular 16 currently are facing an issue having an NG0912 compilation warning.

Closes #5606 

## What is the new behaviour?
Styles components now use host.class to insure that there will be no similar metadata for two different components. The additional side-effect, a bonus, of this approach is that the IDE won't suggest these components to use in the template.