### PR TITLE
fix(cdk): `Media` throws SSR error `TypeError: this.el.pause is not a function`

### DIFF
--- a/projects/cdk/directives/media/media.directive.ts
+++ b/projects/cdk/directives/media/media.directive.ts
@@ -47,19 +47,19 @@ export class TuiMediaDirective {
     @Input()
     public set paused(paused: boolean) {
         if (paused) {
-            this.el.pause();
+            this.el.pause?.();
         } else {
-            void this.el.play();
+            void this.el.play?.();
             this.updatePlaybackRate(this.playbackRate);
         }
     }
 
     public get currentTime(): number {
-        return this.el.currentTime;
+        return this.el.currentTime ?? 0;
     }
 
     public get paused(): boolean {
-        return this.el.paused;
+        return Boolean(this.el.paused);
     }
 
     // @bad TODO: Make sure no other events can affect this like network issues etc.


### PR DESCRIPTION
Run `nx serve-ssr` and open `/directives/media`.
Node.js throws:


```shell
TypeError: this.el.pause is not a function
    at TuiMediaDirective.set paused (webpack:///projects/cdk/directives/media/media.directive.ts:50:21)
    at writeToDirectiveInput (webpack:///node_modules/@angular/core/fesm2022/core.mjs:12889:34)
    at setInputsForProperty (webpack:///node_modules/@angular/core/fesm2022/core.mjs:13123:9)
    at elementPropertyInternal (webpack:///node_modules/@angular/core/fesm2022/core.mjs:12414:9)
    at ɵɵproperty (webpack:///node_modules/@angular/core/fesm2022/core.mjs:16255:9)
    at TuiMediaExample1_Template (webpack:///projects/demo/src/modules/directives/media/examples/1/index.html:6:34)
    at executeTemplate (webpack:///node_modules/@angular/core/fesm2022/core.mjs:12003:13)
    at refreshView (webpack:///node_modules/@angular/core/fesm2022/core.mjs:13498:13)
    at detectChangesInView (webpack:///node_modules/@angular/core/fesm2022/core.mjs:13663:9)
    at detectChangesInComponent (webpack:///node_modules/@angular/core/fesm2022/core.mjs:13638:5)
```

https://github.com/taiga-family/taiga-ui/blob/f6bdcb938959a3f7ad2f6889a23ae9607ccdf7f9/projects/cdk/directives/media/media.directive.ts#L50


Relates to https://github.com/taiga-family/taiga-ui/issues/2332