### PR TITLE
fix(kit): ignore native calendar for desktop

### DIFF
--- a/projects/kit/components/input-date/input-date.component.ts
+++ b/projects/kit/components/input-date/input-date.component.ts
@@ -170,7 +170,7 @@ export class TuiInputDateComponent
     }
 
     get nativePicker(): boolean {
-        return this.options.nativePicker;
+        return this.options.nativePicker && !!this.mobileCalendar && this.isMobile;
     }
 
     get calendarIcon(): TuiInputDateOptions['icon'] {

--- a/projects/kit/components/input-date/input-date.template.html
+++ b/projects/kit/components/input-date/input-date.template.html
@@ -42,7 +42,7 @@
             (click)="onIconClick()"
         ></tui-svg>
         <input
-            *ngIf="isMobile && nativePicker"
+            *ngIf="nativePicker"
             tuiDate
             class="t-native-input"
         />


### PR DESCRIPTION
Desktop:
<img width="534" alt="image" src="https://github.com/taiga-family/taiga-ui/assets/12021443/1cb7c617-771f-4cea-9e58-ea6ad17b0278">

Mobile:
<img width="707" alt="image" src="https://github.com/taiga-family/taiga-ui/assets/12021443/6ce71e0b-0ff6-454b-9814-1ddd3bcb529f">
