### PR TITLE
fix(cdk): add checks before destroying hostView and viewRef

### DIFF
--- a/projects/cdk/abstract/portal-service.ts
+++ b/projects/cdk/abstract/portal-service.ts
@@ -28,7 +28,9 @@ export abstract class AbstractTuiPortalService {
     }
 
     remove<C>({hostView}: ComponentRef<C>): void {
-        hostView.destroy();
+        if (!hostView.destroyed) {
+            hostView.destroy();
+        }
     }
 
     addTemplate<C>(templateRef: TemplateRef<C>, context?: C): EmbeddedViewRef<C> {
@@ -36,6 +38,8 @@ export abstract class AbstractTuiPortalService {
     }
 
     removeTemplate<C>(viewRef: EmbeddedViewRef<C>): void {
-        viewRef.destroy();
+        if (!viewRef.destroyed) {
+            viewRef.destroy();
+        }
     }
 }


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring
- [ ] Build or CI related changes
- [ ] Tests related changes
- [ ] Documentation content changes

## What is the current behaviour?

The second call of the destroy method on the same hostView does not destroy the parent component.

## What is the new behaviour?

If hostView is already destroyed, the destroy method does not call.
