### PR TITLE
refactor(core): `Link` uses `Icon` instead of legacy `Svg`

### DIFF
--- a/projects/addon-doc/components/doc-tab/doc-tab.component.html
+++ b/projects/addon-doc/components/doc-tab/doc-tab.component.html
@@ -1,5 +1,6 @@
 <div class="t-tab">
-    <tui-svg
+    <img
+        alt="Documentation tab icon"
         class="t-icon"
         [src]="src"
     />

--- a/projects/addon-doc/components/doc-tab/doc-tab.component.less
+++ b/projects/addon-doc/components/doc-tab/doc-tab.component.less
@@ -9,6 +9,5 @@
     .t-icon {
         width: 1rem;
         height: 1rem;
-        color: var(--tui-text-01);
     }
 }

--- a/projects/addon-doc/components/doc-tab/doc-tab.module.ts
+++ b/projects/addon-doc/components/doc-tab/doc-tab.module.ts
@@ -1,10 +1,8 @@
 import {NgModule} from '@angular/core';
-import {TuiIconComponent} from '@taiga-ui/core';
 
 import {TuiDocTabComponent} from './doc-tab.component';
 
 @NgModule({
-    imports: [TuiIconComponent],
     declarations: [TuiDocTabComponent],
     exports: [TuiDocTabComponent],
 })

--- a/projects/addon-doc/components/doc-tab/doc-tab.module.ts
+++ b/projects/addon-doc/components/doc-tab/doc-tab.module.ts
@@ -1,10 +1,10 @@
 import {NgModule} from '@angular/core';
-import {TuiSvgModule} from '@taiga-ui/core';
+import {TuiIconComponent} from '@taiga-ui/core';
 
 import {TuiDocTabComponent} from './doc-tab.component';
 
 @NgModule({
-    imports: [TuiSvgModule],
+    imports: [TuiIconComponent],
     declarations: [TuiDocTabComponent],
     exports: [TuiDocTabComponent],
 })

--- a/projects/core/components/link/link.module.ts
+++ b/projects/core/components/link/link.module.ts
@@ -1,11 +1,11 @@
 import {CommonModule} from '@angular/common';
 import {NgModule} from '@angular/core';
-import {TuiSvgModule} from '@taiga-ui/core/components/svg';
+import {TuiIconComponent} from '@taiga-ui/core/components/icon';
 
 import {TuiLinkComponent} from './link.component';
 
 @NgModule({
-    imports: [CommonModule, TuiSvgModule],
+    imports: [CommonModule, TuiIconComponent],
     declarations: [TuiLinkComponent],
     exports: [TuiLinkComponent],
 })

--- a/projects/core/components/link/link.style.less
+++ b/projects/core/components/link/link.style.less
@@ -146,8 +146,8 @@
 .t-icon {
     .transition(~'transform');
 
-    width: var(--tui-link-icon-size, 1.5rem);
-    height: var(--tui-link-icon-size, 1.5rem);
+    width: var(--tui-link-icon-size, 1rem);
+    height: var(--tui-link-icon-size, 1rem);
     margin-top: -0.125rem;
 
     &_left {

--- a/projects/core/components/link/link.template.html
+++ b/projects/core/components/link/link.template.html
@@ -1,13 +1,13 @@
-<tui-svg
+<tui-icon
     *ngIf="iconAlignLeft"
     class="t-icon t-icon_left"
-    [src]="icon || ''"
+    [icon]="icon || ''"
 />
 <span class="t-content">
     <ng-content />
 </span>
-<tui-svg
+<tui-icon
     *ngIf="iconAlignRight"
     class="t-icon t-icon_right"
-    [src]="icon || ''"
+    [icon]="icon || ''"
 />

--- a/projects/demo/src/modules/app/app.style.less
+++ b/projects/demo/src/modules/app/app.style.less
@@ -24,5 +24,5 @@ app {
 }
 
 .app-link {
-    margin-left: 1rem;
+    margin-left: 1.5rem;
 }


### PR DESCRIPTION
Run `nx serve-ssr` and open `/getting-started` page

# Previous behavior
```shell
Assertion failed: Failed to load external SVG assets/images/github.svg
Assertion failed: Failed to load external SVG assets/icons/telegram.svg
Assertion failed: Failed to load external SVG assets/icons/discord.svg
Assertion failed: Failed to load external SVG assets/icons/stackblitz.svg
Assertion failed: Failed to load external SVG assets/icons/angular.svg
Assertion failed: Failed to load external SVG assets/icons/angular.svg
Assertion failed: Failed to load external SVG assets/icons/angular.svg
Assertion failed: Failed to load external SVG assets/icons/angular.svg
Assertion failed: Failed to load external SVG assets/icons/nx.svg
Assertion failed: Failed to load external SVG assets/icons/nx.svg
Assertion failed: Failed to load external SVG assets/icons/nx.svg
Assertion failed: Failed to load external SVG assets/icons/nx.svg
Assertion failed: Failed to load external SVG assets/icons/npm.svg
Assertion failed: Failed to load external SVG assets/icons/npm.svg
Assertion failed: Failed to load external SVG assets/icons/ts.svg
Assertion failed: Failed to load external SVG assets/icons/ts.svg
Assertion failed: Failed to load extern
al SVG assets/icons/ts.svg
Assertion failed: Failed to load external SVG assets/icons/ts.svg
Assertion failed: Failed to load external SVG assets/icons/css.svg
Assertion failed: Failed to load external SVG assets/icons/html.svg
Assertion failed: Failed to load external SVG assets/icons/html.svg

```

# New behavior
The mentioned errors are solved.