### PR TITLE
refactor(testing): improve flexibility of `TuiNativeInputPO`

### DIFF
--- a/projects/legacy/components/input-range/test/input-range.component.spec.ts
+++ b/projects/legacy/components/input-range/test/input-range.component.spec.ts
@@ -440,13 +440,17 @@ describe('InputRange', () => {
 
         inputPOLeft = new TuiNativeInputPO(
             fixture,
-            testContext.nativeInputAutoId,
-            leftInputWrapper,
+            pageObject.getByAutomationId(
+                testContext.nativeInputAutoId,
+                leftInputWrapper,
+            )!,
         );
         inputPORight = new TuiNativeInputPO(
             fixture,
-            testContext.nativeInputAutoId,
-            rightInputWrapper,
+            pageObject.getByAutomationId(
+                testContext.nativeInputAutoId,
+                rightInputWrapper,
+            )!,
         );
     }
 });

--- a/projects/testing/utils/native-input.page-object.ts
+++ b/projects/testing/utils/native-input.page-object.ts
@@ -10,17 +10,15 @@ export class TuiNativeInputPO {
 
     constructor(
         private readonly fixture: ComponentFixture<unknown>,
-        private readonly automationId: string,
-        private readonly hostDebugElement?: DebugElement,
+        private readonly automationIdOrElement: DebugElement | string,
     ) {
         this.pageObject = new TuiPageObject(fixture);
     }
 
     public get nativeElement(): HTMLInputElement | HTMLTextAreaElement | null {
-        return (
-            this.pageObject.getByAutomationId(this.automationId, this.hostDebugElement)
-                ?.nativeElement ?? null
-        );
+        return typeof this.automationIdOrElement === 'string'
+            ? this.pageObject.getByAutomationId(this.automationIdOrElement)?.nativeElement
+            : this.automationIdOrElement.nativeElement;
     }
 
     public get value(): string {


### PR DESCRIPTION
# Why ?

**index.html:**
```html
<div tuiGroup>
    <tui-primitive-textfield #countrySelect />
    <tui-input #actualTextfield />
</div>
```

Not it is impossible to query nested `<input />` from `<tui-input />` without adding `automation-id`.

**New behavior:**
```ts
const inputPO = new TuiNativeInputPO(
    fixture,
    fixture.debugElement.query(By.css('tui-input input')),
);
```