### PR TITLE
chore(core): add `cursor: pointer` for `<select tuiTextfield />`

### DIFF
--- a/projects/core/components/textfield/textfield.style.less
+++ b/projects/core/components/textfield/textfield.style.less
@@ -217,6 +217,10 @@
     ::ng-deep select._empty {
         color: var(--tui-text-02);
     }
+
+    ::ng-deep select:not(._readonly) {
+        cursor: pointer;
+    }
 }
 
 .t-content {


### PR DESCRIPTION
Open https://taiga-ui.dev/next/components/textfield#dropdown

```html
<tui-textfield
    tuiChevron
>
    <select
        tuiTextfield
        [(ngModel)]="value"
    ></select>
</tui-textfield>
```

## Previous behavior

https://github.com/taiga-family/taiga-ui/assets/35179038/95a9834f-43b7-4147-ab84-4c3519f3d6d7

## New behavior

https://github.com/taiga-family/taiga-ui/assets/35179038/5dc7403f-89c1-4fe4-a3e3-b12d321a21fd


___

Relates to:
* https://github.com/taiga-family/taiga-ui/pull/7580#discussion_r1622728628