### PR TITLE
fix(core)!: nested `Dropdown` no longer needs manual active zone

### DIFF
--- a/projects/core/directives/dropdown/dropdown-open.directive.ts
+++ b/projects/core/directives/dropdown/dropdown-open.directive.ts
@@ -31,7 +31,6 @@ import {filter, fromEvent, map, merge} from 'rxjs';
 
 import {TuiDropdownDirective} from './dropdown.directive';
 import {TuiDropdownDriver} from './dropdown.driver';
-import {TUI_DROPDOWN_CONTEXT} from './dropdown.providers';
 
 function shouldClose(
     this: TuiDropdownOpenDirective,
@@ -57,21 +56,7 @@ function shouldClose(
             outputs: ['tuiActiveZoneChange'],
         },
     ],
-    providers: [
-        TuiDropdownDriver,
-        tuiAsDriver(TuiDropdownDriver),
-        {
-            provide: TUI_DROPDOWN_CONTEXT,
-            deps: [TuiActiveZoneDirective, TuiDropdownOpenDirective],
-            useFactory: (
-                $implicit: TuiActiveZoneDirective,
-                self: TuiDropdownOpenDirective,
-            ) => ({
-                $implicit,
-                close: () => self.toggle.call(self, false),
-            }),
-        },
-    ],
+    providers: [TuiDropdownDriver, tuiAsDriver(TuiDropdownDriver)],
 })
 export class TuiDropdownOpenDirective implements OnChanges {
     @ContentChild('tuiDropdownHost', {descendants: true, read: ElementRef})
@@ -87,7 +72,9 @@ export class TuiDropdownOpenDirective implements OnChanges {
         inject(TuiActiveZoneDirective).tuiActiveZoneChange.pipe(filter(a => !a)),
         fromEvent(this.el, 'focusin').pipe(
             map(tuiGetActualTarget),
-            filter(target => !this.host.contains(target)),
+            filter(
+                target => !this.host.contains(target) || !this.directive?.dropdownBoxRef,
+            ),
         ),
     )
         .pipe(tuiWatch(inject(ChangeDetectorRef)), takeUntilDestroyed())

--- a/projects/core/directives/dropdown/dropdown.component.ts
+++ b/projects/core/directives/dropdown/dropdown.component.ts
@@ -29,12 +29,7 @@ import {TuiDropdownPositionDirective} from './dropdown-position.directive';
 @Component({
     standalone: true,
     selector: 'tui-dropdown',
-    imports: [
-        PolymorpheusOutlet,
-        PolymorpheusTemplate,
-        TuiActiveZoneDirective,
-        TuiScrollbarComponent,
-    ],
+    imports: [PolymorpheusOutlet, PolymorpheusTemplate, TuiScrollbarComponent],
     templateUrl: './dropdown.template.html',
     styleUrls: ['./dropdown.style.less'],
     // @bad TODO: OnPush
@@ -50,6 +45,7 @@ import {TuiDropdownPositionDirective} from './dropdown-position.directive';
         '[attr.data-appearance]': 'options.appearance',
         '[attr.tuiTheme]': 'theme',
     },
+    hostDirectives: [TuiActiveZoneDirective],
     animations: [tuiDropdownAnimation],
 })
 export class TuiDropdownComponent implements OnInit {
@@ -75,13 +71,15 @@ export class TuiDropdownComponent implements OnInit {
             if (this.directive.el.isConnected) {
                 this.update(top, left);
             } else {
-                this.directive.toggle(false);
+                this.close();
             }
         });
 
     public ngOnInit(): void {
         this.updateWidth(this.accessor.getClientRect().width);
     }
+
+    protected readonly close = (): void => this.directive.toggle(false);
 
     private update(top: number, left: number): void {
         const {style} = this.el;

--- a/projects/core/directives/dropdown/dropdown.directive.ts
+++ b/projects/core/directives/dropdown/dropdown.directive.ts
@@ -8,7 +8,7 @@ import {
     TemplateRef,
 } from '@angular/core';
 import {takeUntilDestroyed} from '@angular/core/rxjs-interop';
-import type {TuiActiveZoneDirective, TuiContext} from '@taiga-ui/cdk';
+import type {TuiContext} from '@taiga-ui/cdk';
 import {tuiInjectElement, tuiPure} from '@taiga-ui/cdk';
 import type {TuiRectAccessor, TuiVehicle} from '@taiga-ui/core/classes';
 import {tuiAsRectAccessor, tuiAsVehicle} from '@taiga-ui/core/classes';
@@ -61,12 +61,10 @@ export class TuiDropdownDirective
     );
 
     public dropdownBoxRef: ComponentRef<unknown> | null = null;
-    public content: PolymorpheusContent<TuiContext<TuiActiveZoneDirective>>;
+    public content: PolymorpheusContent<TuiContext<() => void>>;
 
     @Input()
-    public set tuiDropdown(
-        content: PolymorpheusContent<TuiContext<TuiActiveZoneDirective>>,
-    ) {
+    public set tuiDropdown(content: PolymorpheusContent<TuiContext<() => void>>) {
         this.content =
             content instanceof TemplateRef
                 ? new PolymorpheusTemplate(content, this.cdr)
@@ -100,8 +98,10 @@ export class TuiDropdownDirective
         if (show && this.content && !this.dropdownBoxRef) {
             this.dropdownBoxRef = this.service.add(this.component);
         } else if (!show && this.dropdownBoxRef) {
-            this.service.remove(this.dropdownBoxRef);
+            const {dropdownBoxRef} = this;
+
             this.dropdownBoxRef = null;
+            this.service.remove(dropdownBoxRef);
         }
     }
 }

--- a/projects/core/directives/dropdown/dropdown.template.html
+++ b/projects/core/directives/dropdown/dropdown.template.html
@@ -1,10 +1,6 @@
-<tui-scrollbar
-    #activeZone="tuiActiveZone"
-    tuiActiveZone
-    class="t-scroll"
->
+<tui-scrollbar class="t-scroll">
     <div
-        *polymorpheusOutlet="directive.content as text; context: context || {$implicit: activeZone}"
+        *polymorpheusOutlet="directive.content as text; context: {$implicit: close}"
         class="t-primitive"
     >
         {{ text }}

--- a/projects/demo/src/modules/components/card-large/examples/7/index.html
+++ b/projects/demo/src/modules/components/card-large/examples/7/index.html
@@ -43,7 +43,7 @@
 
 <ng-template
     #dropdown
-    let-close="close"
+    let-close
 >
     <tui-data-list>
         <tui-opt-group>

--- a/projects/demo/src/modules/components/cell/examples/6/index.html
+++ b/projects/demo/src/modules/components/cell/examples/6/index.html
@@ -24,7 +24,7 @@
     </button>
     <ng-template
         #dropdown
-        let-close="close"
+        let-close
     >
         <tui-data-list-wrapper
             [items]="items"

--- a/projects/demo/src/modules/components/data-list/examples/2/index.html
+++ b/projects/demo/src/modules/components/data-list/examples/2/index.html
@@ -7,14 +7,10 @@
     [tuiDropdown]="content"
     [(tuiDropdownOpen)]="open"
 ></button>
-<ng-template
-    #content
-    let-activeZone
->
+<ng-template #content>
     <tui-data-list
         tuiDataListDropdownManager
         [size]="size"
-        [tuiActiveZoneParent]="activeZone"
     >
         <button
             *tuiLet="'French Fries' as item"
@@ -52,10 +48,7 @@
         </button>
     </tui-data-list>
     <ng-template #burgersTmp>
-        <tui-data-list
-            tuiDataListDropdownManager
-            [tuiActiveZoneParent]="activeZone"
-        >
+        <tui-data-list tuiDataListDropdownManager>
             <button
                 *ngFor="let burger of burgers"
                 tuiOption

--- a/projects/demo/src/modules/components/data-list/examples/2/index.ts
+++ b/projects/demo/src/modules/components/data-list/examples/2/index.ts
@@ -2,7 +2,7 @@ import {NgForOf} from '@angular/common';
 import {Component, inject} from '@angular/core';
 import {changeDetection} from '@demo/emulate/change-detection';
 import {encapsulation} from '@demo/emulate/encapsulation';
-import {TuiActiveZoneDirective, TuiLetDirective} from '@taiga-ui/cdk';
+import {TuiLetDirective} from '@taiga-ui/cdk';
 import type {TuiSizeL, TuiSizeS} from '@taiga-ui/core';
 import {
     TuiButtonDirective,
@@ -24,7 +24,6 @@ import {TuiDataListDropdownManagerDirective} from '@taiga-ui/kit';
         TuiDropdownDirective,
         TuiDropdownOpenDirective,
         TuiDataListDropdownManagerDirective,
-        TuiActiveZoneDirective,
         TuiOptionComponent,
         TuiDataListComponent,
         TuiLetDirective,

--- a/projects/demo/src/modules/components/data-list/examples/5/index.html
+++ b/projects/demo/src/modules/components/data-list/examples/5/index.html
@@ -12,14 +12,8 @@
     List of components
 </button>
 
-<ng-template
-    #content
-    let-activeZone
->
-    <tui-data-list
-        tuiDataListDropdownManager
-        [tuiActiveZoneParent]="activeZone"
-    >
+<ng-template #content>
+    <tui-data-list tuiDataListDropdownManager>
         <button
             iconRight="tuiIconChevronRight"
             tuiDropdownAlign="right"
@@ -79,10 +73,7 @@
             />
         </tui-input>
 
-        <tui-data-list
-            tuiDataListDropdownManager
-            [tuiActiveZoneParent]="activeZone"
-        >
+        <tui-data-list tuiDataListDropdownManager>
             <button
                 iconRight="tuiIconChevronRight"
                 tuiDropdownAlign="right"

--- a/projects/demo/src/modules/components/data-list/examples/5/index.ts
+++ b/projects/demo/src/modules/components/data-list/examples/5/index.ts
@@ -4,7 +4,7 @@ import {FormsModule} from '@angular/forms';
 import {changeDetection} from '@demo/emulate/change-detection';
 import {encapsulation} from '@demo/emulate/encapsulation';
 import {TuiAmountPipe} from '@taiga-ui/addon-commerce';
-import {TuiActiveZoneDirective, TuiDay, TuiDayRange} from '@taiga-ui/cdk';
+import {TuiDay, TuiDayRange} from '@taiga-ui/cdk';
 import {
     TuiButtonDirective,
     TuiCalendarComponent,
@@ -29,7 +29,6 @@ import {TuiInputDateRangeModule, TuiInputModule} from '@taiga-ui/legacy';
         TuiDropdownOpenDirective,
         TuiDataListComponent,
         TuiDataListDropdownManagerDirective,
-        TuiActiveZoneDirective,
         TuiDropdownPositionSidedDirective,
         TuiOptionComponent,
         TuiDropdownManualDirective,

--- a/projects/demo/src/modules/components/data-list/index.html
+++ b/projects/demo/src/modules/components/data-list/index.html
@@ -10,13 +10,6 @@
         </p>
 
         <tui-doc-example
-            id="custom"
-            heading="Custom list"
-            [component]="4 | tuiComponent"
-            [content]="example4"
-        />
-
-        <tui-doc-example
             id="links"
             heading="Links"
             [component]="1 | tuiComponent"
@@ -41,6 +34,13 @@
             heading="Form control"
             [component]="3 | tuiComponent"
             [content]="3 | tuiExample: 'html,ts'"
+        />
+
+        <tui-doc-example
+            id="custom"
+            heading="Custom list"
+            [component]="4 | tuiComponent"
+            [content]="example4"
         />
 
         <tui-doc-example

--- a/projects/demo/src/modules/components/input-date/examples/2/index.html
+++ b/projects/demo/src/modules/components/input-date/examples/2/index.html
@@ -25,14 +25,10 @@
         [tuiDropdown]="dropdown"
     >
         <button tuiButton>In dropdown</button>
-        <ng-template
-            #dropdown
-            let-activeZone
-        >
+        <ng-template #dropdown>
             <tui-input-date
                 formControlName="testValue"
                 tuiTextfieldSize="l"
-                [tuiActiveZoneParent]="activeZone"
             >
                 Choose a date
             </tui-input-date>

--- a/projects/demo/src/modules/components/input-date/examples/2/index.ts
+++ b/projects/demo/src/modules/components/input-date/examples/2/index.ts
@@ -2,7 +2,7 @@ import {Component} from '@angular/core';
 import {FormControl, FormGroup, ReactiveFormsModule} from '@angular/forms';
 import {changeDetection} from '@demo/emulate/change-detection';
 import {encapsulation} from '@demo/emulate/encapsulation';
-import {TuiActiveZoneDirective, TuiDay} from '@taiga-ui/cdk';
+import {TuiDay} from '@taiga-ui/cdk';
 import {TuiButtonDirective, TuiDropdownModule} from '@taiga-ui/core';
 import {TuiInputDateModule, TuiTextfieldControllerModule} from '@taiga-ui/legacy';
 
@@ -14,7 +14,6 @@ import {TuiInputDateModule, TuiTextfieldControllerModule} from '@taiga-ui/legacy
         ReactiveFormsModule,
         TuiDropdownModule,
         TuiButtonDirective,
-        TuiActiveZoneDirective,
     ],
     templateUrl: './index.html',
     encapsulation,

--- a/projects/demo/src/modules/components/line-clamp/examples/4/index.html
+++ b/projects/demo/src/modules/components/line-clamp/examples/4/index.html
@@ -13,14 +13,8 @@
     </button>
 </h3>
 
-<ng-template
-    #template
-    let-activeZone
->
-    <tui-data-list
-        tuiDataListDropdownManager
-        [tuiActiveZoneParent]="activeZone"
-    >
+<ng-template #template>
+    <tui-data-list tuiDataListDropdownManager>
         <tui-opt-group>
             <ng-container *ngFor="let text of texts">
                 <button

--- a/projects/demo/src/modules/components/line-clamp/examples/4/index.ts
+++ b/projects/demo/src/modules/components/line-clamp/examples/4/index.ts
@@ -2,7 +2,6 @@ import {NgForOf} from '@angular/common';
 import {Component} from '@angular/core';
 import {changeDetection} from '@demo/emulate/change-detection';
 import {encapsulation} from '@demo/emulate/encapsulation';
-import {TuiActiveZoneDirective} from '@taiga-ui/cdk';
 import {
     TuiDropdownDirective,
     TuiDropdownOpenDirective,
@@ -40,7 +39,6 @@ function randomString(len: number): string {
         TuiDropdownDirective,
         TuiDropdownOpenDirective,
         TuiDataListDropdownManagerDirective,
-        TuiActiveZoneDirective,
         TuiOptGroupDirective,
         NgForOf,
         TuiOptionComponent,

--- a/projects/demo/src/modules/components/tabs/examples/3/index.html
+++ b/projects/demo/src/modules/components/tabs/examples/3/index.html
@@ -37,10 +37,9 @@
 <section class="content">Currently active: {{ activeElement }}</section>
 <ng-template
     #dropdown
-    let-activeZone
-    let-close="close"
+    let-close
 >
-    <tui-data-list [tuiActiveZoneParent]="activeZone">
+    <tui-data-list>
         <button
             *ngFor="let collaborator of collaborators"
             tuiOption

--- a/projects/demo/src/modules/components/tabs/examples/3/index.ts
+++ b/projects/demo/src/modules/components/tabs/examples/3/index.ts
@@ -2,7 +2,7 @@ import {NgForOf, NgIf} from '@angular/common';
 import {Component} from '@angular/core';
 import {changeDetection} from '@demo/emulate/change-detection';
 import {encapsulation} from '@demo/emulate/encapsulation';
-import {TuiActiveZoneDirective, tuiIsString, TuiItemDirective} from '@taiga-ui/cdk';
+import {tuiIsString, TuiItemDirective} from '@taiga-ui/cdk';
 import {
     TuiDataListComponent,
     TuiDropdownDirective,
@@ -28,7 +28,6 @@ import {
         TuiDropdownDirective,
         TuiDropdownOpenDirective,
         TuiDataListComponent,
-        TuiActiveZoneDirective,
         TuiOptionComponent,
         TuiIconComponent,
     ],

--- a/projects/demo/src/modules/directives/dropdown-context/examples/3/index.html
+++ b/projects/demo/src/modules/directives/dropdown-context/examples/3/index.html
@@ -14,7 +14,7 @@
 
 <ng-template
     #reportForm
-    let-close="close"
+    let-close
 >
     <form
         class="container"

--- a/projects/demo/src/modules/directives/dropdown-context/examples/import/template.md
+++ b/projects/demo/src/modules/directives/dropdown-context/examples/import/template.md
@@ -8,7 +8,7 @@
 
 <ng-template
   #content
-  let-close="close"
+  let-close
 >
   Dropdown content
   <button (click)="close()"></button>

--- a/projects/demo/src/modules/directives/dropdown-hover/examples/3/index.html
+++ b/projects/demo/src/modules/directives/dropdown-hover/examples/3/index.html
@@ -6,21 +6,11 @@
     [(tuiDropdownOpen)]="open"
 >
     Dropdown hover
-    <ng-template
-        #dropdown
-        let-activeZone
-    >
+    <ng-template #dropdown>
         <div [style.padding]="'0 1rem'">
-            <p>
-                There is
-                <code>let-activeZone</code>
-                in dropdown template context to work with nested dropdowns
-            </p>
-
             <tui-select
                 class="margin"
                 [formControl]="selected"
-                [tuiActiveZoneParent]="activeZone"
             >
                 Nested select
                 <tui-data-list-wrapper
@@ -36,7 +26,6 @@
                     tuiDropdownHover
                     tuiDropdownOpen
                     type="button"
-                    [tuiActiveZoneParent]="activeZone"
                     [tuiDropdown]="content"
                 >
                     Nested dropdown hover

--- a/projects/demo/src/modules/directives/dropdown-hover/examples/3/index.ts
+++ b/projects/demo/src/modules/directives/dropdown-hover/examples/3/index.ts
@@ -3,7 +3,6 @@ import {Component} from '@angular/core';
 import {FormControl, ReactiveFormsModule} from '@angular/forms';
 import {changeDetection} from '@demo/emulate/change-detection';
 import {encapsulation} from '@demo/emulate/encapsulation';
-import {TuiActiveZoneDirective} from '@taiga-ui/cdk';
 import {
     TuiButtonDirective,
     TuiDataListComponent,
@@ -24,7 +23,6 @@ import {TuiSelectModule} from '@taiga-ui/legacy';
         TuiDropdownOpenDirective,
         TuiSelectModule,
         ReactiveFormsModule,
-        TuiActiveZoneDirective,
         TuiDataListWrapper,
         TuiDataListComponent,
         NgForOf,

--- a/projects/demo/src/modules/directives/dropdown-open/examples/1/index.html
+++ b/projects/demo/src/modules/directives/dropdown-open/examples/1/index.html
@@ -14,7 +14,7 @@
 </button>
 <ng-template
     #dropdown
-    let-close="close"
+    let-close
 >
     <tui-data-list>
         <tui-opt-group>

--- a/projects/demo/src/modules/directives/dropdown-open/examples/2/index.html
+++ b/projects/demo/src/modules/directives/dropdown-open/examples/2/index.html
@@ -23,18 +23,9 @@
         Menu
     </button>
 </div>
-<ng-template
-    #dropdown
-    let-activeZone
->
-    <p class="margin">
-        There is
-        <code>let-activeZone</code>
-        in dropdown template context to work with nested dropdowns
-    </p>
+<ng-template #dropdown>
     <tui-select
         class="margin"
-        [tuiActiveZoneParent]="activeZone"
         [(ngModel)]="selected"
     >
         Nested Select

--- a/projects/demo/src/modules/directives/dropdown-open/examples/2/index.less
+++ b/projects/demo/src/modules/directives/dropdown-open/examples/2/index.less
@@ -1,10 +1,8 @@
-@import '@taiga-ui/core/styles/taiga-ui-local';
-
 :host {
     display: block;
     width: max-content;
 }
 
 .margin {
-    margin: 4 * @space;
+    margin: 1rem;
 }

--- a/projects/demo/src/modules/directives/dropdown-open/examples/2/index.ts
+++ b/projects/demo/src/modules/directives/dropdown-open/examples/2/index.ts
@@ -3,7 +3,6 @@ import {Component} from '@angular/core';
 import {FormsModule} from '@angular/forms';
 import {changeDetection} from '@demo/emulate/change-detection';
 import {encapsulation} from '@demo/emulate/encapsulation';
-import {TuiActiveZoneDirective} from '@taiga-ui/cdk';
 import {
     TuiButtonDirective,
     TuiDataListComponent,
@@ -26,7 +25,6 @@ import {TuiSelectModule} from '@taiga-ui/legacy';
         TuiButtonDirective,
         TuiChevronDirective,
         TuiSelectModule,
-        TuiActiveZoneDirective,
         FormsModule,
         TuiDataListWrapper,
         TuiDataListComponent,


### PR DESCRIPTION
BREAKING CHANGE: `ActiveZone` is removed from context in favor of close method

Closes # <!-- link to a relevant issue. -->
