### PR TITLE
chore(schematics): optimize `getNamedImportReferences` utility

### DIFF
--- a/projects/cdk/schematics/utils/get-named-import-references.ts
+++ b/projects/cdk/schematics/utils/get-named-import-references.ts
@@ -21,6 +21,17 @@ export function getNamedImportReferences(
     );
 
     return arrayFlat(
-        namedImports.map(specifier => specifier?.findReferencesAsNodes() || []),
+        namedImports.map(
+            specifier =>
+                specifier?.findReferencesAsNodes().filter(
+                    /**
+                     * Otherwise, each `findReferencesAsNodes` will return references across THE WHOLE project.
+                     * It will cause a lot of duplicates in the result and significantly slow down the process.
+                     */
+                    ref =>
+                        ref.getSourceFile().getFilePath() ===
+                        specifier?.getSourceFile().getFilePath(),
+                ) || [],
+        ),
     );
 }


### PR DESCRIPTION
# Previous behaviour
```shell
> nx run cdk:schematics --v=4

Debug mode enabled by default for local collections.
 
🚀 Your packages will be updated to @taiga-ui/*@^3.59.0
  ⚡️ replacing identifiers...
  ✅  identifiers replaced 

  ⚡️ removing modules...
  ✅  modules removed 

  ⚡️ updating TuiMapper typing to the typed version
  ⚡️ renaming TuiTypedMapper to TuiMapper
 🏆 successfully migrated 
  ⚡️ updating TuiMatcher typing to the typed version
  ⚡️ renaming TuiTypedMatcher to TuiMatcher
 🏆 successfully migrated 
  ⚡️ migrating legacy mask utils...
  ⚡️ tuiMaskedMoneyValueIsEmpty
  ⚡️ tuiMaskedNumberStringToNumber
 🏆 successfully migrated 
  ⚡️ migrating TuiDestroyService => takeUntilDestroyed ...
 🏆 successfully migrated 
  ⚡️ migrating templates...
  ✅  templates migrated 

 🏆 We migrated packages to @taiga-ui/*@^3.59.0 in 484.62 sec. 
UPDATE projects/addon-doc/components/demo/demo.template.html (6022 bytes)
UPDATE projects/addon-doc/components/documentation/documentation.template.html (9423 bytes)
UPDATE projects/kit/components/checkbox-labeled/checkbox-labeled.template.html (602 bytes)
UPDATE projects/kit/components/filter/filter.template.html (730 bytes)
# [...]
```
> **484.62 sec**


# New behaviour
```shell
> nx run cdk:schematics --v=4
Debug mode enabled by default for local collections.
 
🚀 Your packages will be updated to @taiga-ui/*@^3.59.0
  ⚡️ replacing identifiers...
  ✅  identifiers replaced 

  ⚡️ removing modules...
  ✅  modules removed 

  ⚡️ updating TuiMapper typing to the typed version
  ⚡️ renaming TuiTypedMapper to TuiMapper
 🏆 successfully migrated 
  ⚡️ updating TuiMatcher typing to the typed version
  ⚡️ renaming TuiTypedMatcher to TuiMatcher
 🏆 successfully migrated 
  ⚡️ migrating legacy mask utils...
  ⚡️ tuiMaskedMoneyValueIsEmpty
  ⚡️ tuiMaskedNumberStringToNumber
 🏆 successfully migrated 
  ⚡️ migrating TuiDestroyService => takeUntilDestroyed ...
 🏆 successfully migrated 
  ⚡️ migrating templates...
  ✅  templates migrated 

 🏆 We migrated packages to @taiga-ui/*@^3.59.0 in 383.13 sec. 
UPDATE projects/addon-doc/components/demo/demo.template.html (6022 bytes)
UPDATE projects/addon-doc/components/documentation/documentation.template.html (9423 bytes)
UPDATE projects/kit/components/checkbox-labeled/checkbox-labeled.template.html (602 bytes)
# [...]
```

> **383.13 sec**