### PR TITLE
refactor: prefer regexp exec

### DIFF
--- a/projects/addon-doc/utils/type-reference-parser.ts
+++ b/projects/addon-doc/utils/type-reference-parser.ts
@@ -21,8 +21,8 @@ export function tuiTypeReferenceParser(types: string): TuiDocTypeReferenceParsed
             .replace(/\[\]/g, '');
 
         extracted =
-            extracted.match(/ReadonlyArray<([^>]+)>/)?.[1]?.split('&')?.[0] ?? extracted;
-        extracted = extracted.match(/\[([^\]]+)\]/)?.[1]?.split(',')?.[0] ?? extracted;
+            /ReadonlyArray<([^>]+)>/.exec(extracted)?.[1]?.split('&')?.[0] ?? extracted;
+        extracted = /\[([^\]]+)\]/.exec(extracted)?.[1]?.split(',')?.[0] ?? extracted;
         extracted = (extracted.split('<')?.[0] ?? extracted)?.trim() ?? '';
         extracted = Number.isNaN(parseFloat(extracted)) ? extracted : 'number';
         extracted = /^'(.+)'$|^"(.+)"$|^`(.+)`$/.test(extracted) ? 'string' : extracted;

--- a/projects/cdk/schematics/ng-add/index.ts
+++ b/projects/cdk/schematics/ng-add/index.ts
@@ -63,7 +63,7 @@ function addAngularCdkDep(tree: Tree): void {
         return;
     }
 
-    const majorVersionArr = angularCore.match(/[0-9]+/);
+    const majorVersionArr = /[0-9]+/.exec(angularCore);
 
     if (majorVersionArr) {
         addPackageJsonDependency(tree, {

--- a/projects/cdk/schematics/ng-update/v3/steps/migrate-polymorpheus.ts
+++ b/projects/cdk/schematics/ng-update/v3/steps/migrate-polymorpheus.ts
@@ -86,7 +86,7 @@ function insertPolymorpheusWithDefault({
     let templateVarName = templateVar?.name;
 
     if (templateVarName?.startsWith('let-')) {
-        templateVarName = template.match(new RegExp(templateVarName, 'i'))?.[0];
+        templateVarName = new RegExp(templateVarName, 'i').exec(template)?.[0];
     }
 
     const varName = templateVarName?.replace('let-', '');

--- a/projects/cdk/services/test/id.service.spec.ts
+++ b/projects/cdk/services/test/id.service.spec.ts
@@ -10,8 +10,8 @@ describe('TuiIdService', () => {
     it('increments number of id', () => {
         const id1 = service.generate();
         const id2 = service.generate();
-        const match1 = id1.match(/\d/) || [];
-        const match2 = id2.match(/\d/) || [];
+        const match1 = Array.from(/\d/.exec(id1) || []);
+        const match2 = Array.from(/\d/.exec(id2) || []);
 
         expect(parseInt(match1[0], 10) + 1).toBe(parseInt(match2[0], 10));
     });

--- a/projects/cdk/utils/color/rgba-to-hex.ts
+++ b/projects/cdk/utils/color/rgba-to-hex.ts
@@ -4,11 +4,9 @@ export function tuiRgbaToHex(color: string): string {
     }
 
     const rgb: number[] =
-        (color
-            .replace(/\s/g, '')
-            // eslint-disable-next-line unicorn/no-unsafe-regex
-            .match(/^rgba?\((\d+),(\d+),(\d+),?([^,\s)]+)?/i) as unknown as number[]) ??
-        [];
+        (/^rgba?\((\d+),(\d+),(\d+),?([^,\s)]+)?/i.exec(
+            color.replace(/\s/g, ''),
+        ) as unknown as number[]) ?? [];
     let alpha: number | string = (rgb?.[4] ?? '').toString().trim();
     let hex = rgb
         ? (rgb[1] | (1 << 8)).toString(16).slice(1) +

--- a/projects/demo/src/modules/app/classes/ts-file-module.parser.ts
+++ b/projects/demo/src/modules/app/classes/ts-file-module.parser.ts
@@ -17,7 +17,7 @@ export class TsFileModuleParser extends TsFileParser {
 
     hasDeclarationEntity(entity: string): boolean {
         const [, declarations = ''] =
-            this.rawFileContent.match(/(?:declarations:\s\[)(.*)(?:\])/i) || [];
+            /(?:declarations:\s\[)(.*)(?:\])/i.exec(this.rawFileContent) || [];
 
         return declarations.includes(entity);
     }

--- a/projects/demo/src/modules/app/classes/ts-file.parser.ts
+++ b/projects/demo/src/modules/app/classes/ts-file.parser.ts
@@ -2,7 +2,7 @@ import {TuiTsParserException} from '@taiga-ui/cdk';
 
 export class TsFileParser {
     get className(): string {
-        const [, className] = this.rawFileContent.match(/(?:export class\s)(\w*)/i) || [];
+        const [, className] = /(?:export class\s)(\w*)/i.exec(this.rawFileContent) || [];
 
         return className || '';
     }

--- a/projects/demo/src/modules/components/combo-box/combo-box.component.ts
+++ b/projects/demo/src/modules/components/combo-box/combo-box.component.ts
@@ -120,7 +120,7 @@ export class ExampleTuiComboBoxComponent extends AbstractExampleTuiControl {
 
     readonly stringifyVariants: Array<TuiStringHandler<Account | string>> = [
         TUI_DEFAULT_STRINGIFY,
-        item => String(String(item).match(/\d+/)),
+        item => String(/\d+/.exec(String(item))),
     ];
 
     stringify = this.stringifyVariants[0];

--- a/projects/demo/src/modules/components/multi-select/multi-select.component.ts
+++ b/projects/demo/src/modules/components/multi-select/multi-select.component.ts
@@ -140,7 +140,7 @@ export class ExampleTuiMultiSelectComponent extends AbstractExampleTuiControl {
 
     stringifyVariants: Array<TuiStringHandler<Account | string>> = [
         TUI_DEFAULT_STRINGIFY,
-        item => String(String(item).match(/\d+/)),
+        item => String(/\d+/.exec(String(item))),
     ];
 
     stringify = this.stringifyVariants[0];


### PR DESCRIPTION
String#match is defined to work the same as RegExp#exec when the regular expression does not include the g flag. Keeping to consistently using one of the two can help improve code readability.

https://typescript-eslint.io/rules/prefer-regexp-exec/