### PR TITLE
chore(cdk): fix duplicating property problem in `TuiDestroyService => takeUntilDestroyed` migration

### DIFF
--- a/projects/cdk/schematics/ng-update/v4/steps/migrate-destroy-service.ts
+++ b/projects/cdk/schematics/ng-update/v4/steps/migrate-destroy-service.ts
@@ -134,11 +134,12 @@ export function migrateDestroyService(options: TuiSchema): void {
             );
 
             if (componentClass) {
-                componentClass.addProperty({
-                    name: 'destroyRef',
-                    initializer: 'inject(DestroyRef)',
-                    isReadonly: true,
-                });
+                !componentClass.getProperty('destroyRef') &&
+                    componentClass.addProperty({
+                        name: 'destroyRef',
+                        initializer: 'inject(DestroyRef)',
+                        isReadonly: true,
+                    });
 
                 return possibleTakeUntil.replaceWithText(
                     'takeUntilDestroyed(this.destroyRef)',


### PR DESCRIPTION
Relates to #5808