### PR TITLE
chore(demo): documentation pages `ProgressBar` & `ProgressCircle` have infinite SSR

### DIFF
--- a/projects/demo/src/modules/components/progress-bar/examples/1/index.ts
+++ b/projects/demo/src/modules/components/progress-bar/examples/1/index.ts
@@ -1,4 +1,5 @@
-import {Component, inject} from '@angular/core';
+import {isPlatformServer} from '@angular/common';
+import {Component, inject, PLATFORM_ID} from '@angular/core';
 import {changeDetection} from '@demo/emulate/change-detection';
 import {encapsulation} from '@demo/emulate/encapsulation';
 import {TUI_IS_E2E} from '@taiga-ui/cdk';
@@ -11,12 +12,11 @@ import {map, of, startWith, timer} from 'rxjs';
     changeDetection,
 })
 export class TuiProgressBarExample1 {
-    private readonly isE2E = inject(TUI_IS_E2E);
-
-    protected readonly value$ = this.isE2E
-        ? of(40)
-        : timer(300, 300).pipe(
-              map(i => i + 30),
-              startWith(30),
-          );
+    protected readonly value$ =
+        inject(TUI_IS_E2E) || isPlatformServer(inject(PLATFORM_ID))
+            ? of(40)
+            : timer(300, 300).pipe(
+                  map(i => i + 30),
+                  startWith(30),
+              );
 }

--- a/projects/demo/src/modules/components/progress-bar/examples/2/index.ts
+++ b/projects/demo/src/modules/components/progress-bar/examples/2/index.ts
@@ -1,4 +1,5 @@
-import {Component, inject} from '@angular/core';
+import {isPlatformServer} from '@angular/common';
+import {Component, inject, PLATFORM_ID} from '@angular/core';
 import {changeDetection} from '@demo/emulate/change-detection';
 import {encapsulation} from '@demo/emulate/encapsulation';
 import {TUI_IS_E2E} from '@taiga-ui/cdk';
@@ -12,10 +13,11 @@ import {of, timer} from 'rxjs';
     changeDetection,
 })
 export class TuiProgressBarExample2 {
-    private readonly isE2E = inject(TUI_IS_E2E);
+    private readonly animationDisabled =
+        inject(TUI_IS_E2E) || isPlatformServer(inject(PLATFORM_ID));
 
-    protected readonly fastValue$ = this.isE2E ? of(80) : timer(500, 100);
-    protected readonly slowValue$ = this.isE2E ? of(4) : timer(500, 2000);
+    protected readonly fastValue$ = this.animationDisabled ? of(80) : timer(500, 100);
+    protected readonly slowValue$ = this.animationDisabled ? of(4) : timer(500, 2000);
     protected readonly colors = [
         'var(--tui-support-01)',
         'var(--tui-support-21)',

--- a/projects/demo/src/modules/components/progress-bar/examples/4/index.ts
+++ b/projects/demo/src/modules/components/progress-bar/examples/4/index.ts
@@ -1,4 +1,5 @@
-import {Component, inject} from '@angular/core';
+import {isPlatformServer} from '@angular/common';
+import {Component, inject, PLATFORM_ID} from '@angular/core';
 import {changeDetection} from '@demo/emulate/change-detection';
 import {encapsulation} from '@demo/emulate/encapsulation';
 import {TUI_IS_E2E} from '@taiga-ui/cdk';
@@ -12,14 +13,13 @@ import {map, of, startWith, takeWhile, timer} from 'rxjs';
     changeDetection,
 })
 export class TuiProgressBarExample4 {
-    private readonly isE2E = inject(TUI_IS_E2E);
-
     protected readonly max = 100;
-    protected readonly value$ = this.isE2E
-        ? of(30)
-        : timer(300, 300).pipe(
-              map(i => i + 30),
-              startWith(30),
-              takeWhile(value => value <= this.max),
-          );
+    protected readonly value$ =
+        inject(TUI_IS_E2E) || isPlatformServer(inject(PLATFORM_ID))
+            ? of(30)
+            : timer(300, 300).pipe(
+                  map(i => i + 30),
+                  startWith(30),
+                  takeWhile(value => value <= this.max),
+              );
 }

--- a/projects/demo/src/modules/components/progress-circle/examples/1/index.ts
+++ b/projects/demo/src/modules/components/progress-circle/examples/1/index.ts
@@ -1,4 +1,5 @@
-import {Component, inject} from '@angular/core';
+import {isPlatformServer} from '@angular/common';
+import {Component, inject, PLATFORM_ID} from '@angular/core';
 import {changeDetection} from '@demo/emulate/change-detection';
 import {encapsulation} from '@demo/emulate/encapsulation';
 import {TUI_IS_E2E} from '@taiga-ui/cdk';
@@ -11,14 +12,13 @@ import {map, of, startWith, takeWhile, timer} from 'rxjs';
     changeDetection,
 })
 export class TuiProgressCircleExample1 {
-    private readonly isE2E = inject(TUI_IS_E2E);
-
     protected readonly max = 100;
-    protected readonly value$ = this.isE2E
-        ? of(30)
-        : timer(300, 200).pipe(
-              map(i => i + 30),
-              startWith(30),
-              takeWhile(value => value <= this.max),
-          );
+    protected readonly value$ =
+        inject(TUI_IS_E2E) || isPlatformServer(inject(PLATFORM_ID))
+            ? of(30)
+            : timer(300, 200).pipe(
+                  map(i => i + 30),
+                  startWith(30),
+                  takeWhile(value => value <= this.max),
+              );
 }

--- a/projects/demo/src/modules/components/progress-circle/examples/3/index.ts
+++ b/projects/demo/src/modules/components/progress-circle/examples/3/index.ts
@@ -1,4 +1,5 @@
-import {Component, inject} from '@angular/core';
+import {isPlatformServer} from '@angular/common';
+import {Component, inject, PLATFORM_ID} from '@angular/core';
 import {changeDetection} from '@demo/emulate/change-detection';
 import {encapsulation} from '@demo/emulate/encapsulation';
 import {TUI_IS_E2E} from '@taiga-ui/cdk';
@@ -12,14 +13,13 @@ import {map, of, startWith, takeWhile, timer} from 'rxjs';
     changeDetection,
 })
 export class TuiProgressCircleExample3 {
-    private readonly isE2E = inject(TUI_IS_E2E);
-
     protected readonly max = 100;
-    protected readonly value$ = this.isE2E
-        ? of(30)
-        : timer(300, 200).pipe(
-              map(i => i + 30),
-              startWith(30),
-              takeWhile(value => value <= this.max),
-          );
+    protected readonly value$ =
+        inject(TUI_IS_E2E) || isPlatformServer(inject(PLATFORM_ID))
+            ? of(30)
+            : timer(300, 200).pipe(
+                  map(i => i + 30),
+                  startWith(30),
+                  takeWhile(value => value <= this.max),
+              );
 }

--- a/projects/demo/src/modules/components/progress-circle/examples/5/index.ts
+++ b/projects/demo/src/modules/components/progress-circle/examples/5/index.ts
@@ -1,4 +1,5 @@
-import {Component, inject} from '@angular/core';
+import {isPlatformServer} from '@angular/common';
+import {Component, inject, PLATFORM_ID} from '@angular/core';
 import {changeDetection} from '@demo/emulate/change-detection';
 import {encapsulation} from '@demo/emulate/encapsulation';
 import {TUI_IS_E2E} from '@taiga-ui/cdk';
@@ -12,17 +13,16 @@ import {map, of, repeat, share, takeWhile, timer} from 'rxjs';
     changeDetection,
 })
 export class TuiProgressCircleExample5 {
-    private readonly isE2E = inject(TUI_IS_E2E);
-
     protected readonly max = 100;
 
-    protected readonly value$ = this.isE2E
-        ? of(30)
-        : timer(300, 200).pipe(
-              takeWhile(value => value <= this.max),
-              share(),
-              repeat(),
-          );
+    protected readonly value$ =
+        inject(TUI_IS_E2E) || isPlatformServer(inject(PLATFORM_ID))
+            ? of(30)
+            : timer(300, 200).pipe(
+                  takeWhile(value => value <= this.max),
+                  share(),
+                  repeat(),
+              );
 
     protected readonly color$ = this.value$.pipe(
         map(value => {

--- a/projects/demo/src/modules/components/progress-circle/examples/6/index.ts
+++ b/projects/demo/src/modules/components/progress-circle/examples/6/index.ts
@@ -1,4 +1,5 @@
-import {Component, inject} from '@angular/core';
+import {isPlatformServer} from '@angular/common';
+import {Component, inject, PLATFORM_ID} from '@angular/core';
 import {changeDetection} from '@demo/emulate/change-detection';
 import {encapsulation} from '@demo/emulate/encapsulation';
 import {TUI_IS_E2E} from '@taiga-ui/cdk';
@@ -12,13 +13,12 @@ import {of, repeat, takeWhile, timer} from 'rxjs';
     changeDetection,
 })
 export class TuiProgressCircleExample6 {
-    private readonly isE2E = inject(TUI_IS_E2E);
-
     protected readonly max = 100;
-    protected readonly value$ = this.isE2E
-        ? of(30)
-        : timer(300, 200).pipe(
-              takeWhile(value => value <= this.max),
-              repeat(),
-          );
+    protected readonly value$ =
+        inject(TUI_IS_E2E) || isPlatformServer(inject(PLATFORM_ID))
+            ? of(30)
+            : timer(300, 200).pipe(
+                  takeWhile(value => value <= this.max),
+                  repeat(),
+              );
 }


### PR DESCRIPTION
Run `nx serve-ssr` and open `/components/progress-bar` or `/components/progress-cicle`.

They will be never loaded.

Relates to https://github.com/taiga-family/taiga-ui/issues/2332