### PR TITLE
chore(demo): update step state input name

### DIFF
--- a/projects/demo/src/modules/components/stepper/stepper.template.html
+++ b/projects/demo/src/modules/components/stepper/stepper.template.html
@@ -73,7 +73,7 @@
         <tui-doc-documentation heading="Step">
             <ng-template
                 documentationPropertyMode="input"
-                documentationPropertyName="state"
+                documentationPropertyName="stepState"
                 documentationPropertyType="'normal' | 'pass' | 'error'"
                 [documentationPropertyValues]="stateVariants"
                 [(documentationPropertyValue)]="state"


### PR DESCRIPTION
`state` has been renamed to `stepState` to avoid
collision with `routerLink`'s `state` input.

