### PR TITLE
chore(experimental): fix invalid value of property `display`

### DIFF
--- a/projects/experimental/components/navigation/main.style.less
+++ b/projects/experimental/components/navigation/main.style.less
@@ -43,7 +43,8 @@ main[tuiNavigationMain] {
             }
 
             [tuiSubtitle] {
-                display: box;
+                /* stylelint-disable-next-line */
+                display: -webkit-box;
                 -webkit-box-orient: vertical;
                 -webkit-line-clamp: 2;
                 white-space: normal;


### PR DESCRIPTION
# Previous behavior 
Run `npm start`.
It throws warning:

```shell
./projects/experimental/components/navigation/main.style.less?ngResource -
Warning: Module Warning (from ./node_modules/postcss-loader/dist/cjs.js):
(47:3) from "autoprefixer" plugin:
You should write display: flex by final spec instead of display: box

Code:
  display: box
```

---

Open http://localhost:3333/experimental/navigation#expansive
![app](https://github.com/taiga-family/taiga-ui/assets/35179038/5fb682de-4f65-42f5-9586-89525e71672d)

---

Open `projects/experimental/components/navigation/main.style.less`
<img width="380" alt="ide" src="https://github.com/taiga-family/taiga-ui/assets/35179038/edee84eb-89e2-4aa8-a0b4-8c6cc4b51d19">

# New behavior
![new](https://github.com/taiga-family/taiga-ui/assets/35179038/4eae4ecd-3110-410d-8cd1-73e5bdf8d7de)

