### PR TITLE
feat(addon-table): reset column direction on third click

### DIFF
--- a/projects/addon-table/components/table/directives/table.directive.ts
+++ b/projects/addon-table/components/table/directives/table.directive.ts
@@ -16,7 +16,7 @@ import {Observable} from 'rxjs';
 
 import {TUI_STUCK} from '../providers/stuck.provider';
 import {TUI_TABLE_PROVIDERS} from '../providers/table.providers';
-import {TUI_TABLE_OPTIONS, TuiTableOptions} from '../table.options';
+import {TUI_TABLE_OPTIONS, TuiTableDirection, TuiTableOptions} from '../table.options';
 
 @Directive({
     selector: 'table[tuiTable]',
@@ -42,7 +42,7 @@ export class TuiTableDirective<T extends Partial<Record<keyof T, any>>>
     direction = this.options.direction;
 
     @Output()
-    readonly directionChange = new EventEmitter<-1 | 1>();
+    readonly directionChange = new EventEmitter<TuiTableDirection>();
 
     @Output()
     readonly sorterChange = new EventEmitter<TuiComparator<T> | null>();
@@ -62,11 +62,23 @@ export class TuiTableDirective<T extends Partial<Record<keyof T, any>>>
     sorter: TuiComparator<T> = () => 0;
 
     updateSorterAndDirection(sorter: TuiComparator<T> | null): void {
-        if (this.sorter === sorter) {
-            this.updateDirection(this.direction === 1 ? -1 : 1);
-        } else {
+        if (this.sorter !== sorter) {
             this.updateSorter(sorter);
             this.updateDirection(1);
+
+            return;
+        }
+
+        switch (this.direction) {
+            case -1:
+                this.updateDirection(0);
+                break;
+            case 0:
+                this.updateDirection(1);
+                break;
+            case 1:
+                this.updateDirection(-1);
+                break;
         }
     }
 
@@ -80,7 +92,7 @@ export class TuiTableDirective<T extends Partial<Record<keyof T, any>>>
         this.change$.next();
     }
 
-    private updateDirection(direction: -1 | 1): void {
+    private updateDirection(direction: TuiTableDirection): void {
         this.direction = direction;
         this.directionChange.emit(this.direction);
         this.change$.next();

--- a/projects/addon-table/components/table/pipes/table-sort.pipe.ts
+++ b/projects/addon-table/components/table/pipes/table-sort.pipe.ts
@@ -3,6 +3,7 @@ import {TuiComparator} from '@taiga-ui/addon-table/types';
 import {tuiPure} from '@taiga-ui/cdk';
 
 import {TuiTableDirective} from '../directives/table.directive';
+import {TuiTableDirection} from '../table.options';
 
 @Pipe({
     name: `tuiTableSort`,
@@ -22,7 +23,7 @@ export class TuiTableSortPipe<K = Partial<Record<any, any>>> implements PipeTran
     private sort<T extends K>(
         data: readonly T[],
         sorter: TuiComparator<T>,
-        direction: -1 | 1,
+        direction: TuiTableDirection,
     ): readonly T[] {
         return [...data].sort((a, b) => direction * sorter(a, b));
     }

--- a/projects/addon-table/components/table/table.options.ts
+++ b/projects/addon-table/components/table/table.options.ts
@@ -2,8 +2,10 @@ import {Provider} from '@angular/core';
 import {tuiCreateToken, tuiProvideOptions} from '@taiga-ui/cdk';
 import {TuiSizeL, TuiSizeS} from '@taiga-ui/core';
 
+export type TuiTableDirection = -1 | 0 | 1;
+
 export interface TuiTableOptions {
-    readonly direction: -1 | 1;
+    readonly direction: TuiTableDirection;
     readonly open: boolean;
     readonly resizable: boolean;
     readonly size: TuiSizeL | TuiSizeS;

--- a/projects/addon-table/components/table/th/th.component.ts
+++ b/projects/addon-table/components/table/th/th.component.ts
@@ -67,10 +67,12 @@ export class TuiThComponent<T extends Partial<Record<keyof T, any>>> {
     }
 
     get icon(): string {
-        if (this.isCurrent) {
-            return this.table?.direction === 1
-                ? this.options.sortIcons.desc
-                : this.options.sortIcons.asc;
+        if (this.isCurrent && this.table?.direction === -1) {
+            return this.options.sortIcons.desc;
+        }
+
+        if (this.isCurrent && this.table?.direction === 1) {
+            return this.options.sortIcons.asc;
         }
 
         return this.options.sortIcons.off;

--- a/projects/demo/src/modules/tables/table/examples/4/index.ts
+++ b/projects/demo/src/modules/tables/table/examples/4/index.ts
@@ -2,7 +2,7 @@ import {Component} from '@angular/core';
 import {FormControl} from '@angular/forms';
 import {changeDetection} from '@demo/emulate/change-detection';
 import {encapsulation} from '@demo/emulate/encapsulation';
-import {TuiComparator} from '@taiga-ui/addon-table';
+import {TuiComparator, TuiTableDirection} from '@taiga-ui/addon-table';
 import {
     TUI_DEFAULT_MATCHER,
     tuiControlValue,
@@ -73,7 +73,7 @@ export class TuiTableExample4 {
     private readonly size$ = new BehaviorSubject(10);
     private readonly page$ = new BehaviorSubject(0);
 
-    readonly direction$ = new BehaviorSubject<-1 | 1>(-1);
+    readonly direction$ = new BehaviorSubject<TuiTableDirection>(-1);
     readonly sorter$ = new BehaviorSubject<Key>('name');
 
     readonly minAge = new FormControl(21);
@@ -122,7 +122,7 @@ export class TuiTableExample4 {
             .map(column => KEYS[column]);
     }
 
-    onDirection(direction: -1 | 1): void {
+    onDirection(direction: TuiTableDirection): void {
         this.direction$.next(direction);
     }
 
@@ -144,7 +144,7 @@ export class TuiTableExample4 {
 
     private getData(
         key: 'age' | 'dob' | 'name',
-        direction: -1 | 1,
+        direction: TuiTableDirection,
         page: number,
         size: number,
         minAge: number,
@@ -163,7 +163,10 @@ export class TuiTableExample4 {
     }
 }
 
-function sortBy(key: 'age' | 'dob' | 'name', direction: -1 | 1): TuiComparator<User> {
+function sortBy(
+    key: 'age' | 'dob' | 'name',
+    direction: TuiTableDirection,
+): TuiComparator<User> {
     return (a, b) =>
         key === 'age'
             ? direction * tuiDefaultSort(getAge(a), getAge(b))


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Refactoring
- [ ] Build or CI related changes
- [ ] Tests related changes
- [ ] Documentation content changes

## What is the current behaviour?

Closes #5064 

click table headers currently toggles through asc and desc states (2 states)

## What is the new behaviour?

adding a 3rd state to column sort behaviour when clicking table headers - rotate through:
1. asc
2. desc
3. off