### PR TITLE
chore(demo): documentation page `Dropdown` has infinite SSR

### DIFF
--- a/projects/demo/src/modules/directives/dropdown/examples/3/index.html
+++ b/projects/demo/src/modules/directives/dropdown/examples/3/index.html
@@ -25,7 +25,7 @@
             <code>polymorpheus</code>
             directive on the template to make changes propagate both ways
         </p>
-        <p *ngIf="showBigText">
+        <p *ngIf="showBigText$ | async">
             Lorem ipsum dolor sit amet, consectetur adipisicing elit. Ab assumenda at corporis ea hic illo ipsa
             laboriosam laudantium nemo neque officiis pariatur quidem quos rerum sunt, temporibus tenetur ullam vitae?
         </p>

--- a/projects/demo/src/modules/directives/dropdown/examples/3/index.ts
+++ b/projects/demo/src/modules/directives/dropdown/examples/3/index.ts
@@ -1,8 +1,7 @@
-import {ChangeDetectorRef, Component, inject} from '@angular/core';
+import {Component} from '@angular/core';
 import {changeDetection} from '@demo/emulate/change-detection';
 import {encapsulation} from '@demo/emulate/encapsulation';
-import {TuiDestroyService, tuiWatch} from '@taiga-ui/cdk';
-import {interval, takeUntil} from 'rxjs';
+import {interval, map} from 'rxjs';
 
 @Component({
     selector: 'tui-dropdown-example-3',
@@ -10,23 +9,11 @@ import {interval, takeUntil} from 'rxjs';
     styleUrls: ['./index.less'],
     encapsulation,
     changeDetection,
-    providers: [TuiDestroyService],
 })
 export class TuiDropdownExample3 {
     protected open = false;
 
     protected value = 'some data';
 
-    protected showBigText = false;
-
-    constructor() {
-        interval(3000)
-            .pipe(
-                tuiWatch(inject(ChangeDetectorRef)),
-                takeUntil(inject(TuiDestroyService, {self: true})),
-            )
-            .subscribe(() => {
-                this.showBigText = !this.showBigText;
-            });
-    }
+    protected showBigText$ = interval(3000).pipe(map(i => !(i % 2)));
 }


### PR DESCRIPTION
Run `nx serve-ssr` and open `/directives/dropdown`.

This page will never be loaded.

Relates to https://github.com/taiga-family/taiga-ui/issues/2332