### PR TITLE
feat(kit): add constant for default country masks

### DIFF
--- a/projects/kit/tokens/countries-masks.ts
+++ b/projects/kit/tokens/countries-masks.ts
@@ -1,4 +1,5 @@
-import {tuiCreateToken} from '@taiga-ui/cdk';
+import type {Provider} from '@angular/core';
+import {tuiCreateToken, tuiProvideOptions} from '@taiga-ui/cdk';
 import {TuiCountryIsoCode} from '@taiga-ui/i18n';
 
 export const TUI_COUNTRIES_DEFAULT_MASKS: Record<TuiCountryIsoCode, string> = {
@@ -219,6 +220,10 @@ export const TUI_COUNTRIES_DEFAULT_MASKS: Record<TuiCountryIsoCode, string> = {
     [TuiCountryIsoCode.ZW]: '+263#-######',
 };
 
-export const TUI_COUNTRIES_MASKS = tuiCreateToken<Record<TuiCountryIsoCode, string>>(
-    TUI_COUNTRIES_DEFAULT_MASKS,
-);
+export const TUI_COUNTRIES_MASKS = tuiCreateToken(TUI_COUNTRIES_DEFAULT_MASKS);
+
+export function tuiCountriesMasksProvider(
+    options: Partial<Record<TuiCountryIsoCode, string>>,
+): Provider {
+    return tuiProvideOptions(TUI_COUNTRIES_MASKS, options, TUI_COUNTRIES_DEFAULT_MASKS);
+}


### PR DESCRIPTION
This PR introduces a new provider `tuiCountriesMasksProvider` that allows overriding or extending the default country masks for phone number formatting.

Usage example:
```js
providers: [
        tuiCountriesMasksProvider({
            [TuiCountryIsoCode.VN]: '+84#########' // Overriding the mask for Vietnam
        })
],
```