### PR TITLE
fix(kit): `File` throws SSR error `ReferenceError: File is not defined`

### DIFF
--- a/projects/kit/components/files/file/file.component.ts
+++ b/projects/kit/components/files/file/file.component.ts
@@ -146,8 +146,13 @@ export class TuiFileComponent {
             return file.src;
         }
 
-        // TODO: iframe warning
-        if (file instanceof File && file.type && file.type.startsWith('image/')) {
+        if (
+            globalThis.File &&
+            // TODO: iframe warning
+            file instanceof globalThis.File &&
+            file.type &&
+            file.type.startsWith('image/')
+        ) {
             return this.sanitizer.bypassSecurityTrustUrl(URL.createObjectURL(file));
         }
 

--- a/projects/kit/components/files/file/file.component.ts
+++ b/projects/kit/components/files/file/file.component.ts
@@ -10,6 +10,7 @@ import {
 } from '@angular/core';
 import type {SafeValue} from '@angular/platform-browser';
 import {DomSanitizer} from '@angular/platform-browser';
+import {WINDOW} from '@ng-web-apis/common';
 import type {TuiContext} from '@taiga-ui/cdk';
 import {tuiIsObserved, tuiPure} from '@taiga-ui/cdk';
 import type {TuiSizeL} from '@taiga-ui/core';
@@ -51,6 +52,7 @@ export class TuiFileComponent {
     private readonly sanitizer = inject(DomSanitizer);
     private readonly options = inject(TUI_FILE_OPTIONS);
     private readonly units$ = inject(TUI_DIGITAL_INFORMATION_UNITS);
+    private readonly win = inject(WINDOW) as Window & {File: typeof File};
 
     @Input()
     public file: TuiFileLike = {name: ''};
@@ -147,9 +149,8 @@ export class TuiFileComponent {
         }
 
         if (
-            globalThis.File &&
-            // TODO: iframe warning
-            file instanceof globalThis.File &&
+            this.win.File &&
+            file instanceof this.win.File &&
             file.type &&
             file.type.startsWith('image/')
         ) {


### PR DESCRIPTION
Run `nx serve-ssr` and open `/components/input-files`.
Node.js throws:


```ts
ReferenceError: File is not defined
    at createPreview (webpack:///projects/kit/components/files/file/file.component.ts:150:29)
    at patched (webpack:///projects/cdk/decorators/pure.ts:141:38)
    at preview (webpack:///projects/kit/components/files/file/file.component.ts:81:34)
    at templateFn (webpack:///projects/kit/components/files/file/file.template.html:47:10)
    at executeTemplate (webpack:///node_modules/@angular/core/fesm2022/core.mjs:12003:13)
    at refreshView (webpack:///node_modules/@angular/core/fesm2022/core.mjs:13498:13)
    at detectChangesInView (webpack:///node_modules/@angular/core/fesm2022/core.mjs:13663:9)
    at detectChangesInEmbeddedViews (webpack:///node_modules/@angular/core/fesm2022/core.mjs:13606:13)
    at refreshView (webpack:///node_modules/@angular/core/fesm2022/core.mjs:13522:9)
    at detectChangesInView (webpack:///node_modules/@angular/core/fesm2022/core.mjs:13663:9)
```

https://github.com/taiga-family/taiga-ui/blob/33e2a8f9b46a6f3e30c42143efb7068ecdbc2883/projects/kit/components/files/file/file.component.ts#L150


Relates to https://github.com/taiga-family/taiga-ui/issues/2332