### PR TITLE
chore(schematics): add migrations for renamed editor's entities

### DIFF
--- a/projects/cdk/schematics/ng-update/v4/steps/constants/identifiers-to-replace.ts
+++ b/projects/cdk/schematics/ng-update/v4/steps/constants/identifiers-to-replace.ts
@@ -171,4 +171,26 @@ export const IDENTIFIERS_TO_REPLACE: ReplacementIdentifier[] = [
             moduleSpecifier: '@taiga-ui/kit',
         },
     },
+    {
+        from: {name: 'TuiEditorModule', moduleSpecifier: '@tinkoff/tui-editor'},
+        to: {name: 'TuiEditorComponent', moduleSpecifier: '@tinkoff/tui-editor'},
+    },
+    {
+        from: {name: 'TuiEditorSocketModule', moduleSpecifier: '@tinkoff/tui-editor'},
+        to: {name: 'TuiEditorSocketComponent', moduleSpecifier: '@tinkoff/tui-editor'},
+    },
+    {
+        from: {name: 'defaultEditorExtensions', moduleSpecifier: '@tinkoff/tui-editor'},
+        to: {
+            name: 'TUI_EDITOR_DEFAULT_EXTENSIONS',
+            moduleSpecifier: '@tinkoff/tui-editor',
+        },
+    },
+    {
+        from: {name: 'defaultEditorTools', moduleSpecifier: '@tinkoff/tui-editor'},
+        to: {
+            name: 'TUI_EDITOR_DEFAULT_TOOLS',
+            moduleSpecifier: '@tinkoff/tui-editor',
+        },
+    },
 ];


### PR DESCRIPTION
**Relates:**

* [`defaultEditorExtensions` => `TUI_EDITOR_DEFAULT_EXTENSIONS`](https://github.com/taiga-family/tui-editor/pull/808/files#diff-13726f73f8debda3b3b6201e956971dbc57dc3d996346ef1fbb53bb1bebea613)
* [`defaultEditorTools` => `TUI_EDITOR_DEFAULT_TOOLS`](https://github.com/taiga-family/tui-editor/pull/808/files#diff-f16b54a2a21fdc42e1aa8feb6f9c7bb03378a01a248805fcc2e230c21fbaf925)