### PR TITLE
fix(core): use overflow wrap for notification content

### DIFF
--- a/projects/core/components/notification/notification.style.less
+++ b/projects/core/components/notification/notification.style.less
@@ -79,7 +79,7 @@
 
 .t-content {
     flex: 1;
-    overflow: hidden;
     word-wrap: break-word;
+    overflow-wrap: anywhere;
     color: var(--tui-text-01);
 }


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring
- [ ] Build or CI related changes
- [ ] Tests related changes
- [ ] Documentation content changes

## What is the current behaviour?

<img width="734" alt="image" src="https://github.com/taiga-family/taiga-ui/assets/12021443/7b7e6be3-53e8-4a41-b47b-2a8b57a529a3">


## What is the new behaviour?

<img width="715" alt="image" src="https://github.com/taiga-family/taiga-ui/assets/12021443/1fa8a9b4-3fdf-458a-a76b-d10b7f99f651">

