### PR TITLE
fix(legacy): InputDateTime should format textfield value on blur in the same way as InputTime

### DIFF
--- a/projects/demo-playwright/tests/kit/input-date-time/input-date-time.spec.ts
+++ b/projects/demo-playwright/tests/kit/input-date-time/input-date-time.spec.ts
@@ -172,6 +172,15 @@ test.describe('InputDateTime', () => {
                 '03-timeMode=HH:MM.SS.MSS.png',
             );
         });
+
+        test('should time to pre-fill with zeros on blur', async ({page}) => {
+            await tuiGoto(page, '/components/input-date-time/API?timeMode=HH:MM:SS.MSS');
+
+            await inputDateTime.textfield.fill('07.06.2024, 23:59');
+            await inputDateTime.textfield.blur();
+
+            await expect(inputDateTime.textfield).toHaveValue('07.06.2024, 23:59:00.000');
+        });
     });
 
     test.describe('invalid date', () => {

--- a/projects/legacy/components/input-date-time/input-date-time.component.ts
+++ b/projects/legacy/components/input-date-time/input-date-time.component.ts
@@ -305,7 +305,7 @@ export class TuiInputDateTimeComponent
         if (
             this.value[0] === null ||
             this.value[1] !== null ||
-            this.nativeValue.length <= this.fillerLength + DATE_TIME_SEPARATOR.length ||
+            this.nativeValue.length === this.fillerLength ||
             this.timeMode === 'HH:MM'
         ) {
             return;


### PR DESCRIPTION
Closes https://github.com/taiga-family/taiga-ui/issues/7638
