### PR TITLE
ci: run `auto-label.yml` only if `github.event.review.state == 'APPROVED'`

### DIFF
--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -1,8 +1,11 @@
 name: 🤖 Auto label
-on: pull_request_review
+on:
+  pull_request_review:
+    types: [submitted]
 
 jobs:
   label-when-approved:
+    if: github.event.review.state == 'APPROVED'
     name: Label when approved
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring
- [X] Build or CI related changes
- [ ] Tests related changes
- [ ] Documentation content changes

## What is the current behaviour?
<img height="300" src="https://github.com/taiga-family/taiga-ui/assets/35179038/763acc9d-5640-4e58-8138-fe21bb1f2556">

Example:
https://github.com/taiga-family/taiga-ui/actions/runs/7198638030/job/19608550014
<img width="1764" alt="Screenshot 2023-12-15 at 12 16 01" src="https://github.com/taiga-family/taiga-ui/assets/35179038/3b8066ee-8278-459a-adf9-321c4eade6cb">

