### PR TITLE
chore(demo): add example for combo-box ID only

### DIFF
--- a/projects/demo/src/modules/components/combo-box/combo-box.component.ts
+++ b/projects/demo/src/modules/components/combo-box/combo-box.component.ts
@@ -95,6 +95,11 @@ export class ExampleTuiComboBoxComponent extends AbstractExampleTuiControl {
         HTML: import('./examples/7/index.html?raw'),
     };
 
+    readonly example8: TuiDocExample = {
+        TypeScript: import('./examples/8/index.ts?raw'),
+        HTML: import('./examples/8/index.html?raw'),
+    };
+
     readonly items = [
         new Account('Rubles', 500),
         new Account('Dollars', 237),

--- a/projects/demo/src/modules/components/combo-box/combo-box.module.ts
+++ b/projects/demo/src/modules/components/combo-box/combo-box.module.ts
@@ -40,6 +40,7 @@ import {TuiComboBoxExample5} from './examples/5';
 import {IndexChangeDirective} from './examples/5/index-change.directive';
 import {TuiComboBoxExample6} from './examples/6';
 import {TuiComboBoxExample7} from './examples/7';
+import {TuiComboBoxExample8} from './examples/8';
 
 @NgModule({
     imports: [
@@ -78,6 +79,7 @@ import {TuiComboBoxExample7} from './examples/7';
         TuiComboBoxExample5,
         TuiComboBoxExample6,
         TuiComboBoxExample7,
+        TuiComboBoxExample8,
         IndexChangeDirective,
     ],
     exports: [ExampleTuiComboBoxComponent],

--- a/projects/demo/src/modules/components/combo-box/combo-box.template.html
+++ b/projects/demo/src/modules/components/combo-box/combo-box.template.html
@@ -34,6 +34,21 @@
         </tui-doc-example>
 
         <tui-doc-example
+            id="id"
+            heading="ID only"
+            [content]="example8"
+        >
+            <tui-notification class="tui-space_bottom-4 b-form">
+                If you receive your id to text mapping from the server, you would need to recreate
+                <code>items</code>
+                and
+                <code>stringify</code>
+                when new data comes, so they will be observables and you would need async pipe in the template
+            </tui-notification>
+            <tui-combox-box-example-8></tui-combox-box-example-8>
+        </tui-doc-example>
+
+        <tui-doc-example
             id="wrapper"
             description="With filtering through tuiFilterByInput pipe"
             heading="DataListWrapper"

--- a/projects/demo/src/modules/components/combo-box/examples/8/index.html
+++ b/projects/demo/src/modules/components/combo-box/examples/8/index.html
@@ -1,0 +1,12 @@
+<tui-combo-box
+    [formControl]="control"
+    [stringify]="stringify"
+>
+    Type a name
+    <tui-data-list-wrapper
+        *tuiDataList
+        [itemContent]="stringify | tuiStringifyContent"
+        [items]="items | tuiFilterByInputWith: stringify"
+    ></tui-data-list-wrapper>
+</tui-combo-box>
+<p class="tui-space_top-2">Selected value: {{ control.value | json }}</p>

--- a/projects/demo/src/modules/components/combo-box/examples/8/index.ts
+++ b/projects/demo/src/modules/components/combo-box/examples/8/index.ts
@@ -1,0 +1,31 @@
+import {Component} from '@angular/core';
+import {FormControl} from '@angular/forms';
+import {changeDetection} from '@demo/emulate/change-detection';
+import {encapsulation} from '@demo/emulate/encapsulation';
+
+interface Dictionary {
+    readonly id: number;
+    readonly name: string;
+}
+
+const DICTIONARY: Dictionary[] = [
+    {id: 1, name: 'Luke Skywalker'},
+    {id: 2, name: 'Princess Leia'},
+    {id: 3, name: 'Darth Vader'},
+    {id: 4, name: 'Han Solo'},
+    {id: 5, name: 'Obi-Wan Kenobi'},
+    {id: 6, name: 'Yoda'},
+];
+
+@Component({
+    selector: 'tui-combox-box-example-8',
+    templateUrl: './index.html',
+    encapsulation,
+    changeDetection,
+})
+export class TuiComboBoxExample8 {
+    readonly control = new FormControl(3);
+    readonly items = DICTIONARY.map(({id}) => id);
+    readonly stringify = (id: number): string =>
+        DICTIONARY.find(item => item.id === id)?.name || '';
+}


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring
- [ ] Build or CI related changes
- [ ] Tests related changes
- [X] Documentation content changes

## What is the current behaviour?

Closes # <!-- link to a relevant issue. -->

The documentation currently lacks an example demonstrating the usage of a combo box that returns and accepts an ID to locate an item

## What is the new behaviour?

This pull request introduces a new example in the documentation, showcasing the implementation of a combo box. The added example illustrates how to use the combo box to interact with items by returning and accepting an ID. Users can refer to this example to better understand how to integrate similar functionality into their projects.
![combobox-id-only](https://github.com/taiga-family/taiga-ui/assets/23726762/0b0a68b8-6261-400e-a2bb-6e46de2f8dd5)

