### PR TITLE
fix(cdk): don't use `layerX` and `layerY` for detect retargated element

### DIFF
--- a/projects/cdk/utils/dom/retarget-boundary-crossing.ts
+++ b/projects/cdk/utils/dom/retarget-boundary-crossing.ts
@@ -1,10 +1,17 @@
 export function tuiRetargetedBoundaryCrossing(event: any): boolean {
+    // firefox
     if (`explicitOriginalTarget` in event) {
-        return event?.explicitOriginalTarget !== event.target; // firefox
+        return event?.explicitOriginalTarget !== event.target;
     }
 
-    if (`layerX` in event && `layerY` in event) {
-        return (event?.layerX ?? 0) < 0 || (event?.layerY ?? 0) < 0; // chrome/safari/etc
+    // chrome
+    if (`pointerId` in event) {
+        return event.pointerId === -1;
+    }
+
+    // safari
+    if (`detail` in event && `webkitForce` in event) {
+        return event?.detail === 0;
     }
 
     return false;


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring
- [ ] Build or CI related changes
- [ ] Tests related changes
- [ ] Documentation content changes

## What is the current behaviour?

Closes #5793
