### PR TITLE
fix(kit): `.t-mark` in `Radio` disappears after toggling `Expand`

### DIFF
--- a/projects/kit/components/radio/radio.component.ts
+++ b/projects/kit/components/radio/radio.component.ts
@@ -1,4 +1,3 @@
-import {AnimationOptions} from '@angular/animations';
 import {
     ChangeDetectionStrategy,
     ChangeDetectorRef,
@@ -22,7 +21,7 @@ import {
     tuiIsNativeFocused,
     TuiNativeFocusableElement,
 } from '@taiga-ui/cdk';
-import {TUI_ANIMATION_OPTIONS, tuiScaleIn, TuiSizeL} from '@taiga-ui/core';
+import {TuiSizeL} from '@taiga-ui/core';
 import {TuiRadioGroupComponent} from '@taiga-ui/kit/components/radio-group';
 
 import {TUI_RADIO_OPTIONS, TuiRadioOptions} from './radio.options';
@@ -36,7 +35,6 @@ import {TUI_RADIO_OPTIONS, TuiRadioOptions} from './radio.options';
         tuiAsFocusableItemAccessor(TuiRadioComponent),
         tuiAsControl(TuiRadioComponent),
     ],
-    animations: [tuiScaleIn],
 })
 export class TuiRadioComponent<T>
     extends AbstractTuiNullableControl<T>
@@ -67,7 +65,6 @@ export class TuiRadioComponent<T>
         @Inject(NgControl)
         control: NgControl | null,
         @Inject(ChangeDetectorRef) cdr: ChangeDetectorRef,
-        @Inject(TUI_ANIMATION_OPTIONS) readonly animation: AnimationOptions,
         @Inject(TUI_RADIO_OPTIONS) private readonly options: TuiRadioOptions,
         @Optional()
         @Inject(TuiRadioGroupComponent)

--- a/projects/kit/components/radio/radio.style.less
+++ b/projects/kit/components/radio/radio.style.less
@@ -28,10 +28,15 @@
 }
 
 .t-mark {
+    .transition(transform);
     position: absolute;
     background-color: currentColor;
     border-radius: 100%;
-    animation: scaleIn 300ms;
+    transform: scale(0);
+
+    &_visible {
+        transform: scale(1);
+    }
 
     :host[data-size='m'] & {
         margin: 0.25rem;
@@ -43,16 +48,6 @@
         margin: 0.4375rem;
         width: @dotSizeL;
         height: @dotSizeL;
-    }
-}
-
-@keyframes scaleIn {
-    0% {
-        transform: scale(0);
-    }
-
-    100% {
-        transform: scale(1);
     }
 }
 

--- a/projects/kit/components/radio/radio.style.less
+++ b/projects/kit/components/radio/radio.style.less
@@ -31,6 +31,7 @@
     position: absolute;
     background-color: currentColor;
     border-radius: 100%;
+    animation: scaleIn 300ms;
 
     :host[data-size='m'] & {
         margin: 0.25rem;
@@ -42,6 +43,16 @@
         margin: 0.4375rem;
         width: @dotSizeL;
         height: @dotSizeL;
+    }
+}
+
+@keyframes scaleIn {
+    0% {
+        transform: scale(0);
+    }
+
+    100% {
+        transform: scale(1);
     }
 }
 

--- a/projects/kit/components/radio/radio.template.html
+++ b/projects/kit/components/radio/radio.template.html
@@ -8,8 +8,8 @@
     [invalid]="computedInvalid"
 >
     <div
-        *ngIf="checked"
         class="t-mark"
+        [class.t-mark_visible]="checked"
     ></div>
     <input
         #focusableElement

--- a/projects/kit/components/radio/radio.template.html
+++ b/projects/kit/components/radio/radio.template.html
@@ -10,7 +10,6 @@
     <div
         *ngIf="checked"
         class="t-mark"
-        [@tuiScaleIn]="animation"
     ></div>
     <input
         #focusableElement


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring
- [ ] Build or CI related changes
- [ ] Tests related changes
- [ ] Documentation content changes

## What is the current behaviour?

Closes #5946

## What is the new behaviour?

Just replace `tuiSlideAnimation` with CSS animation.
