### PR TITLE
fix(kit): `InputDate` fix opening mobile calendar in read-only mode

### DIFF
--- a/projects/kit/components/input-date/input-date.component.ts
+++ b/projects/kit/components/input-date/input-date.component.ts
@@ -246,7 +246,7 @@ export class TuiInputDateComponent
     }
 
     onIconClick(): void {
-        if (!this.computedMobile || !this.mobileCalendar) {
+        if (!this.computedMobile || !this.mobileCalendar || this.readOnly) {
             return;
         }
 


### PR DESCRIPTION
Closes # <!-- link to a relevant issue. -->
