### PR TITLE
fix(cdk): `endWith` should be pass after `takeUntil`

### DIFF
--- a/projects/cdk/services/scroll.service.ts
+++ b/projects/cdk/services/scroll.service.ts
@@ -52,8 +52,8 @@ export class TuiScrollService {
                       initialTop + deltaTop * percent,
                       initialLeft + deltaLeft * percent,
                   ]),
-                  endWith<[number, number]>([scrollTop, scrollLeft]),
                   takeUntil(timer(duration)),
+                  endWith<[number, number]>([scrollTop, scrollLeft]),
               );
 
         return observable.pipe(


### PR DESCRIPTION
Closes #6551

https://rxjs.dev/api/operators/endWith

<img width="468" alt="image" src="https://github.com/taiga-family/taiga-ui/assets/12021443/2d7190b2-b07a-4c96-9498-4b1609508e9e">

