### PR TITLE
fix(core): `Dialog` remove paddings in page mode on mobile

### DIFF
--- a/projects/core/components/dialog/dialog.style.less
+++ b/projects/core/components/dialog/dialog.style.less
@@ -74,12 +74,6 @@
         }
     }
 
-    &[data-size='page'] {
-        .t-content {
-            padding: 0;
-        }
-    }
-
     &._centered {
         text-align: center;
     }
@@ -101,6 +95,13 @@
                 margin-bottom: 0.5rem;
                 font: var(--tui-font-heading-5);
             }
+        }
+    }
+
+    &[data-size='page'],
+    :host-context(tui-root._mobile) &[data-size='page'] {
+        .t-content {
+            padding: 0;
         }
     }
 }
@@ -157,7 +158,6 @@
     top: 1.5rem;
     right: 1.5rem;
     display: none;
-    color: var(--tui-base-01);
 
     :host-context(.t-dialog:last-of-type) & {
         display: inline-flex;
@@ -166,6 +166,7 @@
     :host:not([data-size='fullscreen']):not([data-size='page']) & {
         animation: tuiFadeIn var(--tui-duration);
         background: rgba(104, 104, 104, 0.96);
+        color: var(--tui-base-01);
 
         &:hover {
             background: rgba(159, 159, 159, 0.86);
@@ -177,12 +178,16 @@
     }
 
     :host-context(tui-root._mobile) & {
-        position: absolute;
-        top: 0;
-        right: 0;
-        background: transparent !important;
-        color: var(--tui-text-01);
-        opacity: 0.5;
+        &[data-size] {
+            --tui-fade-end: 0.5;
+
+            position: absolute;
+            top: 0;
+            right: 0;
+            background: transparent !important;
+            color: var(--tui-text-01);
+            opacity: 0.5;
+        }
     }
 }
 

--- a/projects/demo-playwright/tests/core/dialogs/dialogs.spec.ts
+++ b/projects/demo-playwright/tests/core/dialogs/dialogs.spec.ts
@@ -182,5 +182,17 @@ test.describe('Dialogs', () => {
 
             await expect(page).toHaveScreenshot('09-dialog.png');
         });
+
+        test('dismissible = true, fullscreen, desktop', async ({page}) => {
+            await page.setViewportSize({width: 1024, height: 900});
+            await tuiGoto(page, 'components/dialog/API?size=fullscreen&dismissible=true');
+
+            await page.locator('tui-doc-page button[data-appearance="primary"]').click();
+            await page.mouse.click(100, 100);
+
+            await expect(page.locator('tui-dialog')).toHaveCount(1);
+
+            await expect(page).toHaveScreenshot('10-dialog.png');
+        });
     });
 });

--- a/projects/styles/basic/keyframes.less
+++ b/projects/styles/basic/keyframes.less
@@ -10,10 +10,10 @@
 
 @keyframes tuiFadeIn {
     from {
-        opacity: 0;
+        opacity: var(--tui-fade-start, 0);
     }
 
     to {
-        opacity: 1;
+        opacity: var(--tui-fade-end, 1);
     }
 }


### PR DESCRIPTION
also fixed close-button wrong colors in fullsize mode on desktop
before: 
<img width="273" alt="Снимок экрана 2024-05-28 в 16 20 09" src="https://github.com/taiga-family/taiga-ui/assets/46284632/19748339-dd54-46e9-9b07-28aef56d60fb">

and flickering close-button opacity on mobile