### PR TITLE
chore(demo-playwright): make `TuiPrimitiveTextfield` tests compatible with both Chromium & Firefox

### DIFF
--- a/projects/demo-playwright/tests/core/primitive-textfield/primitive-textfield.spec.ts
+++ b/projects/demo-playwright/tests/core/primitive-textfield/primitive-textfield.spec.ts
@@ -13,7 +13,7 @@ test.describe('TuiPrimitiveTextfield', () => {
         const {apiPageExample} = new TuiDocumentationPagePO(page);
 
         await apiPageExample.scrollIntoViewIfNeeded();
-        await apiPageExample.locator('tui-tooltip').click();
+        await apiPageExample.locator('tui-tooltip').hover();
 
         await expect(page.locator('tui-hint')).toBeAttached();
         await expect(apiPageExample).toHaveScreenshot('01-hint.png');


### PR DESCRIPTION
# Previous behavior

Run the following test
https://github.com/taiga-family/taiga-ui/blob/10dffbf9e3b8b52cd649f5afec1f0c0caea6a638/projects/demo-playwright/tests/core/primitive-textfield/primitive-textfield.spec.ts#L7-L20

Chrome ✅ 
Firefox ❌
```shell
  1 failed
    [firefox] › tests/core/primitive-textfield/primitive-textfield.spec.ts:7:9 › TuiPrimitiveTextfield › Tooltip in primitive-textfield works 
  105 passed (9.1m)
Error:   1) [firefox] › tests/core/primitive-textfield/primitive-textfield.spec.ts:7:9 › TuiPrimitiveTextfield › Tooltip in primitive-textfield works 
    Error: Timed out 5000ms waiting for expect(locator).toBeAttached()

    Locator: locator('tui-hint')
    Expected: attached
    Received: <element(s) not found>
    Call log:
      - expect.toBeAttached with timeout 5000ms
      - waiting for locator('tui-hint')


      16 |         await apiPageExample.locator('tui-tooltip').click();
      17 |
    > 18 |         await expect(page.locator('tui-hint')).toBeAttached();
         |                                                ^
      19 |         await expect(apiPageExample).toHaveScreenshot('01-hint.png');
      20 |     });
      21 |
```

# New behaviour
Chrome ✅ 
Firefox ✅ 