### PR TITLE
feat(core): add possibility to control alerts queue

### DIFF
--- a/projects/core/components/alert/alert.providers.ts
+++ b/projects/core/components/alert/alert.providers.ts
@@ -1,6 +1,19 @@
 import {inject} from '@angular/core';
-import {TUI_IS_MOBILE, tuiCreateTokenFromFactory} from '@taiga-ui/cdk';
+import {TUI_IS_MOBILE, tuiCreateToken, tuiCreateTokenFromFactory} from '@taiga-ui/cdk';
+import {mergeAll} from 'rxjs/operators';
+
+import {TuiAlertQueueOperator} from './alert.queue';
 
 export const TUI_ALERT_POSITION = tuiCreateTokenFromFactory<string>(() =>
     inject(TUI_IS_MOBILE) ? '1rem 1rem 0 auto' : '2rem 3rem 0 auto',
+);
+
+/**
+ * A dependency injection token used to provide a specific `TuiAlertQueueOperator`.
+ * This operator is based on the RxJS `mergeAll` operator, but is likely customized
+ * for handling alert queue operations. It can be used to control the behavior of
+ * alert queues, such as managing concurrency or preserving order.
+ */
+export const TUI_ALERT_QUEUE_OPERATOR = tuiCreateToken<TuiAlertQueueOperator>(() =>
+    mergeAll(),
 );

--- a/projects/core/components/alert/alert.queue.ts
+++ b/projects/core/components/alert/alert.queue.ts
@@ -1,0 +1,3 @@
+import {ObservableInput, OperatorFunction} from 'rxjs';
+
+export type TuiAlertQueueOperator = <T>() => OperatorFunction<ObservableInput<T>, T>;

--- a/projects/core/components/alert/alert.service.ts
+++ b/projects/core/components/alert/alert.service.ts
@@ -1,20 +1,48 @@
 import {Inject, Injectable} from '@angular/core';
-import {AbstractTuiDialogService, TuiIdService} from '@taiga-ui/cdk';
+import {
+    AbstractTuiDialogService,
+    TuiBaseDialogContext,
+    TuiIdService,
+} from '@taiga-ui/cdk';
 import {TuiAlertOptions} from '@taiga-ui/core/interfaces';
 import {TUI_NOTIFICATION_OPTIONS} from '@taiga-ui/core/tokens';
-import {PolymorpheusComponent} from '@tinkoff/ng-polymorpheus';
+import {PolymorpheusComponent, PolymorpheusContent} from '@tinkoff/ng-polymorpheus';
+import {Observable, Subject} from 'rxjs';
+import {takeUntil, tap} from 'rxjs/operators';
 
 import {TuiAlertComponent} from './alert.component';
+import {TUI_ALERT_QUEUE_OPERATOR} from './alert.providers';
+import {TuiAlertQueueOperator} from './alert.queue';
 
 @Injectable({providedIn: 'root'})
 export class TuiAlertService extends AbstractTuiDialogService<TuiAlertOptions<any>> {
     protected readonly component = new PolymorpheusComponent(TuiAlertComponent);
 
+    protected readonly alerts$ = new Subject<Observable<unknown>>();
+
     constructor(
         @Inject(TUI_NOTIFICATION_OPTIONS)
         protected readonly defaultOptions: TuiAlertOptions<any>,
         @Inject(TuiIdService) idService: TuiIdService,
+        @Inject(TUI_ALERT_QUEUE_OPERATOR) queueOperator: TuiAlertQueueOperator,
     ) {
         super(idService);
+
+        this.alerts$.pipe(queueOperator()).subscribe();
+    }
+
+    override open<G = void>(
+        content: PolymorpheusContent<TuiAlertOptions<any> & TuiBaseDialogContext<G>>,
+        options: Partial<TuiAlertOptions<any>> = {},
+    ): Observable<G> {
+        const alert$ = super.open(content, options);
+
+        return new Observable<G>(subscriber => {
+            const destroy$ = new Subject();
+
+            this.alerts$.next(alert$.pipe(tap(subscriber), takeUntil(destroy$)));
+
+            return () => destroy$.next();
+        });
     }
 }

--- a/projects/core/components/alert/index.ts
+++ b/projects/core/components/alert/index.ts
@@ -2,4 +2,5 @@ export * from './alert.component';
 export * from './alert.directive';
 export * from './alert.module';
 export * from './alert.providers';
+export * from './alert.queue';
 export * from './alert.service';

--- a/projects/demo/src/modules/services/alerts/alerts.component.ts
+++ b/projects/demo/src/modules/services/alerts/alerts.component.ts
@@ -104,6 +104,19 @@ export class ExampleTuiAlertsComponent {
         HTML: import('./examples/6/index.html?raw'),
     };
 
+    readonly example7: TuiDocExample = {
+        TypeScript: import('./examples/7/index.ts?raw'),
+        HTML: import('./examples/7/index.html?raw'),
+        'app.module.ts': import('./examples/7/app.module.ts?raw'),
+    };
+
+    readonly example8: TuiDocExample = {
+        TypeScript: import('./examples/8/index.ts?raw'),
+        HTML: import('./examples/8/index.html?raw'),
+        'app.module.ts': import('./examples/8/app.module.ts?raw'),
+        'latest-all.ts': import('./examples/8/latest-all.ts?raw'),
+    };
+
     data = 100;
 
     label = 'Heading';

--- a/projects/demo/src/modules/services/alerts/alerts.module.ts
+++ b/projects/demo/src/modules/services/alerts/alerts.module.ts
@@ -8,6 +8,7 @@ import {
     tuiGenerateRoutes,
     TuiTextCodeModule,
 } from '@taiga-ui/addon-doc';
+import {TuiAlertHostModule} from '@taiga-ui/cdk';
 import {
     TuiAlertModule,
     TuiButtonModule,
@@ -28,6 +29,10 @@ import {TuiAlertsExampleComponent5} from './examples/5';
 import {AlertExampleWithCustomLabelModule} from './examples/5/alert-example-with-custom-label/alert-example-with-custom-label.module';
 import {CustomLabelModule} from './examples/5/custom-label/custom-label.module';
 import {TuiAlertsExampleComponent6} from './examples/6';
+import {TuiAlertsExampleComponent7} from './examples/7';
+import {TuiAlertsExampleComponent8} from './examples/8';
+import {CustomAlertsQueueOverrideDirective} from './overrides/custom-alerts-queue-override.directive';
+import {LimitOfAlertsOverrideDirective} from './overrides/limit-of-alerts-override.directive';
 
 @NgModule({
     imports: [
@@ -48,15 +53,20 @@ import {TuiAlertsExampleComponent6} from './examples/6';
         TuiLinkModule,
         TuiAddonDocModule,
         RouterModule.forChild(tuiGenerateRoutes(ExampleTuiAlertsComponent)),
+        TuiAlertHostModule,
     ],
     declarations: [
         ExampleTuiAlertsComponent,
+        LimitOfAlertsOverrideDirective,
+        CustomAlertsQueueOverrideDirective,
         TuiAlertsExampleComponent1,
         TuiAlertsExampleComponent2,
         TuiAlertsExampleComponent3,
         TuiAlertsExampleComponent4,
         TuiAlertsExampleComponent5,
         TuiAlertsExampleComponent6,
+        TuiAlertsExampleComponent7,
+        TuiAlertsExampleComponent8,
     ],
     exports: [ExampleTuiAlertsComponent],
 })

--- a/projects/demo/src/modules/services/alerts/alerts.template.html
+++ b/projects/demo/src/modules/services/alerts/alerts.template.html
@@ -71,6 +71,28 @@
         >
             <tui-alerts-example-6></tui-alerts-example-6>
         </tui-doc-example>
+
+        <ng-container limitOfAlertsOverride>
+            <tui-doc-example
+                id="limit-of-alerts"
+                heading="Limit of alerts"
+                [content]="example7"
+            >
+                <tui-alerts-example-7></tui-alerts-example-7>
+            </tui-doc-example>
+            <tui-alert-host></tui-alert-host>
+        </ng-container>
+
+        <ng-container customAlertsQueueOverride>
+            <tui-doc-example
+                id="custom-alets-queue"
+                heading="Custom alerts queue"
+                [content]="example8"
+            >
+                <tui-alerts-example-8></tui-alerts-example-8>
+            </tui-doc-example>
+            <tui-alert-host></tui-alert-host>
+        </ng-container>
     </ng-template>
 
     <ng-template pageTab>

--- a/projects/demo/src/modules/services/alerts/examples/7/app.module.ts
+++ b/projects/demo/src/modules/services/alerts/examples/7/app.module.ts
@@ -1,0 +1,14 @@
+import {NgModule} from '@angular/core';
+import {TUI_ALERT_QUEUE_OPERATOR, TuiAlertModule} from '@taiga-ui/core';
+import {mergeAll} from 'rxjs/operators';
+
+@NgModule({
+    providers: [
+        TuiAlertModule,
+        {
+            provide: TUI_ALERT_QUEUE_OPERATOR,
+            useValue: () => mergeAll(3),
+        },
+    ],
+})
+export class AppModule {}

--- a/projects/demo/src/modules/services/alerts/examples/7/index.html
+++ b/projects/demo/src/modules/services/alerts/examples/7/index.html
@@ -1,0 +1,9 @@
+<p>Notifications are limited to a maximum of 3 at a time (see app.module.ts). The rest get in queue.</p>
+<button
+    size="m"
+    tuiButton
+    type="button"
+    (click)="showNotification()"
+>
+    Show
+</button>

--- a/projects/demo/src/modules/services/alerts/examples/7/index.ts
+++ b/projects/demo/src/modules/services/alerts/examples/7/index.ts
@@ -1,0 +1,20 @@
+import {Component, Inject} from '@angular/core';
+import {changeDetection} from '@demo/emulate/change-detection';
+import {encapsulation} from '@demo/emulate/encapsulation';
+import {TuiAlertService} from '@taiga-ui/core';
+
+@Component({
+    selector: 'tui-alerts-example-7',
+    templateUrl: './index.html',
+    encapsulation,
+    changeDetection,
+})
+export class TuiAlertsExampleComponent7 {
+    constructor(@Inject(TuiAlertService) private readonly alerts: TuiAlertService) {}
+
+    showNotification(): void {
+        this.alerts
+            .open('Basic <strong>HTML</strong>', {label: 'With a heading!'})
+            .subscribe();
+    }
+}

--- a/projects/demo/src/modules/services/alerts/examples/8/app.module.ts
+++ b/projects/demo/src/modules/services/alerts/examples/8/app.module.ts
@@ -1,0 +1,15 @@
+import {NgModule} from '@angular/core';
+import {TUI_ALERT_QUEUE_OPERATOR, TuiAlertModule} from '@taiga-ui/core';
+
+import {latestAll} from './latest-all';
+
+@NgModule({
+    providers: [
+        TuiAlertModule,
+        {
+            provide: TUI_ALERT_QUEUE_OPERATOR,
+            useValue: () => latestAll(3),
+        },
+    ],
+})
+export class AppModule {}

--- a/projects/demo/src/modules/services/alerts/examples/8/index.html
+++ b/projects/demo/src/modules/services/alerts/examples/8/index.html
@@ -1,0 +1,12 @@
+<p>
+    The number of notifications is limited, there can be no more than 3 at a time. When a new one appears, the first one
+    is deleted.
+</p>
+<button
+    size="m"
+    tuiButton
+    type="button"
+    (click)="showNotification()"
+>
+    Show
+</button>

--- a/projects/demo/src/modules/services/alerts/examples/8/index.ts
+++ b/projects/demo/src/modules/services/alerts/examples/8/index.ts
@@ -1,0 +1,20 @@
+import {Component, Inject} from '@angular/core';
+import {changeDetection} from '@demo/emulate/change-detection';
+import {encapsulation} from '@demo/emulate/encapsulation';
+import {TuiAlertService} from '@taiga-ui/core';
+
+@Component({
+    selector: 'tui-alerts-example-8',
+    templateUrl: './index.html',
+    encapsulation,
+    changeDetection,
+})
+export class TuiAlertsExampleComponent8 {
+    constructor(@Inject(TuiAlertService) private readonly alerts: TuiAlertService) {}
+
+    showNotification(): void {
+        this.alerts
+            .open('Basic <strong>HTML</strong>', {label: 'With a heading!'})
+            .subscribe();
+    }
+}

--- a/projects/demo/src/modules/services/alerts/examples/8/latest-all.ts
+++ b/projects/demo/src/modules/services/alerts/examples/8/latest-all.ts
@@ -1,0 +1,48 @@
+/* eslint rxjs/no-implicit-any-catch: 0 */
+/* eslint rxjs/no-nested-subscribe: 0 */
+
+import {Observable, Subscription} from 'rxjs';
+
+/**
+ * Custom RxJS operator that subscribes to the latest `concurrent` inner observables.
+ * It automatically unsubscribes from the oldest active inner observable once the limit is exceeded.
+ *
+ * @param {number} concurrent - Maximum number of concurrent subscriptions allowed.
+ */
+export const latestAll =
+    <T>(concurrent: number) =>
+    (source: Observable<Observable<T>>): Observable<T> =>
+        new Observable<T>(subscriber => {
+            const activeSubscriptions: Subscription[] = [];
+
+            const subscription = source.subscribe({
+                next: innerObservable => {
+                    const innerSubscription = innerObservable.subscribe({
+                        next: value => subscriber.next(value),
+                        error: err => subscriber.error(err),
+                        complete: () => {
+                            const index = activeSubscriptions.indexOf(innerSubscription);
+
+                            if (index !== -1) {
+                                activeSubscriptions.splice(index, 1);
+                            }
+                        },
+                    });
+
+                    activeSubscriptions.push(innerSubscription);
+
+                    if (activeSubscriptions.length > concurrent) {
+                        activeSubscriptions.shift()?.unsubscribe();
+                    }
+                },
+                error: err => subscriber.error(err),
+                complete: () => subscriber.complete(),
+            });
+
+            // Ensure all active subscriptions are cleaned up on un-subscription
+            subscription.add(() => {
+                activeSubscriptions.forEach(sub => sub.unsubscribe());
+            });
+
+            return subscription;
+        });

--- a/projects/demo/src/modules/services/alerts/overrides/custom-alerts-queue-override.directive.ts
+++ b/projects/demo/src/modules/services/alerts/overrides/custom-alerts-queue-override.directive.ts
@@ -1,0 +1,22 @@
+import {Directive} from '@angular/core';
+import {TUI_ALERTS} from '@taiga-ui/cdk';
+import {TUI_ALERT_QUEUE_OPERATOR, TuiAlertService} from '@taiga-ui/core';
+
+import {latestAll} from '../examples/8/latest-all';
+
+@Directive({
+    selector: '[customAlertsQueueOverride]',
+    providers: [
+        {
+            provide: TUI_ALERT_QUEUE_OPERATOR,
+            useValue: () => latestAll(3),
+        },
+        TuiAlertService,
+        {
+            provide: TUI_ALERTS,
+            useExisting: TuiAlertService,
+            multi: true,
+        },
+    ],
+})
+export class CustomAlertsQueueOverrideDirective {}

--- a/projects/demo/src/modules/services/alerts/overrides/limit-of-alerts-override.directive.ts
+++ b/projects/demo/src/modules/services/alerts/overrides/limit-of-alerts-override.directive.ts
@@ -1,0 +1,21 @@
+import {Directive} from '@angular/core';
+import {TUI_ALERTS} from '@taiga-ui/cdk';
+import {TUI_ALERT_QUEUE_OPERATOR, TuiAlertService} from '@taiga-ui/core';
+import {mergeAll} from 'rxjs/operators';
+
+@Directive({
+    selector: '[limitOfAlertsOverride]',
+    providers: [
+        {
+            provide: TUI_ALERT_QUEUE_OPERATOR,
+            useValue: () => mergeAll(3),
+        },
+        TuiAlertService,
+        {
+            provide: TUI_ALERTS,
+            useExisting: TuiAlertService,
+            multi: true,
+        },
+    ],
+})
+export class LimitOfAlertsOverrideDirective {}


### PR DESCRIPTION
I added the ability to manage the queue. I implemented this through the operator because we need to modify not only the number of alerts but also their order. By default, `mergeAll` displays the first `N ?? Infinity` alerts, but we need to show the last `N` alerts. To achieve this, we need to pass not only a number but also an operator who will control the process.

Generally speaking, if you need to restrict the first N elements, it is sufficient to provide:
```
{
  provide: TUI_ALERT_QUEUE_OPERATOR,
  useValue: () => mergeAll(N),
}
```

Alternatively, you can use your own operator.
