### PR TITLE
feat(kit): round corners of progress can be toggled off in new version of `ProgressBar`

### DIFF
--- a/projects/demo/src/modules/components/progress-bar/examples/7/index.html
+++ b/projects/demo/src/modules/components/progress-bar/examples/7/index.html
@@ -1,0 +1,6 @@
+<progress
+    new
+    tuiProgressBar
+    [max]="100"
+    [value]="50"
+></progress>

--- a/projects/demo/src/modules/components/progress-bar/examples/7/index.less
+++ b/projects/demo/src/modules/components/progress-bar/examples/7/index.less
@@ -1,0 +1,8 @@
+/*
+This duplication is artificial way to increase selector specificity.
+In Taiga UI 4.0 you can delete it.
+TODO: remove in v4.0
+ */
+[tuiProgressBar][tuiProgressBar] {
+    border-radius: 0;
+}

--- a/projects/demo/src/modules/components/progress-bar/examples/7/index.ts
+++ b/projects/demo/src/modules/components/progress-bar/examples/7/index.ts
@@ -1,0 +1,12 @@
+import {Component} from '@angular/core';
+import {changeDetection} from '@demo/emulate/change-detection';
+import {encapsulation} from '@demo/emulate/encapsulation';
+
+@Component({
+    selector: 'tui-progress-bar-example-7',
+    templateUrl: './index.html',
+    styleUrls: ['./index.less'],
+    encapsulation,
+    changeDetection,
+})
+export class TuiProgressBarExample7 {}

--- a/projects/demo/src/modules/components/progress-bar/progress-bar.component.html
+++ b/projects/demo/src/modules/components/progress-bar/progress-bar.component.html
@@ -81,6 +81,26 @@
             </ng-template>
             <tui-progress-bar-example-6></tui-progress-bar-example-6>
         </tui-doc-example>
+
+        <tui-doc-example
+            id="customizable-corners"
+            heading="Customizable corners"
+            [content]="customizableCornersExample"
+            [description]="customizableCornersDescription"
+        >
+            <ng-template #customizableCornersDescription>
+                You can toggle off round corners of the progress bar by setting
+                <code>border-radius: 0</code>
+                .
+                <tui-notification
+                    status="warning"
+                    class="tui-space_top-1"
+                >
+                    This customization properly works only for "new"-mode.
+                </tui-notification>
+            </ng-template>
+            <tui-progress-bar-example-7></tui-progress-bar-example-7>
+        </tui-doc-example>
     </ng-template>
 
     <ng-template pageTab>

--- a/projects/demo/src/modules/components/progress-bar/progress-bar.component.ts
+++ b/projects/demo/src/modules/components/progress-bar/progress-bar.component.ts
@@ -68,6 +68,12 @@ export class ExampleProgressBarComponent {
         TypeScript: import('./examples/6/index.ts?raw'),
     };
 
+    readonly customizableCornersExample: TuiDocExample = {
+        HTML: import('./examples/7/index.html?raw'),
+        LESS: import('./examples/7/index.less?raw'),
+        TypeScript: import('./examples/7/index.ts?raw'),
+    };
+
     readonly exampleModule = import('./examples/import/import-module.md?raw');
     readonly exampleHtml = import('./examples/import/insert-template.md?raw');
 }

--- a/projects/demo/src/modules/components/progress-bar/progress-bar.module.ts
+++ b/projects/demo/src/modules/components/progress-bar/progress-bar.module.ts
@@ -15,6 +15,7 @@ import {TuiProgressBarExample3} from './examples/3';
 import {TuiProgressBarExample4} from './examples/4';
 import {TuiProgressBarExample5} from './examples/5';
 import {TuiProgressBarExample6} from './examples/6';
+import {TuiProgressBarExample7} from './examples/7';
 import {ExampleProgressBarComponent} from './progress-bar.component';
 
 @NgModule({
@@ -35,6 +36,7 @@ import {ExampleProgressBarComponent} from './progress-bar.component';
         TuiProgressBarExample4,
         TuiProgressBarExample5,
         TuiProgressBarExample6,
+        TuiProgressBarExample7,
     ],
     exports: [ExampleProgressBarComponent],
 })

--- a/projects/kit/components/progress/progress-bar/progress-bar.component.less
+++ b/projects/kit/components/progress/progress-bar/progress-bar.component.less
@@ -66,7 +66,11 @@
 
     // TODO: drop new attribute in v4.0 and make all these styles as default ones
     &[new] {
-        clip-path: inset(0 round var(--tui-radius-m));
+        /* stylelint-disable meowtec/no-px */
+        clip-path: inset(
+            0 0.5px round var(--tui-radius-m)
+        ); // 0.5px is a hack to prevent jagged edges on low dpi screens
+        /* stylelint-enable meowtec/no-px */
         border-radius: 1rem;
         .progressValue({ border-radius: inherit });
 

--- a/projects/kit/components/progress/progress-bar/progress-bar.component.less
+++ b/projects/kit/components/progress/progress-bar/progress-bar.component.less
@@ -47,7 +47,7 @@
     height: var(--t-height);
     color: var(--tui-primary);
     background: @track-color;
-    border-radius: var(--tui-radius-xs);
+    clip-path: inset(0 round var(--tui-radius-xs));
     overflow: hidden;
 
     &[data-mode='onDark'] {
@@ -64,13 +64,11 @@
         --t-height: 0.5rem;
     }
 
-    // TODO: drop new attribute in v4.0
+    // TODO: drop new attribute in v4.0 and make all these styles as default ones
     &[new] {
-        &[data-size='xs'],
-        &[data-size='s'],
-        &[data-size='m'] {
-            .progressValue({ border-radius: var(--tui-radius-xs) });
-        }
+        clip-path: inset(0 round var(--tui-radius-m));
+        border-radius: 1rem;
+        .progressValue({ border-radius: inherit });
 
         &[data-size='xs'] {
             --t-height: 0.25rem;
@@ -104,8 +102,13 @@
         animation: tuiIndeterminateAnimation 3s infinite ease-in-out;
     }
 
+    &::-webkit-progress-inner-element {
+        border-radius: inherit;
+    }
+
     &::-webkit-progress-bar {
         background: transparent;
+        border-radius: inherit;
     }
 }
 


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [X] Feature
- [ ] Refactoring
- [ ] Build or CI related changes
- [ ] Tests related changes
- [ ] Documentation content changes

## What is the new behaviour?
**index.html:**
```html
<progress
    new
    tuiProgressBar
    [max]="100"
    [value]="50"
></progress>
```

**index.less:**
```less
[tuiProgressBar][tuiProgressBar] {
    border-radius: 0;
}
```
![Screenshot 2023-11-10 at 17 20 45](https://github.com/taiga-family/taiga-ui/assets/35179038/72be9ed4-415d-47d7-9e2c-0a1a2da8d587)
