### PR TITLE
fix(core): fix caret in InputPassword while clicking show/hide button

### DIFF
--- a/projects/kit/components/input-password/input-password.component.ts
+++ b/projects/kit/components/input-password/input-password.component.ts
@@ -1,8 +1,10 @@
 import {
     ChangeDetectionStrategy,
     Component,
+    EventEmitter,
     HostBinding,
     inject,
+    Output,
     ViewChild,
 } from '@angular/core';
 import type {
@@ -47,6 +49,10 @@ export class TuiInputPasswordComponent
     private readonly textfield?: TuiPrimitiveTextfieldComponent;
 
     private readonly textfieldSize = inject(TUI_TEXTFIELD_SIZE);
+
+    @Output()
+    public readonly passwordHidden = new EventEmitter<boolean>();
+
     protected readonly hintOptions = inject(TuiHintOptionsDirective, {optional: true});
     protected readonly directive$: Observable<any> = this.hintOptions?.change$ || EMPTY;
 
@@ -95,6 +101,7 @@ export class TuiInputPasswordComponent
 
     protected togglePasswordVisibility(): void {
         this.isPasswordHidden = !this.isPasswordHidden;
+        this.passwordHidden.emit(this.isPasswordHidden);
     }
 
     protected getFallbackValue(): string {

--- a/projects/kit/components/input-password/input-password.directive.ts
+++ b/projects/kit/components/input-password/input-password.directive.ts
@@ -1,7 +1,9 @@
-import type {DoCheck} from '@angular/core';
+import type {AfterViewInit} from '@angular/core';
 import {Directive} from '@angular/core';
+import {takeUntilDestroyed} from '@angular/core/rxjs-interop';
 import {tuiIsInput} from '@taiga-ui/cdk';
 import {AbstractTuiTextfieldHost, tuiAsTextfieldHost} from '@taiga-ui/core';
+import {startWith} from 'rxjs';
 
 import type {TuiInputPasswordComponent} from './input-password.component';
 
@@ -11,9 +13,14 @@ import type {TuiInputPasswordComponent} from './input-password.component';
 })
 export class TuiInputPasswordDirective
     extends AbstractTuiTextfieldHost<TuiInputPasswordComponent>
-    implements DoCheck
+    implements AfterViewInit
 {
     protected input?: HTMLInputElement;
+
+    protected readonly isPasswordHidden$ = this.host.passwordHidden.pipe(
+        startWith(this.host.inputType),
+        takeUntilDestroyed(),
+    );
 
     public onValueChange(value: string): void {
         this.host.onValueChange(value);
@@ -23,12 +30,14 @@ export class TuiInputPasswordDirective
         this.input = input;
     }
 
-    public ngDoCheck(): void {
-        if (
-            this.host.nativeFocusableElement &&
-            tuiIsInput(this.host.nativeFocusableElement)
-        ) {
-            this.host.nativeFocusableElement.type = this.host.inputType;
-        }
+    public ngAfterViewInit(): void {
+        this.isPasswordHidden$.subscribe(() => {
+            if (
+                this.host.nativeFocusableElement &&
+                tuiIsInput(this.host.nativeFocusableElement)
+            ) {
+                this.host.nativeFocusableElement.type = this.host.inputType;
+            }
+        });
     }
 }

--- a/projects/kit/components/input-password/test/input-password.component.spec.ts
+++ b/projects/kit/components/input-password/test/input-password.component.spec.ts
@@ -40,6 +40,10 @@ describe('InputPassword', () => {
         return pageObject.getByAutomationId('tui-password__icon');
     }
 
+    function getInput(): HTMLInputElement {
+        return fixture.nativeElement.querySelector('input');
+    }
+
     beforeEach(async () => {
         TestBed.configureTestingModule({
             imports: [
@@ -65,14 +69,17 @@ describe('InputPassword', () => {
             const inputType = component.inputType;
 
             expect(inputType).toBe('password');
+            expect(getInput().type).toBe('password');
         });
 
         it('When you click on the "Show password" icon, the field becomes type = "text"', () => {
             getIcon()!.nativeElement.click();
+            fixture.detectChanges();
 
             const inputType = component.inputType;
 
             expect(inputType).toBe('text');
+            expect(getInput().type).toBe('text');
         });
 
         it('With readOnly, the type field="password"', () => {
@@ -82,6 +89,7 @@ describe('InputPassword', () => {
             const inputType = component.inputType;
 
             expect(inputType).toBe('password');
+            expect(getInput().type).toBe('password');
         });
 
         it('When the field is disabled type="password"', () => {
@@ -91,6 +99,7 @@ describe('InputPassword', () => {
             const inputType = component.inputType;
 
             expect(inputType).toBe('password');
+            expect(getInput().type).toBe('password');
         });
     });
 });


### PR DESCRIPTION
Closes #7281

NgDoCheck was invoking type change of the input too frequently, which, I believe, was causing the cursor to lag. In the current implementation, the type changes only when necessary, and the issue is no longer observed.