### PR TITLE
fix(addon-doc): `Navigation` fix invalid two-way binding error in Angular v18

### DIFF
--- a/projects/addon-doc/components/navigation/navigation.template.html
+++ b/projects/addon-doc/components/navigation/navigation.template.html
@@ -64,7 +64,8 @@
                 *ngFor="let label of labels; index as index"
                 size="s"
                 [borders]="null"
-                [(open)]="!!openPagesArr[index]"
+                [open]="!!openPagesArr[index]"
+                (openChange)="openPagesArr[index] = $event"
             >
                 <span class="t-label">
                     <strong>{{ label }}</strong>


### PR DESCRIPTION
Closes #7824
