### PR TITLE
refactor: use `String.replaceAll`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,7 @@
                 "@taiga-ui/eslint-plugin-experience": "0.54.1",
                 "@taiga-ui/prettier-config": "0.8.3",
                 "@taiga-ui/stylelint-config": "0.16.0",
-                "@taiga-ui/tsconfig": "0.15.0",
+                "@taiga-ui/tsconfig": "0.16.0",
                 "@types/glob": "8.1.0",
                 "@types/node": "20.11.19",
                 "@types/webpack-env": "1.18.4",
@@ -10089,9 +10089,9 @@
             "link": true
         },
         "node_modules/@taiga-ui/tsconfig": {
-            "version": "0.15.0",
-            "resolved": "https://registry.npmjs.org/@taiga-ui/tsconfig/-/tsconfig-0.15.0.tgz",
-            "integrity": "sha512-a0mmPCnnAQqun2LxZekQlYlFSss+OF2SVstR+Srswo9wzPkDlUEu77L0Ga1QDHEd1FJ3w03cxFZn6zKoEhafjw==",
+            "version": "0.16.0",
+            "resolved": "https://registry.npmjs.org/@taiga-ui/tsconfig/-/tsconfig-0.16.0.tgz",
+            "integrity": "sha512-uccxubC1Q796EaAqJ8vXZGZ9+xfd4IqtBXqHShKMBmqMiVcU25AfhSibpWkbfHe00WnurOFhMK17AvyYQYcR3w==",
             "dev": true
         },
         "node_modules/@tinkoff/ng-dompurify": {

--- a/package.json
+++ b/package.json
@@ -119,7 +119,7 @@
         "@taiga-ui/eslint-plugin-experience": "0.54.1",
         "@taiga-ui/prettier-config": "0.8.3",
         "@taiga-ui/stylelint-config": "0.16.0",
-        "@taiga-ui/tsconfig": "0.15.0",
+        "@taiga-ui/tsconfig": "0.16.0",
         "@types/glob": "8.1.0",
         "@types/node": "20.11.19",
         "@types/webpack-env": "1.18.4",

--- a/projects/addon-doc/components/navigation/navigation.component.ts
+++ b/projects/addon-doc/components/navigation/navigation.component.ts
@@ -165,7 +165,7 @@ export class TuiDocNavigationComponent {
                         keywords.includes(search) ||
                         title.includes(tuiTransliterateKeyboardLayout(search)) ||
                         keywords.includes(tuiTransliterateKeyboardLayout(search)) ||
-                        search.replaceAll(/-/gi, '').includes(title) ||
+                        search.replaceAll('-', '').includes(title) ||
                         title.includes(search.replaceAll(/\s|tui/g, '')) ||
                         keywords.includes(search.replaceAll(/\s|tui/g, '')) ||
                         search.split(/\s/).find(word => title.includes(word))

--- a/projects/addon-doc/components/navigation/navigation.component.ts
+++ b/projects/addon-doc/components/navigation/navigation.component.ts
@@ -165,9 +165,9 @@ export class TuiDocNavigationComponent {
                         keywords.includes(search) ||
                         title.includes(tuiTransliterateKeyboardLayout(search)) ||
                         keywords.includes(tuiTransliterateKeyboardLayout(search)) ||
-                        search.replace(/-/gi, '').includes(title) ||
-                        title.includes(search.replace(/\s|tui/g, '')) ||
-                        keywords.includes(search.replace(/\s|tui/g, '')) ||
+                        search.replaceAll(/-/gi, '').includes(title) ||
+                        title.includes(search.replaceAll(/\s|tui/g, '')) ||
+                        keywords.includes(search.replaceAll(/\s|tui/g, '')) ||
                         search.split(/\s/).find(word => title.includes(word))
                     );
                 }),

--- a/projects/addon-doc/pipes/markdown/markdown.pipe.ts
+++ b/projects/addon-doc/pipes/markdown/markdown.pipe.ts
@@ -47,9 +47,9 @@ export class TuiMarkdownPipe implements PipeTransform {
                                 level: 1 | 2 | 3 | 4 | 5 | 6,
                             ): string {
                                 const id = text
-                                    .replace(/[^\w\s]/gi, '')
-                                    .replace(/[\u0250-\uE007]/g, '')
-                                    .replace(
+                                    .replaceAll(/[^\w\s]/gi, '')
+                                    .replaceAll(/[\u0250-\uE007]/g, '')
+                                    .replaceAll(
                                         /([\u2700-\u27BF]|[\uE000-\uF8FF]|\uD83C[\uDC00-\uDFFF]|\uD83D[\uDC00-\uDFFF]|[\u2011-\u26FF]|\uD83E[\uDD10-\uDDFF])/g,
                                         '',
                                     )

--- a/projects/addon-doc/utils/type-reference-parser.ts
+++ b/projects/addon-doc/utils/type-reference-parser.ts
@@ -7,7 +7,7 @@ export function tuiTypeReferenceParser(types: string): TuiDocTypeReferenceParsed
         ? generics
               .reduce(
                   (result, current) =>
-                      result.replace(current, current.replace(/\|/g, '&')),
+                      result.replace(current, current.replaceAll('|', '&')),
                   types,
               )
               .split('|')
@@ -15,10 +15,7 @@ export function tuiTypeReferenceParser(types: string): TuiDocTypeReferenceParsed
         : types.split('|').map(item => item.trim());
 
     return escaped.reduce<TuiDocTypeReferenceParsed>((result, type) => {
-        let extracted = type
-            .trim()
-            .replace(/readonly /g, '')
-            .replace(/\[\]/g, '');
+        let extracted = type.trim().replaceAll('readonly ', '').replaceAll('[]', '');
 
         extracted =
             extracted.match(/ReadonlyArray<([^>]+)>/)?.[1]?.split('&')?.[0] ?? extracted;
@@ -28,6 +25,6 @@ export function tuiTypeReferenceParser(types: string): TuiDocTypeReferenceParsed
         extracted = /^'(.+)'$|^"(.+)"$|^`(.+)`$/.test(extracted) ? 'string' : extracted;
         extracted = extracted.length === 1 ? 'unknown' : extracted;
 
-        return result.concat({type: type.replace(/&/g, '|'), extracted});
+        return result.concat({type: type.replaceAll('&', '|'), extracted});
     }, []);
 }

--- a/projects/cdk/date-time/date-separator.ts
+++ b/projects/cdk/date-time/date-separator.ts
@@ -8,4 +8,4 @@ export const TUI_DATE_SEPARATOR = tuiCreateToken('.');
 export const changeDateSeparator = (
     dateString: string,
     newDateSeparator: string,
-): string => dateString.replace(/[^0-9A-Za-zА-Яа-я]/gi, newDateSeparator);
+): string => dateString.replaceAll(/[^0-9A-Za-zА-Яа-я]/gi, newDateSeparator);

--- a/projects/cdk/schematics/ng-add/steps/wrap-with-tui-root.ts
+++ b/projects/cdk/schematics/ng-add/steps/wrap-with-tui-root.ts
@@ -92,7 +92,7 @@ function getTemplatePathFromComponent(component: ClassDeclaration): string {
 
     return `${appComponentPath
         .splice(0, appComponentPath.length - 1)
-        .join('/')}/${templateInitializer?.getText().replace(/['"]/g, '')}`;
+        .join('/')}/${templateInitializer?.getText().replaceAll(/['"]/g, '')}`;
 }
 
 function getTemplateInitializer(

--- a/projects/cdk/schematics/ng-update/steps/rename-types.ts
+++ b/projects/cdk/schematics/ng-update/steps/rename-types.ts
@@ -53,7 +53,7 @@ function processImport(node: ImportSpecifier, from: string, to?: string): void {
 }
 
 function removeGeneric(type: string): string {
-    return type.replace(/<.*>$/gi, '');
+    return type.replaceAll(/<.*>$/gi, '');
 }
 
 function addGeneric(typeName: string, generics: TypeNode[]): string {

--- a/projects/cdk/schematics/ng-update/v3/steps/migrate-progress.ts
+++ b/projects/cdk/schematics/ng-update/v3/steps/migrate-progress.ts
@@ -46,7 +46,7 @@ export function replaceProgressColorSegmentsPipe(
             const oldValue =
                 progressEl.attrs.find(attr => attr.name === PROPERTY_FOR_DEPRECATED_PIPES)
                     ?.value || '';
-            const newValue = oldValue.replace(DEPRECATED_PROGRESS_PIPES_REG, '');
+            const newValue = oldValue.replaceAll(DEPRECATED_PROGRESS_PIPES_REG, '');
 
             const attrLocations = progressEl.sourceCodeLocation?.attrs;
 

--- a/projects/cdk/schematics/ng-update/v3/steps/migrate-templates.ts
+++ b/projects/cdk/schematics/ng-update/v3/steps/migrate-templates.ts
@@ -281,7 +281,7 @@ function migrateTuiHideSelectedPipe({
             return;
         }
 
-        const newValue = oldValue.replace(
+        const newValue = oldValue.replaceAll(
             HIDE_SELECTED_PIPE_WITH_ARGS_REG,
             '| tuiHideSelected',
         );

--- a/projects/cdk/schematics/ng-update/v3/steps/replace-styles.ts
+++ b/projects/cdk/schematics/ng-update/v3/steps/replace-styles.ts
@@ -18,7 +18,7 @@ export function replaceStyles(): void {
 
             if (fullText.includes('taiga-ui')) {
                 DEPRECATED_BREAKPOINTS.forEach(({from, to}) => {
-                    fullText = fullText.replace(
+                    fullText = fullText.replaceAll(
                         new RegExp(`(?<=@media.*)(${from})(?=[\\s,{])`, 'g'),
                         to,
                     );
@@ -32,12 +32,12 @@ export function replaceStyles(): void {
                 .replace('tui-portal-host', 'tui-dropdown-host')
                 .replace('tui-dropdown-box', 'tui-dropdown')
                 .replace('--tui-color-link', '--tui-link')
-                .replace(/@import '~@taiga-ui/g, "@import '@taiga-ui")
-                .replace(
-                    /@import '@taiga-ui\/core\/styles\/taiga-ui-global/g,
+                .replaceAll("@import '~@taiga-ui", "@import '@taiga-ui")
+                .replaceAll(
+                    "@import '@taiga-ui/core/styles/taiga-ui-global",
                     `${TUI_WARNING_NORMALIZE}\n@import '@taiga-ui/styles/taiga-ui-global`,
                 )
-                .replace(/@import '@taiga-ui\/.+(.less)?';/g, val =>
+                .replaceAll(/@import '@taiga-ui\/.+(.less)?';/g, val =>
                     `${val.replace("';", '')}.less';`.replace('.less.less', '.less'),
                 );
 

--- a/projects/cdk/schematics/utils/templates/get-component-templates.ts
+++ b/projects/cdk/schematics/utils/templates/get-component-templates.ts
@@ -21,7 +21,7 @@ function decoratorToTemplateResource(decorator: Decorator): TemplateResource | n
 
     if (templateUrl) {
         const templatePath = path.parse(
-            templateUrl?.getInitializer()?.getText().replace(/['"`]/g, '') || '',
+            templateUrl?.getInitializer()?.getText().replaceAll(/['"`]/g, '') || '',
         );
 
         return {

--- a/projects/cdk/utils/color/rgba-to-hex.ts
+++ b/projects/cdk/utils/color/rgba-to-hex.ts
@@ -5,7 +5,7 @@ export function tuiRgbaToHex(color: string): string {
 
     const rgb: number[] =
         (color
-            .replace(/\s/g, '')
+            .replaceAll(/\s/g, '')
             // eslint-disable-next-line unicorn/no-unsafe-regex
             .match(/^rgba?\((\d+),(\d+),(\d+),?([^,\s)]+)?/i) as unknown as number[]) ??
         [];

--- a/projects/cdk/utils/svg/svg-linear-gradient-processor.ts
+++ b/projects/cdk/utils/svg/svg-linear-gradient-processor.ts
@@ -6,12 +6,12 @@ function makeRandomSalt(): number {
 }
 
 function escapeRegExp(search: string): string {
-    return search.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, '\\$&');
+    return search.replaceAll(/[-[\]{}()*+?.,\\^$|#\s]/g, '\\$&');
 }
 
 function extractLinearGradientIdsFromSvg(svg: string): string[] {
     const ids = (svg.match(/url\(("?)('*)#(.*?)('*)\)/g) ?? []).map(url =>
-        url.slice(4, url.length - 1).replace(/['"#]+/g, ''),
+        url.slice(4, url.length - 1).replaceAll(/['"#]+/g, ''),
     );
 
     return Array.from(new Set(ids));
@@ -43,11 +43,17 @@ export function tuiSvgLinearGradientProcessor(
             const newId = `id_${salt}_${previousId}`;
 
             return newSvg
-                .replace(new RegExp(`"${escapedId}"`, 'g'), `"${newId}"`)
-                .replace(new RegExp(`'${escapedId}'`, 'g'), `'${newId}'`)
-                .replace(new RegExp(`url\\('#${escapedId}'\\)`, 'g'), `url('#${newId}')`)
-                .replace(new RegExp(`url\\("#${escapedId}"\\)`, 'g'), `url("#${newId}")`)
-                .replace(new RegExp(`url\\(#${escapedId}\\)`, 'g'), `url(#${newId})`);
+                .replaceAll(new RegExp(`"${escapedId}"`, 'g'), `"${newId}"`)
+                .replaceAll(new RegExp(`'${escapedId}'`, 'g'), `'${newId}'`)
+                .replaceAll(
+                    new RegExp(`url\\('#${escapedId}'\\)`, 'g'),
+                    `url('#${newId}')`,
+                )
+                .replaceAll(
+                    new RegExp(`url\\("#${escapedId}"\\)`, 'g'),
+                    `url("#${newId}")`,
+                )
+                .replaceAll(new RegExp(`url\\(#${escapedId}\\)`, 'g'), `url(#${newId})`);
         }, svg);
     }
 

--- a/projects/cdk/utils/svg/svg-linear-gradient-processor.ts
+++ b/projects/cdk/utils/svg/svg-linear-gradient-processor.ts
@@ -5,10 +5,6 @@ function makeRandomSalt(): number {
     return Math.floor(Math.random() * Date.now());
 }
 
-function escapeRegExp(search: string): string {
-    return search.replaceAll(/[-[\]{}()*+?.,\\^$|#\s]/g, '\\$&');
-}
-
 function extractLinearGradientIdsFromSvg(svg: string): string[] {
     const ids = (svg.match(/url\(("?)('*)#(.*?)('*)\)/g) ?? []).map(url =>
         url.slice(4, url.length - 1).replaceAll(/['"#]+/g, ''),
@@ -39,21 +35,14 @@ export function tuiSvgLinearGradientProcessor(
         const uniqueIds = extractLinearGradientIdsFromSvg(svg);
 
         return uniqueIds.reduce((newSvg, previousId) => {
-            const escapedId = escapeRegExp(previousId);
             const newId = `id_${salt}_${previousId}`;
 
             return newSvg
-                .replaceAll(new RegExp(`"${escapedId}"`, 'g'), `"${newId}"`)
-                .replaceAll(new RegExp(`'${escapedId}'`, 'g'), `'${newId}'`)
-                .replaceAll(
-                    new RegExp(`url\\('#${escapedId}'\\)`, 'g'),
-                    `url('#${newId}')`,
-                )
-                .replaceAll(
-                    new RegExp(`url\\("#${escapedId}"\\)`, 'g'),
-                    `url("#${newId}")`,
-                )
-                .replaceAll(new RegExp(`url\\(#${escapedId}\\)`, 'g'), `url(#${newId})`);
+                .replaceAll(`"${previousId}"`, `"${newId}"`)
+                .replaceAll(`'${previousId}'`, `'${newId}'`)
+                .replaceAll(`url('#${previousId}')`, `url('#${newId}')`)
+                .replaceAll(`url("#${previousId}")`, `url("#${newId}")`)
+                .replaceAll(`url(#${previousId})`, `url(#${newId})`);
         }, svg);
     }
 

--- a/projects/core/utils/format/capitalize.ts
+++ b/projects/core/utils/format/capitalize.ts
@@ -6,5 +6,5 @@
  * @return the capitalized string
  */
 export function tuiCapitalize(value: string): string {
-    return value.toLowerCase().replace(/(?:^|\s)\S/g, char => char.toUpperCase());
+    return value.toLowerCase().replaceAll(/(?:^|\s)\S/g, char => char.toUpperCase());
 }

--- a/projects/core/utils/format/format-phone.ts
+++ b/projects/core/utils/format/format-phone.ts
@@ -30,7 +30,7 @@ export function tuiFormatPhone(
 
     let result = countryCode;
 
-    countryCode = countryCode.replace(/[()]/g, '');
+    countryCode = countryCode.replaceAll(/[()]/g, '');
 
     if (!value.startsWith(countryCode)) {
         value = countryCode + value.replace(CHAR_PLUS, '');

--- a/projects/demo-playwright/tests/demo/demo.spec.ts
+++ b/projects/demo-playwright/tests/demo/demo.spec.ts
@@ -35,7 +35,7 @@ test.describe('Demo', () => {
                 await documentation.networkidle(); // note: load lazy loading images
 
                 await expect(example).toHaveScreenshot([
-                    path.replace('/', '').replace(/\//g, '-'),
+                    path.replace('/', '').replaceAll('/', '-'),
                     `${i + 1}.png`,
                 ]);
             }

--- a/projects/demo/src/modules/app/app.providers.ts
+++ b/projects/demo/src/modules/app/app.providers.ts
@@ -103,7 +103,7 @@ export const APP_PROVIDERS: Provider[] = [
             if (type) {
                 return `${link}/${pkg.toLowerCase()}/${type.toLowerCase()}/${(
                     header[0].toLowerCase() + header.slice(1)
-                ).replace(/[A-Z]/g, m => `-${m.toLowerCase()}`)}`;
+                ).replaceAll(/[A-Z]/g, m => `-${m.toLowerCase()}`)}`;
             }
 
             return `${link}/${path}`;

--- a/projects/demo/src/modules/app/classes/ts-file-component.parser.ts
+++ b/projects/demo/src/modules/app/classes/ts-file-component.parser.ts
@@ -2,21 +2,21 @@ import {TsFileParser} from './ts-file.parser';
 
 export class TsFileComponentParser extends TsFileParser {
     set selector(newSelector: string) {
-        this.rawFileContent = this.rawFileContent.replace(
+        this.rawFileContent = this.rawFileContent.replaceAll(
             /(selector:\s['"`])(.*)(['"`])/gi,
             `$1${newSelector}$3`,
         );
     }
 
     set templateUrl(newUrl: string) {
-        this.rawFileContent = this.rawFileContent.replace(
+        this.rawFileContent = this.rawFileContent.replaceAll(
             /(templateUrl:\s['"`])(.*)(['"`])/gi,
             `$1${newUrl}$3`,
         );
     }
 
     set styleUrls(newUrls: string[] | readonly string[]) {
-        this.rawFileContent = this.rawFileContent.replace(
+        this.rawFileContent = this.rawFileContent.replaceAll(
             /(styleUrls:\s)(\[.*\])/gi,
             `$1${JSON.stringify(newUrls)}`,
         );

--- a/projects/demo/src/modules/app/home/home.component.ts
+++ b/projects/demo/src/modules/app/home/home.component.ts
@@ -55,7 +55,7 @@ export class HomeComponent {
     ).then(({default: content}) => ({
         default: content
             // eslint-disable-next-line @typescript-eslint/quotes
-            .replace(/@import '/g, `@import '@taiga-ui/styles/`)
+            .replaceAll("@import '", `@import '@taiga-ui/styles/`)
             .replace('@taiga-ui/styles/@taiga-ui/core', '@taiga-ui/core'),
     }));
 }

--- a/projects/demo/src/modules/app/stackblitz/utils.ts
+++ b/projects/demo/src/modules/app/stackblitz/utils.ts
@@ -27,7 +27,7 @@ function getAllModules(entryPoint: Record<string, unknown>, names: Set<string>):
 }
 
 export const prepareLess = (content: string): string =>
-    content.replace(
+    content.replaceAll(
         /@import.+taiga-ui-local(.less)?';/g,
         "@import '@taiga-ui/core/styles/taiga-ui-local.less';",
     );

--- a/projects/demo/src/modules/app/utils/example-content-processor/typescript-processor.ts
+++ b/projects/demo/src/modules/app/utils/example-content-processor/typescript-processor.ts
@@ -9,10 +9,10 @@ export function processTs(fileContent: string): string {
 
     return tsFileContent
         .toString()
-        .replace(/import {encapsulation} from '.*';\n/gm, '')
-        .replace(/import {changeDetection} from '.*';\n/gm, '')
-        .replace(/\n +encapsulation,/gm, '')
-        .replace(
+        .replaceAll(/import {encapsulation} from '.*';\n/gm, '')
+        .replaceAll(/import {changeDetection} from '.*';\n/gm, '')
+        .replaceAll(/\n +encapsulation,/gm, '')
+        .replaceAll(
             /changeDetection,/gm,
             'changeDetection: ChangeDetectionStrategy.OnPush,',
         );

--- a/projects/demo/src/modules/app/version-manager/version-manager.component.ts
+++ b/projects/demo/src/modules/app/version-manager/version-manager.component.ts
@@ -21,7 +21,7 @@ export class VersionManagerComponent {
 
     @tuiPure
     getVersionHref(version: TuiVersionMeta): string {
-        return `${this.locationRef.origin}/${version.baseHref}${this.router.url}${this.locationRef.search}`.replace(
+        return `${this.locationRef.origin}/${version.baseHref}${this.router.url}${this.locationRef.search}`.replaceAll(
             /(https?:\/\/)|(\/)+/g,
             '$1$2',
         );

--- a/projects/demo/src/modules/components/input/examples/3/index.ts
+++ b/projects/demo/src/modules/components/input/examples/3/index.ts
@@ -39,5 +39,5 @@ export class TuiInputExample3 {
         ],
     };
 
-    readonly unmask = (value: string): string => value.replace(/-/g, '');
+    readonly unmask = (value: string): string => value.replaceAll('-', '');
 }

--- a/projects/demo/src/modules/directives/copy-processor/examples/1/index.ts
+++ b/projects/demo/src/modules/directives/copy-processor/examples/1/index.ts
@@ -32,7 +32,7 @@ export class TuiCopyProcessorExample1 {
     readonly numberProcessor: TuiStringHandler<string> = text =>
         text
             .replace(this.format.decimalSeparator, '.')
-            .replace(new RegExp(this.format.thousandSeparator, 'g'), '');
+            .replaceAll(new RegExp(this.format.thousandSeparator, 'g'), '');
 
     readonly textProcessor: TuiStringHandler<string> = text => text.toUpperCase();
 }

--- a/projects/demo/src/modules/markup/breakpoints/breakpoints.component.ts
+++ b/projects/demo/src/modules/markup/breakpoints/breakpoints.component.ts
@@ -18,14 +18,14 @@ const CODE_COMMENTS = /(\/\*([^*]|(\*+[^*/]))*\*+\/)|(\/\/.*)/g;
 
 function parseBreakpoints(file: string): Array<{name: string; value: string}> {
     return file
-        .replace(CODE_COMMENTS, '')
+        .replaceAll(CODE_COMMENTS, '')
         .split(';')
         .map(line => line.trim())
         .filter(Boolean)
         .map(line => {
             const [name, ...value] = line.split(':');
 
-            return {name, value: value.join(':').replace(/[~'"]/g, '').trim()};
+            return {name, value: value.join(':').replaceAll(/[~'"]/g, '').trim()};
         });
 }
 

--- a/projects/icons/scripts/prepare-feather-icons.ts
+++ b/projects/icons/scripts/prepare-feather-icons.ts
@@ -24,7 +24,7 @@ const NO_FILL = ['check.svg'];
         // TODO: Make icons just regular and filled if filled makes sense
         fs.writeFileSync(
             path.join(dest, processName(filename, 'Outline')),
-            processed.replace(
+            processed.replaceAll(
                 /<(circle|ellipse|line|polygon|polyline|path|rect)/g,
                 '<$1 vector-effect="non-scaling-stroke"',
             ),
@@ -37,7 +37,7 @@ const NO_FILL = ['check.svg'];
 
         fs.writeFileSync(
             path.join(dest, processName(filename, 'Large')),
-            filled.replace(
+            filled.replaceAll(
                 /<(circle|ellipsis|line|polygon|polyline|path|rect)/g,
                 '<$1 vector-effect="non-scaling-stroke"',
             ),

--- a/projects/kit/components/input-phone/input-phone.component.ts
+++ b/projects/kit/components/input-phone/input-phone.component.ts
@@ -234,7 +234,7 @@ export class TuiInputPhoneComponent
     private get maxPhoneLength(): number {
         return (
             this.countryCode.length +
-            this.phoneMaskAfterCountryCode.replace(/[^#]+/g, '').length
+            this.phoneMaskAfterCountryCode.replaceAll(/[^#]+/g, '').length
         );
     }
 

--- a/projects/kit/components/input-phone/utils/complete-phone-insertion-preprocessor.ts
+++ b/projects/kit/components/input-phone/utils/complete-phone-insertion-preprocessor.ts
@@ -1,6 +1,6 @@
 import {MaskitoPreprocessor} from '@maskito/core';
 
-const countDigits = (value: string): number => value.replace(/\D/g, '').length;
+const countDigits = (value: string): number => value.replaceAll(/\D/g, '').length;
 
 /**
  * `InputPhone` component sets country code as non-removable prefix.
@@ -13,7 +13,7 @@ export function tuiCreateCompletePhoneInsertionPreprocessor(
     countryCode: string,
     phoneMaskAfterCountryCode: string,
 ): MaskitoPreprocessor {
-    const completePhoneLength = (countryCode + phoneMaskAfterCountryCode).replace(
+    const completePhoneLength = (countryCode + phoneMaskAfterCountryCode).replaceAll(
         /[^#\d]+/g,
         '',
     ).length;

--- a/projects/kit/components/input-phone/utils/create-phone-mask-expression.ts
+++ b/projects/kit/components/input-phone/utils/create-phone-mask-expression.ts
@@ -12,7 +12,7 @@ export function tuiCreatePhoneMaskExpression(
         ...countryCode.split(''),
         ' ',
         ...phoneMaskAfterCountryCode
-            .replace(/[^#\- ()]+/g, '')
+            .replaceAll(/[^#\- ()]+/g, '')
             .split('')
             .map(item => (item === '#' ? /\d/ : item)),
     ];

--- a/projects/kit/utils/phone/get-max-allowed-phone-length.ts
+++ b/projects/kit/utils/phone/get-max-allowed-phone-length.ts
@@ -4,5 +4,5 @@ export function tuiGetMaxAllowedPhoneLength(
     countries: Record<TuiCountryIsoCode, string>,
     isoCode: TuiCountryIsoCode,
 ): number {
-    return countries[isoCode].replace(/[()\- ]/g, '').length;
+    return countries[isoCode].replaceAll(/[()\- ]/g, '').length;
 }


### PR DESCRIPTION
> The [String#replaceAll()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replaceAll) method is both faster and safer as you don't have to use a regex and remember to escape it if the string is not a literal. And when used with a regex, it makes the intent clearer.

Learn more:
https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-string-replace-all.md