### PR TITLE
fix(kit): `Textarea` incorrectly highlights extra characters for long words with hyphen in Safari/FF

### DIFF
--- a/projects/kit/components/textarea/textarea.style.less
+++ b/projects/kit/components/textarea/textarea.style.less
@@ -148,6 +148,7 @@
 .t-pseudo-content {
     white-space: pre-wrap;
     word-wrap: break-word;
+    word-break: keep-all;
     pointer-events: none;
     color: transparent;
     overflow: hidden;


### PR DESCRIPTION
## Reproduction
1. Use Safari / Firefox Desktop
2. Open https://taiga-ui.dev/components/textarea/API?expandable=true&maxLength=97&tuiTextfieldLabelOutside=true&sandboxWidth=243
3. Paste the following text inside textfield
```
Lorem Ipsum is simply dummy text of the printing and typesetting industry. https://my-site.abc.qwertyuiop.com/group1/group2/3921234
```
<img width="379" alt="before" src="https://github.com/taiga-family/taiga-ui/assets/35179038/053d9674-c5f9-47cc-a04f-3a9d55b3c70f">



## Why ?
According to [MDN specifications](https://developer.mozilla.org/en-US/docs/Web/CSS/word-break#values) about "word-break":
<img width="778" alt="mdn" src="https://github.com/taiga-family/taiga-ui/assets/35179038/81838843-c671-4707-ba01-a1a2171b1ffe">


`normal` (default value) and `keep-all` should work in the same way for Non-CJK!
It is true for Chrome, yep. However, there is difference for some browsers (i.e. Safari & FF).
Explore this stackblitz (use Safari or FF):
https://stackblitz.com/edit/normal-and-keep-all-diff?file=styles.css,index.html

<img width="1492" alt="ff-vs-safari" src="https://github.com/taiga-family/taiga-ui/assets/35179038/dbdd186e-6d33-4615-aaf0-bed85fcb70d4">


Before this fix, `<textarea>` had `word-break: keep-all` and `<span>` (ghost container with the same text) had `word-break: normal`.
https://github.com/taiga-family/taiga-ui/blob/cabd2d7dcd5615e1efc7c73ef5847fb63a572991/projects/core/styles/mixins/mixins.less#L135

# New behavior
`<textarea>` and `<span>` (ghost container with the same text) have the same value for `word-break`-property.
<img width="379" alt="after" src="https://github.com/taiga-family/taiga-ui/assets/35179038/802ceab5-a49a-4c64-b992-c4e32976b779">

Closes #7328
