### PR TITLE
fix(legacy): fix `InputNumber` buttons styles priority for Safari

### DIFF
--- a/projects/legacy/components/input-number/input-number.style.less
+++ b/projects/legacy/components/input-number/input-number.style.less
@@ -48,22 +48,22 @@
     [data-size='l'] + & .t-button {
         width: calc(var(--tui-height-l) * 0.75);
     }
-}
 
-.t-button {
-    display: flex;
-    flex: 1;
-    height: auto;
-    align-items: center;
-    justify-content: center;
-    border-radius: 0;
+    & .t-button {
+        display: flex;
+        flex: 1;
+        height: auto;
+        align-items: center;
+        justify-content: center;
+        border-radius: 0;
 
-    &:first-child {
-        margin-bottom: 0.125rem;
-        border-top-right-radius: inherit;
-    }
+        &:first-child {
+            margin-bottom: 0.125rem;
+            border-top-right-radius: inherit;
+        }
 
-    &:last-child {
-        border-bottom-right-radius: inherit;
+        &:last-child {
+            border-bottom-right-radius: inherit;
+        }
     }
 }


### PR DESCRIPTION
Closes #7622 
