### PR TITLE
fix(kit): `CalendarRange` should not distinguish ranges with same dates and different names

### DIFF
--- a/projects/kit/components/calendar-range/calendar-range.component.ts
+++ b/projects/kit/components/calendar-range/calendar-range.component.ts
@@ -55,6 +55,7 @@ export class TuiCalendarRangeComponent implements OnChanges {
     protected readonly icons = inject(TUI_COMMON_ICONS);
     protected previousValue: TuiDayRange | null = null;
     protected hoveredItem: TuiDay | null = null;
+    protected selectedActivePeriod: TuiDayRangePeriod | null = null;
     protected readonly capsMapper = TUI_DAY_CAPS_MAPPER;
 
     @Input()
@@ -149,10 +150,12 @@ export class TuiCalendarRangeComponent implements OnChanges {
     }
 
     protected onItemSelect(item: TuiDayRangePeriod | string): void {
-        if (typeof item !== 'string') {
+        if (!tuiIsString(item)) {
             this.updateValue(item.range.dayLimit(this.min, this.max));
+            this.selectedActivePeriod = item;
         } else if (this.activePeriod !== null) {
             this.updateValue(null);
+            this.selectedActivePeriod = null;
         }
     }
 
@@ -162,6 +165,7 @@ export class TuiCalendarRangeComponent implements OnChanges {
 
     protected onDayClick(day: TuiDay): void {
         this.previousValue = this.value;
+        this.selectedActivePeriod = null;
 
         if (!this.value?.isSingleDay) {
             this.value = new TuiDayRange(day, day);
@@ -177,7 +181,8 @@ export class TuiCalendarRangeComponent implements OnChanges {
 
     private get activePeriod(): TuiDayRangePeriod | null {
         return (
-            this.items.find(item =>
+            this.selectedActivePeriod ??
+            (this.items.find(item =>
                 tuiNullableSame<TuiDayRange>(
                     this.value,
                     item.range,
@@ -185,7 +190,8 @@ export class TuiCalendarRangeComponent implements OnChanges {
                         a.from.daySame(b.from.dayLimit(this.min, this.max)) &&
                         a.to.daySame(b.to.dayLimit(this.min, this.max)),
                 ),
-            ) || null
+            ) ||
+                null)
         );
     }
 

--- a/projects/kit/components/calendar-range/test/calendar-range.component.spec.ts
+++ b/projects/kit/components/calendar-range/test/calendar-range.component.spec.ts
@@ -32,6 +32,7 @@ describe('rangeCalendarComponent', () => {
                 [items]="items"
                 [max]="max"
                 [min]="min"
+                [value]="value"
                 (valueChange)="onRangeChange($event)"
             />
         `,
@@ -59,6 +60,8 @@ describe('rangeCalendarComponent', () => {
         public min = new TuiDay(1900, 0, 1);
 
         public max = TUI_LAST_DAY;
+
+        public value: TuiDayRange | null = null;
 
         public onRangeChange(range: TuiDayRange | null): void {
             this.control.setValue(range);
@@ -108,6 +111,17 @@ describe('rangeCalendarComponent', () => {
             expect(items.length).toBe(7);
         });
 
+        it('If the value fit any range, check the box next to appropriate range', () => {
+            const today = TuiDay.currentLocal();
+
+            testComponent.value = new TuiDayRange(today, today);
+            fixture.detectChanges();
+
+            const items = getItems();
+
+            expect(items[1].nativeElement.contains(getCheckmark())).toBe(true);
+        });
+
         it('If the value does not fit any range, check the box next to "Other date..."', () => {
             expect(getItems()[6].nativeElement.contains(getCheckmark())).toBe(true);
         });
@@ -124,6 +138,7 @@ describe('rangeCalendarComponent', () => {
 
             testComponent.min = min;
             fixture.detectChanges();
+
             component['onItemSelect'](component.items[5]);
             fixture.detectChanges();
 
@@ -167,6 +182,47 @@ describe('rangeCalendarComponent', () => {
             expect(items.length).toBe(2);
             expect(items[0].nativeElement.textContent.trim()).toBe(title);
             expect(items[1].nativeElement.textContent.trim()).toBe('Other date...');
+        });
+
+        it('When redefining intervals, displays appropriate checkbox', () => {
+            const today = TuiDay.currentLocal();
+            const previousMonth = today.append({month: -1});
+            const title = 'New interval';
+
+            component['onItemSelect'](component.items[0]);
+            fixture.detectChanges();
+
+            testComponent.items = [
+                new TuiDayRangePeriod(new TuiDayRange(previousMonth, today), title),
+                ...testComponent.items,
+            ];
+            fixture.detectChanges();
+
+            const items = getItems();
+
+            expect(items[0].nativeElement.textContent.trim()).toBe(title);
+
+            expect(items[0].nativeElement.contains(getCheckmark())).toBe(false);
+            expect(items[1].nativeElement.contains(getCheckmark())).toBe(true);
+        });
+
+        it('If there are ranges with same range dates, displays appropriate checkbox when switching between them', () => {
+            const today = TuiDay.currentLocal();
+            const previousMonth = today.append({month: -1});
+
+            testComponent.items = [
+                new TuiDayRangePeriod(new TuiDayRange(previousMonth, today), '1'),
+                new TuiDayRangePeriod(new TuiDayRange(previousMonth, today), '2'),
+            ];
+            fixture.detectChanges();
+
+            component['onItemSelect'](component.items[1]);
+            fixture.detectChanges();
+
+            const items = getItems();
+
+            expect(items[0].nativeElement.contains(getCheckmark())).toBe(false);
+            expect(items[1].nativeElement.contains(getCheckmark())).toBe(true);
         });
     });
 


### PR DESCRIPTION
Closes #7781 

Problem: on item select, control value hold **only range**, not considering name/content

```
onItemSelect(item: TuiDayRangePeriod | string): void {
        if (typeof item !== 'string') {
            this.updateValue(item.range.dayLimit(this.min, this.max));

            return;
        }

        if (this.activePeriod !== null) {
            this.updateValue(null);
        }
}
```
And when it attemps to get current active period, in finds only by range  
```
private get activePeriod(): TuiDayRangePeriod | null {
        return (
            this.items.find(item =>
                tuiNullableSame<TuiDayRange>(
                    this.value,
                    item.range,
                    (a, b) =>
                        a.from.daySame(b.from.dayLimit(this.min, this.max)) &&
                        a.to.daySame(b.to.dayLimit(this.min, this.max)),
                ),
            ) || null
        );
}
```

Solutions:
1. To hold current item index
2. To hold TuiDayRangePeriod separately
3. To hold TuiDayRangePeriod in value (breaking change)