### PR TITLE
fix(demo): add missing id to `BadgedContent` examples

### DIFF
--- a/projects/demo/src/modules/components/badged-content/index.html
+++ b/projects/demo/src/modules/components/badged-content/index.html
@@ -12,6 +12,7 @@
             [content]="index + 1 | tuiExample"
             [description]="index === 1 && description"
             [heading]="example"
+            [id]="example | tuiKebab"
         />
 
         <ng-template #description>


### PR DESCRIPTION
Closes #7149 
Done: add missing "id" to `tui-doc-example` components
