### PR TITLE
feat(layout): add tuiSlot `action` to be able to template any element into the action container of BlockStatus

### DIFF
--- a/projects/layout/components/block-status/block-status.directive.ts
+++ b/projects/layout/components/block-status/block-status.directive.ts
@@ -5,5 +5,5 @@ import {Directive, Input} from '@angular/core';
 })
 export class TuiBlockStatusDirective {
     @Input()
-    tuiSlot: string | 'top' | 'action' = 'top';
+    tuiSlot: string | 'action' | 'top' = 'top';
 }

--- a/projects/layout/components/block-status/block-status.directive.ts
+++ b/projects/layout/components/block-status/block-status.directive.ts
@@ -5,5 +5,5 @@ import {Directive, Input} from '@angular/core';
 })
 export class TuiBlockStatusDirective {
     @Input()
-    tuiSlot: string | 'top' = 'top';
+    tuiSlot: string | 'top' | 'action' = 'top';
 }

--- a/projects/layout/components/block-status/block-status.template.html
+++ b/projects/layout/components/block-status/block-status.template.html
@@ -9,5 +9,5 @@
 </div>
 
 <div class="t-block-actions">
-    <ng-content select="a,button"></ng-content>
+    <ng-content select="a,button,[tuiSlot='action']"></ng-content>
 </div>


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Refactoring
- [ ] Build or CI related changes
- [ ] Tests related changes
- [ ] Documentation content changes

## What is the current behavior?
Only `a` and `button` elements are currently templated into the action container.

## What is the new behavior?
Elements with the directive `tuiSlot='action'` are also templated into the action container.
