### PR TITLE
fix(kit): `InputDateRange` can have empty control value after selecting something from `[items]`

### DIFF
--- a/projects/demo-playwright/tests/kit/input-date-range/input-date-range.spec.ts
+++ b/projects/demo-playwright/tests/kit/input-date-range/input-date-range.spec.ts
@@ -2,7 +2,12 @@ import {expect, Locator, test} from '@playwright/test';
 // eslint-disable-next-line @taiga-ui/experience/no-deep-imports
 import {CHAR_NO_BREAK_SPACE} from '@taiga-ui/cdk/constants';
 
-import {TuiDocumentationPagePO, tuiGoto, TuiInputDateRangePO} from '../../../utils';
+import {
+    TuiCalendarPO,
+    TuiDocumentationPagePO,
+    tuiGoto,
+    TuiInputDateRangePO,
+} from '../../../utils';
 
 test.describe(`InputDateRange`, () => {
     let example!: Locator;
@@ -34,7 +39,7 @@ test.describe(`InputDateRange`, () => {
                 await expect(inputDateRange.textfield).toHaveScreenshot(
                     `01-textfield-size-${size}-empty.png`,
                 );
-                await expect(inputDateRange.calendar).toHaveScreenshot(
+                await expect(inputDateRange.calendarRange).toHaveScreenshot(
                     `01-calendar-size-${size}-empty.png`,
                 );
 
@@ -42,7 +47,7 @@ test.describe(`InputDateRange`, () => {
                 await expect(inputDateRange.textfield).toHaveScreenshot(
                     `02-textfield-size-${size}-set-day.png`,
                 );
-                await expect(inputDateRange.calendar).toHaveScreenshot(
+                await expect(inputDateRange.calendarRange).toHaveScreenshot(
                     `02-calendar-size-${size}-set-day.png`,
                 );
 
@@ -50,7 +55,7 @@ test.describe(`InputDateRange`, () => {
                 await expect(inputDateRange.textfield).toHaveScreenshot(
                     `03-textfield-size-${size}-set-from-date.png`,
                 );
-                await expect(inputDateRange.calendar).toHaveScreenshot(
+                await expect(inputDateRange.calendarRange).toHaveScreenshot(
                     `03-calendar-size-${size}-set-from-date.png`,
                 );
 
@@ -58,7 +63,7 @@ test.describe(`InputDateRange`, () => {
                 await expect(inputDateRange.textfield).toHaveScreenshot(
                     `04-textfield-size-${size}-set-to-date.png`,
                 );
-                await expect(inputDateRange.calendar).toHaveScreenshot(
+                await expect(inputDateRange.calendarRange).toHaveScreenshot(
                     `04-calendar-size-${size}-set-to-date.png`,
                 );
             });
@@ -71,7 +76,7 @@ test.describe(`InputDateRange`, () => {
             await expect(inputDateRange.textfield).toHaveScreenshot(
                 `05-textfield-maximum-month.png`,
             );
-            await expect(inputDateRange.calendar).toHaveScreenshot(
+            await expect(inputDateRange.calendarRange).toHaveScreenshot(
                 `05-calendar-maximum-month.png`,
             );
         });
@@ -128,6 +133,29 @@ test.describe(`InputDateRange`, () => {
                     `20.05.2023${CHAR_NO_BREAK_SPACE}–${CHAR_NO_BREAK_SPACE}24.05.2023`,
                 );
             });
+        });
+
+        test(`Select from [items] => select date range from calendar`, async ({page}) => {
+            const calendar = new TuiCalendarPO(
+                inputDateRange.calendarRange.locator('tui-calendar'),
+            );
+
+            await tuiGoto(
+                page,
+                `components/input-date-range/API?items$=1&sandboxExpanded=true`,
+            );
+
+            await inputDateRange.textfield.click();
+            await inputDateRange.selectItem(1);
+            await expect(inputDateRange.textfield).toHaveValue('Today');
+
+            await inputDateRange.textfield.click();
+            await calendar.clickOnCalendarDay(21);
+
+            await expect(inputDateRange.textfield).toHaveValue('21.09.2020 – 25.09.2020');
+            await expect(example).toHaveScreenshot(
+                '07-item-and-calendar-interactions.png',
+            );
         });
     });
 });

--- a/projects/demo-playwright/utils/page-objects/calendar.po.ts
+++ b/projects/demo-playwright/utils/page-objects/calendar.po.ts
@@ -1,0 +1,19 @@
+import {Locator} from '@playwright/test';
+
+export class TuiCalendarPO {
+    constructor(private readonly host: Locator) {}
+
+    async getDays(): Promise<Locator[]> {
+        return this.host.locator('[automation-id="tui-primitive-calendar__cell"]').all();
+    }
+
+    async clickOnCalendarDay(day: number): Promise<void> {
+        const cells = await this.getDays();
+
+        for (const cell of cells) {
+            if ((await cell.textContent())?.trim() === day.toString()) {
+                return cell.click();
+            }
+        }
+    }
+}

--- a/projects/demo-playwright/utils/page-objects/index.ts
+++ b/projects/demo-playwright/utils/page-objects/index.ts
@@ -1,3 +1,4 @@
+export * from './calendar.po';
 export * from './documentation-page.po';
 export * from './input-card.po';
 export * from './input-card-grouped.po';

--- a/projects/demo-playwright/utils/page-objects/input-date-range.po.ts
+++ b/projects/demo-playwright/utils/page-objects/input-date-range.po.ts
@@ -1,8 +1,27 @@
-import {Locator} from '@playwright/test';
+import {expect, Locator} from '@playwright/test';
 
 export class TuiInputDateRangePO {
     readonly textfield: Locator = this.host.getByRole(`textbox`);
-    readonly calendar: Locator = this.host.page().locator(`tui-calendar-range`);
+    readonly calendarRange: Locator = this.host.page().locator(`tui-calendar-range`);
+    readonly items = this.calendarRange.locator(
+        '[automation-id="tui-calendar-range__menu"]',
+    );
 
     constructor(private readonly host: Locator) {}
+
+    async getItems(): Promise<Locator[]> {
+        const dataList = this.calendarRange.locator(
+            '[automation-id="tui-calendar-range__menu"]',
+        );
+
+        await expect(dataList).toBeAttached();
+
+        return dataList.locator(`[tuiOption]`).all();
+    }
+
+    async selectItem(index: number): Promise<void> {
+        const items = await this.getItems();
+
+        await items[index].click();
+    }
 }

--- a/projects/kit/components/calendar-range/calendar-range.component.ts
+++ b/projects/kit/components/calendar-range/calendar-range.component.ts
@@ -156,6 +156,7 @@ export class TuiCalendarRangeComponent implements TuiWithOptionalMinMax<TuiDay> 
         return (tuiIsString(item) && activePeriod === null) || activePeriod === item;
     }
 
+    // TODO: investigate if it is used anywhere and (if not) delete it in v4.0
     onRangeChange(dayRange: TuiDayRange): void {
         this.updateValue(dayRange);
     }

--- a/projects/kit/components/input-date-range/input-date-range.component.ts
+++ b/projects/kit/components/input-date-range/input-date-range.component.ts
@@ -191,7 +191,15 @@ export class TuiInputDateRangeComponent
     }
 
     get computedMask(): MaskitoOptions {
-        return this.activePeriod
+        /**
+         * TODO: we can delete this workaround in v4.0
+         * after solving this issue:
+         * https://github.com/taiga-family/maskito/issues/604
+         */
+        const nativeValueIsNotSynced =
+            this.textfield?.nativeFocusableElement?.value !== this.computedValue;
+
+        return this.activePeriod || nativeValueIsNotSynced
             ? MASKITO_DEFAULT_OPTIONS
             : this.calculateMask(
                   this.dateFormat,
@@ -335,6 +343,7 @@ export class TuiInputDateRangeComponent
         this.value = range;
     }
 
+    // TODO: investigate if it is used anywhere and (if not) delete it in v4.0
     onItemSelect(item: TuiDayRangePeriod | string): void {
         this.toggle();
         this.focusInput();


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- [X] Bugfix
- [ ] Feature
- [ ] Refactoring
- [ ] Build or CI related changes
- [ ] Tests related changes
- [ ] Documentation content changes

## What is the current behaviour?

Closes #5997
