### PR TITLE
chore(demo-playwright): `tuiGoto` should mock both `.ttf` and `.woff2` fonts

### DIFF
--- a/projects/demo-playwright/utils/goto.ts
+++ b/projects/demo-playwright/utils/goto.ts
@@ -50,7 +50,7 @@ export async function tuiGoto(
 
     await tuiMockDate(page, date);
 
-    await page.route('https://fonts.gstatic.com/**/*.ttf', async route =>
+    await page.route('https://fonts.gstatic.com/**', async route =>
         route.fulfill({path: `${__dirname}/../stubs/manrope-fonts.ttf`}),
     );
 


### PR DESCRIPTION
# New behavior

<img width="1057" alt="fulfilled" src="https://github.com/taiga-family/taiga-ui/assets/35179038/a04d7915-c3ea-4eeb-9216-e984af6dac43">

# How to check ?
1. Replace this file https://github.com/taiga-family/taiga-ui/blob/main/projects/demo-playwright/stubs/manrope-fonts.ttf with any another font
2. Run playwright tests

<img height="300" src="https://github.com/taiga-family/taiga-ui/assets/35179038/042d9b27-4f4c-4875-9a5a-f67edfd96876" />


