### PR TITLE
fix(kit): `InputDateRange` should not distinguish ranges with same dates and different names

### DIFF
--- a/projects/demo-playwright/tests/kit/input-date-range/input-date-range.spec.ts
+++ b/projects/demo-playwright/tests/kit/input-date-range/input-date-range.spec.ts
@@ -11,6 +11,7 @@ import {
 test.describe('InputDateRange', () => {
     let example!: Locator;
     let inputDateRange!: TuiInputDateRangePO;
+    let documentationPage!: TuiDocumentationPagePO;
 
     test.use({
         viewport: {width: 650, height: 650},
@@ -19,7 +20,8 @@ test.describe('InputDateRange', () => {
     test.beforeEach(async ({page}) => {
         await tuiGoto(page, 'components/input-date-range');
 
-        example = new TuiDocumentationPagePO(page).apiPageExample;
+        documentationPage = new TuiDocumentationPagePO(page);
+        example = documentationPage.apiPageExample;
 
         inputDateRange = new TuiInputDateRangePO(example.locator('tui-input-date-range'));
     });
@@ -156,6 +158,28 @@ test.describe('InputDateRange', () => {
             );
             await expect(example).toHaveScreenshot(
                 '07-item-and-calendar-interactions.png',
+            );
+        });
+    });
+
+    test.describe('Examples', () => {
+        test('Select second same range => after close/open calendar displays selected period displays correctly', async () => {
+            const example = documentationPage.getExample('#custom-period');
+
+            const inputDateRange = new TuiInputDateRangePO(
+                example.locator('tui-input-date-range'),
+            );
+
+            await inputDateRange.textfield.click();
+            await inputDateRange.selectItem(2);
+            await inputDateRange.textfield.click();
+
+            expect(await inputDateRange.itemHasCheckmark(1)).toBeFalsy();
+            expect(await inputDateRange.itemHasCheckmark(2)).toBeTruthy();
+
+            await expect(inputDateRange.textfield).toHaveValue('Yet another yesterday');
+            await expect(inputDateRange.calendarRange).toHaveScreenshot(
+                '08-calendar-correct-selected-period-after-close-open.png',
             );
         });
     });

--- a/projects/demo-playwright/utils/page-objects/input-date-range.po.ts
+++ b/projects/demo-playwright/utils/page-objects/input-date-range.po.ts
@@ -24,4 +24,14 @@ export class TuiInputDateRangePO {
 
         await items[index].click();
     }
+
+    async itemHasCheckmark(index: number): Promise<boolean> {
+        const items = await this.getItems();
+
+        const itemCheckmark = await items[index]
+            .locator('[automation-id="tui-calendar-range__checkmark"]')
+            .count();
+
+        return !!itemCheckmark;
+    }
 }

--- a/projects/demo/src/modules/components/input-date-range/examples/5/index.ts
+++ b/projects/demo/src/modules/components/input-date-range/examples/5/index.ts
@@ -28,5 +28,10 @@ export class TuiInputDateRangeExample5 {
             'Yesterday',
             ({$implicit}) => `Yesterday (${$implicit.from})`,
         ),
+        new TuiDayRangePeriod(
+            new TuiDayRange(yesterday, yesterday),
+            'Yet another yesterday',
+            ({$implicit}) => `Yet another yesterday (${$implicit.from})`,
+        ),
     ];
 }

--- a/projects/kit/components/calendar-range/calendar-range.component.ts
+++ b/projects/kit/components/calendar-range/calendar-range.component.ts
@@ -96,7 +96,7 @@ export class TuiCalendarRangeComponent implements TuiWithOptionalMinMax<TuiDay> 
         @Optional()
         @Inject(TUI_CALENDAR_DATE_STREAM)
         valueChanges: Observable<TuiDayRange | null> | null,
-        @Inject(ChangeDetectorRef) cdr: ChangeDetectorRef,
+        @Inject(ChangeDetectorRef) readonly cdr: ChangeDetectorRef,
         @Self() @Inject(TuiDestroyService) destroy$: TuiDestroyService,
         @Inject(TUI_OTHER_DATE_TEXT) readonly otherDateText$: Observable<string>,
         @Inject(TUI_COMMON_ICONS) readonly icons: TuiCommonIcons,
@@ -180,15 +180,15 @@ export class TuiCalendarRangeComponent implements TuiWithOptionalMinMax<TuiDay> 
 
     onItemSelect(item: TuiDayRangePeriod | string): void {
         if (!tuiIsString(item)) {
-            this.updateValue(item.range.dayLimit(this.min, this.max));
             this.selectedActivePeriod = item;
+            this.updateValue(item.range.dayLimit(this.min, this.max));
 
             return;
         }
 
         if (this.activePeriod !== null) {
-            this.updateValue(null);
             this.selectedActivePeriod = null;
+            this.updateValue(null);
         }
     }
 

--- a/projects/kit/components/input-date-range/test/input-date-range.component.spec.ts
+++ b/projects/kit/components/input-date-range/test/input-date-range.component.spec.ts
@@ -92,6 +92,28 @@ describe('InputDateRangeComponent', () => {
             initializeEnvironment();
         });
 
+        it('When switching between ranges with same date, displays appropriate input value', async () => {
+            const today = TuiDay.currentLocal();
+            const previousMonth = today.append({month: -1});
+            const first = '1';
+            const second = '2';
+
+            testComponent.items = [
+                new TuiDayRangePeriod(new TuiDayRange(previousMonth, today), first),
+                new TuiDayRangePeriod(new TuiDayRange(previousMonth, today), second),
+            ];
+            fixture.detectChanges();
+
+            clickOnTextfield();
+
+            getCalendarItems()[1]?.nativeElement.click();
+            fixture.detectChanges();
+
+            await fixture.whenStable();
+
+            expect(inputPO.value).toBe(second);
+        });
+
         describe('Click on the input field', () => {
             it('opens the calendar', () => {
                 clickOnTextfield();
@@ -404,6 +426,10 @@ describe('InputDateRangeComponent', () => {
 
     function getCalendarsWrapper(): DebugElement | null {
         return pageObject.getByAutomationId('tui-calendar-range__calendars');
+    }
+
+    function getCalendarItems(): DebugElement[] {
+        return pageObject.getAllByAutomationId('tui-calendar-range__menu__item');
     }
 
     function getTextfield(): DebugElement | null {


### PR DESCRIPTION
Closes #7909 
