### PR TITLE
refactor(core): use `childNodes.length` instead of `textContent` to detect label for `Textfield`

### DIFF
--- a/projects/core/components/textfield/textfield.component.ts
+++ b/projects/core/components/textfield/textfield.component.ts
@@ -154,6 +154,6 @@ export class TuiTextfieldComponent<T>
     }
 
     protected get hasLabel(): boolean {
-        return Boolean(this.label?.nativeElement?.textContent?.trim());
+        return Boolean(this.label?.nativeElement?.childNodes.length);
     }
 }


### PR DESCRIPTION
Relates to:
* https://github.com/taiga-family/taiga-ui/pull/7606

**your-component.template.html:**
```html
<tui-textfield>
    <input tuiTextfield />

    <label tuiLabel><ng-content /></label>
</tui-textfield>
```

Public API of your component:
```html
<your-custom-input>
    <tui-icon icon="iconName" />
</your-custom-input>

<your-custom-input/>
```
