### PR TITLE
fix(kit): `InputDateTime` does not change filler on dynamic change of `[timeMode]` prop

### DIFF
--- a/projects/demo-playwright/tests/kit/input-date-time/input-date-time.spec.ts
+++ b/projects/demo-playwright/tests/kit/input-date-time/input-date-time.spec.ts
@@ -2,6 +2,7 @@ import {
     TuiDocumentationPagePO,
     tuiGoto,
     TuiInputDateTimePO,
+    TuiSelectPO,
 } from '@demo-playwright/utils';
 import {expect, Locator, test} from '@playwright/test';
 
@@ -145,6 +146,29 @@ test.describe('InputDateTime', () => {
             await expect(inputDateTime.textfield).toHaveJSProperty(
                 'selectionEnd',
                 '15.11.2018, '.length,
+            );
+        });
+
+        test('change filler on dynamic change of [timeMode] prop', async ({page}) => {
+            await tuiGoto(page, 'components/input-date-time/API?timeMode=HH:MM');
+            await inputDateTime.textfield.focus();
+            await expect(inputDateTime.host).toHaveScreenshot('03-timeMode=HH:MM.png');
+
+            const timeModeRow = documentationPage.getRow('[timeMode]');
+            const timeModeSelect = new TuiSelectPO(
+                (await documentationPage.getSelect(timeModeRow)) as Locator,
+            );
+
+            await timeModeSelect.textfield.click();
+            await timeModeSelect.selectOptions([1]);
+            await inputDateTime.textfield.focus();
+            await expect(inputDateTime.host).toHaveScreenshot('03-timeMode=HH:MM.SS.png');
+
+            await timeModeSelect.textfield.click();
+            await timeModeSelect.selectOptions([2]);
+            await inputDateTime.textfield.focus();
+            await expect(inputDateTime.host).toHaveScreenshot(
+                '03-timeMode=HH:MM.SS.MSS.png',
             );
         });
     });

--- a/projects/demo-playwright/utils/page-objects/documentation-api-page.po.ts
+++ b/projects/demo-playwright/utils/page-objects/documentation-api-page.po.ts
@@ -99,6 +99,10 @@ export class TuiDocumentationApiPagePO {
         }
     }
 
+    protected getRow(rowName: string): Locator {
+        return this.page.locator(`.t-table .t-row:has-text("${rowName}")`);
+    }
+
     protected async getRows(): Promise<Locator[]> {
         return this.page.locator('.t-table .t-row:not(.t-row_header)').all();
     }

--- a/projects/demo-playwright/utils/page-objects/index.ts
+++ b/projects/demo-playwright/utils/page-objects/index.ts
@@ -15,6 +15,7 @@ export * from './input-tag.po';
 export * from './input-time.po';
 export * from './multi-select.po';
 export * from './range.po';
+export * from './select.po';
 export * from './slider.po';
 export * from './table-pagination-page.po';
 export * from './textfield-with-data-list.po';

--- a/projects/demo-playwright/utils/page-objects/input-date-time.po.ts
+++ b/projects/demo-playwright/utils/page-objects/input-date-time.po.ts
@@ -4,7 +4,7 @@ export class TuiInputDateTimePO {
     protected readonly textfield: Locator = this.host.getByRole('textbox');
     protected readonly calendar: Locator = this.host.page().locator('tui-calendar');
 
-    constructor(private readonly host: Locator) {}
+    constructor(readonly host: Locator) {}
 
     protected async selectDayViaCalendar(day: number): Promise<void> {
         return this.calendar

--- a/projects/demo-playwright/utils/page-objects/input-date-time.po.ts
+++ b/projects/demo-playwright/utils/page-objects/input-date-time.po.ts
@@ -4,7 +4,7 @@ export class TuiInputDateTimePO {
     protected readonly textfield: Locator = this.host.getByRole('textbox');
     protected readonly calendar: Locator = this.host.page().locator('tui-calendar');
 
-    constructor(readonly host: Locator) {}
+    constructor(public readonly host: Locator) {}
 
     protected async selectDayViaCalendar(day: number): Promise<void> {
         return this.calendar


### PR DESCRIPTION
1. Open https://taiga-ui.dev/components/input-date-time/API?timeMode=HH:MM:SS
2. Select new value for `[timeMode]`
3. Focus textfield