### PR TITLE
fix(kit): `Textarea` incorrectly highlights extra characters for long words with hyphen in Safari/FF

### DIFF
--- a/projects/kit/components/textarea/textarea.style.less
+++ b/projects/kit/components/textarea/textarea.style.less
@@ -149,6 +149,7 @@
 .t-pseudo-content {
     white-space: pre-wrap;
     word-wrap: break-word;
+    word-break: keep-all;
     pointer-events: none;
     color: transparent;
     overflow: hidden;


### PR DESCRIPTION
Cherry-picked from `main`.

Read in-depth description of this problem here:
* https://github.com/taiga-family/taiga-ui/pull/7335

Relates to #7328