### PR TITLE
fix(kit): preventing hover from being transmitted to nested accordion item

### DIFF
--- a/projects/demo/src/modules/components/accordion/accordion.component.ts
+++ b/projects/demo/src/modules/components/accordion/accordion.component.ts
@@ -48,6 +48,11 @@ export class ExampleTuiAccordionComponent {
         LESS: import('./examples/4/index.less?raw'),
     };
 
+    readonly example5: TuiDocExample = {
+        TypeScript: import('./examples/5/index.ts?raw'),
+        HTML: import('./examples/5/index.html?raw'),
+    };
+
     readonly bordersVariants = ['all', 'top-bottom'] as const;
 
     borders: 'all' | 'top-bottom' = this.bordersVariants[0];

--- a/projects/demo/src/modules/components/accordion/accordion.module.ts
+++ b/projects/demo/src/modules/components/accordion/accordion.module.ts
@@ -23,6 +23,7 @@ import {TuiAccordionExample1} from './examples/1';
 import {TuiAccordionExample2} from './examples/2';
 import {TuiAccordionExample3} from './examples/3';
 import {TuiAccordionExample4} from './examples/4';
+import {TuiAccordionExample5} from './examples/5';
 
 @NgModule({
     imports: [
@@ -48,6 +49,7 @@ import {TuiAccordionExample4} from './examples/4';
         TuiAccordionExample2,
         TuiAccordionExample3,
         TuiAccordionExample4,
+        TuiAccordionExample5,
     ],
     exports: [ExampleTuiAccordionComponent],
 })

--- a/projects/demo/src/modules/components/accordion/accordion.template.html
+++ b/projects/demo/src/modules/components/accordion/accordion.template.html
@@ -39,6 +39,15 @@
         >
             <tui-accordion-example-4></tui-accordion-example-4>
         </tui-doc-example>
+
+        <tui-doc-example
+            id="nested"
+            heading="Nested"
+            [content]="example5"
+            [fullsize]="true"
+        >
+            <tui-accordion-example-5></tui-accordion-example-5>
+        </tui-doc-example>
     </ng-template>
 
     <ng-template pageTab>

--- a/projects/demo/src/modules/components/accordion/examples/5/index.html
+++ b/projects/demo/src/modules/components/accordion/examples/5/index.html
@@ -1,0 +1,27 @@
+<tui-accordion>
+    <tui-accordion-item [open]="true">
+        Level 1
+        <ng-template tuiAccordionItemContent>
+            Development kit consisting of the low level tools and abstractions used to develop Taiga UI Angular entities
+
+            <tui-accordion class="tui-space_top-3">
+                <tui-accordion-item [open]="true">
+                    Level 2
+                    <ng-template tuiAccordionItemContent>
+                        The main set of components used to build Taiga UI based Angular applications
+
+                        <tui-accordion class="tui-space_top-3">
+                            <tui-accordion-item [open]="true">
+                                Level 3
+                                <ng-template tuiAccordionItemContent>
+                                    Basic elements needed to develop components, directives and more using Taiga UI
+                                    design system
+                                </ng-template>
+                            </tui-accordion-item>
+                        </tui-accordion>
+                    </ng-template>
+                </tui-accordion-item>
+            </tui-accordion>
+        </ng-template>
+    </tui-accordion-item>
+</tui-accordion>

--- a/projects/demo/src/modules/components/accordion/examples/5/index.ts
+++ b/projects/demo/src/modules/components/accordion/examples/5/index.ts
@@ -1,0 +1,11 @@
+import {Component} from '@angular/core';
+import {changeDetection} from '@demo/emulate/change-detection';
+import {encapsulation} from '@demo/emulate/encapsulation';
+
+@Component({
+    selector: 'tui-accordion-example-5',
+    templateUrl: './index.html',
+    encapsulation,
+    changeDetection,
+})
+export class TuiAccordionExample5 {}

--- a/projects/kit/components/accordion/accordion-item/accordion-item.style.less
+++ b/projects/kit/components/accordion/accordion-item/accordion-item.style.less
@@ -126,15 +126,15 @@
     }
 
     &_hoverable {
-        :host:hover:not([data-mode]) & {
+        .t-wrapper:hover:not([data-mode]) > & {
             background: var(--tui-base-02);
         }
 
-        :host:hover[data-mode='onDark'] & {
+        .t-wrapper:hover[data-mode='onDark'] > & {
             background: var(--tui-clear-inverse);
         }
 
-        :host:hover[data-mode='onLight'] & {
+        .t-wrapper:hover[data-mode='onLight'] > & {
             background: var(--tui-clear);
         }
     }


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring
- [ ] Build or CI related changes
- [ ] Tests related changes
- [ ] Documentation content changes

## What is the current behaviour?

hover on top

<img width="1048" alt="image" src="https://github.com/taiga-family/taiga-ui/assets/12021443/fcc9833c-dff8-41c8-b6c3-6fa9fe19fe68">


## What is the new behaviour?

<img width="990" alt="image" src="https://github.com/taiga-family/taiga-ui/assets/12021443/95ed27c6-1c7e-4815-ab40-d3de4ac1fb44">


