### PR TITLE
feat(addon-charts): `Axes` allows to add label for the end of axisX

### DIFF
--- a/projects/addon-charts/components/axes/axes.style.less
+++ b/projects/addon-charts/components/axes/axes.style.less
@@ -172,7 +172,7 @@
     }
 
     :host[new]:not(._centered) & {
-        &:last-child {
+        &:last-child:not(:first-child) {
             flex: 0.5;
             text-align: right;
             border-left: none;

--- a/projects/addon-charts/components/axes/axes.style.less
+++ b/projects/addon-charts/components/axes/axes.style.less
@@ -170,6 +170,18 @@
         border: none;
         margin: 0;
     }
+
+    :host[new]:not(._centered) & {
+        &:last-child {
+            flex: 0.5;
+            text-align: right;
+            border-left: none;
+        }
+
+        &:nth-last-child(2) {
+            flex: 0.5;
+        }
+    }
 }
 
 .t-label-y {

--- a/projects/demo/src/modules/charts/axes/axes.component.ts
+++ b/projects/demo/src/modules/charts/axes/axes.component.ts
@@ -30,13 +30,19 @@ export class ExampleTuiAxesComponent {
         LESS: import('./examples/2/index.less?raw'),
     };
 
+    readonly example3: TuiDocExample = {
+        TypeScript: import('./examples/3/index.ts?raw'),
+        HTML: import('./examples/3/index.html?raw'),
+        LESS: import('./examples/3/index.less?raw'),
+    };
+
     readonly lineVariants: readonly TuiLineType[] = ['solid', 'dashed', 'none', 'hidden'];
 
     readonly labelsXVariants: ReadonlyArray<ReadonlyArray<string | null>> = [
         [],
         ['', '25%', '50%', '100%'],
         ['One', 'Two', 'Three'],
-        ['One', null, '', 'Two and a half', 'Three', null],
+        ['One', null, '', 'Two and a half', 'Three', null, null],
     ];
 
     readonly labelsYVariants: ReadonlyArray<readonly string[]> = [

--- a/projects/demo/src/modules/charts/axes/axes.component.ts
+++ b/projects/demo/src/modules/charts/axes/axes.component.ts
@@ -42,7 +42,7 @@ export class ExampleTuiAxesComponent {
         [],
         ['', '25%', '50%', '100%'],
         ['One', 'Two', 'Three'],
-        ['One', null, '', 'Two and a half', 'Three', null, null],
+        ['One', null, '', 'Two and a half', 'Three', null],
     ];
 
     readonly labelsYVariants: ReadonlyArray<readonly string[]> = [

--- a/projects/demo/src/modules/charts/axes/axes.module.ts
+++ b/projects/demo/src/modules/charts/axes/axes.module.ts
@@ -1,15 +1,16 @@
 import {CommonModule} from '@angular/common';
 import {NgModule} from '@angular/core';
 import {RouterModule} from '@angular/router';
-import {TuiAxesModule, TuiBarChartModule} from '@taiga-ui/addon-charts';
+import {TuiAxesModule, TuiBarChartModule, TuiBarModule} from '@taiga-ui/addon-charts';
 import {TuiMoneyModule} from '@taiga-ui/addon-commerce';
 import {TuiAddonDocModule, tuiGenerateRoutes} from '@taiga-ui/addon-doc';
-import {TuiHintModule} from '@taiga-ui/core';
+import {TuiHintModule, TuiNotificationModule} from '@taiga-ui/core';
 import {PolymorpheusModule} from '@tinkoff/ng-polymorpheus';
 
 import {ExampleTuiAxesComponent} from './axes.component';
 import {TuiAxesExample1} from './examples/1';
 import {TuiAxesExample2} from './examples/2';
+import {TuiAxesExample3} from './examples/3';
 
 @NgModule({
     imports: [
@@ -17,13 +18,20 @@ import {TuiAxesExample2} from './examples/2';
         RouterModule,
         TuiAxesModule,
         TuiBarChartModule,
+        TuiBarModule,
         TuiHintModule,
         PolymorpheusModule,
         TuiMoneyModule,
         TuiAddonDocModule,
         RouterModule.forChild(tuiGenerateRoutes(ExampleTuiAxesComponent)),
+        TuiNotificationModule,
     ],
-    declarations: [ExampleTuiAxesComponent, TuiAxesExample1, TuiAxesExample2],
+    declarations: [
+        ExampleTuiAxesComponent,
+        TuiAxesExample1,
+        TuiAxesExample2,
+        TuiAxesExample3,
+    ],
     exports: [ExampleTuiAxesComponent],
 })
 export class ExampleTuiAxesModule {}

--- a/projects/demo/src/modules/charts/axes/axes.template.html
+++ b/projects/demo/src/modules/charts/axes/axes.template.html
@@ -21,6 +21,19 @@
         >
             <tui-axes-example-2></tui-axes-example-2>
         </tui-doc-example>
+
+        <tui-doc-example
+            id="labels"
+            heading="With horizontal bars"
+            [content]="example3"
+        >
+            <tui-notification class="tui-space_bottom-4">
+                Labels positioning on x axes were updated. To prevent breaking changes
+                <code>new</code>
+                attribute has to be added to enable new behaviour.
+            </tui-notification>
+            <tui-axes-example-3></tui-axes-example-3>
+        </tui-doc-example>
     </ng-template>
 
     <ng-template pageTab>

--- a/projects/demo/src/modules/charts/axes/examples/3/index.html
+++ b/projects/demo/src/modules/charts/axes/examples/3/index.html
@@ -1,0 +1,15 @@
+<tui-axes
+    new
+    class="axes"
+    [axisXLabels]="axisXLabels"
+    [verticalLines]="4"
+>
+    <div class="tui-horizontal-bars">
+        <tui-bar
+            *ngFor="let bar of value; let i = index"
+            size="m"
+            [style.background-color]="getBackground(i)"
+            [style.height.%]="getHeight(bar)"
+        ></tui-bar>
+    </div>
+</tui-axes>

--- a/projects/demo/src/modules/charts/axes/examples/3/index.html
+++ b/projects/demo/src/modules/charts/axes/examples/3/index.html
@@ -4,7 +4,7 @@
     [axisXLabels]="axisXLabels"
     [verticalLines]="4"
 >
-    <div class="tui-horizontal-bars">
+    <div class="t-horizontal-bars">
         <tui-bar
             *ngFor="let bar of value; let i = index"
             size="m"

--- a/projects/demo/src/modules/charts/axes/examples/3/index.less
+++ b/projects/demo/src/modules/charts/axes/examples/3/index.less
@@ -1,0 +1,14 @@
+.axes {
+    height: 18.75rem;
+    width: 37.5rem;
+}
+
+.tui-horizontal-bars {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-end;
+    width: 16.75rem;
+    height: 37.5rem;
+    transform-origin: bottom left;
+    transform: rotate(90deg) translate(-16.75rem, 0);
+}

--- a/projects/demo/src/modules/charts/axes/examples/3/index.less
+++ b/projects/demo/src/modules/charts/axes/examples/3/index.less
@@ -3,7 +3,7 @@
     width: 37.5rem;
 }
 
-.tui-horizontal-bars {
+.t-horizontal-bars {
     display: flex;
     justify-content: space-between;
     align-items: flex-end;

--- a/projects/demo/src/modules/charts/axes/examples/3/index.ts
+++ b/projects/demo/src/modules/charts/axes/examples/3/index.ts
@@ -1,0 +1,26 @@
+import {Component} from '@angular/core';
+import {changeDetection} from '@demo/emulate/change-detection';
+import {encapsulation} from '@demo/emulate/encapsulation';
+
+const PERCENT = 100;
+
+@Component({
+    selector: 'tui-axes-example-3',
+    templateUrl: './index.html',
+    styleUrls: ['./index.less'],
+    encapsulation,
+    changeDetection,
+})
+export class TuiAxesExample3 {
+    readonly axisXLabels = ['0', '25', '50', '75', '100'];
+    readonly value = [50, 24, 36, 95];
+    readonly largest = 100;
+
+    getBackground(index: number): string {
+        return `var(--tui-chart-${index})`;
+    }
+
+    getHeight(value: number): number {
+        return Math.abs((value * PERCENT) / this.largest);
+    }
+}


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Refactoring
- [ ] Build or CI related changes
- [ ] Tests related changes
- [ ] Documentation content changes

## What is the current behaviour?

Closes  #4886

## What is the new behaviour?

```
[axisXLabels]=[
    ' ', // first label
    '25%',
    '50%',
    '75%',
    ' ', // last label
]
```
![image](https://github.com/taiga-family/taiga-ui/assets/101005283/f3d3be2f-037c-4543-840f-f6db2771003e)

```
[axisXLabels]=[
    'One ',  // first label
    'Two',
    'Three' // last label
]
```
![image](https://github.com/taiga-family/taiga-ui/assets/101005283/d4ff6eab-913d-4414-92c8-960cb6c65dcf)

New docs example added

![image](https://github.com/taiga-family/taiga-ui/assets/101005283/88f290c2-97ac-4431-b180-6b6e04ddafcd)
