### PR TITLE
feat!: new browser support

### DIFF
--- a/projects/demo/src/modules/info/browsers/browsers.component.ts
+++ b/projects/demo/src/modules/info/browsers/browsers.component.ts
@@ -1,13 +1,32 @@
-import {Component} from '@angular/core';
-import {changeDetection} from '@demo/emulate/change-detection';
+import {NgFor, NgIf} from '@angular/common';
+import {ChangeDetectionStrategy, Component} from '@angular/core';
 import {TuiDocPageModule} from '@taiga-ui/addon-doc';
 
 @Component({
     standalone: true,
-    selector: 'browsers',
-    imports: [TuiDocPageModule],
+    selector: 'browser-support',
+    imports: [TuiDocPageModule, NgFor, NgIf],
     templateUrl: './browsers.template.html',
-    styleUrls: ['./browsers.style.less'],
-    changeDetection,
+    styles: ['td {width: 18.75rem}'],
+    changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export default class BrowsersComponent {}
+export default class BrowserSupportComponent {
+    readonly desktopBrowsers = [
+        {name: 'Google Chrome', version: '88+'},
+        {name: 'Mozilla Firefox', version: '120+'},
+        {name: 'Safari', version: '13.1+'},
+        {name: 'Opera', version: '74+'},
+        {name: 'Edge', version: '88+'},
+        {name: 'Yandex Browser', version: '21.2+'},
+        {name: 'Microsoft Internet Explorer', version: null},
+    ] as const;
+
+    readonly mobileBrowsers = [
+        {name: 'Google Chrome', version: '88+'},
+        {name: 'Mozilla Firefox', version: '120+'},
+        {name: 'Safari', version: '13.4+'},
+        {name: 'Opera', version: '63+'},
+        {name: 'Samsung Mobile', version: '15+'},
+        {name: 'Yandex Browser', version: '21.2+'},
+    ];
+}

--- a/projects/demo/src/modules/info/browsers/browsers.style.less
+++ b/projects/demo/src/modules/info/browsers/browsers.style.less
@@ -1,7 +1,0 @@
-:host {
-    display: block;
-}
-
-.cell {
-    width: 18.75rem;
-}

--- a/projects/demo/src/modules/info/browsers/browsers.template.html
+++ b/projects/demo/src/modules/info/browsers/browsers.template.html
@@ -6,40 +6,15 @@
                 <th class="tui-table__th">Browser</th>
                 <th class="tui-table__th">Version</th>
             </tr>
-            <tr class="tui-table__tr">
-                <td class="tui-table__td cell">Google Chrome</td>
-                <td class="tui-table__td">74+</td>
-            </tr>
-            <tr class="tui-table__tr">
-                <td class="tui-table__td">Yandex.Browser</td>
-                <td class="tui-table__td">19+</td>
-            </tr>
-            <tr class="tui-table__tr">
-                <td class="tui-table__td">Safari</td>
-                <td class="tui-table__td">12.1+</td>
-            </tr>
-            <tr class="tui-table__tr">
-                <td class="tui-table__td">Mozilla Firefox</td>
-                <td class="tui-table__td">55+</td>
-            </tr>
-            <tr class="tui-table__tr">
-                <td class="tui-table__td">Opera</td>
-                <td class="tui-table__td">62+</td>
-            </tr>
-            <tr class="tui-table__tr">
-                <td class="tui-table__td">Edge (Chromium)</td>
-                <td class="tui-table__td">80+</td>
-            </tr>
-            <tr class="tui-table__tr">
-                <td class="tui-table__td">Microsoft Internet Explorer</td>
+            <tr
+                *ngFor="let browser of desktopBrowsers"
+                class="tui-table__tr"
+            >
+                <td class="tui-table__td">{{ browser.name }}</td>
                 <td class="tui-table__td">
-                    <strong>Not supported</strong>
-                </td>
-            </tr>
-            <tr class="tui-table__tr">
-                <td class="tui-table__td">Edge (EdgeHTML)</td>
-                <td class="tui-table__td">
-                    <strong>Not supported</strong>
+                    <ng-container *ngIf="browser.version; else notSupported">
+                        {{ browser.version }}
+                    </ng-container>
                 </td>
             </tr>
         </tbody>
@@ -51,30 +26,17 @@
                 <th class="tui-table__th">Browser</th>
                 <th class="tui-table__th">Version</th>
             </tr>
-            <tr class="tui-table__tr">
-                <td class="tui-table__td cell">Google Chrome</td>
-                <td class="tui-table__td">90+</td>
-            </tr>
-            <tr class="tui-table__tr">
-                <td class="tui-table__td">Safari</td>
-                <td class="tui-table__td">12.2+</td>
-            </tr>
-            <tr class="tui-table__tr">
-                <td class="tui-table__td">Yandex.Browser</td>
-                <td class="tui-table__td">19+</td>
-            </tr>
-            <tr class="tui-table__tr">
-                <td class="tui-table__td">Mozilla Firefox</td>
-                <td class="tui-table__td">99+</td>
-            </tr>
-            <tr class="tui-table__tr">
-                <td class="tui-table__td">Opera Mobile</td>
-                <td class="tui-table__td">64+</td>
-            </tr>
-            <tr class="tui-table__tr">
-                <td class="tui-table__td">UC Browser</td>
-                <td class="tui-table__td">13.4+</td>
+            <tr
+                *ngFor="let browser of mobileBrowsers"
+                class="tui-table__tr"
+            >
+                <td class="tui-table__td">{{ browser.name }}</td>
+                <td class="tui-table__td">{{ browser.version }}</td>
             </tr>
         </tbody>
     </table>
 </tui-doc-page>
+
+<ng-template #notSupported>
+    <strong>Not supported</strong>
+</ng-template>


### PR DESCRIPTION

| Browser name         | Before  | After | Description                                                             |
|-----------------|-------|-------|-------------------------------------------------------------------------|
| Chrome Mobile   | 90+   | 88+   |                                                                         |
| Chrome Desktop  | 74+   | 88+   |                                                                         |
| Edge Desktop    | 74+   | 88+   |                                                                         |
| Yandex Desktop  | 19+   | 21.2+ | 21.2 uses Chromium 88                                             |
| Yandex Mobile   | 19+   | 21.2+ | 21.2 uses Chromium 88                                             |
| Opera Desktop   | 62+   | 74+   | 74 uses Chromium 88                                               |
| Opera Mobile    | 64+   | 63+   | Opera Android 62 uses Chromium 87; Opera Android 63 – Chromium 89 |
| Safari Mobile   | 12.2+ | 13.4+ |                                                                         |
| Safari Desktop  | 12.1+ | 13.1+ |                                                                         |
| Samsung Mobile  | 15+   | 15+   | Samsung 14 uses Chromium 87; Samsung 15 – Chromium 90             |
| Firefox Mobile  | 99+   | 120+  |                               |
| Firefox Desktop | 55+   | 120+  |                            |
