### PR TITLE
chore: fix `v4` migration `TypeError: Cannot read properties of null (reading 'getSourceFiles')`

### DIFF
--- a/.github/workflows/schematics.yml
+++ b/.github/workflows/schematics.yml
@@ -8,7 +8,7 @@ jobs:
   schematics:
     if: ${{ !contains(github.head_ref , 'release/') }}
     runs-on: ubuntu-latest
-    name: Testing latest migration
+    name: Run the latest migration
     steps:
       - uses: taiga-family/ci/actions/setup/checkout@v1.51.14
       - uses: taiga-family/ci/actions/setup/node@v1.51.14

--- a/.github/workflows/schematics.yml
+++ b/.github/workflows/schematics.yml
@@ -9,11 +9,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: taiga-family/ci/actions/setup/checkout@v1.51.14
-        with:
-          fetch-depth: 10
-        continue-on-error: true
+      - uses: taiga-family/ci/actions/setup/variables@v1.51.14
       - uses: taiga-family/ci/actions/setup/node@v1.51.14
+
       - run: npx nx build cdk
+
+      - name: Upload cache / ${{ env.CACHE_DIST_KEY }}
+        uses: actions/cache/save@v4.0.1
+        with:
+          path: dist/demo
+          key: ${{ env.CACHE_DIST_KEY }}
 
   schematics:
     if: ${{ !contains(github.head_ref , 'release/') }}
@@ -23,10 +28,18 @@ jobs:
       fail-fast: false
       matrix:
         version: [3, 4]
-    name: Schematics / Testing v${{ matrix.version }} migration
+    name: Testing v${{ matrix.version }} migration
     steps:
       - uses: taiga-family/ci/actions/setup/checkout@v1.51.14
+      - uses: taiga-family/ci/actions/setup/variables@v1.51.14
       - uses: taiga-family/ci/actions/setup/node@v1.51.14
+
+      - name: Download cache / ${{ env.CACHE_DIST_KEY }}
+        uses: actions/cache/restore@v4.0.1
+        with:
+          path: dist/demo
+          key: ${{ env.CACHE_DIST_KEY }}
+
       - run: npx nx run cdk:schematics --v=${{ matrix.version }}
 
 concurrency:

--- a/.github/workflows/schematics.yml
+++ b/.github/workflows/schematics.yml
@@ -3,9 +3,22 @@ on:
   pull_request:
 
 jobs:
+  build-cdk:
+    if: ${{ !contains(github.head_ref , 'release/') }}
+    name: Build @taiga-ui/cdk
+    runs-on: ubuntu-latest
+    steps:
+      - uses: taiga-family/ci/actions/setup/checkout@v1.51.14
+        with:
+          fetch-depth: 10
+        continue-on-error: true
+      - uses: taiga-family/ci/actions/setup/node@v1.51.14
+      - run: npx nx build cdk
+
   schematics:
     if: ${{ !contains(github.head_ref , 'release/') }}
     runs-on: ubuntu-latest
+    needs: [build-cdk]
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/schematics.yml
+++ b/.github/workflows/schematics.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Upload cache / ${{ env.CACHE_DIST_KEY }}
         uses: actions/cache/save@v4.0.1
         with:
-          path: dist/demo
+          path: dist/cdk
           key: ${{ env.CACHE_DIST_KEY }}
 
   schematics:
@@ -37,7 +37,7 @@ jobs:
       - name: Download cache / ${{ env.CACHE_DIST_KEY }}
         uses: actions/cache/restore@v4.0.1
         with:
-          path: dist/demo
+          path: dist/cdk
           key: ${{ env.CACHE_DIST_KEY }}
 
       - run: npx nx run cdk:schematics --v=${{ matrix.version }}

--- a/.github/workflows/schematics.yml
+++ b/.github/workflows/schematics.yml
@@ -1,0 +1,21 @@
+name: ⚙️ Schematics
+on:
+  pull_request:
+
+jobs:
+  schematics:
+    if: ${{ !contains(github.head_ref , 'release/') }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        version: [3, 4]
+    name: Schematics / Testing v${{ matrix.version }} migration
+    steps:
+      - uses: taiga-family/ci/actions/setup/checkout@v1.51.14
+      - uses: taiga-family/ci/actions/setup/node@v1.51.14
+        run: npx nx run cdk:schematics --v=${{ matrix.version }}
+
+concurrency:
+  group: schematics-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true

--- a/.github/workflows/schematics.yml
+++ b/.github/workflows/schematics.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - uses: taiga-family/ci/actions/setup/checkout@v1.51.14
       - uses: taiga-family/ci/actions/setup/node@v1.51.14
-        run: npx nx run cdk:schematics --v=${{ matrix.version }}
+      - run: npx nx run cdk:schematics --v=${{ matrix.version }}
 
 concurrency:
   group: schematics-${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/schematics.yml
+++ b/.github/workflows/schematics.yml
@@ -29,7 +29,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: [3, 4]
+        version: [4]
     name: Testing v${{ matrix.version }} migration
     steps:
       - uses: taiga-family/ci/actions/setup/checkout@v1.51.14

--- a/.github/workflows/schematics.yml
+++ b/.github/workflows/schematics.yml
@@ -16,11 +16,11 @@ jobs:
 
       - run: npx nx build cdk
 
-      - name: Upload cache / ${{ env.CACHE_DIST_KEY }}
+      - name: Upload cache / ${{ env.CACHE_DIST_KEY }}_cdk
         uses: actions/cache/save@v4.0.1
         with:
           path: dist/cdk
-          key: ${{ env.CACHE_DIST_KEY }}
+          key: ${{ env.CACHE_DIST_KEY }}_cdk
 
   schematics:
     if: ${{ !contains(github.head_ref , 'release/') }}
@@ -36,11 +36,11 @@ jobs:
       - uses: taiga-family/ci/actions/setup/variables@v1.51.14
       - uses: taiga-family/ci/actions/setup/node@v1.51.14
 
-      - name: Download cache / ${{ env.CACHE_DIST_KEY }}
+      - name: Download cache / ${{ env.CACHE_DIST_KEY }}_cdk
         uses: actions/cache/restore@v4.0.1
         with:
           path: dist/cdk
-          key: ${{ env.CACHE_DIST_KEY }}
+          key: ${{ env.CACHE_DIST_KEY }}_cdk
 
       - run: npx nx run cdk:schematics --v=${{ matrix.version }}
 

--- a/.github/workflows/schematics.yml
+++ b/.github/workflows/schematics.yml
@@ -1,6 +1,8 @@
 name: ⚙️ Schematics
 on:
   pull_request:
+    paths:
+      - 'projects/cdk/schematics/**'
 
 jobs:
   build-cdk:

--- a/.github/workflows/schematics.yml
+++ b/.github/workflows/schematics.yml
@@ -5,44 +5,14 @@ on:
       - 'projects/cdk/schematics/**'
 
 jobs:
-  build-cdk:
-    if: ${{ !contains(github.head_ref , 'release/') }}
-    name: Build @taiga-ui/cdk
-    runs-on: ubuntu-latest
-    steps:
-      - uses: taiga-family/ci/actions/setup/checkout@v1.51.14
-      - uses: taiga-family/ci/actions/setup/variables@v1.51.14
-      - uses: taiga-family/ci/actions/setup/node@v1.51.14
-
-      - run: npx nx build cdk
-
-      - name: Upload cache / ${{ env.CACHE_DIST_KEY }}_cdk
-        uses: actions/cache/save@v4.0.1
-        with:
-          path: dist/cdk
-          key: ${{ env.CACHE_DIST_KEY }}_cdk
-
   schematics:
     if: ${{ !contains(github.head_ref , 'release/') }}
     runs-on: ubuntu-latest
-    needs: [build-cdk]
-    strategy:
-      fail-fast: false
-      matrix:
-        version: [4]
-    name: Testing v${{ matrix.version }} migration
+    name: Testing latest migration
     steps:
       - uses: taiga-family/ci/actions/setup/checkout@v1.51.14
-      - uses: taiga-family/ci/actions/setup/variables@v1.51.14
       - uses: taiga-family/ci/actions/setup/node@v1.51.14
-
-      - name: Download cache / ${{ env.CACHE_DIST_KEY }}_cdk
-        uses: actions/cache/restore@v4.0.1
-        with:
-          path: dist/cdk
-          key: ${{ env.CACHE_DIST_KEY }}_cdk
-
-      - run: npx nx run cdk:schematics --v=${{ matrix.version }}
+      - run: npx nx run cdk:schematics --v=4
 
 concurrency:
   group: schematics-${{ github.workflow }}-${{ github.ref }}

--- a/projects/cdk/project.json
+++ b/projects/cdk/project.json
@@ -38,7 +38,13 @@
             "executor": "nx:run-commands",
             "options": {
                 "command": "schematics ./dist/cdk:updateToV{args.v} --allow-private --dry-run true"
-            }
+            },
+            "dependsOn": [
+                {
+                    "target": "build",
+                    "params": "ignore"
+                }
+            ]
         },
         "test": {
             "executor": "@nx/jest:jest",

--- a/projects/cdk/project.json
+++ b/projects/cdk/project.json
@@ -34,6 +34,18 @@
                 "command": "tsc -p ./projects/cdk/schematics/tsconfig.schematics.json"
             }
         },
+        "schematics": {
+            "executor": "nx:run-commands",
+            "options": {
+                "command": "schematics ./dist/cdk:updateToV4 --allow-private --dry-run true"
+            },
+            "dependsOn": [
+                {
+                    "target": "postbuild",
+                    "params": "forward"
+                }
+            ]
+        },
         "test": {
             "executor": "@nx/jest:jest",
             "outputs": ["{workspaceRoot}/coverage/cdk"],

--- a/projects/cdk/project.json
+++ b/projects/cdk/project.json
@@ -38,13 +38,7 @@
             "executor": "nx:run-commands",
             "options": {
                 "command": "schematics ./dist/cdk:updateToV{args.v} --allow-private --dry-run true"
-            },
-            "dependsOn": [
-                {
-                    "target": "postbuild",
-                    "params": "ignore"
-                }
-            ]
+            }
         },
         "test": {
             "executor": "@nx/jest:jest",

--- a/projects/cdk/project.json
+++ b/projects/cdk/project.json
@@ -37,12 +37,12 @@
         "schematics": {
             "executor": "nx:run-commands",
             "options": {
-                "command": "schematics ./dist/cdk:updateToV4 --allow-private --dry-run true"
+                "command": "schematics ./dist/cdk:updateToV{args.v} --allow-private --dry-run true"
             },
             "dependsOn": [
                 {
                     "target": "postbuild",
-                    "params": "forward"
+                    "params": "ignore"
                 }
             ]
         },

--- a/projects/cdk/schematics/ng-update/v4/index.ts
+++ b/projects/cdk/schematics/ng-update/v4/index.ts
@@ -1,15 +1,14 @@
 import type {Rule, SchematicContext, Tree} from '@angular-devkit/schematics';
 import {chain} from '@angular-devkit/schematics';
-import {createProject, saveActiveProject} from 'ng-morph';
+import {saveActiveProject} from 'ng-morph';
 import {performance} from 'perf_hooks';
 
-import {ALL_FILES} from '../../constants';
 import {TAIGA_VERSION} from '../../ng-add/constants/versions';
 import type {TuiSchema} from '../../ng-add/schema';
 import {FINISH_SYMBOL, START_SYMBOL, titleLog} from '../../utils/colored-log';
 import {getExecutionTime} from '../../utils/get-execution-time';
-import {projectRoot} from '../../utils/project-root';
 import {removeModules, replaceIdentifiers, showWarnings} from '../steps';
+import {getFileSystem} from '../utils/get-file-system';
 import {
     migrateDestroyService,
     migrateLegacyMask,
@@ -25,9 +24,7 @@ import {
 
 function main(options: TuiSchema): Rule {
     return (tree: Tree, context: SchematicContext) => {
-        const project = createProject(tree, projectRoot(), ALL_FILES);
-
-        const fileSystem = project.getFileSystem().fs;
+        const fileSystem = getFileSystem(tree);
 
         replaceIdentifiers(options, IDENTIFIERS_TO_REPLACE);
         removeModules(options, MODULES_TO_REMOVE);


### PR DESCRIPTION
Relates to #5808

# Previous behaviour

```shell
➜ schematics ./dist/cdk:updateToV4 --allow-private --dry-run true
Debug mode enabled by default for local collections.
 

🚀 Your packages will be updated to @taiga-ui/*@^3.59.0

  ⚡️ replacing identifiers...
An error occured:
TypeError: Cannot read properties of null (reading 'getSourceFiles')
    at getSourceFiles (/Users/n.barsukov/WebstormProjects/taiga-ui/node_modules/ng-morph/source-file/helpers/get-source-files.js:6:45)
    at /Users/n.barsukov/WebstormProjects/taiga-ui/node_modules/ng-morph/imports/helpers/get-imports.js:7:58
    at getDeclaration (/Users/n.barsukov/WebstormProjects/taiga-ui/node_modules/ng-morph/utils/helpers/get-declaration-getter.js:7:16)
    at getNamedImportReferences (/Users/n.barsukov/WebstormProjects/taiga-ui/dist/cdk/schematics/utils/get-named-import-references.js:7:58)
    at replaceIdentifier (/Users/n.barsukov/WebstormProjects/taiga-ui/dist/cdk/schematics/ng-update/steps/replace-identifier.js:18:83)
    at Array.forEach (<anonymous>)
    at replaceIdentifiers (/Users/n.barsukov/WebstormProjects/taiga-ui/dist/cdk/schematics/ng-update/steps/replace-identifier.js:12:15)
    at /Users/n.barsukov/WebstormProjects/taiga-ui/dist/cdk/schematics/ng-update/v4/index.js:19:40
    at callRuleAsync (/Users/n.barsukov/WebstormProjects/taiga-ui/node_modules/@angular-devkit/schematics/src/rules/call.js:77:24)
    at /Users/n.barsukov/WebstormProjects/taiga-ui/node_modules/@angular-devkit/schematics/src/rules/call.js:72:40
```

# New behaviour
```shell
➜ schematics ./dist/cdk:updateToV4 --allow-private --dry-run true

🚀 Your packages will be updated to @taiga-ui/*@^3.59.0
  ⚡️ replacing identifiers...
  ✅  identifiers replaced 

  ⚡️ removing modules...
  ✅  modules removed 

  ⚡️ updating TuiMapper typing to the typed version
  ⚡️ renaming TuiTypedMapper to TuiMapper
 🏆 successfully migrated 
  ⚡️ updating TuiMatcher typing to the typed version
  ⚡️ renaming TuiTypedMatcher to TuiMatcher
 🏆 successfully migrated 
  ⚡️ migrating legacy mask utils...
  ⚡️ tuiMaskedMoneyValueIsEmpty
  ⚡️ tuiMaskedNumberStringToNumber
 🏆 successfully migrated 
  ⚡️ migrating TuiDestroyService => takeUntilDestroyed ...
 🏆 successfully migrated 
  ⚡️ migrating templates...
    (1162 / 1162)  ✅ 
  ✅  templates migrated 

 🏆 We migrated packages to @taiga-ui/*@^3.59.0 in 309.55 sec. 
UPDATE projects/addon-doc/components/documentation/documentation.template.html (9537 bytes)
UPDATE projects/kit/components/checkbox-labeled/checkbox-labeled.template.html (613 bytes)
UPDATE projects/kit/components/filter/filter.template.html (730 bytes)
# [...]
```

+ add CI checks