### PR TITLE
chore(demo): fix some warning logs during `nx serve-ssr`

### DIFF
--- a/projects/demo/tsconfig.server.json
+++ b/projects/demo/tsconfig.server.json
@@ -1,5 +1,5 @@
 {
-    "extends": "../../tsconfig.json",
+    "extends": "./tsconfig.app.json",
     "files": ["src/main.server.ts", "server.ts"],
     "angularCompilerOptions": {
         "compilationMode": "full"


### PR DESCRIPTION
Run `nx serve-ssr` and open `/getting-started`.
It throws:

```shell
Warning: /Users/n.barsukov/WebstormProjects/taiga-ui/projects/demo-playwright/utils/common.ts is part of the TypeScript compilation but it's unused.
Add only entry points to the 'files' or 'include' properties in your tsconfig.

Warning: /Users/n.barsukov/WebstormProjects/taiga-ui/projects/demo-playwright/utils/goto.ts is part of the TypeScript compilation but it's unused.
Add only entry points to the 'files' or 'include' properties in your tsconfig.

Warning: /Users/n.barsukov/WebstormProjects/taiga-ui/projects/demo-playwright/utils/hide-element.ts is part of the TypeScript compilation but it's unused.
Add only entry points to the 'files' or 'include' properties in your tsconfig.

# [...]
```

and 

```shell
TypeScript compiler options "target" and "useDefineForClassFields" are set to 
"ES2022" and "false" respectively by the Angular CLI. 
To control ECMA version and features use the Browerslist configuration.
For more information, see https://angular.io/guide/build#configuring-browser-compatibility
```