### PR TITLE
fix(core): close `Hint` and `Dropdown` when host is detached from dom

### DIFF
--- a/projects/core/directives/dropdown/dropdown.component.ts
+++ b/projects/core/directives/dropdown/dropdown.component.ts
@@ -67,7 +67,11 @@ export class TuiDropdownComponent implements OnInit {
             takeUntilDestroyed(),
         )
         .subscribe(([top, left]) => {
-            this.update(top, left);
+            if (this.directive.el.isConnected) {
+                this.update(top, left);
+            } else {
+                this.directive.toggle(false);
+            }
         });
 
     public ngOnInit(): void {

--- a/projects/core/directives/hint/hint.component.ts
+++ b/projects/core/directives/hint/hint.component.ts
@@ -117,6 +117,12 @@ export class TuiHintComponent<C = any> {
 
     @tuiPure
     private update(top: number, left: number): void {
+        if (!this.hover.el.isConnected) {
+            this.hover.toggle(false);
+
+            return;
+        }
+
         const {height, width} = this.el.getBoundingClientRect();
         const rect = this.accessor.getClientRect();
         const viewport = this.viewport.getClientRect();

--- a/projects/demo-cypress/src/tests/hint.cy.ts
+++ b/projects/demo-cypress/src/tests/hint.cy.ts
@@ -1,0 +1,67 @@
+import {Component, Input} from '@angular/core';
+import {BrowserAnimationsModule} from '@angular/platform-browser/animations';
+import {TuiSwipeDirective} from '@taiga-ui/cdk';
+import {TuiHint, TuiRootComponent} from '@taiga-ui/core';
+import {NG_EVENT_PLUGINS} from '@tinkoff/ng-event-plugins';
+import type {MountResponse} from 'cypress/angular';
+
+describe('TuiHint', () => {
+    let component: TestComponent;
+    let wrapper: MountResponse<TestComponent>;
+
+    @Component({
+        selector: 'my-host',
+        template: `
+            <ng-container *ngIf="!hideElement">
+                <ng-content></ng-content>
+            </ng-container>
+        `,
+    })
+    class HostComponent {
+        @Input()
+        public hideElement = false;
+    }
+
+    @Component({
+        template: `
+            <tui-root>
+                <my-host [hideElement]="hide">
+                    <button tuiHint="hint">button</button>
+                </my-host>
+            </tui-root>
+        `,
+    })
+    class TestComponent {
+        public hide = false;
+    }
+
+    beforeEach(() =>
+        cy
+            .mount(TestComponent, {
+                imports: [
+                    BrowserAnimationsModule,
+                    TuiRootComponent,
+                    TuiSwipeDirective,
+                    TuiHint,
+                ],
+                declarations: [HostComponent],
+                providers: [NG_EVENT_PLUGINS],
+            })
+            .then(wrap => {
+                component = wrap.component;
+                wrapper = wrap;
+            }),
+    );
+
+    it('hint should hidden when detached from dom', () => {
+        cy.get('button').trigger('mouseenter');
+        cy.get('tui-hint')
+            .should('exist')
+            .then(() => {
+                component.hide = true;
+                wrapper.fixture.detectChanges();
+
+                cy.get('tui-hint').should('not.exist');
+            });
+    });
+});


### PR DESCRIPTION
cherry-pick + component test

Closes #7531
