### PR TITLE
fix(kit): `Tile` throws SSR error `TypeError: element.getBoundingClientRect is not a function`

### DIFF
--- a/projects/kit/components/tiles/tile.component.ts
+++ b/projects/kit/components/tiles/tile.component.ts
@@ -1,3 +1,4 @@
+import {isPlatformBrowser} from '@angular/common';
 import type {AfterViewInit, OnDestroy} from '@angular/core';
 import {
     ChangeDetectionStrategy,
@@ -7,6 +8,7 @@ import {
     HostListener,
     inject,
     Input,
+    PLATFORM_ID,
     ViewChild,
 } from '@angular/core';
 
@@ -25,6 +27,7 @@ export class TuiTileComponent implements OnDestroy, AfterViewInit {
 
     private readonly service = inject(TuiTileService);
     private readonly tiles = inject(TuiTilesComponent);
+    private readonly isBrowser = isPlatformBrowser(inject(PLATFORM_ID));
 
     @Input()
     public width = 1;
@@ -46,7 +49,7 @@ export class TuiTileComponent implements OnDestroy, AfterViewInit {
     }
 
     public ngAfterViewInit(): void {
-        if (this.wrapper) {
+        if (this.wrapper && this.isBrowser) {
             this.service.init(this.wrapper.nativeElement);
         }
     }

--- a/projects/kit/components/tiles/tile.component.ts
+++ b/projects/kit/components/tiles/tile.component.ts
@@ -1,4 +1,3 @@
-import {isPlatformBrowser} from '@angular/common';
 import type {AfterViewInit, OnDestroy} from '@angular/core';
 import {
     ChangeDetectionStrategy,
@@ -8,7 +7,6 @@ import {
     HostListener,
     inject,
     Input,
-    PLATFORM_ID,
     ViewChild,
 } from '@angular/core';
 
@@ -27,7 +25,6 @@ export class TuiTileComponent implements OnDestroy, AfterViewInit {
 
     private readonly service = inject(TuiTileService);
     private readonly tiles = inject(TuiTilesComponent);
-    private readonly isBrowser = isPlatformBrowser(inject(PLATFORM_ID));
 
     @Input()
     public width = 1;
@@ -49,7 +46,7 @@ export class TuiTileComponent implements OnDestroy, AfterViewInit {
     }
 
     public ngAfterViewInit(): void {
-        if (this.wrapper && this.isBrowser) {
+        if (this.wrapper) {
             this.service.init(this.wrapper.nativeElement);
         }
     }

--- a/projects/kit/components/tiles/tile.service.ts
+++ b/projects/kit/components/tiles/tile.service.ts
@@ -1,5 +1,6 @@
+import {isPlatformBrowser} from '@angular/common';
 import type {OnDestroy} from '@angular/core';
-import {ElementRef, inject, Injectable} from '@angular/core';
+import {ElementRef, inject, Injectable, PLATFORM_ID} from '@angular/core';
 import {MutationObserverService} from '@ng-web-apis/mutation-observer';
 import {ResizeObserverService} from '@ng-web-apis/resize-observer';
 import {tuiArrayShallowEquals, tuiPx} from '@taiga-ui/cdk';
@@ -18,6 +19,7 @@ import {TuiTilesComponent} from './tiles.component';
 
 @Injectable()
 export class TuiTileService implements OnDestroy {
+    private readonly isBrowser = isPlatformBrowser(inject(PLATFORM_ID));
     private readonly el: HTMLElement = inject(ElementRef).nativeElement;
     private readonly tiles = inject(TuiTilesComponent);
     private readonly sub = new Subscription();
@@ -30,12 +32,16 @@ export class TuiTileService implements OnDestroy {
     ]).pipe(map(([offset]) => offset));
 
     public init(element: HTMLElement): void {
-        this.sub.add(
-            this.position$.subscribe(offset => {
-                this.setPosition(element, offset);
-                this.setRect(element, offset);
-            }),
-        );
+        if (this.isBrowser) {
+            this.sub.add(
+                this.position$.subscribe(offset => {
+                    this.setPosition(element, offset);
+                    this.setRect(element, offset);
+                }),
+            );
+        } else {
+            this.el.style.setProperty('position', 'relative');
+        }
     }
 
     public setOffset(offset: readonly [number, number]): void {

--- a/projects/kit/components/tiles/tiles.style.less
+++ b/projects/kit/components/tiles/tiles.style.less
@@ -28,7 +28,8 @@ tui-tiles {
 
 tui-tile {
     & > .t-wrapper {
-        position: absolute;
+        .fullsize(absolute);
+
         z-index: 0;
         border-radius: inherit;
     }


### PR DESCRIPTION
Run `nx serve-ssr` and open `/components/reorder`.
Node.js throws:


```shell
TypeError: element.getBoundingClientRect is not a function
    at setPosition (webpack:///projects/kit/components/tiles/tile.service.ts:87:30)
    at offset (webpack:///projects/kit/components/tiles/tile.service.ts:35:22)
    at next (webpack:///node_modules/rxjs/dist/cjs/internal/Subscriber.js:161:21)
    at _next (webpack:///node_modules/rxjs/dist/cjs/internal/Subscriber.js:101:26)
    at next (webpack:///node_modules/rxjs/dist/cjs/internal/Subscriber.js:72:18)
    at onNext (webpack:///node_modules/rxjs/dist/cjs/internal/operators/map.js:10:24)
    at _next (webpack:///node_modules/rxjs/dist/cjs/internal/operators/OperatorSubscriber.js:28:21)
    at next (webpack:///node_modules/rxjs/dist/cjs/internal/Subscriber.js:72:18)
    at onNext (webpack:///node_modules/rxjs/dist/cjs/internal/observable/combineLatest.js:51:40)
    at OperatorSubscriber.OperatorSubscriber._this._next (webpack:///node_modules/rxjs/dist/cjs/internal/operators/OperatorSubscriber.js:28:21)
```

https://github.com/taiga-family/taiga-ui/blob/f75d81085d78fbe149e5f00f42eb339eb7fd536d/projects/kit/components/tiles/tile.service.ts#L87


Relates to https://github.com/taiga-family/taiga-ui/issues/2332