### PR TITLE
docs: fix import in docs

### DIFF
--- a/projects/demo/src/modules/components/toggle/examples/import/define-options.md
+++ b/projects/demo/src/modules/components/toggle/examples/import/define-options.md
@@ -1,8 +1,8 @@
 ```ts
-import {ToggleOptions, TUI_TOGGLE_DEFAULT_OPTIONS, TUI_TOGGLE_OPTIONS} from '@taiga-ui/kit';
+import {TuiToggleOptions, TUI_TOGGLE_DEFAULT_OPTIONS, TUI_TOGGLE_OPTIONS} from '@taiga-ui/kit';
 
 // ...
-const options: Partial<ToggleOptions> = {
+const options: Partial<TuiToggleOptions> = {
   icons: {
     toggleOff: ({$implicit}) => ($implicit === 'm' ? 'tuiIconChevronRight' : 'tuiIconChevronRightLarge'),
     toggleOn: ({$implicit}) => ($implicit === 'm' ? 'tuiIconChevronLeft' : 'tuiIconChevronLeftLarge'),


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring
- [ ] Build or CI related changes
- [ ] Tests related changes
- [x] Documentation content changes

## What is the current behaviour?

The docs list the wrong import path for `TuiToggleModule` as `ToggleModule`:

## What is the new behaviour?
Fixed the correct import path