### PR TITLE
fix(kit): `InputFiles` fix drag over detection when zone.js event coalescing is enabled

### DIFF
--- a/projects/demo/src/emulate/ng-zone-options.ts
+++ b/projects/demo/src/emulate/ng-zone-options.ts
@@ -1,5 +1,5 @@
 export const NgZoneOptionsCoalescing = {
     ngZone: 'zone.js' as const,
-    ngZoneEventCoalescing: false,
+    ngZoneEventCoalescing: true,
     ngZoneRunCoalescing: false,
 };

--- a/projects/kit/components/input-files/input-files.component.ts
+++ b/projects/kit/components/input-files/input-files.component.ts
@@ -54,7 +54,7 @@ export class TuiInputFilesComponent
     @ViewChild('input')
     private readonly input?: ElementRef<HTMLInputElement>;
 
-    private dataTransfer: DataTransfer | null = null;
+    private files?: FileList | null = null;
 
     @ContentChild(forwardRef(() => TuiInputFilesDirective))
     readonly nativeInput?: TuiInputFilesDirective;
@@ -158,7 +158,7 @@ export class TuiInputFilesComponent
     }
 
     get fileDragged(): boolean {
-        return !!this.dataTransfer?.types.includes('Files');
+        return !!this.files && !this.computedDisabled;
     }
 
     get arrayValue(): readonly TuiFileLike[] {
@@ -185,11 +185,12 @@ export class TuiInputFilesComponent
     }
 
     onDropped(event: DataTransfer): void {
+        this.files = null;
         this.processSelectedFiles(event.files);
     }
 
     onDragOver(dataTransfer: DataTransfer | null): void {
-        this.dataTransfer = dataTransfer;
+        this.files = dataTransfer?.files;
     }
 
     removeFile(removedFile: TuiFileLike): void {


### PR DESCRIPTION


Closes #7004
