### PR TITLE
chore: add `projects/demo-playwright/tests-report` to `exclude` of root `tsconfig.json`

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,12 @@
 {
     "extends": "@taiga-ui/tsconfig",
     "include": ["projects/**/*"],
-    "exclude": ["projects/**/*.spec.ts", "projects/demo-cypress", "**/schematics/**/*"],
+    "exclude": [
+        "projects/**/*.spec.ts",
+        "projects/demo-cypress",
+        "projects/demo-playwright/tests-report",
+        "**/schematics/**/*"
+    ],
     "compilerOptions": {
         "baseUrl": "./",
         "outDir": "./dist",


### PR DESCRIPTION
## Previous behavior

1. Locally run playwright tests (it will produce `projects/demo-playwright/tests-report` folder)
2. Change any another file
3. Try to create commit
4. Pre-commit hooks run (it triggers also `npm run typecheck`)

It throws
```sh
Found 8252 errors in 11 files.

Errors  Files
  2910  projects/demo-playwright/tests-report/trace/assets/codeMirrorModule-ITBVLGwz.js:1
  4008  projects/demo-playwright/tests-report/trace/assets/testServerConnection-Dj8RHZjQ.js:1
    52  projects/demo-playwright/tests-report/trace/index.64QeAVuG.js:1
   910  projects/demo-playwright/tests-report/trace/sw.bundle.js:1
   339  projects/demo-playwright/tests-report/trace/uiMode.Bug1KrYi.js:1

[...]
```