### PR TITLE
fix(cdk): `ActiveZone` fix event handling for IOS Safari

### DIFF
--- a/projects/cdk/directives/active-zone/active-zone.directive.ts
+++ b/projects/cdk/directives/active-zone/active-zone.directive.ts
@@ -20,6 +20,9 @@ import {distinctUntilChanged, map, skip, startWith} from 'rxjs/operators';
     selector:
         '[tuiActiveZone]:not(ng-container), [tuiActiveZoneChange]:not(ng-container), [tuiActiveZoneParent]:not(ng-container)',
     exportAs: 'tuiActiveZone',
+    host: {
+        '(document:mousedown.silent)': '(0)',
+    },
 })
 export class TuiActiveZoneDirective implements OnDestroy {
     private subActiveZones: readonly TuiActiveZoneDirective[] = [];


### PR DESCRIPTION
Closes #7150
