### PR TITLE
chore(demo): fix `API` section of documentation page `FormatNumber`

### DIFF
--- a/projects/demo/src/modules/pipes/format-number/format-number.template.html
+++ b/projects/demo/src/modules/pipes/format-number/format-number.template.html
@@ -29,7 +29,7 @@
     <ng-template pageTab>
         <p class="text b-full-width">
             Formatted number:
-            {{ value | tuiFormatNumber: {decimalLimit, decimalSeparator} }}
+            {{ value | tuiFormatNumber: {decimalLimit, decimalSeparator} | async }}
         </p>
         <tui-input-slider
             tuiTextfieldSize="m"


### PR DESCRIPTION
Open https://taiga-ui.dev/next/pipes/format-number/API

<img width="337" alt="format-number-page" src="https://github.com/taiga-family/taiga-ui/assets/35179038/8cbd699d-0185-47f7-9ff3-707f4be17665">
