### PR TITLE
chore(demo): documentation page `Carousel` has infinite SSR

### DIFF
--- a/projects/demo/src/modules/components/carousel/examples/1/index.html
+++ b/projects/demo/src/modules/components/carousel/examples/1/index.html
@@ -1,5 +1,5 @@
 <tui-carousel
-    [duration]="4000"
+    [duration]="duration"
     [(index)]="index"
 >
     <ng-container *ngFor="let item of items">

--- a/projects/demo/src/modules/components/carousel/examples/1/index.ts
+++ b/projects/demo/src/modules/components/carousel/examples/1/index.ts
@@ -1,4 +1,5 @@
-import {Component} from '@angular/core';
+import {isPlatformBrowser} from '@angular/common';
+import {Component, inject, PLATFORM_ID} from '@angular/core';
 import {changeDetection} from '@demo/emulate/change-detection';
 import {encapsulation} from '@demo/emulate/encapsulation';
 
@@ -10,6 +11,7 @@ import {encapsulation} from '@demo/emulate/encapsulation';
     changeDetection,
 })
 export class TuiCarouselExample1 {
+    protected duration = isPlatformBrowser(inject(PLATFORM_ID)) ? 4_000 : 0;
     protected index = 2;
 
     protected readonly items = [


### PR DESCRIPTION
Run `nx serve-ssr` and open `/components/carousel`.

This page will never be loaded.

Relates to https://github.com/taiga-family/taiga-ui/issues/2332