### PR TITLE
fix(kit): `TabsWithMore` should not hide all tabs inside `More` during SSR

### DIFF
--- a/projects/addon-doc/components/example/example.style.less
+++ b/projects/addon-doc/components/example/example.style.less
@@ -54,6 +54,7 @@
     box-shadow: inset 0 -1px var(--tui-base-03);
     justify-content: space-between;
     align-items: center;
+    gap: 0.5rem;
 
     :host-context(tui-root._mobile) & {
         padding: 0 0.875rem 0 1rem;
@@ -62,6 +63,10 @@
 
 .t-tabs {
     flex-grow: 1;
+}
+
+.t-code-editor {
+    flex-shrink: 0;
 }
 
 .t-demo {

--- a/projects/addon-doc/components/example/example.template.html
+++ b/projects/addon-doc/components/example/example.template.html
@@ -58,6 +58,7 @@
             <tui-loader
                 *ngIf="files | tuiMapper: visible"
                 size="xs"
+                class="t-code-editor"
                 [overlay]="true"
                 [showLoader]="!!(loading$ | async)"
                 (click)="edit(files)"

--- a/projects/kit/components/tabs/tabs-with-more.component.ts
+++ b/projects/kit/components/tabs/tabs-with-more.component.ts
@@ -243,7 +243,7 @@ export class TuiTabsWithMoreComponent implements AfterViewChecked, AfterViewInit
             maxIndex * margin -
             tabs[tabs.length - 1].scrollWidth;
 
-        if (total <= clientWidth) {
+        if (Number.isNaN(total) || total <= clientWidth) {
             return Infinity;
         }
 


### PR DESCRIPTION
1. Run `nx serve-ssr`
2. Disable JS in browser
3. Open http://localhost:4200/components/alert

# Previous behavior
<img height="500" src="https://github.com/taiga-family/taiga-ui/assets/35179038/d28c064c-f79d-4736-9128-0299495d287c" />

# New behavior
<img height="500" src="https://github.com/taiga-family/taiga-ui/assets/35179038/0320575f-41c8-4e75-b9e9-defc9d128167" />

Closes #7091

