### PR TITLE
feat(addon-doc): support standalone route in addon-doc

### DIFF
--- a/projects/addon-doc/utils/index.ts
+++ b/projects/addon-doc/utils/index.ts
@@ -4,6 +4,7 @@ export * from './generate-routes';
 export * from './inspect';
 export * from './is-page-group';
 export * from './parse-code-block';
+export * from './provide-route-page-tab';
 export * from './raw-load';
 export * from './raw-load-record';
 export * from './sort-pages';

--- a/projects/addon-doc/utils/provide-route-page-tab.ts
+++ b/projects/addon-doc/utils/provide-route-page-tab.ts
@@ -20,6 +20,6 @@ export function tuiProvideRoutePageTab({
         path,
         loadComponent,
         data: {title},
-        children: [{path: `:tab`, loadComponent}],
+        children: [{path: ':tab', loadComponent}],
     };
 }

--- a/projects/addon-doc/utils/provide-route-page-tab.ts
+++ b/projects/addon-doc/utils/provide-route-page-tab.ts
@@ -1,0 +1,25 @@
+import {Type} from '@angular/core';
+import {DefaultExport, Route} from '@angular/router';
+import {Observable} from 'rxjs';
+
+interface Options {
+    path?: string;
+    title?: string;
+    loadComponent?: () =>
+        | Observable<DefaultExport<Type<unknown>> | Type<unknown>>
+        | Promise<DefaultExport<Type<unknown>> | Type<unknown>>
+        | Type<unknown>;
+}
+
+export function tuiProvideRoutePageTab({
+    path,
+    title,
+    loadComponent,
+}: Options = {}): Route {
+    return {
+        path,
+        loadComponent,
+        data: {title},
+        children: [{path: `:tab`, loadComponent}],
+    };
+}


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Refactoring
- [ ] Build or CI related changes
- [ ] Tests related changes
- [ ] Documentation content changes

## What is the current behaviour?

<img width="740" alt="image" src="https://github.com/taiga-family/taiga-ui/assets/12021443/2b0b8525-c949-4383-ae1c-3f4a6707831b">


## What is the new behaviour?

<img width="996" alt="image" src="https://github.com/taiga-family/taiga-ui/assets/12021443/4b17a442-6acc-4d48-8f41-abc75915f3f8">
