### PR TITLE
fix(schematics): typo in provideAnimations for animations

### DIFF
--- a/projects/cdk/schematics/ng-add/steps/add-taiga-modules.ts
+++ b/projects/cdk/schematics/ng-add/steps/add-taiga-modules.ts
@@ -170,7 +170,7 @@ function addRootTuiProvidersToBootstrapFn(
                 Node.isCallExpression(el) &&
                 el.getExpression().getText() === `importProvidersFrom`,
         );
-    const providerAnimation = initializer
+    const provideAnimations = initializer
         .getElements()
         .find(
             el =>
@@ -197,13 +197,13 @@ function addRootTuiProvidersToBootstrapFn(
         );
     }
 
-    if (!providerAnimation) {
+    if (!provideAnimations) {
         modules.push({
-            name: `providerAnimation`,
+            name: `provideAnimations`,
             packageName: `@angular/platform-browser/animations`,
         });
 
-        pushToObjectArrayProperty(bootstrapOptions, `providers`, `providerAnimation()`, {
+        pushToObjectArrayProperty(bootstrapOptions, `providers`, `provideAnimations()`, {
             index: 0,
         });
     }

--- a/projects/cdk/schematics/ng-add/tests/schematic-ng-add-standalone.spec.ts
+++ b/projects/cdk/schematics/ng-add/tests/schematic-ng-add-standalone.spec.ts
@@ -375,7 +375,7 @@ export const appConfig: ApplicationConfig = {
 
         expect(tree.readContent(`test/main.ts`))
             .toBe(`import { importProvidersFrom } from "@angular/core";
-import { providerAnimation } from "@angular/platform-browser/animations";
+import { provideAnimations } from "@angular/platform-browser/animations";
 import { TuiRootModule } from "@taiga-ui/core";
 import { bootstrapApplication } from '@angular/platform-browser';
 import {
@@ -386,7 +386,7 @@ import { appRoutes } from './app/app.routes';
 import { AppComponent } from './app/app.component';
 
 bootstrapApplication(AppComponent, {
-  providers: [providerAnimation(), provideRouter(appRoutes, withEnabledBlockingInitialNavigation()), importProvidersFrom(TuiRootModule)],
+  providers: [provideAnimations(), provideRouter(appRoutes, withEnabledBlockingInitialNavigation()), importProvidersFrom(TuiRootModule)],
 }).catch((err) => console.error(err));
 `);
     });


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring
- [ ] Build or CI related changes
- [ ] Tests related changes
- [ ] Documentation content changes

## What is the current behaviour?

Currently, running `nx g taiga-ui:ng-add` with animations selected creates the wrong imports: 
`providerAnimation` instead of [`provideAnimations`](https://angular.io/guide/animations#step-1-enabling-the-animations-module).
```diff
- providerAnimation
+ provideAnimations
```

## What is the new behaviour?
The update fixes the typo