### PR TITLE
fix(kit): `InputDateTime` should format textfield value on blur 

### DIFF
--- a/projects/core/directives/hint/hint.style.less
+++ b/projects/core/directives/hint/hint.style.less
@@ -12,6 +12,7 @@
     font: var(--tui-font-text-s);
     white-space: pre-line;
     word-wrap: break-word;
+    line-height: 1.25rem;
 
     &:before {
         content: '';

--- a/projects/demo-playwright/tests/kit/input-date-time/input-date-time.spec.ts
+++ b/projects/demo-playwright/tests/kit/input-date-time/input-date-time.spec.ts
@@ -149,6 +149,15 @@ describe('InputDateTime', () => {
                 '15.11.2018, '.length,
             );
         });
+
+        test('should time to pre-fill with zeros on blur', async ({page}) => {
+            await tuiGoto(page, '/components/input-date-time/API?timeMode=HH:MM:SS.MSS');
+
+            await inputDateTime.textfield.fill('07.06.2024, 23:59');
+            await inputDateTime.textfield.blur();
+
+            await expect(inputDateTime.textfield).toHaveValue('07.06.2024, 23:59:00.000');
+        });
     });
 
     describe('invalid date', () => {

--- a/projects/kit/components/input-date-time/input-date-time.component.ts
+++ b/projects/kit/components/input-date-time/input-date-time.component.ts
@@ -312,7 +312,7 @@ export class TuiInputDateTimeComponent
         if (
             this.value[0] === null ||
             this.value[1] !== null ||
-            this.nativeValue.length <= this.fillerLength + DATE_TIME_SEPARATOR.length ||
+            this.nativeValue.length === this.fillerLength ||
             this.timeMode === 'HH:MM'
         ) {
             return;


### PR DESCRIPTION
Closes https://github.com/taiga-family/taiga-ui/issues/7638
