### PR TITLE
chore: export `TUI_ANIMATIONS_DEFAULT_DURATION`

### DIFF
--- a/projects/core/utils/miscellaneous/to-animation-options.ts
+++ b/projects/core/utils/miscellaneous/to-animation-options.ts
@@ -1,15 +1,14 @@
 import {AnimationOptions} from '@angular/animations';
 
-const TUI_ANIMATIONS_DEFAULT_DURATION = 300;
+export const TUI_ANIMATIONS_DEFAULT_DURATION = 300;
 
 export function tuiToAnimationOptions(speed: number): AnimationOptions {
-    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
     return {
         value: '',
         params: {
             duration: tuiGetDuration(speed),
         },
-    } as AnimationOptions;
+    } as unknown as AnimationOptions;
 }
 
 export function tuiGetDuration(speed: number): number {


### PR DESCRIPTION
I have a problem in tui-editor

<img width="1176" alt="image" src="https://github.com/taiga-family/taiga-ui/assets/12021443/1984ab8b-4d87-49eb-98d3-2108cde2b615">
