### PR TITLE
fix(kit): `ComboBox` fix empty string option incorrect behavior

### DIFF
--- a/projects/kit/components/combo-box/combo-box.component.ts
+++ b/projects/kit/components/combo-box/combo-box.component.ts
@@ -223,7 +223,7 @@ export class TuiComboBoxComponent<T>
     }
 
     private isStrictMatch(item: T): boolean {
-        return !!this.strictMatcher?.(item, this.search || '', this.stringify);
+        return !!this.search && !!this.strictMatcher?.(item, this.search, this.stringify);
     }
 
     private close(): void {


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- [X] Bugfix
- [ ] Feature
- [ ] Refactoring
- [ ] Build or CI related changes
- [ ] Tests related changes
- [ ] Documentation content changes

Possible solution for [#6166](https://github.com/taiga-family/taiga-ui/issues/6166)

We shouldn't check strict matcher for empty string, so it's impossible to choose empty string by typing empty string for now, but maybe it's an expected behavior
