### PR TITLE
fix(core): `Hint` fix content vertical centering with reduced line-height

### DIFF
--- a/projects/core/directives/hint/hint.component.ts
+++ b/projects/core/directives/hint/hint.component.ts
@@ -44,11 +44,13 @@ const GAP = 4;
 @Component({
     selector: 'tui-hint',
     template: `
-        <ng-content></ng-content>
-        <span
-            *polymorpheusOutlet="content as text; context: context"
-            [innerHTML]="text"
-        ></span>
+        <div>
+            <ng-content></ng-content>
+            <span
+                *polymorpheusOutlet="content as text; context: context"
+                [innerHTML]="text"
+            ></span>
+        </div>
     `,
     styleUrls: ['./hint.style.less'],
     changeDetection: ChangeDetectionStrategy.OnPush,

--- a/projects/core/directives/hint/hint.style.less
+++ b/projects/core/directives/hint/hint.style.less
@@ -2,6 +2,8 @@
 
 :host {
     position: absolute;
+    display: flex;
+    align-items: center;
     max-width: 18rem;
     min-height: var(--tui-height-m);
     padding: 0.75rem 1rem;


### PR DESCRIPTION
before with 16px line-height font:
<img width="169" alt="Снимок экрана 2024-06-04 в 17 27 22" src="https://github.com/taiga-family/taiga-ui/assets/46284632/de6baaab-1634-4c81-97b6-00f8c6d337c8">

after: 
<img width="174" alt="Снимок экрана 2024-06-04 в 17 27 30" src="https://github.com/taiga-family/taiga-ui/assets/46284632/474f8657-69dc-4118-a588-57f481980b35">


Closes #7259 
