### PR TITLE
chore(demo-playwright): improve screenshot test for `Error`

### DIFF
--- a/projects/demo-playwright/tests/core/error/error.spec.ts
+++ b/projects/demo-playwright/tests/core/error/error.spec.ts
@@ -17,6 +17,6 @@ test.describe('TuiError', () => {
         await expect(error).toBeVisible();
         await expect(error).toHaveText('An error');
 
-        await expect(example).toHaveScreenshot('01-error.png');
+        await expect(example).toHaveScreenshot('01-error.png', {animations: 'allow'});
     });
 });


### PR DESCRIPTION
## Before
![01-error-expected](https://github.com/taiga-family/taiga-ui/assets/35179038/e108e2fc-00db-4d00-a4ed-1d5dd3bb57e5)

## After
![01-error-actual](https://github.com/taiga-family/taiga-ui/assets/35179038/ff859fb2-0e03-4143-91d3-b08dfe4d5328)
