### PR TITLE
fix(core): close `Hint` and `Dropdown` when host is detached from dom

### DIFF
--- a/projects/core/directives/dropdown/dropdown.component.ts
+++ b/projects/core/directives/dropdown/dropdown.component.ts
@@ -77,13 +77,11 @@ export class TuiDropdownComponent {
                 takeUntil(destroy$),
             )
             .subscribe(([top, left]) => {
-                if (!this.directive.el.nativeElement.isConnected) {
+                if (this.directive.el.nativeElement.isConnected) {
+                    this.update(top, left);
+                } else {
                     this.directive.toggle(false);
-
-                    return;
                 }
-
-                this.update(top, left);
             });
 
         this.updateWidth(this.accessor.getClientRect().width);

--- a/projects/core/directives/dropdown/dropdown.component.ts
+++ b/projects/core/directives/dropdown/dropdown.component.ts
@@ -77,6 +77,12 @@ export class TuiDropdownComponent {
                 takeUntil(destroy$),
             )
             .subscribe(([top, left]) => {
+                if (!this.directive.el.nativeElement.isConnected) {
+                    this.directive.toggle(false);
+
+                    return;
+                }
+
                 this.update(top, left);
             });
 

--- a/projects/core/directives/hint/hint.component.ts
+++ b/projects/core/directives/hint/hint.component.ts
@@ -93,6 +93,12 @@ export class TuiHintComponent<C = any> {
                 takeUntil(destroy$),
             )
             .subscribe(([top, left]) => {
+                if (!this.hover.el.nativeElement.isConnected) {
+                    this.hover.toggle(false);
+
+                    return;
+                }
+
                 this.update(top, left);
             });
 

--- a/projects/core/directives/hint/hint.component.ts
+++ b/projects/core/directives/hint/hint.component.ts
@@ -93,13 +93,11 @@ export class TuiHintComponent<C = any> {
                 takeUntil(destroy$),
             )
             .subscribe(([top, left]) => {
-                if (!this.hover.el.nativeElement.isConnected) {
+                if (this.hover.el.nativeElement.isConnected) {
+                    this.update(top, left);
+                } else {
                     this.hover.toggle(false);
-
-                    return;
                 }
-
-                this.update(top, left);
             });
 
         hovered$.pipe(takeUntil(destroy$)).subscribe(hover => this.hover.toggle(hover));


### PR DESCRIPTION
Closes #7531
