### PR TITLE
chore: include inputs/outputs of host directive `ActiveZone` in `DropdownOpen`'s API

### DIFF
--- a/projects/core/directives/dropdown/dropdown-open.directive.ts
+++ b/projects/core/directives/dropdown/dropdown-open.directive.ts
@@ -49,7 +49,14 @@ function shouldClose(
 @Directive({
     standalone: true,
     selector: '[tuiDropdownOpen],[tuiDropdownOpenChange]',
-    hostDirectives: [TuiObscuredDirective, TuiActiveZoneDirective],
+    hostDirectives: [
+        TuiObscuredDirective,
+        {
+            directive: TuiActiveZoneDirective,
+            inputs: ['tuiActiveZoneParent'],
+            outputs: ['tuiActiveZoneChange'],
+        },
+    ],
     providers: [
         TuiDropdownDriver,
         tuiAsDriver(TuiDropdownDriver),


### PR DESCRIPTION
```ts
@Component({
    standalone: true,
    imports: [TuiButtonDirective, TuiActiveZoneDirective, TuiDropdownModule],
    template: `
        <button
            tuiButton
            type="button"
            [tuiDropdown]="'ANY CONTENT DROPDOWN'"
            [(tuiDropdownOpen)]="open"
            (tuiActiveZoneChange)="(0)"
        >
            Button
        </button>
    `,
})
export default class ExampleComponent {
    protected open = false;
}
```

It will throw:
```shell
Error: NG0309:
Directive TuiActiveZoneDirective matches multiple times on the same element.
Directives can only match an element once.
```