### PR TITLE
fix(addon-mobile): add smooth opacity change for `MobileCalendar` to hide blinking initial view

### DIFF
--- a/projects/addon-mobile/components/mobile-calendar/mobile-calendar.component.ts
+++ b/projects/addon-mobile/components/mobile-calendar/mobile-calendar.component.ts
@@ -71,7 +71,7 @@ import {
     styleUrls: ['./mobile-calendar.style.less'],
     changeDetection: ChangeDetectionStrategy.OnPush,
     providers: TUI_MOBILE_CALENDAR_PROVIDERS,
-    host: {'[class._ios]': 'isIOS'},
+    host: {'[class._ios]': 'isIOS', '[class._initialized]': 'initialized'},
 })
 export class TuiMobileCalendarComponent implements AfterViewInit {
     @ViewChild('yearsScrollRef')
@@ -117,6 +117,8 @@ export class TuiMobileCalendarComponent implements AfterViewInit {
                 i % MONTHS_IN_YEAR,
             ),
     );
+
+    initialized = false;
 
     constructor(
         @Inject(TUI_IS_IOS) readonly isIOS: boolean,
@@ -304,6 +306,7 @@ export class TuiMobileCalendarComponent implements AfterViewInit {
                 takeUntil(this.destroy$),
             )
             .subscribe(() => {
+                this.initialized = true;
                 this.updateViewportDimension();
                 this.initYearScroll();
                 this.initMonthScroll();

--- a/projects/addon-mobile/components/mobile-calendar/mobile-calendar.style.less
+++ b/projects/addon-mobile/components/mobile-calendar/mobile-calendar.style.less
@@ -212,3 +212,14 @@
         font-size: 1.0625rem;
     }
 }
+
+.t-week,
+.t-years,
+.t-months {
+    .transition(opacity);
+    opacity: 0;
+
+    :host(._initialized) & {
+        opacity: 1;
+    }
+}

--- a/projects/cdk/constants/version.ts
+++ b/projects/cdk/constants/version.ts
@@ -1,1 +1,1 @@
-export const TUI_VERSION = `3.62.0`;
+export const TUI_VERSION = '3.62.0';


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- [X] Bugfix
- [ ] Feature
- [ ] Refactoring
- [ ] Build or CI related changes
- [ ] Tests related changes
- [ ] Documentation content changes

## What is the current behaviour?
Closes #6456

