### PR TITLE
fix(addon-table): `Table` disappearing borders

### DIFF
--- a/projects/addon-table/components/table/td/td.style.less
+++ b/projects/addon-table/components/table/td/td.style.less
@@ -11,7 +11,7 @@
     border-top: none;
     box-sizing: border-box;
     // Create new viewport for fixed positioning
-    transform: translate3d(0, 0, 0);
+    filter: opacity(1);
 
     &:first-child {
         left: 0;

--- a/projects/addon-table/components/table/th/th.style.less
+++ b/projects/addon-table/components/table/th/th.style.less
@@ -16,7 +16,7 @@
     box-shadow: 0 0.3125rem rgba(237, 237, 237, 0);
     border: 1px solid var(--tui-base-04);
     // Create new viewport for fixed positioning
-    transform: translate3d(0, 0, 0);
+    filter: opacity(1);
 
     &:not(:first-child) {
         border-left: none;


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring
- [ ] Build or CI related changes
- [ ] Tests related changes
- [ ] Documentation content changes

## What is the current behaviour?

Part of [#5645 ](https://github.com/taiga-family/taiga-ui/issues/5645)

## What is the new behaviour?
So we remove `transform: translate3d(0, 0, 0)` for `filter: opacity(1)` because experiments shows that this fixes the borders dissapearing, except the borders inside of tables header with `position: sticky`
