### PR TITLE
chore(schematics): enable possibility to manually run migration for `4.0.0`

### DIFF
--- a/projects/cdk/schematics/collection.json
+++ b/projects/cdk/schematics/collection.json
@@ -17,6 +17,12 @@
             "description": "Manually run migration to update Taiga to v3.x.x",
             "factory": "./ng-update/v3/index#updateToV3",
             "schema": "./ng-update/v3/schema.json"
+        },
+        "updateToV4": {
+            "private": true,
+            "description": "Manually run migration to update Taiga to v4.x.x",
+            "factory": "./ng-update/v4/index#updateToV4",
+            "schema": "./ng-update/v4/schema.json"
         }
     }
 }

--- a/projects/cdk/schematics/ng-update/v4/schema.json
+++ b/projects/cdk/schematics/ng-update/v4/schema.json
@@ -1,0 +1,7 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema",
+    "$id": "taiga-ui-ng-update-v4",
+    "title": "Taiga UI ng-update v4",
+    "type": "object",
+    "properties": {}
+}

--- a/projects/cdk/schematics/ng-update/v4/steps/migrate-destroy-service.ts
+++ b/projects/cdk/schematics/ng-update/v4/steps/migrate-destroy-service.ts
@@ -1,17 +1,17 @@
-import {
-    addUniqueImport,
-    FINISH_SYMBOL,
-    getNamedImportReferences,
-    infoLog,
-    removeImport,
-    REPLACE_SYMBOL,
-    SMALL_TAB_SYMBOL,
-    titleLog,
-} from '@taiga-ui/cdk/schematics';
 import {Node} from 'ng-morph';
 import type {CallExpression} from 'ts-morph';
 
 import type {TuiSchema} from '../../../ng-add/schema';
+import {addUniqueImport} from '../../../utils/add-unique-import';
+import {
+    FINISH_SYMBOL,
+    infoLog,
+    REPLACE_SYMBOL,
+    SMALL_TAB_SYMBOL,
+    titleLog,
+} from '../../../utils/colored-log';
+import {getNamedImportReferences} from '../../../utils/get-named-import-references';
+import {removeImport} from '../../../utils/import-manipulations';
 
 export function migrateDestroyService(options: TuiSchema): void {
     !options['skip-logs'] &&

--- a/projects/cdk/schematics/ng-update/v4/steps/migrate-legacy-mask.ts
+++ b/projects/cdk/schematics/ng-update/v4/steps/migrate-legacy-mask.ts
@@ -1,16 +1,16 @@
-import {
-    addUniqueImport,
-    FINISH_SYMBOL,
-    getNamedImportReferences,
-    infoLog,
-    removeImport,
-    REPLACE_SYMBOL,
-    SMALL_TAB_SYMBOL,
-    titleLog,
-} from '@taiga-ui/cdk/schematics';
 import {Node} from 'ng-morph';
 
 import type {TuiSchema} from '../../../ng-add/schema';
+import {addUniqueImport} from '../../../utils/add-unique-import';
+import {
+    FINISH_SYMBOL,
+    infoLog,
+    REPLACE_SYMBOL,
+    SMALL_TAB_SYMBOL,
+    titleLog,
+} from '../../../utils/colored-log';
+import {getNamedImportReferences} from '../../../utils/get-named-import-references';
+import {removeImport} from '../../../utils/import-manipulations';
 
 export function migrateLegacyMask(options: TuiSchema): void {
     !options['skip-logs'] &&

--- a/projects/cdk/schematics/ng-update/v4/steps/templates/migrate-badged-content.ts
+++ b/projects/cdk/schematics/ng-update/v4/steps/templates/migrate-badged-content.ts
@@ -1,9 +1,9 @@
 import type {UpdateRecorder} from '@angular-devkit/schematics';
-import {findAttr} from '@taiga-ui/cdk/schematics/utils/templates/inputs';
 import type {DevkitFileSystem} from 'ng-morph';
 import type {Attribute, ElementLocation} from 'parse5';
 
 import {findElementsByTagName} from '../../../../utils/templates/elements';
+import {findAttr} from '../../../../utils/templates/inputs';
 import {
     getTemplateFromTemplateResource,
     getTemplateOffset,

--- a/projects/cdk/schematics/ng-update/v4/steps/templates/migrate-money.ts
+++ b/projects/cdk/schematics/ng-update/v4/steps/templates/migrate-money.ts
@@ -2,7 +2,7 @@ import type {UpdateRecorder} from '@angular-devkit/schematics';
 import type {DevkitFileSystem} from 'ng-morph';
 import type {Attribute} from 'parse5';
 
-import {tuiCleanObject} from '../../../../../utils/miscellaneous/clean-object'; // TODO
+import {tuiCleanObject} from '../../../../../utils/miscellaneous/clean-object';
 import type {TemplateResource} from '../../../../ng-update/interfaces';
 import {removeAttrs} from '../../../../ng-update/v4/steps/utils/remove-attrs';
 import {addImportToClosestModule} from '../../../../utils/add-import-to-closest-module';

--- a/projects/cdk/schematics/ng-update/v4/steps/templates/migrate-money.ts
+++ b/projects/cdk/schematics/ng-update/v4/steps/templates/migrate-money.ts
@@ -1,16 +1,17 @@
 import type {UpdateRecorder} from '@angular-devkit/schematics';
-import {tuiCleanObject} from '@taiga-ui/cdk';
-import {addImportToClosestModule} from '@taiga-ui/cdk/schematics';
-import type {TemplateResource} from '@taiga-ui/cdk/schematics/ng-update/interfaces';
-import {removeAttrs} from '@taiga-ui/cdk/schematics/ng-update/v4/steps/utils/remove-attrs';
-import {findElementsByTagName} from '@taiga-ui/cdk/schematics/utils/templates/elements';
-import {findAttr, isBinding} from '@taiga-ui/cdk/schematics/utils/templates/inputs';
+import type {DevkitFileSystem} from 'ng-morph';
+import type {Attribute} from 'parse5';
+
+import {tuiCleanObject} from '../../../../../utils/miscellaneous/clean-object'; // TODO
+import type {TemplateResource} from '../../../../ng-update/interfaces';
+import {removeAttrs} from '../../../../ng-update/v4/steps/utils/remove-attrs';
+import {addImportToClosestModule} from '../../../../utils/add-import-to-closest-module';
+import {findElementsByTagName} from '../../../../utils/templates/elements';
+import {findAttr, isBinding} from '../../../../utils/templates/inputs';
 import {
     getTemplateFromTemplateResource,
     getTemplateOffset,
-} from '@taiga-ui/cdk/schematics/utils/templates/template-resource';
-import type {DevkitFileSystem} from 'ng-morph';
-import type {Attribute} from 'parse5';
+} from '../../../../utils/templates/template-resource';
 
 export function migrateMoney({
     resource,

--- a/projects/cdk/schematics/ng-update/v4/steps/templates/migrate-prevent-default.ts
+++ b/projects/cdk/schematics/ng-update/v4/steps/templates/migrate-prevent-default.ts
@@ -1,12 +1,13 @@
 import type {UpdateRecorder} from '@angular-devkit/schematics';
-import type {TemplateResource} from '@taiga-ui/cdk/schematics/ng-update/interfaces';
-import {findElementsWithAttribute} from '@taiga-ui/cdk/schematics/utils/templates/elements';
-import {findAttr} from '@taiga-ui/cdk/schematics/utils/templates/inputs';
+import type {DevkitFileSystem} from 'ng-morph';
+
+import type {TemplateResource} from '../../../../ng-update/interfaces';
+import {findElementsWithAttribute} from '../../../../utils/templates/elements';
+import {findAttr} from '../../../../utils/templates/inputs';
 import {
     getTemplateFromTemplateResource,
     getTemplateOffset,
-} from '@taiga-ui/cdk/schematics/utils/templates/template-resource';
-import type {DevkitFileSystem} from 'ng-morph';
+} from '../../../../utils/templates/template-resource';
 
 export function migratePreventDefault({
     resource,


### PR DESCRIPTION
Relates #5808

# Previous behaviour
1. Manually run migration for `4.0.0`
```shell
nx build cdk
schematics ./dist/cdk:updateToV4 --allow-private --dry-run true
```

it throws:
```shell
Debug mode enabled by default for local collections.
An error occured:
Error: Schematic "updateToV4" not found in collection "./dist/cdk".
```

2. Add `projects/cdk/schematics/ng-update/v4/schema.json` and update `projects/cdk/schematics/collection.json`
3. Manually run migration for `4.0.0`
```shell
nx build cdk --skip-nx-cache
schematics ./dist/cdk:updateToV4 --allow-private --dry-run true
```

It throws:
```shell
An error occured:
Error [ERR_PACKAGE_PATH_NOT_EXPORTED]:
Package subpath './schematics' is not defined by "exports" in
/Users/n.barsukov/WebstormProjects/taiga-ui/dist/cdk/package.json imported
from
/Users/n.barsukov/WebstormProjects/taiga-ui/dist/cdk/schematics/ng-update/v4/steps/migrate-destroy-service.js
```

# New bahaviour

```shell
➜ schematics ./dist/cdk:updateToV4 --allow-private --dry-run true
Debug mode enabled by default for local collections.
 

🚀 Your packages will be updated to @taiga-ui/*@^3.59.0

  ⚡️ replacing identifiers...
An error occured:
TypeError: Cannot read properties of null (reading 'getSourceFiles')
    at getSourceFiles (/Users/n.barsukov/WebstormProjects/taiga-ui/node_modules/ng-morph/source-file/helpers/get-source-files.js:6:45)
    at /Users/n.barsukov/WebstormProjects/taiga-ui/node_modules/ng-morph/imports/helpers/get-imports.js:7:58
    at getDeclaration (/Users/n.barsukov/WebstormProjects/taiga-ui/node_modules/ng-morph/utils/helpers/get-declaration-getter.js:7:16)
    at getNamedImportReferences (/Users/n.barsukov/WebstormProjects/taiga-ui/dist/cdk/schematics/utils/get-named-import-references.js:7:58)
    at replaceIdentifier (/Users/n.barsukov/WebstormProjects/taiga-ui/dist/cdk/schematics/ng-update/steps/replace-identifier.js:18:83)
    at Array.forEach (<anonymous>)
    at replaceIdentifiers (/Users/n.barsukov/WebstormProjects/taiga-ui/dist/cdk/schematics/ng-update/steps/replace-identifier.js:12:15)
    at /Users/n.barsukov/WebstormProjects/taiga-ui/dist/cdk/schematics/ng-update/v4/index.js:19:40
    at callRuleAsync (/Users/n.barsukov/WebstormProjects/taiga-ui/node_modules/@angular-devkit/schematics/src/rules/call.js:77:24)
    at /Users/n.barsukov/WebstormProjects/taiga-ui/node_modules/@angular-devkit/schematics/src/rules/call.js:72:40

```


Yep, it another error.
But manual launch of schematic works now!