### PR TITLE
chore(demo-playwright): make `DropdownContext` tests be compatible both Chromium & Firefox

### DIFF
--- a/projects/demo-playwright/tests/kit/dropdown-context/dropdown-context.spec.ts
+++ b/projects/demo-playwright/tests/kit/dropdown-context/dropdown-context.spec.ts
@@ -10,7 +10,7 @@ test.describe('DropdownContext', () => {
         const tr = example.locator('tr');
 
         await example.scrollIntoViewIfNeeded();
-        await tr.last().click({button: 'right', position: {x: 0, y: 0}});
+        await tr.last().click({button: 'right', position: {x: 1, y: 1}});
         await api.waitStableState();
         await expect(example).toHaveScreenshot('01-dropdown-context.png');
     });
@@ -21,11 +21,11 @@ test.describe('DropdownContext', () => {
         const tr = example.locator('tr');
 
         await example.scrollIntoViewIfNeeded();
-        await tr.nth(1).click({button: 'right', position: {x: 0, y: 0}});
+        await tr.nth(1).click({button: 'right', position: {x: 1, y: 1}});
         await api.waitStableState();
         await expect(example).toHaveScreenshot('02-dropdown-context.png');
         await api.focusOnBody();
-        await tr.nth(2).click({button: 'right', position: {x: 0, y: 0}});
+        await tr.nth(2).click({button: 'right', position: {x: 1, y: 1}});
         await api.waitStableState();
         await expect(example).toHaveScreenshot('03-dropdown-context.png');
     });
@@ -36,7 +36,7 @@ test.describe('DropdownContext', () => {
         const tr = example.locator('tr');
 
         await example.scrollIntoViewIfNeeded();
-        await tr.nth(1).click({button: 'right', position: {x: 0, y: 0}});
+        await tr.nth(1).click({button: 'right', position: {x: 1, y: 1}});
         await page.locator('[tuiOption]').last().click();
         await api.waitStableState();
         await expect(example).toHaveScreenshot('04-dropdown-context.png');


### PR DESCRIPTION
Relates to:
* https://github.com/microsoft/playwright/issues/30793