### PR TITLE
fix(core): use correct host portal viewport for dropdown position

### DIFF
--- a/projects/core/directives/dropdown/dropdown-position.directive.ts
+++ b/projects/core/directives/dropdown/dropdown-position.directive.ts
@@ -36,23 +36,30 @@ export class TuiDropdownPositionDirective extends TuiPositionAccessor {
         }
 
         const hostRect = this.accessor?.getClientRect() ?? EMPTY_CLIENT_RECT;
-        const viewport = this.viewport.getClientRect();
+        const viewportRect = this.viewport.getClientRect();
         const {minHeight, align, direction, offset} = this.options;
+        const viewport = {
+            top: viewportRect.top - offset,
+            bottom: viewportRect.bottom - offset,
+            right: viewportRect.right - offset,
+            left: viewportRect.left - offset,
+        } as const;
         const previous = this.previous || direction || 'bottom';
-        const right = Math.max(hostRect.right - width, offset);
         const available = {
             top: hostRect.top - 2 * offset - viewport.top,
             bottom: viewport.bottom - hostRect.bottom - 2 * offset,
         } as const;
+        const right = Math.max(hostRect.right - width, offset);
+        const left = hostRect.left + width < viewport.right ? hostRect.left : right;
         const position = {
             top: hostRect.top - offset - height,
             bottom: hostRect.bottom + offset,
-            right,
+            right: Math.max(viewport.left, right),
             center:
-                hostRect.left + hostRect.width / 2 + width / 2 < viewport.right - offset
+                hostRect.left + hostRect.width / 2 + width / 2 < viewport.right
                     ? hostRect.left + hostRect.width / 2 - width / 2
                     : right,
-            left: hostRect.left + width < viewport.right - offset ? hostRect.left : right,
+            left: Math.max(viewport.left, left),
         } as const;
         const better = available.top > available.bottom ? 'top' : 'bottom';
 


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring
- [ ] Build or CI related changes
- [ ] Tests related changes
- [ ] Documentation content changes

## What is the current behaviour?

Closes https://github.com/taiga-family/tui-editor/issues/201

<img width="829" alt="image" src="https://github.com/taiga-family/taiga-ui/assets/12021443/58353683-58ae-47b4-9bed-59c1e46aab47">


## What is the new behaviour?

<img width="732" alt="image" src="https://github.com/taiga-family/taiga-ui/assets/12021443/d6094fd2-11e1-49bd-8e1b-a859af19e38c">


