### PR TITLE
feat(kit): prevent combobox dropdown opening on value reset

### DIFF
--- a/projects/kit/components/combo-box/combo-box.component.ts
+++ b/projects/kit/components/combo-box/combo-box.component.ts
@@ -207,7 +207,10 @@ export class TuiComboBoxComponent<T>
             this.value = null;
         }
 
-        this.hostedDropdown?.updateOpen(true);
+        // Clearing sets the empty value, the dropdown should not be opened on clear.
+        if (this.search !== '') {
+            this.hostedDropdown?.updateOpen(true);
+        }
     }
 
     /** @deprecated use 'value' setter */

--- a/projects/kit/components/combo-box/test/combo-box.component.spec.ts
+++ b/projects/kit/components/combo-box/test/combo-box.component.spec.ts
@@ -159,7 +159,9 @@ describe(`ComboBox`, () => {
         expect(testComponent.control.value).toBeNull();
 
         testComponent.items = ITEMS;
+        testComponent.component.toggle();
         fixture.detectChanges();
+        inputPO.sendText(`Sly cat`);
 
         await fixture.whenStable();
         expect(testComponent.control.value).toBe(ITEMS[1]);
@@ -209,8 +211,14 @@ describe(`ComboBox`, () => {
         });
 
         describe(`dropdown`, () => {
-            it(`empty value opens dropdown`, () => {
+            it(`empty value does not open dropdown`, () => {
                 testComponent.component.onValueChange(``);
+                fixture.detectChanges();
+                expect(testComponent.component.open).toBe(false);
+            });
+
+            it(`not empty value opens dropdown`, () => {
+                testComponent.component.onValueChange(`raccoon`);
                 fixture.detectChanges();
                 expect(testComponent.component.open).toBe(true);
             });

--- a/projects/kit/components/input-tag/input-tag.component.ts
+++ b/projects/kit/components/input-tag/input-tag.component.ts
@@ -194,9 +194,6 @@ export class TuiInputTagComponent
         readonly controller: TuiTextfieldController,
         @Inject(TUI_INPUT_TAG_OPTIONS)
         private readonly options: TuiInputTagOptions,
-        @Optional()
-        @Inject(TuiHostedDropdownComponent)
-        private readonly parentHostedDropdown: TuiHostedDropdownComponent | null,
         @Inject(TUI_COMMON_ICONS) readonly icons: TuiCommonIcons,
     ) {
         super(control, cdr);
@@ -327,7 +324,6 @@ export class TuiInputTagComponent
         this.updateSearch('');
         this.clear();
         this.focusInput();
-        this.parentHostedDropdown?.updateOpen(true);
     }
 
     onActiveZone(active: boolean): void {

--- a/projects/kit/components/multi-select/multi-select.component.ts
+++ b/projects/kit/components/multi-select/multi-select.component.ts
@@ -264,7 +264,11 @@ export class TuiMultiSelectComponent<T>
     }
 
     onSearch(search: string | null): void {
-        this.hostedDropdown?.updateOpen(true);
+        // Clearing sets the empty value, the dropdown should not be opened on clear.
+        if (search !== '') {
+            this.hostedDropdown?.updateOpen(true);
+        }
+
         this.updateSearch(search);
     }
 

--- a/projects/kit/components/multi-select/test/multi-select.component.spec.ts
+++ b/projects/kit/components/multi-select/test/multi-select.component.spec.ts
@@ -106,11 +106,20 @@ describe(`MultiSelect`, () => {
                     inputPO.focus();
                 });
 
-                it(`opens a dropdown`, () => {
-                    getInputTag(pageObject).nativeElement.click();
-                    fixture.detectChanges();
+                describe(`opens the dropdown`, () => {
+                    it(`on click`, () => {
+                        getInputTag(pageObject).nativeElement.click();
+                        fixture.detectChanges();
 
-                    expect(getDropdown(pageObject)).not.toBeNull();
+                        expect(getDropdown(pageObject)).not.toBeNull();
+                    });
+
+                    it(`on search`, () => {
+                        testComponent.component.onSearch(`Marsi`);
+                        fixture.detectChanges();
+
+                        expect(getDropdown(pageObject)).not.toBeNull();
+                    });
                 });
 
                 describe(`does not open the dropdown`, () => {
@@ -127,6 +136,13 @@ describe(`MultiSelect`, () => {
                         testComponent.control.disable();
                         fixture.detectChanges();
                         getInputTag(pageObject).nativeElement.click();
+                        fixture.detectChanges();
+
+                        expect(getDropdown(pageObject)).toBeNull();
+                    });
+
+                    it(`on empty search`, () => {
+                        testComponent.component.onSearch(``);
                         fixture.detectChanges();
 
                         expect(getDropdown(pageObject)).toBeNull();


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring
- [ ] Build or CI related changes
- [ ] Tests related changes
- [ ] Documentation content changes

## What is the current behaviour?

Closes #5598

## What is the new behaviour?

A combox dropdown is not opened on value reset 