### PR TITLE
chore(schematics): fix possibility to manually run migration schematics

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,7 @@
             "version": "3.59.0",
             "hasInstallScript": true,
             "license": "Apache-2.0",
-            "workspaces": [
-                "projects/*"
-            ],
+            "workspaces": ["projects/*"],
             "devDependencies": {
                 "@angular-devkit/build-angular": "16.2.12",
                 "@angular-devkit/core": "16.2.12",
@@ -299,14 +297,10 @@
             "version": "0.18.17",
             "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.18.17.tgz",
             "integrity": "sha512-wHsmJG/dnL3OkpAcwbgoBTTMHVi4Uyou3F5mf58ZtmUyIKfcdA7TROav/6tCzET4A3QW2Q2FC+eFneMU+iyOxg==",
-            "cpu": [
-                "arm"
-            ],
+            "cpu": ["arm"],
             "dev": true,
             "optional": true,
-            "os": [
-                "android"
-            ],
+            "os": ["android"],
             "engines": {
                 "node": ">=12"
             }
@@ -315,14 +309,10 @@
             "version": "0.18.17",
             "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.18.17.tgz",
             "integrity": "sha512-9np+YYdNDed5+Jgr1TdWBsozZ85U1Oa3xW0c7TWqH0y2aGghXtZsuT8nYRbzOMcl0bXZXjOGbksoTtVOlWrRZg==",
-            "cpu": [
-                "arm64"
-            ],
+            "cpu": ["arm64"],
             "dev": true,
             "optional": true,
-            "os": [
-                "android"
-            ],
+            "os": ["android"],
             "engines": {
                 "node": ">=12"
             }
@@ -331,14 +321,10 @@
             "version": "0.18.17",
             "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.18.17.tgz",
             "integrity": "sha512-O+FeWB/+xya0aLg23hHEM2E3hbfwZzjqumKMSIqcHbNvDa+dza2D0yLuymRBQQnC34CWrsJUXyH2MG5VnLd6uw==",
-            "cpu": [
-                "x64"
-            ],
+            "cpu": ["x64"],
             "dev": true,
             "optional": true,
-            "os": [
-                "android"
-            ],
+            "os": ["android"],
             "engines": {
                 "node": ">=12"
             }
@@ -347,14 +333,10 @@
             "version": "0.18.17",
             "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.18.17.tgz",
             "integrity": "sha512-M9uJ9VSB1oli2BE/dJs3zVr9kcCBBsE883prage1NWz6pBS++1oNn/7soPNS3+1DGj0FrkSvnED4Bmlu1VAE9g==",
-            "cpu": [
-                "arm64"
-            ],
+            "cpu": ["arm64"],
             "dev": true,
             "optional": true,
-            "os": [
-                "darwin"
-            ],
+            "os": ["darwin"],
             "engines": {
                 "node": ">=12"
             }
@@ -363,14 +345,10 @@
             "version": "0.18.17",
             "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.18.17.tgz",
             "integrity": "sha512-XDre+J5YeIJDMfp3n0279DFNrGCXlxOuGsWIkRb1NThMZ0BsrWXoTg23Jer7fEXQ9Ye5QjrvXpxnhzl3bHtk0g==",
-            "cpu": [
-                "x64"
-            ],
+            "cpu": ["x64"],
             "dev": true,
             "optional": true,
-            "os": [
-                "darwin"
-            ],
+            "os": ["darwin"],
             "engines": {
                 "node": ">=12"
             }
@@ -379,14 +357,10 @@
             "version": "0.18.17",
             "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.18.17.tgz",
             "integrity": "sha512-cjTzGa3QlNfERa0+ptykyxs5A6FEUQQF0MuilYXYBGdBxD3vxJcKnzDlhDCa1VAJCmAxed6mYhA2KaJIbtiNuQ==",
-            "cpu": [
-                "arm64"
-            ],
+            "cpu": ["arm64"],
             "dev": true,
             "optional": true,
-            "os": [
-                "freebsd"
-            ],
+            "os": ["freebsd"],
             "engines": {
                 "node": ">=12"
             }
@@ -395,14 +369,10 @@
             "version": "0.18.17",
             "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.18.17.tgz",
             "integrity": "sha512-sOxEvR8d7V7Kw8QqzxWc7bFfnWnGdaFBut1dRUYtu+EIRXefBc/eIsiUiShnW0hM3FmQ5Zf27suDuHsKgZ5QrA==",
-            "cpu": [
-                "x64"
-            ],
+            "cpu": ["x64"],
             "dev": true,
             "optional": true,
-            "os": [
-                "freebsd"
-            ],
+            "os": ["freebsd"],
             "engines": {
                 "node": ">=12"
             }
@@ -411,14 +381,10 @@
             "version": "0.18.17",
             "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.18.17.tgz",
             "integrity": "sha512-2d3Lw6wkwgSLC2fIvXKoMNGVaeY8qdN0IC3rfuVxJp89CRfA3e3VqWifGDfuakPmp90+ZirmTfye1n4ncjv2lg==",
-            "cpu": [
-                "arm"
-            ],
+            "cpu": ["arm"],
             "dev": true,
             "optional": true,
-            "os": [
-                "linux"
-            ],
+            "os": ["linux"],
             "engines": {
                 "node": ">=12"
             }
@@ -427,14 +393,10 @@
             "version": "0.18.17",
             "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.18.17.tgz",
             "integrity": "sha512-c9w3tE7qA3CYWjT+M3BMbwMt+0JYOp3vCMKgVBrCl1nwjAlOMYzEo+gG7QaZ9AtqZFj5MbUc885wuBBmu6aADQ==",
-            "cpu": [
-                "arm64"
-            ],
+            "cpu": ["arm64"],
             "dev": true,
             "optional": true,
-            "os": [
-                "linux"
-            ],
+            "os": ["linux"],
             "engines": {
                 "node": ">=12"
             }
@@ -443,14 +405,10 @@
             "version": "0.18.17",
             "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.18.17.tgz",
             "integrity": "sha512-1DS9F966pn5pPnqXYz16dQqWIB0dmDfAQZd6jSSpiT9eX1NzKh07J6VKR3AoXXXEk6CqZMojiVDSZi1SlmKVdg==",
-            "cpu": [
-                "ia32"
-            ],
+            "cpu": ["ia32"],
             "dev": true,
             "optional": true,
-            "os": [
-                "linux"
-            ],
+            "os": ["linux"],
             "engines": {
                 "node": ">=12"
             }
@@ -459,14 +417,10 @@
             "version": "0.18.17",
             "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.18.17.tgz",
             "integrity": "sha512-EvLsxCk6ZF0fpCB6w6eOI2Fc8KW5N6sHlIovNe8uOFObL2O+Mr0bflPHyHwLT6rwMg9r77WOAWb2FqCQrVnwFg==",
-            "cpu": [
-                "loong64"
-            ],
+            "cpu": ["loong64"],
             "dev": true,
             "optional": true,
-            "os": [
-                "linux"
-            ],
+            "os": ["linux"],
             "engines": {
                 "node": ">=12"
             }
@@ -475,14 +429,10 @@
             "version": "0.18.17",
             "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.18.17.tgz",
             "integrity": "sha512-e0bIdHA5p6l+lwqTE36NAW5hHtw2tNRmHlGBygZC14QObsA3bD4C6sXLJjvnDIjSKhW1/0S3eDy+QmX/uZWEYQ==",
-            "cpu": [
-                "mips64el"
-            ],
+            "cpu": ["mips64el"],
             "dev": true,
             "optional": true,
-            "os": [
-                "linux"
-            ],
+            "os": ["linux"],
             "engines": {
                 "node": ">=12"
             }
@@ -491,14 +441,10 @@
             "version": "0.18.17",
             "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.18.17.tgz",
             "integrity": "sha512-BAAilJ0M5O2uMxHYGjFKn4nJKF6fNCdP1E0o5t5fvMYYzeIqy2JdAP88Az5LHt9qBoUa4tDaRpfWt21ep5/WqQ==",
-            "cpu": [
-                "ppc64"
-            ],
+            "cpu": ["ppc64"],
             "dev": true,
             "optional": true,
-            "os": [
-                "linux"
-            ],
+            "os": ["linux"],
             "engines": {
                 "node": ">=12"
             }
@@ -507,14 +453,10 @@
             "version": "0.18.17",
             "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.18.17.tgz",
             "integrity": "sha512-Wh/HW2MPnC3b8BqRSIme/9Zhab36PPH+3zam5pqGRH4pE+4xTrVLx2+XdGp6fVS3L2x+DrsIcsbMleex8fbE6g==",
-            "cpu": [
-                "riscv64"
-            ],
+            "cpu": ["riscv64"],
             "dev": true,
             "optional": true,
-            "os": [
-                "linux"
-            ],
+            "os": ["linux"],
             "engines": {
                 "node": ">=12"
             }
@@ -523,14 +465,10 @@
             "version": "0.18.17",
             "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.18.17.tgz",
             "integrity": "sha512-j/34jAl3ul3PNcK3pfI0NSlBANduT2UO5kZ7FCaK33XFv3chDhICLY8wJJWIhiQ+YNdQ9dxqQctRg2bvrMlYgg==",
-            "cpu": [
-                "s390x"
-            ],
+            "cpu": ["s390x"],
             "dev": true,
             "optional": true,
-            "os": [
-                "linux"
-            ],
+            "os": ["linux"],
             "engines": {
                 "node": ">=12"
             }
@@ -539,14 +477,10 @@
             "version": "0.18.17",
             "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.18.17.tgz",
             "integrity": "sha512-QM50vJ/y+8I60qEmFxMoxIx4de03pGo2HwxdBeFd4nMh364X6TIBZ6VQ5UQmPbQWUVWHWws5MmJXlHAXvJEmpQ==",
-            "cpu": [
-                "x64"
-            ],
+            "cpu": ["x64"],
             "dev": true,
             "optional": true,
-            "os": [
-                "linux"
-            ],
+            "os": ["linux"],
             "engines": {
                 "node": ">=12"
             }
@@ -555,14 +489,10 @@
             "version": "0.18.17",
             "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.18.17.tgz",
             "integrity": "sha512-/jGlhWR7Sj9JPZHzXyyMZ1RFMkNPjC6QIAan0sDOtIo2TYk3tZn5UDrkE0XgsTQCxWTTOcMPf9p6Rh2hXtl5TQ==",
-            "cpu": [
-                "x64"
-            ],
+            "cpu": ["x64"],
             "dev": true,
             "optional": true,
-            "os": [
-                "netbsd"
-            ],
+            "os": ["netbsd"],
             "engines": {
                 "node": ">=12"
             }
@@ -571,14 +501,10 @@
             "version": "0.18.17",
             "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.18.17.tgz",
             "integrity": "sha512-rSEeYaGgyGGf4qZM2NonMhMOP/5EHp4u9ehFiBrg7stH6BYEEjlkVREuDEcQ0LfIl53OXLxNbfuIj7mr5m29TA==",
-            "cpu": [
-                "x64"
-            ],
+            "cpu": ["x64"],
             "dev": true,
             "optional": true,
-            "os": [
-                "openbsd"
-            ],
+            "os": ["openbsd"],
             "engines": {
                 "node": ">=12"
             }
@@ -587,14 +513,10 @@
             "version": "0.18.17",
             "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.18.17.tgz",
             "integrity": "sha512-Y7ZBbkLqlSgn4+zot4KUNYst0bFoO68tRgI6mY2FIM+b7ZbyNVtNbDP5y8qlu4/knZZ73fgJDlXID+ohY5zt5g==",
-            "cpu": [
-                "x64"
-            ],
+            "cpu": ["x64"],
             "dev": true,
             "optional": true,
-            "os": [
-                "sunos"
-            ],
+            "os": ["sunos"],
             "engines": {
                 "node": ">=12"
             }
@@ -603,14 +525,10 @@
             "version": "0.18.17",
             "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.18.17.tgz",
             "integrity": "sha512-bwPmTJsEQcbZk26oYpc4c/8PvTY3J5/QK8jM19DVlEsAB41M39aWovWoHtNm78sd6ip6prilxeHosPADXtEJFw==",
-            "cpu": [
-                "arm64"
-            ],
+            "cpu": ["arm64"],
             "dev": true,
             "optional": true,
-            "os": [
-                "win32"
-            ],
+            "os": ["win32"],
             "engines": {
                 "node": ">=12"
             }
@@ -619,14 +537,10 @@
             "version": "0.18.17",
             "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.18.17.tgz",
             "integrity": "sha512-H/XaPtPKli2MhW+3CQueo6Ni3Avggi6hP/YvgkEe1aSaxw+AeO8MFjq8DlgfTd9Iz4Yih3QCZI6YLMoyccnPRg==",
-            "cpu": [
-                "ia32"
-            ],
+            "cpu": ["ia32"],
             "dev": true,
             "optional": true,
-            "os": [
-                "win32"
-            ],
+            "os": ["win32"],
             "engines": {
                 "node": ">=12"
             }
@@ -635,14 +549,10 @@
             "version": "0.18.17",
             "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.18.17.tgz",
             "integrity": "sha512-fGEb8f2BSA3CW7riJVurug65ACLuQAzKq0SSqkY2b2yHHH0MzDfbLyKIGzHwOI/gkHcxM/leuSW6D5w/LMNitA==",
-            "cpu": [
-                "x64"
-            ],
+            "cpu": ["x64"],
             "dev": true,
             "optional": true,
-            "os": [
-                "win32"
-            ],
+            "os": ["win32"],
             "engines": {
                 "node": ">=12"
             }
@@ -934,6 +844,28 @@
                 "magic-string": "0.30.1",
                 "ora": "5.4.1",
                 "rxjs": "7.8.1"
+            },
+            "engines": {
+                "node": "^16.14.0 || >=18.10.0",
+                "npm": "^6.11.0 || ^7.5.6 || >=8.0.0",
+                "yarn": ">= 1.13.0"
+            }
+        },
+        "node_modules/@angular-devkit/schematics-cli": {
+            "version": "16.2.12",
+            "resolved": "https://registry.npmjs.org/@angular-devkit/schematics-cli/-/schematics-cli-16.2.12.tgz",
+            "integrity": "sha512-1rq3fUmj/+//6Dp/TUwP1ST0R68ahQF7MRr5xHFropCYxiQydREIYgOtfNe0pU/nB5K65ncfPWGEgrLJ1rSSOQ==",
+            "dev": true,
+            "dependencies": {
+                "@angular-devkit/core": "16.2.12",
+                "@angular-devkit/schematics": "16.2.12",
+                "ansi-colors": "4.1.3",
+                "inquirer": "8.2.4",
+                "symbol-observable": "4.0.0",
+                "yargs-parser": "21.1.1"
+            },
+            "bin": {
+                "schematics": "bin/schematics.js"
             },
             "engines": {
                 "node": "^16.14.0 || >=18.10.0",
@@ -4837,14 +4769,10 @@
             "version": "0.19.12",
             "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.19.12.tgz",
             "integrity": "sha512-bmoCYyWdEL3wDQIVbcyzRyeKLgk2WtWLTWz1ZIAZF/EGbNOwSA6ew3PftJ1PqMiOOGu0OyFMzG53L0zqIpPeNA==",
-            "cpu": [
-                "ppc64"
-            ],
+            "cpu": ["ppc64"],
             "dev": true,
             "optional": true,
-            "os": [
-                "aix"
-            ],
+            "os": ["aix"],
             "engines": {
                 "node": ">=12"
             }
@@ -4853,14 +4781,10 @@
             "version": "0.19.12",
             "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.19.12.tgz",
             "integrity": "sha512-qg/Lj1mu3CdQlDEEiWrlC4eaPZ1KztwGJ9B6J+/6G+/4ewxJg7gqj8eVYWvao1bXrqGiW2rsBZFSX3q2lcW05w==",
-            "cpu": [
-                "arm"
-            ],
+            "cpu": ["arm"],
             "dev": true,
             "optional": true,
-            "os": [
-                "android"
-            ],
+            "os": ["android"],
             "engines": {
                 "node": ">=12"
             }
@@ -4869,14 +4793,10 @@
             "version": "0.19.12",
             "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.19.12.tgz",
             "integrity": "sha512-P0UVNGIienjZv3f5zq0DP3Nt2IE/3plFzuaS96vihvD0Hd6H/q4WXUGpCxD/E8YrSXfNyRPbpTq+T8ZQioSuPA==",
-            "cpu": [
-                "arm64"
-            ],
+            "cpu": ["arm64"],
             "dev": true,
             "optional": true,
-            "os": [
-                "android"
-            ],
+            "os": ["android"],
             "engines": {
                 "node": ">=12"
             }
@@ -4885,14 +4805,10 @@
             "version": "0.19.12",
             "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.19.12.tgz",
             "integrity": "sha512-3k7ZoUW6Q6YqhdhIaq/WZ7HwBpnFBlW905Fa4s4qWJyiNOgT1dOqDiVAQFwBH7gBRZr17gLrlFCRzF6jFh7Kew==",
-            "cpu": [
-                "x64"
-            ],
+            "cpu": ["x64"],
             "dev": true,
             "optional": true,
-            "os": [
-                "android"
-            ],
+            "os": ["android"],
             "engines": {
                 "node": ">=12"
             }
@@ -4901,14 +4817,10 @@
             "version": "0.19.12",
             "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.19.12.tgz",
             "integrity": "sha512-B6IeSgZgtEzGC42jsI+YYu9Z3HKRxp8ZT3cqhvliEHovq8HSX2YX8lNocDn79gCKJXOSaEot9MVYky7AKjCs8g==",
-            "cpu": [
-                "arm64"
-            ],
+            "cpu": ["arm64"],
             "dev": true,
             "optional": true,
-            "os": [
-                "darwin"
-            ],
+            "os": ["darwin"],
             "engines": {
                 "node": ">=12"
             }
@@ -4917,14 +4829,10 @@
             "version": "0.19.12",
             "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.19.12.tgz",
             "integrity": "sha512-hKoVkKzFiToTgn+41qGhsUJXFlIjxI/jSYeZf3ugemDYZldIXIxhvwN6erJGlX4t5h417iFuheZ7l+YVn05N3A==",
-            "cpu": [
-                "x64"
-            ],
+            "cpu": ["x64"],
             "dev": true,
             "optional": true,
-            "os": [
-                "darwin"
-            ],
+            "os": ["darwin"],
             "engines": {
                 "node": ">=12"
             }
@@ -4933,14 +4841,10 @@
             "version": "0.19.12",
             "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.19.12.tgz",
             "integrity": "sha512-4aRvFIXmwAcDBw9AueDQ2YnGmz5L6obe5kmPT8Vd+/+x/JMVKCgdcRwH6APrbpNXsPz+K653Qg8HB/oXvXVukA==",
-            "cpu": [
-                "arm64"
-            ],
+            "cpu": ["arm64"],
             "dev": true,
             "optional": true,
-            "os": [
-                "freebsd"
-            ],
+            "os": ["freebsd"],
             "engines": {
                 "node": ">=12"
             }
@@ -4949,14 +4853,10 @@
             "version": "0.19.12",
             "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.19.12.tgz",
             "integrity": "sha512-EYoXZ4d8xtBoVN7CEwWY2IN4ho76xjYXqSXMNccFSx2lgqOG/1TBPW0yPx1bJZk94qu3tX0fycJeeQsKovA8gg==",
-            "cpu": [
-                "x64"
-            ],
+            "cpu": ["x64"],
             "dev": true,
             "optional": true,
-            "os": [
-                "freebsd"
-            ],
+            "os": ["freebsd"],
             "engines": {
                 "node": ">=12"
             }
@@ -4965,14 +4865,10 @@
             "version": "0.19.12",
             "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.19.12.tgz",
             "integrity": "sha512-J5jPms//KhSNv+LO1S1TX1UWp1ucM6N6XuL6ITdKWElCu8wXP72l9MM0zDTzzeikVyqFE6U8YAV9/tFyj0ti+w==",
-            "cpu": [
-                "arm"
-            ],
+            "cpu": ["arm"],
             "dev": true,
             "optional": true,
-            "os": [
-                "linux"
-            ],
+            "os": ["linux"],
             "engines": {
                 "node": ">=12"
             }
@@ -4981,14 +4877,10 @@
             "version": "0.19.12",
             "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.19.12.tgz",
             "integrity": "sha512-EoTjyYyLuVPfdPLsGVVVC8a0p1BFFvtpQDB/YLEhaXyf/5bczaGeN15QkR+O4S5LeJ92Tqotve7i1jn35qwvdA==",
-            "cpu": [
-                "arm64"
-            ],
+            "cpu": ["arm64"],
             "dev": true,
             "optional": true,
-            "os": [
-                "linux"
-            ],
+            "os": ["linux"],
             "engines": {
                 "node": ">=12"
             }
@@ -4997,14 +4889,10 @@
             "version": "0.19.12",
             "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.19.12.tgz",
             "integrity": "sha512-Thsa42rrP1+UIGaWz47uydHSBOgTUnwBwNq59khgIwktK6x60Hivfbux9iNR0eHCHzOLjLMLfUMLCypBkZXMHA==",
-            "cpu": [
-                "ia32"
-            ],
+            "cpu": ["ia32"],
             "dev": true,
             "optional": true,
-            "os": [
-                "linux"
-            ],
+            "os": ["linux"],
             "engines": {
                 "node": ">=12"
             }
@@ -5013,14 +4901,10 @@
             "version": "0.19.12",
             "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.19.12.tgz",
             "integrity": "sha512-LiXdXA0s3IqRRjm6rV6XaWATScKAXjI4R4LoDlvO7+yQqFdlr1Bax62sRwkVvRIrwXxvtYEHHI4dm50jAXkuAA==",
-            "cpu": [
-                "loong64"
-            ],
+            "cpu": ["loong64"],
             "dev": true,
             "optional": true,
-            "os": [
-                "linux"
-            ],
+            "os": ["linux"],
             "engines": {
                 "node": ">=12"
             }
@@ -5029,14 +4913,10 @@
             "version": "0.19.12",
             "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.19.12.tgz",
             "integrity": "sha512-fEnAuj5VGTanfJ07ff0gOA6IPsvrVHLVb6Lyd1g2/ed67oU1eFzL0r9WL7ZzscD+/N6i3dWumGE1Un4f7Amf+w==",
-            "cpu": [
-                "mips64el"
-            ],
+            "cpu": ["mips64el"],
             "dev": true,
             "optional": true,
-            "os": [
-                "linux"
-            ],
+            "os": ["linux"],
             "engines": {
                 "node": ">=12"
             }
@@ -5045,14 +4925,10 @@
             "version": "0.19.12",
             "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.19.12.tgz",
             "integrity": "sha512-nYJA2/QPimDQOh1rKWedNOe3Gfc8PabU7HT3iXWtNUbRzXS9+vgB0Fjaqr//XNbd82mCxHzik2qotuI89cfixg==",
-            "cpu": [
-                "ppc64"
-            ],
+            "cpu": ["ppc64"],
             "dev": true,
             "optional": true,
-            "os": [
-                "linux"
-            ],
+            "os": ["linux"],
             "engines": {
                 "node": ">=12"
             }
@@ -5061,14 +4937,10 @@
             "version": "0.19.12",
             "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.19.12.tgz",
             "integrity": "sha512-2MueBrlPQCw5dVJJpQdUYgeqIzDQgw3QtiAHUC4RBz9FXPrskyyU3VI1hw7C0BSKB9OduwSJ79FTCqtGMWqJHg==",
-            "cpu": [
-                "riscv64"
-            ],
+            "cpu": ["riscv64"],
             "dev": true,
             "optional": true,
-            "os": [
-                "linux"
-            ],
+            "os": ["linux"],
             "engines": {
                 "node": ">=12"
             }
@@ -5077,14 +4949,10 @@
             "version": "0.19.12",
             "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.19.12.tgz",
             "integrity": "sha512-+Pil1Nv3Umes4m3AZKqA2anfhJiVmNCYkPchwFJNEJN5QxmTs1uzyy4TvmDrCRNT2ApwSari7ZIgrPeUx4UZDg==",
-            "cpu": [
-                "s390x"
-            ],
+            "cpu": ["s390x"],
             "dev": true,
             "optional": true,
-            "os": [
-                "linux"
-            ],
+            "os": ["linux"],
             "engines": {
                 "node": ">=12"
             }
@@ -5093,14 +4961,10 @@
             "version": "0.19.12",
             "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.19.12.tgz",
             "integrity": "sha512-B71g1QpxfwBvNrfyJdVDexenDIt1CiDN1TIXLbhOw0KhJzE78KIFGX6OJ9MrtC0oOqMWf+0xop4qEU8JrJTwCg==",
-            "cpu": [
-                "x64"
-            ],
+            "cpu": ["x64"],
             "dev": true,
             "optional": true,
-            "os": [
-                "linux"
-            ],
+            "os": ["linux"],
             "engines": {
                 "node": ">=12"
             }
@@ -5109,14 +4973,10 @@
             "version": "0.19.12",
             "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.19.12.tgz",
             "integrity": "sha512-3ltjQ7n1owJgFbuC61Oj++XhtzmymoCihNFgT84UAmJnxJfm4sYCiSLTXZtE00VWYpPMYc+ZQmB6xbSdVh0JWA==",
-            "cpu": [
-                "x64"
-            ],
+            "cpu": ["x64"],
             "dev": true,
             "optional": true,
-            "os": [
-                "netbsd"
-            ],
+            "os": ["netbsd"],
             "engines": {
                 "node": ">=12"
             }
@@ -5125,14 +4985,10 @@
             "version": "0.19.12",
             "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.19.12.tgz",
             "integrity": "sha512-RbrfTB9SWsr0kWmb9srfF+L933uMDdu9BIzdA7os2t0TXhCRjrQyCeOt6wVxr79CKD4c+p+YhCj31HBkYcXebw==",
-            "cpu": [
-                "x64"
-            ],
+            "cpu": ["x64"],
             "dev": true,
             "optional": true,
-            "os": [
-                "openbsd"
-            ],
+            "os": ["openbsd"],
             "engines": {
                 "node": ">=12"
             }
@@ -5141,14 +4997,10 @@
             "version": "0.19.12",
             "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.19.12.tgz",
             "integrity": "sha512-HKjJwRrW8uWtCQnQOz9qcU3mUZhTUQvi56Q8DPTLLB+DawoiQdjsYq+j+D3s9I8VFtDr+F9CjgXKKC4ss89IeA==",
-            "cpu": [
-                "x64"
-            ],
+            "cpu": ["x64"],
             "dev": true,
             "optional": true,
-            "os": [
-                "sunos"
-            ],
+            "os": ["sunos"],
             "engines": {
                 "node": ">=12"
             }
@@ -5157,14 +5009,10 @@
             "version": "0.19.12",
             "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.19.12.tgz",
             "integrity": "sha512-URgtR1dJnmGvX864pn1B2YUYNzjmXkuJOIqG2HdU62MVS4EHpU2946OZoTMnRUHklGtJdJZ33QfzdjGACXhn1A==",
-            "cpu": [
-                "arm64"
-            ],
+            "cpu": ["arm64"],
             "dev": true,
             "optional": true,
-            "os": [
-                "win32"
-            ],
+            "os": ["win32"],
             "engines": {
                 "node": ">=12"
             }
@@ -5173,14 +5021,10 @@
             "version": "0.19.12",
             "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.19.12.tgz",
             "integrity": "sha512-+ZOE6pUkMOJfmxmBZElNOx72NKpIa/HFOMGzu8fqzQJ5kgf6aTGrcJaFsNiVMH4JKpMipyK+7k0n2UXN7a8YKQ==",
-            "cpu": [
-                "ia32"
-            ],
+            "cpu": ["ia32"],
             "dev": true,
             "optional": true,
-            "os": [
-                "win32"
-            ],
+            "os": ["win32"],
             "engines": {
                 "node": ">=12"
             }
@@ -5189,14 +5033,10 @@
             "version": "0.19.12",
             "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.19.12.tgz",
             "integrity": "sha512-T1QyPSDCyMXaO3pzBkF96E8xMkiRYbUEZADd29SyPGabqxMViNoii+NcK7eWJAEoU6RZyEm5lVSIjTmcdoB9HA==",
-            "cpu": [
-                "x64"
-            ],
+            "cpu": ["x64"],
             "dev": true,
             "optional": true,
-            "os": [
-                "win32"
-            ],
+            "os": ["win32"],
             "engines": {
                 "node": ">=12"
             }
@@ -5279,6 +5119,13 @@
                 "url": "https://github.com/sponsors/epoberezkin"
             }
         },
+        "node_modules/@eslint/eslintrc/node_modules/argparse": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+            "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+            "dev": true,
+            "peer": true
+        },
         "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
             "version": "1.1.11",
             "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -5304,6 +5151,19 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/@eslint/eslintrc/node_modules/js-yaml": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+            "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+            "dev": true,
+            "peer": true,
+            "dependencies": {
+                "argparse": "^2.0.1"
+            },
+            "bin": {
+                "js-yaml": "bin/js-yaml.js"
             }
         },
         "node_modules/@eslint/eslintrc/node_modules/json-schema-traverse": {
@@ -5568,15 +5428,6 @@
                 "node": ">=8"
             }
         },
-        "node_modules/@istanbuljs/load-nyc-config/node_modules/argparse": {
-            "version": "1.0.10",
-            "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-            "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-            "dev": true,
-            "dependencies": {
-                "sprintf-js": "~1.0.2"
-            }
-        },
         "node_modules/@istanbuljs/load-nyc-config/node_modules/find-up": {
             "version": "4.1.0",
             "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
@@ -5588,19 +5439,6 @@
             },
             "engines": {
                 "node": ">=8"
-            }
-        },
-        "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
-            "version": "3.14.1",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-            "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
-            "dev": true,
-            "dependencies": {
-                "argparse": "^1.0.7",
-                "esprima": "^4.0.0"
-            },
-            "bin": {
-                "js-yaml": "bin/js-yaml.js"
             }
         },
         "node_modules/@istanbuljs/load-nyc-config/node_modules/locate-path": {
@@ -7750,14 +7588,10 @@
             "version": "17.2.8",
             "resolved": "https://registry.npmjs.org/@nx/nx-darwin-arm64/-/nx-darwin-arm64-17.2.8.tgz",
             "integrity": "sha512-dMb0uxug4hM7tusISAU1TfkDK3ixYmzc1zhHSZwpR7yKJIyKLtUpBTbryt8nyso37AS1yH+dmfh2Fj2WxfBHTg==",
-            "cpu": [
-                "arm64"
-            ],
+            "cpu": ["arm64"],
             "dev": true,
             "optional": true,
-            "os": [
-                "darwin"
-            ],
+            "os": ["darwin"],
             "engines": {
                 "node": ">= 10"
             }
@@ -7766,14 +7600,10 @@
             "version": "17.2.8",
             "resolved": "https://registry.npmjs.org/@nx/nx-darwin-x64/-/nx-darwin-x64-17.2.8.tgz",
             "integrity": "sha512-0cXzp1tGr7/6lJel102QiLA4NkaLCkQJj6VzwbwuvmuCDxPbpmbz7HC1tUteijKBtOcdXit1/MEoEU007To8Bw==",
-            "cpu": [
-                "x64"
-            ],
+            "cpu": ["x64"],
             "dev": true,
             "optional": true,
-            "os": [
-                "darwin"
-            ],
+            "os": ["darwin"],
             "engines": {
                 "node": ">= 10"
             }
@@ -7782,14 +7612,10 @@
             "version": "17.2.8",
             "resolved": "https://registry.npmjs.org/@nx/nx-freebsd-x64/-/nx-freebsd-x64-17.2.8.tgz",
             "integrity": "sha512-YFMgx5Qpp2btCgvaniDGdu7Ctj56bfFvbbaHQWmOeBPK1krNDp2mqp8HK6ZKOfEuDJGOYAp7HDtCLvdZKvJxzA==",
-            "cpu": [
-                "x64"
-            ],
+            "cpu": ["x64"],
             "dev": true,
             "optional": true,
-            "os": [
-                "freebsd"
-            ],
+            "os": ["freebsd"],
             "engines": {
                 "node": ">= 10"
             }
@@ -7798,14 +7624,10 @@
             "version": "17.2.8",
             "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm-gnueabihf/-/nx-linux-arm-gnueabihf-17.2.8.tgz",
             "integrity": "sha512-iN2my6MrhLRkVDtdivQHugK8YmR7URo1wU9UDuHQ55z3tEcny7LV3W9NSsY9UYPK/FrxdDfevj0r2hgSSdhnzA==",
-            "cpu": [
-                "arm"
-            ],
+            "cpu": ["arm"],
             "dev": true,
             "optional": true,
-            "os": [
-                "linux"
-            ],
+            "os": ["linux"],
             "engines": {
                 "node": ">= 10"
             }
@@ -7814,14 +7636,10 @@
             "version": "17.2.8",
             "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm64-gnu/-/nx-linux-arm64-gnu-17.2.8.tgz",
             "integrity": "sha512-Iy8BjoW6mOKrSMiTGujUcNdv+xSM1DALTH6y3iLvNDkGbjGK1Re6QNnJAzqcXyDpv32Q4Fc57PmuexyysZxIGg==",
-            "cpu": [
-                "arm64"
-            ],
+            "cpu": ["arm64"],
             "dev": true,
             "optional": true,
-            "os": [
-                "linux"
-            ],
+            "os": ["linux"],
             "engines": {
                 "node": ">= 10"
             }
@@ -7830,14 +7648,10 @@
             "version": "17.2.8",
             "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm64-musl/-/nx-linux-arm64-musl-17.2.8.tgz",
             "integrity": "sha512-9wkAxWzknjpzdofL1xjtU6qPFF1PHlvKCZI3hgEYJDo4mQiatGI+7Ttko+lx/ZMP6v4+Umjtgq7+qWrApeKamQ==",
-            "cpu": [
-                "arm64"
-            ],
+            "cpu": ["arm64"],
             "dev": true,
             "optional": true,
-            "os": [
-                "linux"
-            ],
+            "os": ["linux"],
             "engines": {
                 "node": ">= 10"
             }
@@ -7846,14 +7660,10 @@
             "version": "17.2.8",
             "resolved": "https://registry.npmjs.org/@nx/nx-linux-x64-gnu/-/nx-linux-x64-gnu-17.2.8.tgz",
             "integrity": "sha512-sjG1bwGsjLxToasZ3lShildFsF0eyeGu+pOQZIp9+gjFbeIkd19cTlCnHrOV9hoF364GuKSXQyUlwtFYFR4VTQ==",
-            "cpu": [
-                "x64"
-            ],
+            "cpu": ["x64"],
             "dev": true,
             "optional": true,
-            "os": [
-                "linux"
-            ],
+            "os": ["linux"],
             "engines": {
                 "node": ">= 10"
             }
@@ -7862,14 +7672,10 @@
             "version": "17.2.8",
             "resolved": "https://registry.npmjs.org/@nx/nx-linux-x64-musl/-/nx-linux-x64-musl-17.2.8.tgz",
             "integrity": "sha512-QiakXZ1xBCIptmkGEouLHQbcM4klQkcr+kEaz2PlNwy/sW3gH1b/1c0Ed5J1AN9xgQxWspriAONpScYBRgxdhA==",
-            "cpu": [
-                "x64"
-            ],
+            "cpu": ["x64"],
             "dev": true,
             "optional": true,
-            "os": [
-                "linux"
-            ],
+            "os": ["linux"],
             "engines": {
                 "node": ">= 10"
             }
@@ -7878,14 +7684,10 @@
             "version": "17.2.8",
             "resolved": "https://registry.npmjs.org/@nx/nx-win32-arm64-msvc/-/nx-win32-arm64-msvc-17.2.8.tgz",
             "integrity": "sha512-XBWUY/F/GU3vKN9CAxeI15gM4kr3GOBqnzFZzoZC4qJt2hKSSUEWsMgeZtsMgeqEClbi4ZyCCkY7YJgU32WUGA==",
-            "cpu": [
-                "arm64"
-            ],
+            "cpu": ["arm64"],
             "dev": true,
             "optional": true,
-            "os": [
-                "win32"
-            ],
+            "os": ["win32"],
             "engines": {
                 "node": ">= 10"
             }
@@ -7894,14 +7696,10 @@
             "version": "17.2.8",
             "resolved": "https://registry.npmjs.org/@nx/nx-win32-x64-msvc/-/nx-win32-x64-msvc-17.2.8.tgz",
             "integrity": "sha512-HTqDv+JThlLzbcEm/3f+LbS5/wYQWzb5YDXbP1wi7nlCTihNZOLNqGOkEmwlrR5tAdNHPRpHSmkYg4305W0CtA==",
-            "cpu": [
-                "x64"
-            ],
+            "cpu": ["x64"],
             "dev": true,
             "optional": true,
-            "os": [
-                "win32"
-            ],
+            "os": ["win32"],
             "engines": {
                 "node": ">= 10"
             }
@@ -8383,14 +8181,10 @@
             "version": "17.3.1",
             "resolved": "https://registry.npmjs.org/@nx/nx-darwin-arm64/-/nx-darwin-arm64-17.3.1.tgz",
             "integrity": "sha512-19YkMr/9fMWQsaiFxkLmz50WzIQ6nktEwDfjhSOOFeRc40SCw848ZWZ4EZDH6dOgKK3UOeW6OX9vr5+GMn2yLA==",
-            "cpu": [
-                "arm64"
-            ],
+            "cpu": ["arm64"],
             "dev": true,
             "optional": true,
-            "os": [
-                "darwin"
-            ],
+            "os": ["darwin"],
             "engines": {
                 "node": ">= 10"
             }
@@ -8399,14 +8193,10 @@
             "version": "17.3.1",
             "resolved": "https://registry.npmjs.org/@nx/nx-darwin-x64/-/nx-darwin-x64-17.3.1.tgz",
             "integrity": "sha512-FaI9VI7XwG32jDArAZK0F+mWN6ZU7Y8anFr7C1VMcgVbaMLz6i4kp3sy5kFAbFDgFcpTdUOiZq5Ay+hJtDyufg==",
-            "cpu": [
-                "x64"
-            ],
+            "cpu": ["x64"],
             "dev": true,
             "optional": true,
-            "os": [
-                "darwin"
-            ],
+            "os": ["darwin"],
             "engines": {
                 "node": ">= 10"
             }
@@ -8415,14 +8205,10 @@
             "version": "17.3.1",
             "resolved": "https://registry.npmjs.org/@nx/nx-freebsd-x64/-/nx-freebsd-x64-17.3.1.tgz",
             "integrity": "sha512-AZ+kl5x+O+8Ptrzw/RXgSZFs6V4U6TlieTOoCtrPtmVR7mz9nxMfwQNf/GAz8kbiC+u9PDH5rFl/UblEi4WF6g==",
-            "cpu": [
-                "x64"
-            ],
+            "cpu": ["x64"],
             "dev": true,
             "optional": true,
-            "os": [
-                "freebsd"
-            ],
+            "os": ["freebsd"],
             "engines": {
                 "node": ">= 10"
             }
@@ -8431,14 +8217,10 @@
             "version": "17.3.1",
             "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm-gnueabihf/-/nx-linux-arm-gnueabihf-17.3.1.tgz",
             "integrity": "sha512-a8Y7435O2lxbtNsQ4vciYqXJ8eFVyOJizhiQ6koh/VHN/0FEYuGVkJRRXinDS44W0dfiDRXvbQKvPtjAvD5gJQ==",
-            "cpu": [
-                "arm"
-            ],
+            "cpu": ["arm"],
             "dev": true,
             "optional": true,
-            "os": [
-                "linux"
-            ],
+            "os": ["linux"],
             "engines": {
                 "node": ">= 10"
             }
@@ -8447,14 +8229,10 @@
             "version": "17.3.1",
             "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm64-gnu/-/nx-linux-arm64-gnu-17.3.1.tgz",
             "integrity": "sha512-B/o/xTvSUlWG/OTCh96BkaWD1rE1kSJ20BdRgyG4CGGH318/PgcvimeMvJcwNJNDoRsyJxAEKveGGD6gKkffcQ==",
-            "cpu": [
-                "arm64"
-            ],
+            "cpu": ["arm64"],
             "dev": true,
             "optional": true,
-            "os": [
-                "linux"
-            ],
+            "os": ["linux"],
             "engines": {
                 "node": ">= 10"
             }
@@ -8463,14 +8241,10 @@
             "version": "17.3.1",
             "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm64-musl/-/nx-linux-arm64-musl-17.3.1.tgz",
             "integrity": "sha512-lOIAE3N6I1U2/dctuw2b3QIR+pXjlag3dYk+hLC+p/Sd5FZ0GBzpQhGzi03VsbQdIkIJ95K2gd05yolZLFOVqw==",
-            "cpu": [
-                "arm64"
-            ],
+            "cpu": ["arm64"],
             "dev": true,
             "optional": true,
-            "os": [
-                "linux"
-            ],
+            "os": ["linux"],
             "engines": {
                 "node": ">= 10"
             }
@@ -8479,14 +8253,10 @@
             "version": "17.3.1",
             "resolved": "https://registry.npmjs.org/@nx/nx-linux-x64-gnu/-/nx-linux-x64-gnu-17.3.1.tgz",
             "integrity": "sha512-pTCwQFAojEpeYP02xDZtnmRvViRLzbBXXWZNBf5pprCJGGKtHsVrwrswRJlt3btN/UWn2J/uFbTXyHDFWu8egA==",
-            "cpu": [
-                "x64"
-            ],
+            "cpu": ["x64"],
             "dev": true,
             "optional": true,
-            "os": [
-                "linux"
-            ],
+            "os": ["linux"],
             "engines": {
                 "node": ">= 10"
             }
@@ -8495,14 +8265,10 @@
             "version": "17.3.1",
             "resolved": "https://registry.npmjs.org/@nx/nx-linux-x64-musl/-/nx-linux-x64-musl-17.3.1.tgz",
             "integrity": "sha512-WIV4gQjQAVp2oW/qtY4FmP7eeLwyo+bkoVw9PY42A89N6o7rYa/z77s9ajnl98A3eGb2ghe9fwwgAerLgmuFzA==",
-            "cpu": [
-                "x64"
-            ],
+            "cpu": ["x64"],
             "dev": true,
             "optional": true,
-            "os": [
-                "linux"
-            ],
+            "os": ["linux"],
             "engines": {
                 "node": ">= 10"
             }
@@ -8511,14 +8277,10 @@
             "version": "17.3.1",
             "resolved": "https://registry.npmjs.org/@nx/nx-win32-arm64-msvc/-/nx-win32-arm64-msvc-17.3.1.tgz",
             "integrity": "sha512-HKc4QWIP7r+FmK0Anzrey7udlDLaKscHbrNGQN9YV2/ulYVtHidIVZCXYZq3p93Gg55e4t2uAiUuXSXdyy8Q6g==",
-            "cpu": [
-                "arm64"
-            ],
+            "cpu": ["arm64"],
             "dev": true,
             "optional": true,
-            "os": [
-                "win32"
-            ],
+            "os": ["win32"],
             "engines": {
                 "node": ">= 10"
             }
@@ -8527,14 +8289,10 @@
             "version": "17.3.1",
             "resolved": "https://registry.npmjs.org/@nx/nx-win32-x64-msvc/-/nx-win32-x64-msvc-17.3.1.tgz",
             "integrity": "sha512-o2QrIeHGBG6BqViVCPP0J3V9UEDMjyDxyMJF/l/DT4dWr/+zdrIJ11eiQs7Tvo2GLXJFXI0fMur8p3HopnOvAQ==",
-            "cpu": [
-                "x64"
-            ],
+            "cpu": ["x64"],
             "dev": true,
             "optional": true,
-            "os": [
-                "win32"
-            ],
+            "os": ["win32"],
             "engines": {
                 "node": ">= 10"
             }
@@ -8553,6 +8311,12 @@
             "funding": {
                 "url": "https://github.com/chalk/ansi-styles?sponsor=1"
             }
+        },
+        "node_modules/@nx/workspace/node_modules/argparse": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+            "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+            "dev": true
         },
         "node_modules/@nx/workspace/node_modules/axios": {
             "version": "1.6.7",
@@ -8620,6 +8384,18 @@
             "dev": true,
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/@nx/workspace/node_modules/js-yaml": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+            "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+            "dev": true,
+            "dependencies": {
+                "argparse": "^2.0.1"
+            },
+            "bin": {
+                "js-yaml": "bin/js-yaml.js"
             }
         },
         "node_modules/@nx/workspace/node_modules/lru-cache": {
@@ -8900,170 +8676,118 @@
             "version": "4.13.0",
             "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.13.0.tgz",
             "integrity": "sha512-5ZYPOuaAqEH/W3gYsRkxQATBW3Ii1MfaT4EQstTnLKViLi2gLSQmlmtTpGucNP3sXEpOiI5tdGhjdE111ekyEg==",
-            "cpu": [
-                "arm"
-            ],
+            "cpu": ["arm"],
             "dev": true,
             "optional": true,
-            "os": [
-                "android"
-            ]
+            "os": ["android"]
         },
         "node_modules/@rollup/rollup-android-arm64": {
             "version": "4.13.0",
             "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.13.0.tgz",
             "integrity": "sha512-BSbaCmn8ZadK3UAQdlauSvtaJjhlDEjS5hEVVIN3A4bbl3X+otyf/kOJV08bYiRxfejP3DXFzO2jz3G20107+Q==",
-            "cpu": [
-                "arm64"
-            ],
+            "cpu": ["arm64"],
             "dev": true,
             "optional": true,
-            "os": [
-                "android"
-            ]
+            "os": ["android"]
         },
         "node_modules/@rollup/rollup-darwin-arm64": {
             "version": "4.13.0",
             "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.13.0.tgz",
             "integrity": "sha512-Ovf2evVaP6sW5Ut0GHyUSOqA6tVKfrTHddtmxGQc1CTQa1Cw3/KMCDEEICZBbyppcwnhMwcDce9ZRxdWRpVd6g==",
-            "cpu": [
-                "arm64"
-            ],
+            "cpu": ["arm64"],
             "dev": true,
             "optional": true,
-            "os": [
-                "darwin"
-            ]
+            "os": ["darwin"]
         },
         "node_modules/@rollup/rollup-darwin-x64": {
             "version": "4.13.0",
             "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.13.0.tgz",
             "integrity": "sha512-U+Jcxm89UTK592vZ2J9st9ajRv/hrwHdnvyuJpa5A2ngGSVHypigidkQJP+YiGL6JODiUeMzkqQzbCG3At81Gg==",
-            "cpu": [
-                "x64"
-            ],
+            "cpu": ["x64"],
             "dev": true,
             "optional": true,
-            "os": [
-                "darwin"
-            ]
+            "os": ["darwin"]
         },
         "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
             "version": "4.13.0",
             "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.13.0.tgz",
             "integrity": "sha512-8wZidaUJUTIR5T4vRS22VkSMOVooG0F4N+JSwQXWSRiC6yfEsFMLTYRFHvby5mFFuExHa/yAp9juSphQQJAijQ==",
-            "cpu": [
-                "arm"
-            ],
+            "cpu": ["arm"],
             "dev": true,
             "optional": true,
-            "os": [
-                "linux"
-            ]
+            "os": ["linux"]
         },
         "node_modules/@rollup/rollup-linux-arm64-gnu": {
             "version": "4.13.0",
             "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.13.0.tgz",
             "integrity": "sha512-Iu0Kno1vrD7zHQDxOmvweqLkAzjxEVqNhUIXBsZ8hu8Oak7/5VTPrxOEZXYC1nmrBVJp0ZcL2E7lSuuOVaE3+w==",
-            "cpu": [
-                "arm64"
-            ],
+            "cpu": ["arm64"],
             "dev": true,
             "optional": true,
-            "os": [
-                "linux"
-            ]
+            "os": ["linux"]
         },
         "node_modules/@rollup/rollup-linux-arm64-musl": {
             "version": "4.13.0",
             "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.13.0.tgz",
             "integrity": "sha512-C31QrW47llgVyrRjIwiOwsHFcaIwmkKi3PCroQY5aVq4H0A5v/vVVAtFsI1nfBngtoRpeREvZOkIhmRwUKkAdw==",
-            "cpu": [
-                "arm64"
-            ],
+            "cpu": ["arm64"],
             "dev": true,
             "optional": true,
-            "os": [
-                "linux"
-            ]
+            "os": ["linux"]
         },
         "node_modules/@rollup/rollup-linux-riscv64-gnu": {
             "version": "4.13.0",
             "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.13.0.tgz",
             "integrity": "sha512-Oq90dtMHvthFOPMl7pt7KmxzX7E71AfyIhh+cPhLY9oko97Zf2C9tt/XJD4RgxhaGeAraAXDtqxvKE1y/j35lA==",
-            "cpu": [
-                "riscv64"
-            ],
+            "cpu": ["riscv64"],
             "dev": true,
             "optional": true,
-            "os": [
-                "linux"
-            ]
+            "os": ["linux"]
         },
         "node_modules/@rollup/rollup-linux-x64-gnu": {
             "version": "4.13.0",
             "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.13.0.tgz",
             "integrity": "sha512-yUD/8wMffnTKuiIsl6xU+4IA8UNhQ/f1sAnQebmE/lyQ8abjsVyDkyRkWop0kdMhKMprpNIhPmYlCxgHrPoXoA==",
-            "cpu": [
-                "x64"
-            ],
+            "cpu": ["x64"],
             "dev": true,
             "optional": true,
-            "os": [
-                "linux"
-            ]
+            "os": ["linux"]
         },
         "node_modules/@rollup/rollup-linux-x64-musl": {
             "version": "4.13.0",
             "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.13.0.tgz",
             "integrity": "sha512-9RyNqoFNdF0vu/qqX63fKotBh43fJQeYC98hCaf89DYQpv+xu0D8QFSOS0biA7cGuqJFOc1bJ+m2rhhsKcw1hw==",
-            "cpu": [
-                "x64"
-            ],
+            "cpu": ["x64"],
             "dev": true,
             "optional": true,
-            "os": [
-                "linux"
-            ]
+            "os": ["linux"]
         },
         "node_modules/@rollup/rollup-win32-arm64-msvc": {
             "version": "4.13.0",
             "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.13.0.tgz",
             "integrity": "sha512-46ue8ymtm/5PUU6pCvjlic0z82qWkxv54GTJZgHrQUuZnVH+tvvSP0LsozIDsCBFO4VjJ13N68wqrKSeScUKdA==",
-            "cpu": [
-                "arm64"
-            ],
+            "cpu": ["arm64"],
             "dev": true,
             "optional": true,
-            "os": [
-                "win32"
-            ]
+            "os": ["win32"]
         },
         "node_modules/@rollup/rollup-win32-ia32-msvc": {
             "version": "4.13.0",
             "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.13.0.tgz",
             "integrity": "sha512-P5/MqLdLSlqxbeuJ3YDeX37srC8mCflSyTrUsgbU1c/U9j6l2g2GiIdYaGD9QjdMQPMSgYm7hgg0551wHyIluw==",
-            "cpu": [
-                "ia32"
-            ],
+            "cpu": ["ia32"],
             "dev": true,
             "optional": true,
-            "os": [
-                "win32"
-            ]
+            "os": ["win32"]
         },
         "node_modules/@rollup/rollup-win32-x64-msvc": {
             "version": "4.13.0",
             "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.13.0.tgz",
             "integrity": "sha512-UKXUQNbO3DOhzLRwHSpa0HnhhCgNODvfoPWv2FCXme8N/ANFfhIPMGuOT+QuKd16+B5yxZ0HdpNlqPvTMS1qfw==",
-            "cpu": [
-                "x64"
-            ],
+            "cpu": ["x64"],
             "dev": true,
             "optional": true,
-            "os": [
-                "win32"
-            ]
+            "os": ["win32"]
         },
         "node_modules/@schematics/angular": {
             "version": "16.2.12",
@@ -11214,28 +10938,6 @@
                 "node": ">=14.15.0"
             }
         },
-        "node_modules/@yarnpkg/parsers/node_modules/argparse": {
-            "version": "1.0.10",
-            "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-            "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-            "dev": true,
-            "dependencies": {
-                "sprintf-js": "~1.0.2"
-            }
-        },
-        "node_modules/@yarnpkg/parsers/node_modules/js-yaml": {
-            "version": "3.14.1",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-            "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
-            "dev": true,
-            "dependencies": {
-                "argparse": "^1.0.7",
-                "esprima": "^4.0.0"
-            },
-            "bin": {
-                "js-yaml": "bin/js-yaml.js"
-            }
-        },
         "node_modules/@zkochan/js-yaml": {
             "version": "0.0.6",
             "resolved": "https://registry.npmjs.org/@zkochan/js-yaml/-/js-yaml-0.0.6.tgz",
@@ -11247,6 +10949,12 @@
             "bin": {
                 "js-yaml": "bin/js-yaml.js"
             }
+        },
+        "node_modules/@zkochan/js-yaml/node_modules/argparse": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+            "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+            "dev": true
         },
         "node_modules/abab": {
             "version": "2.0.6",
@@ -11495,9 +11203,7 @@
             "resolved": "https://registry.npmjs.org/ansi-html-community/-/ansi-html-community-0.0.8.tgz",
             "integrity": "sha512-1APHAyr3+PCamwNw3bXCPp4HFLONZt/yIH0sZp0/469KWNTEy+qN5jQ3GVX6DMZ1UXAi34yVwtTeaG/HpBuuzw==",
             "dev": true,
-            "engines": [
-                "node >= 0.8.0"
-            ],
+            "engines": ["node >= 0.8.0"],
             "bin": {
                 "ansi-html": "bin/ansi-html"
             }
@@ -11579,9 +11285,13 @@
             "dev": true
         },
         "node_modules/argparse": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-            "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
+            "version": "1.0.10",
+            "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+            "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+            "dev": true,
+            "dependencies": {
+                "sprintf-js": "~1.0.2"
+            }
         },
         "node_modules/aria-query": {
             "version": "5.3.0",
@@ -13681,9 +13391,7 @@
             "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
             "integrity": "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==",
             "dev": true,
-            "engines": [
-                "node >= 6.0"
-            ],
+            "engines": ["node >= 6.0"],
             "dependencies": {
                 "buffer-from": "^1.0.0",
                 "inherits": "^2.0.3",
@@ -15028,6 +14736,24 @@
                 "@types/node": "*",
                 "cosmiconfig": ">=8.2",
                 "typescript": ">=4"
+            }
+        },
+        "node_modules/cosmiconfig/node_modules/argparse": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+            "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+            "dev": true
+        },
+        "node_modules/cosmiconfig/node_modules/js-yaml": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+            "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+            "dev": true,
+            "dependencies": {
+                "argparse": "^2.0.1"
+            },
+            "bin": {
+                "js-yaml": "bin/js-yaml.js"
             }
         },
         "node_modules/cp-file": {
@@ -18444,9 +18170,6 @@
             "integrity": "sha512-LtOB9myIX1O7HHqg9vtvBLjvXq1MXKuXIcD1nS+qZiMUJV6s9HBdilURAr9pIFc9kEelbVF54hOJ8pMxHvJP7g==",
             "dev": true,
             "peer": true,
-            "workspaces": [
-                "examples"
-            ],
             "dependencies": {
                 "globals": "^13.23.0"
             },
@@ -18872,6 +18595,13 @@
                 "url": "https://github.com/chalk/ansi-styles?sponsor=1"
             }
         },
+        "node_modules/eslint/node_modules/argparse": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+            "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+            "dev": true,
+            "peer": true
+        },
         "node_modules/eslint/node_modules/brace-expansion": {
             "version": "1.1.11",
             "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -19045,6 +18775,19 @@
             "peer": true,
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/eslint/node_modules/js-yaml": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+            "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+            "dev": true,
+            "peer": true,
+            "dependencies": {
+                "argparse": "^2.0.1"
+            },
+            "bin": {
+                "js-yaml": "bin/js-yaml.js"
             }
         },
         "node_modules/eslint/node_modules/json-schema-traverse": {
@@ -19554,9 +19297,7 @@
             "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
             "integrity": "sha512-11Ndz7Nv+mvAC1j0ktTa7fAb0vLyGGX+rMHNBYQviQDGU0Hw7lhctJANqbPhu9nV9/izT/IntTgZ7Im/9LJs9g==",
             "dev": true,
-            "engines": [
-                "node >=0.6.0"
-            ]
+            "engines": ["node >=0.6.0"]
         },
         "node_modules/fast-deep-equal": {
             "version": "3.1.3",
@@ -20229,9 +19970,7 @@
             "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
             "hasInstallScript": true,
             "optional": true,
-            "os": [
-                "darwin"
-            ],
+            "os": ["darwin"],
             "engines": {
                 "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
             }
@@ -24801,12 +24540,13 @@
             "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
         },
         "node_modules/js-yaml": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-            "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+            "version": "3.14.1",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+            "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
             "dev": true,
             "dependencies": {
-                "argparse": "^2.0.1"
+                "argparse": "^1.0.7",
+                "esprima": "^4.0.0"
             },
             "bin": {
                 "js-yaml": "bin/js-yaml.js"
@@ -24972,9 +24712,7 @@
             "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
             "integrity": "sha512-POQXvpdL69+CluYsillJ7SUhKvytYjW9vG/GKpnf+xP8UWgYEM/RaMzHHofbALDiKbbP1W8UEYmgGl39WkPZsg==",
             "dev": true,
-            "engines": [
-                "node >= 0.2.0"
-            ]
+            "engines": ["node >= 0.2.0"]
         },
         "node_modules/JSONStream": {
             "version": "1.3.5",
@@ -24997,9 +24735,7 @@
             "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-2.0.2.tgz",
             "integrity": "sha512-gqXddjPqQ6G40VdnI6T6yObEC+pDNvyP95wdQhkWkg7crHH3km5qP1FsOXEkzEQwnz6gz5qGTn1c2Y52wP3OyQ==",
             "dev": true,
-            "engines": [
-                "node >=0.6.0"
-            ],
+            "engines": ["node >=0.6.0"],
             "dependencies": {
                 "assert-plus": "1.0.0",
                 "extsprintf": "1.3.0",
@@ -26455,6 +26191,11 @@
                 "markdown-it": "bin/markdown-it.mjs"
             }
         },
+        "node_modules/markdown-it/node_modules/argparse": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+            "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
+        },
         "node_modules/marked": {
             "version": "11.2.0",
             "resolved": "https://registry.npmjs.org/marked/-/marked-11.2.0.tgz",
@@ -27242,9 +26983,7 @@
             "dev": true,
             "hasInstallScript": true,
             "optional": true,
-            "os": [
-                "!win32"
-            ],
+            "os": ["!win32"],
             "dependencies": {
                 "node-addon-api": "^3.0.0",
                 "node-gyp-build": "^4.2.2"
@@ -27775,6 +27514,12 @@
                 "url": "https://github.com/chalk/ansi-styles?sponsor=1"
             }
         },
+        "node_modules/nx/node_modules/argparse": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+            "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+            "dev": true
+        },
         "node_modules/nx/node_modules/axios": {
             "version": "1.6.7",
             "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.7.tgz",
@@ -27868,6 +27613,18 @@
             "dev": true,
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/nx/node_modules/js-yaml": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+            "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+            "dev": true,
+            "dependencies": {
+                "argparse": "^2.0.1"
+            },
+            "bin": {
+                "js-yaml": "bin/js-yaml.js"
             }
         },
         "node_modules/nx/node_modules/lru-cache": {
@@ -29046,9 +28803,7 @@
             "dev": true,
             "hasInstallScript": true,
             "optional": true,
-            "os": [
-                "darwin"
-            ],
+            "os": ["darwin"],
             "engines": {
                 "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
             }
@@ -32974,6 +32729,13 @@
                 "url": "https://github.com/chalk/ansi-regex?sponsor=1"
             }
         },
+        "node_modules/stylelint/node_modules/argparse": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+            "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+            "dev": true,
+            "peer": true
+        },
         "node_modules/stylelint/node_modules/balanced-match": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-2.0.0.tgz",
@@ -33023,6 +32785,19 @@
             },
             "engines": {
                 "node": ">=8.6.0"
+            }
+        },
+        "node_modules/stylelint/node_modules/js-yaml": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+            "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+            "dev": true,
+            "peer": true,
+            "dependencies": {
+                "argparse": "^2.0.1"
+            },
+            "bin": {
+                "js-yaml": "bin/js-yaml.js"
             }
         },
         "node_modules/stylelint/node_modules/meow": {
@@ -34795,9 +34570,7 @@
             "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
             "integrity": "sha512-ZZKSmDAEFOijERBLkmYfJ+vmk3w+7hOLYDNkRCuRuMJGEmqYNCNLyBBFwWKVMhfwaEF3WOd0Zlw86U/WC/+nYw==",
             "dev": true,
-            "engines": [
-                "node >=0.6.0"
-            ],
+            "engines": ["node >=0.6.0"],
             "dependencies": {
                 "assert-plus": "^1.0.0",
                 "core-util-is": "1.0.2",
@@ -34869,14 +34642,10 @@
             "version": "0.18.20",
             "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.18.20.tgz",
             "integrity": "sha512-fyi7TDI/ijKKNZTUJAQqiG5T7YjJXgnzkURqmGj13C6dCqckZBLdl4h7bkhHt/t0WP+zO9/zwroDvANaOqO5Sw==",
-            "cpu": [
-                "arm"
-            ],
+            "cpu": ["arm"],
             "dev": true,
             "optional": true,
-            "os": [
-                "android"
-            ],
+            "os": ["android"],
             "engines": {
                 "node": ">=12"
             }
@@ -34885,14 +34654,10 @@
             "version": "0.18.20",
             "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.18.20.tgz",
             "integrity": "sha512-Nz4rJcchGDtENV0eMKUNa6L12zz2zBDXuhj/Vjh18zGqB44Bi7MBMSXjgunJgjRhCmKOjnPuZp4Mb6OKqtMHLQ==",
-            "cpu": [
-                "arm64"
-            ],
+            "cpu": ["arm64"],
             "dev": true,
             "optional": true,
-            "os": [
-                "android"
-            ],
+            "os": ["android"],
             "engines": {
                 "node": ">=12"
             }
@@ -34901,14 +34666,10 @@
             "version": "0.18.20",
             "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.18.20.tgz",
             "integrity": "sha512-8GDdlePJA8D6zlZYJV/jnrRAi6rOiNaCC/JclcXpB+KIuvfBN4owLtgzY2bsxnx666XjJx2kDPUmnTtR8qKQUg==",
-            "cpu": [
-                "x64"
-            ],
+            "cpu": ["x64"],
             "dev": true,
             "optional": true,
-            "os": [
-                "android"
-            ],
+            "os": ["android"],
             "engines": {
                 "node": ">=12"
             }
@@ -34917,14 +34678,10 @@
             "version": "0.18.20",
             "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.18.20.tgz",
             "integrity": "sha512-bxRHW5kHU38zS2lPTPOyuyTm+S+eobPUnTNkdJEfAddYgEcll4xkT8DB9d2008DtTbl7uJag2HuE5NZAZgnNEA==",
-            "cpu": [
-                "arm64"
-            ],
+            "cpu": ["arm64"],
             "dev": true,
             "optional": true,
-            "os": [
-                "darwin"
-            ],
+            "os": ["darwin"],
             "engines": {
                 "node": ">=12"
             }
@@ -34933,14 +34690,10 @@
             "version": "0.18.20",
             "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.18.20.tgz",
             "integrity": "sha512-pc5gxlMDxzm513qPGbCbDukOdsGtKhfxD1zJKXjCCcU7ju50O7MeAZ8c4krSJcOIJGFR+qx21yMMVYwiQvyTyQ==",
-            "cpu": [
-                "x64"
-            ],
+            "cpu": ["x64"],
             "dev": true,
             "optional": true,
-            "os": [
-                "darwin"
-            ],
+            "os": ["darwin"],
             "engines": {
                 "node": ">=12"
             }
@@ -34949,14 +34702,10 @@
             "version": "0.18.20",
             "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.18.20.tgz",
             "integrity": "sha512-yqDQHy4QHevpMAaxhhIwYPMv1NECwOvIpGCZkECn8w2WFHXjEwrBn3CeNIYsibZ/iZEUemj++M26W3cNR5h+Tw==",
-            "cpu": [
-                "arm64"
-            ],
+            "cpu": ["arm64"],
             "dev": true,
             "optional": true,
-            "os": [
-                "freebsd"
-            ],
+            "os": ["freebsd"],
             "engines": {
                 "node": ">=12"
             }
@@ -34965,14 +34714,10 @@
             "version": "0.18.20",
             "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.18.20.tgz",
             "integrity": "sha512-tgWRPPuQsd3RmBZwarGVHZQvtzfEBOreNuxEMKFcd5DaDn2PbBxfwLcj4+aenoh7ctXcbXmOQIn8HI6mCSw5MQ==",
-            "cpu": [
-                "x64"
-            ],
+            "cpu": ["x64"],
             "dev": true,
             "optional": true,
-            "os": [
-                "freebsd"
-            ],
+            "os": ["freebsd"],
             "engines": {
                 "node": ">=12"
             }
@@ -34981,14 +34726,10 @@
             "version": "0.18.20",
             "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.18.20.tgz",
             "integrity": "sha512-/5bHkMWnq1EgKr1V+Ybz3s1hWXok7mDFUMQ4cG10AfW3wL02PSZi5kFpYKrptDsgb2WAJIvRcDm+qIvXf/apvg==",
-            "cpu": [
-                "arm"
-            ],
+            "cpu": ["arm"],
             "dev": true,
             "optional": true,
-            "os": [
-                "linux"
-            ],
+            "os": ["linux"],
             "engines": {
                 "node": ">=12"
             }
@@ -34997,14 +34738,10 @@
             "version": "0.18.20",
             "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.18.20.tgz",
             "integrity": "sha512-2YbscF+UL7SQAVIpnWvYwM+3LskyDmPhe31pE7/aoTMFKKzIc9lLbyGUpmmb8a8AixOL61sQ/mFh3jEjHYFvdA==",
-            "cpu": [
-                "arm64"
-            ],
+            "cpu": ["arm64"],
             "dev": true,
             "optional": true,
-            "os": [
-                "linux"
-            ],
+            "os": ["linux"],
             "engines": {
                 "node": ">=12"
             }
@@ -35013,14 +34750,10 @@
             "version": "0.18.20",
             "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.18.20.tgz",
             "integrity": "sha512-P4etWwq6IsReT0E1KHU40bOnzMHoH73aXp96Fs8TIT6z9Hu8G6+0SHSw9i2isWrD2nbx2qo5yUqACgdfVGx7TA==",
-            "cpu": [
-                "ia32"
-            ],
+            "cpu": ["ia32"],
             "dev": true,
             "optional": true,
-            "os": [
-                "linux"
-            ],
+            "os": ["linux"],
             "engines": {
                 "node": ">=12"
             }
@@ -35029,14 +34762,10 @@
             "version": "0.18.20",
             "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.18.20.tgz",
             "integrity": "sha512-nXW8nqBTrOpDLPgPY9uV+/1DjxoQ7DoB2N8eocyq8I9XuqJ7BiAMDMf9n1xZM9TgW0J8zrquIb/A7s3BJv7rjg==",
-            "cpu": [
-                "loong64"
-            ],
+            "cpu": ["loong64"],
             "dev": true,
             "optional": true,
-            "os": [
-                "linux"
-            ],
+            "os": ["linux"],
             "engines": {
                 "node": ">=12"
             }
@@ -35045,14 +34774,10 @@
             "version": "0.18.20",
             "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.18.20.tgz",
             "integrity": "sha512-d5NeaXZcHp8PzYy5VnXV3VSd2D328Zb+9dEq5HE6bw6+N86JVPExrA6O68OPwobntbNJ0pzCpUFZTo3w0GyetQ==",
-            "cpu": [
-                "mips64el"
-            ],
+            "cpu": ["mips64el"],
             "dev": true,
             "optional": true,
-            "os": [
-                "linux"
-            ],
+            "os": ["linux"],
             "engines": {
                 "node": ">=12"
             }
@@ -35061,14 +34786,10 @@
             "version": "0.18.20",
             "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.18.20.tgz",
             "integrity": "sha512-WHPyeScRNcmANnLQkq6AfyXRFr5D6N2sKgkFo2FqguP44Nw2eyDlbTdZwd9GYk98DZG9QItIiTlFLHJHjxP3FA==",
-            "cpu": [
-                "ppc64"
-            ],
+            "cpu": ["ppc64"],
             "dev": true,
             "optional": true,
-            "os": [
-                "linux"
-            ],
+            "os": ["linux"],
             "engines": {
                 "node": ">=12"
             }
@@ -35077,14 +34798,10 @@
             "version": "0.18.20",
             "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.18.20.tgz",
             "integrity": "sha512-WSxo6h5ecI5XH34KC7w5veNnKkju3zBRLEQNY7mv5mtBmrP/MjNBCAlsM2u5hDBlS3NGcTQpoBvRzqBcRtpq1A==",
-            "cpu": [
-                "riscv64"
-            ],
+            "cpu": ["riscv64"],
             "dev": true,
             "optional": true,
-            "os": [
-                "linux"
-            ],
+            "os": ["linux"],
             "engines": {
                 "node": ">=12"
             }
@@ -35093,14 +34810,10 @@
             "version": "0.18.20",
             "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.18.20.tgz",
             "integrity": "sha512-+8231GMs3mAEth6Ja1iK0a1sQ3ohfcpzpRLH8uuc5/KVDFneH6jtAJLFGafpzpMRO6DzJ6AvXKze9LfFMrIHVQ==",
-            "cpu": [
-                "s390x"
-            ],
+            "cpu": ["s390x"],
             "dev": true,
             "optional": true,
-            "os": [
-                "linux"
-            ],
+            "os": ["linux"],
             "engines": {
                 "node": ">=12"
             }
@@ -35109,14 +34822,10 @@
             "version": "0.18.20",
             "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.18.20.tgz",
             "integrity": "sha512-UYqiqemphJcNsFEskc73jQ7B9jgwjWrSayxawS6UVFZGWrAAtkzjxSqnoclCXxWtfwLdzU+vTpcNYhpn43uP1w==",
-            "cpu": [
-                "x64"
-            ],
+            "cpu": ["x64"],
             "dev": true,
             "optional": true,
-            "os": [
-                "linux"
-            ],
+            "os": ["linux"],
             "engines": {
                 "node": ">=12"
             }
@@ -35125,14 +34834,10 @@
             "version": "0.18.20",
             "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.18.20.tgz",
             "integrity": "sha512-iO1c++VP6xUBUmltHZoMtCUdPlnPGdBom6IrO4gyKPFFVBKioIImVooR5I83nTew5UOYrk3gIJhbZh8X44y06A==",
-            "cpu": [
-                "x64"
-            ],
+            "cpu": ["x64"],
             "dev": true,
             "optional": true,
-            "os": [
-                "netbsd"
-            ],
+            "os": ["netbsd"],
             "engines": {
                 "node": ">=12"
             }
@@ -35141,14 +34846,10 @@
             "version": "0.18.20",
             "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.18.20.tgz",
             "integrity": "sha512-e5e4YSsuQfX4cxcygw/UCPIEP6wbIL+se3sxPdCiMbFLBWu0eiZOJ7WoD+ptCLrmjZBK1Wk7I6D/I3NglUGOxg==",
-            "cpu": [
-                "x64"
-            ],
+            "cpu": ["x64"],
             "dev": true,
             "optional": true,
-            "os": [
-                "openbsd"
-            ],
+            "os": ["openbsd"],
             "engines": {
                 "node": ">=12"
             }
@@ -35157,14 +34858,10 @@
             "version": "0.18.20",
             "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.18.20.tgz",
             "integrity": "sha512-kDbFRFp0YpTQVVrqUd5FTYmWo45zGaXe0X8E1G/LKFC0v8x0vWrhOWSLITcCn63lmZIxfOMXtCfti/RxN/0wnQ==",
-            "cpu": [
-                "x64"
-            ],
+            "cpu": ["x64"],
             "dev": true,
             "optional": true,
-            "os": [
-                "sunos"
-            ],
+            "os": ["sunos"],
             "engines": {
                 "node": ">=12"
             }
@@ -35173,14 +34870,10 @@
             "version": "0.18.20",
             "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.18.20.tgz",
             "integrity": "sha512-ddYFR6ItYgoaq4v4JmQQaAI5s7npztfV4Ag6NrhiaW0RrnOXqBkgwZLofVTlq1daVTQNhtI5oieTvkRPfZrePg==",
-            "cpu": [
-                "arm64"
-            ],
+            "cpu": ["arm64"],
             "dev": true,
             "optional": true,
-            "os": [
-                "win32"
-            ],
+            "os": ["win32"],
             "engines": {
                 "node": ">=12"
             }
@@ -35189,14 +34882,10 @@
             "version": "0.18.20",
             "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.18.20.tgz",
             "integrity": "sha512-Wv7QBi3ID/rROT08SABTS7eV4hX26sVduqDOTe1MvGMjNd3EjOz4b7zeexIR62GTIEKrfJXKL9LFxTYgkyeu7g==",
-            "cpu": [
-                "ia32"
-            ],
+            "cpu": ["ia32"],
             "dev": true,
             "optional": true,
-            "os": [
-                "win32"
-            ],
+            "os": ["win32"],
             "engines": {
                 "node": ">=12"
             }
@@ -35205,14 +34894,10 @@
             "version": "0.18.20",
             "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.18.20.tgz",
             "integrity": "sha512-kTdfRcSiDfQca/y9QIkng02avJ+NCaQvrMejlsB3RRv5sE9rRoeBPISaZpKxHELzRxZyLvNts1P27W3wV+8geQ==",
-            "cpu": [
-                "x64"
-            ],
+            "cpu": ["x64"],
             "dev": true,
             "optional": true,
-            "os": [
-                "win32"
-            ],
+            "os": ["win32"],
             "engines": {
                 "node": ">=12"
             }
@@ -36326,6 +36011,7 @@
             "devDependencies": {
                 "@angular-devkit/core": "16.2.12",
                 "@angular-devkit/schematics": "16.2.12",
+                "@angular-devkit/schematics-cli": "16.2.12",
                 "@schematics/angular": "16.2.12",
                 "@types/parse5": "6.0.3"
             },

--- a/package-lock.json
+++ b/package-lock.json
@@ -5119,13 +5119,6 @@
                 "url": "https://github.com/sponsors/epoberezkin"
             }
         },
-        "node_modules/@eslint/eslintrc/node_modules/argparse": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-            "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-            "dev": true,
-            "peer": true
-        },
         "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
             "version": "1.1.11",
             "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -5151,19 +5144,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/@eslint/eslintrc/node_modules/js-yaml": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-            "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-            "dev": true,
-            "peer": true,
-            "dependencies": {
-                "argparse": "^2.0.1"
-            },
-            "bin": {
-                "js-yaml": "bin/js-yaml.js"
             }
         },
         "node_modules/@eslint/eslintrc/node_modules/json-schema-traverse": {
@@ -5428,6 +5408,15 @@
                 "node": ">=8"
             }
         },
+        "node_modules/@istanbuljs/load-nyc-config/node_modules/argparse": {
+            "version": "1.0.10",
+            "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+            "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+            "dev": true,
+            "dependencies": {
+                "sprintf-js": "~1.0.2"
+            }
+        },
         "node_modules/@istanbuljs/load-nyc-config/node_modules/find-up": {
             "version": "4.1.0",
             "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
@@ -5439,6 +5428,19 @@
             },
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
+            "version": "3.14.1",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+            "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+            "dev": true,
+            "dependencies": {
+                "argparse": "^1.0.7",
+                "esprima": "^4.0.0"
+            },
+            "bin": {
+                "js-yaml": "bin/js-yaml.js"
             }
         },
         "node_modules/@istanbuljs/load-nyc-config/node_modules/locate-path": {
@@ -8312,12 +8314,6 @@
                 "url": "https://github.com/chalk/ansi-styles?sponsor=1"
             }
         },
-        "node_modules/@nx/workspace/node_modules/argparse": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-            "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-            "dev": true
-        },
         "node_modules/@nx/workspace/node_modules/axios": {
             "version": "1.6.7",
             "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.7.tgz",
@@ -8384,18 +8380,6 @@
             "dev": true,
             "engines": {
                 "node": ">=8"
-            }
-        },
-        "node_modules/@nx/workspace/node_modules/js-yaml": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-            "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-            "dev": true,
-            "dependencies": {
-                "argparse": "^2.0.1"
-            },
-            "bin": {
-                "js-yaml": "bin/js-yaml.js"
             }
         },
         "node_modules/@nx/workspace/node_modules/lru-cache": {
@@ -10938,6 +10922,28 @@
                 "node": ">=14.15.0"
             }
         },
+        "node_modules/@yarnpkg/parsers/node_modules/argparse": {
+            "version": "1.0.10",
+            "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+            "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+            "dev": true,
+            "dependencies": {
+                "sprintf-js": "~1.0.2"
+            }
+        },
+        "node_modules/@yarnpkg/parsers/node_modules/js-yaml": {
+            "version": "3.14.1",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+            "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+            "dev": true,
+            "dependencies": {
+                "argparse": "^1.0.7",
+                "esprima": "^4.0.0"
+            },
+            "bin": {
+                "js-yaml": "bin/js-yaml.js"
+            }
+        },
         "node_modules/@zkochan/js-yaml": {
             "version": "0.0.6",
             "resolved": "https://registry.npmjs.org/@zkochan/js-yaml/-/js-yaml-0.0.6.tgz",
@@ -10949,12 +10955,6 @@
             "bin": {
                 "js-yaml": "bin/js-yaml.js"
             }
-        },
-        "node_modules/@zkochan/js-yaml/node_modules/argparse": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-            "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-            "dev": true
         },
         "node_modules/abab": {
             "version": "2.0.6",
@@ -11285,13 +11285,9 @@
             "dev": true
         },
         "node_modules/argparse": {
-            "version": "1.0.10",
-            "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-            "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-            "dev": true,
-            "dependencies": {
-                "sprintf-js": "~1.0.2"
-            }
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+            "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
         },
         "node_modules/aria-query": {
             "version": "5.3.0",
@@ -14736,24 +14732,6 @@
                 "@types/node": "*",
                 "cosmiconfig": ">=8.2",
                 "typescript": ">=4"
-            }
-        },
-        "node_modules/cosmiconfig/node_modules/argparse": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-            "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-            "dev": true
-        },
-        "node_modules/cosmiconfig/node_modules/js-yaml": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-            "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-            "dev": true,
-            "dependencies": {
-                "argparse": "^2.0.1"
-            },
-            "bin": {
-                "js-yaml": "bin/js-yaml.js"
             }
         },
         "node_modules/cp-file": {
@@ -18595,13 +18573,6 @@
                 "url": "https://github.com/chalk/ansi-styles?sponsor=1"
             }
         },
-        "node_modules/eslint/node_modules/argparse": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-            "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-            "dev": true,
-            "peer": true
-        },
         "node_modules/eslint/node_modules/brace-expansion": {
             "version": "1.1.11",
             "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -18775,19 +18746,6 @@
             "peer": true,
             "engines": {
                 "node": ">=8"
-            }
-        },
-        "node_modules/eslint/node_modules/js-yaml": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-            "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-            "dev": true,
-            "peer": true,
-            "dependencies": {
-                "argparse": "^2.0.1"
-            },
-            "bin": {
-                "js-yaml": "bin/js-yaml.js"
             }
         },
         "node_modules/eslint/node_modules/json-schema-traverse": {
@@ -24540,13 +24498,12 @@
             "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
         },
         "node_modules/js-yaml": {
-            "version": "3.14.1",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-            "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+            "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
             "dev": true,
             "dependencies": {
-                "argparse": "^1.0.7",
-                "esprima": "^4.0.0"
+                "argparse": "^2.0.1"
             },
             "bin": {
                 "js-yaml": "bin/js-yaml.js"
@@ -26191,11 +26148,6 @@
                 "markdown-it": "bin/markdown-it.mjs"
             }
         },
-        "node_modules/markdown-it/node_modules/argparse": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-            "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
-        },
         "node_modules/marked": {
             "version": "11.2.0",
             "resolved": "https://registry.npmjs.org/marked/-/marked-11.2.0.tgz",
@@ -27514,12 +27466,6 @@
                 "url": "https://github.com/chalk/ansi-styles?sponsor=1"
             }
         },
-        "node_modules/nx/node_modules/argparse": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-            "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-            "dev": true
-        },
         "node_modules/nx/node_modules/axios": {
             "version": "1.6.7",
             "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.7.tgz",
@@ -27613,18 +27559,6 @@
             "dev": true,
             "engines": {
                 "node": ">=8"
-            }
-        },
-        "node_modules/nx/node_modules/js-yaml": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-            "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-            "dev": true,
-            "dependencies": {
-                "argparse": "^2.0.1"
-            },
-            "bin": {
-                "js-yaml": "bin/js-yaml.js"
             }
         },
         "node_modules/nx/node_modules/lru-cache": {
@@ -32729,13 +32663,6 @@
                 "url": "https://github.com/chalk/ansi-regex?sponsor=1"
             }
         },
-        "node_modules/stylelint/node_modules/argparse": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-            "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-            "dev": true,
-            "peer": true
-        },
         "node_modules/stylelint/node_modules/balanced-match": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-2.0.0.tgz",
@@ -32785,19 +32712,6 @@
             },
             "engines": {
                 "node": ">=8.6.0"
-            }
-        },
-        "node_modules/stylelint/node_modules/js-yaml": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-            "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-            "dev": true,
-            "peer": true,
-            "dependencies": {
-                "argparse": "^2.0.1"
-            },
-            "bin": {
-                "js-yaml": "bin/js-yaml.js"
             }
         },
         "node_modules/stylelint/node_modules/meow": {

--- a/projects/cdk/package.json
+++ b/projects/cdk/package.json
@@ -20,6 +20,7 @@
     "devDependencies": {
         "@angular-devkit/core": "16.2.12",
         "@angular-devkit/schematics": "16.2.12",
+        "@angular-devkit/schematics-cli": "16.2.12",
         "@schematics/angular": "16.2.12",
         "@types/parse5": "6.0.3"
     },

--- a/projects/cdk/schematics/utils/templates/elements.ts
+++ b/projects/cdk/schematics/utils/templates/elements.ts
@@ -1,4 +1,3 @@
-import {ALWAYS_TRUE_HANDLER} from '@taiga-ui/cdk';
 import type {ChildNode, Element} from 'parse5';
 import {parseFragment} from 'parse5';
 
@@ -44,7 +43,8 @@ export function findElementsInTemplateByFn(
 export function findElementsByTagName(
     html: string,
     tagName: string,
-    filterFn: (element: Element) => boolean = ALWAYS_TRUE_HANDLER,
+    // eslint-disable-next-line no-restricted-syntax
+    filterFn: (element: Element) => boolean = () => true,
 ): Element[] {
     return findElementsInTemplateByFn(html, el => el.tagName === tagName && filterFn(el));
 }


### PR DESCRIPTION
# Previous behaviour
1. Manually run migration

```shell
nx build cdk
schematics ./dist/cdk:updateToV3 --allow-private --dry-run true
```

It throws:

```shell
command not found: schematics
```

2. Add `@angular-devkit/schematics-cli` to `projects/package.json`.
3. Manually run migration again
```shell
schematics ./dist/cdk:updateToV3 --allow-private --dry-run true
```

it throws:
```shell
An error occured:
Error [ERR_REQUIRE_ESM]: require() of ES Module
/<path>/taiga-ui/dist/cdk/fesm2022/taiga-ui-cdk.mjs
not supported.
Instead change the require of 
/<path>/taiga-ui/dist/cdk/fesm2022/taiga-ui-cdk.mjs
to a dynamic import() which is available in all CommonJS modules.
```

# New behaviour
```shell
➜ schematics ./dist/cdk:updateToV3 --allow-private --dry-run true
Debug mode enabled by default for local collections.
 

🚀 Your packages will be updated to @taiga-ui/*@^3.59.0

  ⚡️ replacing deep imports...
  ✅  deep imports replaced 

  ⚡️ replacing enums imports...

  # [...]
```