### PR TITLE
refactor(addon-mobile): use `TuiLoaderModule` inside `TUI_ANDROID_LOADER`

### DIFF
--- a/projects/addon-mobile/components/pull-to-refresh/loader-android/loader-android.component.ts
+++ b/projects/addon-mobile/components/pull-to-refresh/loader-android/loader-android.component.ts
@@ -1,5 +1,7 @@
+import {NgIf} from '@angular/common';
 import {ChangeDetectionStrategy, Component, HostBinding, Inject} from '@angular/core';
 import {TuiContext} from '@taiga-ui/cdk';
+import {TuiLoaderModule} from '@taiga-ui/core';
 import {POLYMORPHEUS_CONTEXT, PolymorpheusComponent} from '@tinkoff/ng-polymorpheus';
 
 import {TUI_PULL_TO_REFRESH_THRESHOLD} from '../pull-to-refresh.providers';
@@ -10,7 +12,9 @@ const ROTATE_X_MAX = 500;
 const ROTATE_X_MULTIPLIER = 2.3;
 
 @Component({
+    standalone: true,
     selector: 'tui-mobile-android-loader',
+    imports: [NgIf, TuiLoaderModule],
     templateUrl: './loader-android.template.html',
     styleUrls: ['./loader-android.style.less'],
     changeDetection: ChangeDetectionStrategy.OnPush,

--- a/projects/addon-mobile/components/pull-to-refresh/loader-android/loader-android.style.less
+++ b/projects/addon-mobile/components/pull-to-refresh/loader-android/loader-android.style.less
@@ -35,16 +35,6 @@
     margin-left: -1.125rem;
 }
 
-.t-loading {
-    display: block;
-    width: 1rem;
-    border-radius: 100%;
-    animation: tuiLoaderRotate 3s linear infinite;
-}
-
-.t-circle {
-    fill: none;
-    stroke: var(--tui-text-01);
-    stroke-width: 1.5rem;
-    animation: tuiLoaderDashOffset 3s linear infinite;
+.t-loader {
+    color: var(--tui-text-01);
 }

--- a/projects/addon-mobile/components/pull-to-refresh/loader-android/loader-android.template.html
+++ b/projects/addon-mobile/components/pull-to-refresh/loader-android/loader-android.template.html
@@ -30,17 +30,9 @@
     </svg>
 </div>
 <ng-template #loading>
-    <svg
-        viewBox="0 0 100 100"
-        xmlns="http://www.w3.org/2000/svg"
-        class="t-loading"
-    >
-        <circle
-            cx="50"
-            cy="50"
-            r="50"
-            stroke-dasharray="314"
-            class="t-circle"
-        ></circle>
-    </svg>
+    <tui-loader
+        size="s"
+        class="t-loader"
+        [inheritColor]="true"
+    ></tui-loader>
 </ng-template>

--- a/projects/addon-mobile/components/pull-to-refresh/pull-to-refresh.module.ts
+++ b/projects/addon-mobile/components/pull-to-refresh/pull-to-refresh.module.ts
@@ -9,12 +9,14 @@ import {TuiMobileLoaderIOSComponent} from './loader-ios/loader-ios.component';
 import {TuiPullToRefreshComponent} from './pull-to-refresh.component';
 
 @NgModule({
-    imports: [CommonModule, TuiSvgModule, TuiRepeatTimesModule, PolymorpheusModule],
-    declarations: [
-        TuiPullToRefreshComponent,
+    imports: [
+        CommonModule,
+        TuiSvgModule,
+        TuiRepeatTimesModule,
+        PolymorpheusModule,
         TuiMobileLoaderAndroidComponent,
-        TuiMobileLoaderIOSComponent,
     ],
+    declarations: [TuiPullToRefreshComponent, TuiMobileLoaderIOSComponent],
     exports: [TuiPullToRefreshComponent],
 })
 export class TuiPullToRefreshModule {}


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [X] Refactoring
- [ ] Build or CI related changes
- [ ] Tests related changes
- [ ] Documentation content changes

## What is the current behaviour?
Open stackblitz https://taiga-ui.dev/components/pull-to-refresh#android
Pull to see loader:

https://github.com/taiga-family/taiga-ui/assets/35179038/cb185ffa-6f94-4c40-81a6-7dcb1808c7bb



This component use animations from `Loader`
https://github.com/taiga-family/taiga-ui/blob/b30552dfca7b78dcb102a94b31ae2db8e28ceec1/projects/addon-mobile/components/pull-to-refresh/loader-android/loader-android.style.less#L42
https://github.com/taiga-family/taiga-ui/blob/b30552dfca7b78dcb102a94b31ae2db8e28ceec1/projects/addon-mobile/components/pull-to-refresh/loader-android/loader-android.style.less#L49

But it does not import these animations to its `.less`-file!

## What is the new behaviour?
this branch <=> main branch


https://github.com/taiga-family/taiga-ui/assets/35179038/63833926-94a3-4a25-a62e-efbff0ae521c

