### PR TITLE
fix(kit): `TasbWithMore` fix redundant left margin for single element (#7022)

### DIFF
--- a/projects/kit/components/tabs/tab/tab.style.less
+++ b/projects/kit/components/tabs/tab/tab.style.less
@@ -6,9 +6,14 @@
 
 :host-context(tui-tabs >):first-child,
 :host-context([tuiTabs] >):first-child,
-:host-context(tui-tabs > :first-child),
-:host-context([tuiTabs] > :first-child) {
+:host-context(tui-tabs > :not(.t-overflown) >):first-child,
+:host-context([tuiTabs] > :not(.t-overflown) >):first-child {
     margin-left: 0;
+}
+
+:host-context([tuiTabs] > [tuiTab] ~ :not(.t-overflown) >):first-child,
+:host-context(tui-tabs > [tuiTab] ~ :not(.t-overflown) >):first-child {
+    margin-left: var(--tui-tab-margin, 1.5rem);
 }
 
 :host {


### PR DESCRIPTION
(cherry picked from commit 9245d8b4f6db6fbd2350c413c4ca651470c69f98)

Closes # <!-- link to a relevant issue. -->
