### PR TITLE
fix(addon-table): added a check that `total` is zero

### DIFF
--- a/projects/addon-table/components/table-pagination/table-pagination.template.html
+++ b/projects/addon-table/components/table-pagination/table-pagination.template.html
@@ -9,6 +9,7 @@
         {{ texts.linesPerPage }}
 
         <button
+            *ngIf="total !== 0; else zeroTotal"
             tuiLink
             type="button"
             [tuiDropdown]="content"
@@ -16,6 +17,9 @@
         >
             <strong>{{ start + 1 }}–{{ end }}</strong>
         </button>
+        <ng-template #zeroTotal>
+            <strong>0 - 0</strong>
+        </ng-template>
         <ng-template #content>
             <tui-data-list size="s">
                 <ng-container *ngFor="let item of items">


### PR DESCRIPTION
I figured that it is not necessary to output `tuiDropdown` at `total === 0`
Closes #7025
