### PR TITLE
chore(demo): fix `Source code` links for `@taiga-ui/experimental` documentatation

### DIFF
--- a/projects/demo/src/modules/experimental/amount/amount.template.html
+++ b/projects/demo/src/modules/experimental/amount/amount.template.html
@@ -1,5 +1,5 @@
 <tui-doc-page
-    header="AmountPipe"
+    header="Amount"
     package="EXPERIMENTAL"
     type="pipes"
 >

--- a/projects/demo/src/modules/experimental/cell/cell.template.html
+++ b/projects/demo/src/modules/experimental/cell/cell.template.html
@@ -1,7 +1,7 @@
 <tui-doc-page
     header="Cell"
     package="EXPERIMENTAL"
-    type="components"
+    type="directives"
 >
     <ng-template pageTab>
         <tui-notification status="warning">

--- a/projects/demo/src/modules/experimental/surface/surface.template.html
+++ b/projects/demo/src/modules/experimental/surface/surface.template.html
@@ -1,7 +1,7 @@
 <tui-doc-page
     header="Surface"
     package="EXPERIMENTAL"
-    type="directive"
+    type="directives"
 >
     <ng-template pageTab>
         <tui-notification status="warning">

--- a/projects/demo/src/modules/experimental/title/title.template.html
+++ b/projects/demo/src/modules/experimental/title/title.template.html
@@ -1,7 +1,7 @@
 <tui-doc-page
     header="Title"
     package="EXPERIMENTAL"
-    type="components"
+    type="directives"
 >
     <ng-template pageTab>
         <tui-notification status="warning">


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring
- [ ] Build or CI related changes
- [ ] Tests related changes
- [X] Documentation content changes

## What is the current behaviour?
Click on `Source code` button on these pages:

* https://taiga-ui.dev/next/experimental/amount
* https://taiga-ui.dev/next/experimental/cell
* https://taiga-ui.dev/next/experimental/surface
* https://taiga-ui.dev/next/experimental/title

![Screenshot 2023-11-08 at 16 34 05](https://github.com/taiga-family/taiga-ui/assets/35179038/d3487669-53eb-4e85-9b3b-3b437bdd14a7)

It navigates to 404 page error.
