### PR TITLE
chore(cdk): migrations for `@taiga-ui/polymorpheus` & `@taiga-ui/event-plugins`

### DIFF
--- a/projects/cdk/schematics/ng-update/steps/index.ts
+++ b/projects/cdk/schematics/ng-update/steps/index.ts
@@ -3,4 +3,5 @@ export * from './rename-types';
 export * from './replace-deep-import';
 export * from './replace-enums';
 export * from './replace-identifier';
+export * from './replace-package-name';
 export * from './show-warnings';

--- a/projects/cdk/schematics/ng-update/steps/replace-package-name.ts
+++ b/projects/cdk/schematics/ng-update/steps/replace-package-name.ts
@@ -1,0 +1,31 @@
+import type {Tree} from '@angular-devkit/schematics';
+import {
+    addPackageJsonDependency,
+    getPackageJsonDependency,
+    removePackageJsonDependency,
+    saveActiveProject,
+} from 'ng-morph';
+
+import {ALL_TS_FILES} from '../../constants';
+import {getFileSystem} from '../utils/get-file-system';
+import {replaceText} from '../utils/replace-text';
+
+export function replacePackageName(
+    oldPackage: string,
+    newPackage: {name: string; version: string},
+    tree: Tree,
+): void {
+    if (!getPackageJsonDependency(tree, oldPackage)) {
+        return;
+    }
+
+    const fileSystem = getFileSystem(tree);
+
+    replaceText([{from: oldPackage, to: newPackage.name}], ALL_TS_FILES);
+    removePackageJsonDependency(tree, oldPackage);
+
+    addPackageJsonDependency(tree, newPackage);
+
+    fileSystem.commitEdits();
+    saveActiveProject();
+}

--- a/projects/cdk/schematics/ng-update/v3-36/index.ts
+++ b/projects/cdk/schematics/ng-update/v3-36/index.ts
@@ -1,13 +1,6 @@
 import type {Rule, SchematicContext, Tree} from '@angular-devkit/schematics';
 import {NodePackageInstallTask} from '@angular-devkit/schematics/tasks';
-import {
-    addPackageJsonDependency,
-    getPackageJsonDependency,
-    removePackageJsonDependency,
-    saveActiveProject,
-} from 'ng-morph';
 
-import {ALL_TS_FILES} from '../../constants';
 import type {TuiSchema} from '../../ng-add/schema';
 import {
     FINISH_SYMBOL,
@@ -16,8 +9,7 @@ import {
     SMALL_TAB_SYMBOL,
     titleLog,
 } from '../../utils/colored-log';
-import {getFileSystem} from '../utils/get-file-system';
-import {replaceText} from '../utils/replace-text';
+import {replacePackageName} from '../steps';
 
 const OLD_PACKAGE = '@taiga-ui/addon-editor';
 const NEW_PACKAGE = '@taiga-ui/editor';
@@ -26,28 +18,20 @@ const NEW_PACKAGE_VERSION = '^2.0.0';
 // TODO: drop in v4.x
 export function updateToV3_36(options: TuiSchema): Rule {
     return (tree: Tree, context: SchematicContext): void => {
-        if (!getPackageJsonDependency(tree, OLD_PACKAGE)) {
-            !options['skip-logs'] &&
-                titleLog(`${FINISH_SYMBOL} No migrations required for ${OLD_PACKAGE}\n`);
-
-            return;
-        }
-
-        const fileSystem = getFileSystem(tree);
-
         !options['skip-logs'] &&
             infoLog(
                 `${SMALL_TAB_SYMBOL}${REPLACE_SYMBOL} replacing imports for ${OLD_PACKAGE}...`,
             );
 
-        replaceText([{from: OLD_PACKAGE, to: NEW_PACKAGE}], ALL_TS_FILES);
-        removePackageJsonDependency(tree, OLD_PACKAGE);
-
-        addPackageJsonDependency(tree, {name: NEW_PACKAGE, version: NEW_PACKAGE_VERSION});
+        replacePackageName(
+            OLD_PACKAGE,
+            {
+                name: NEW_PACKAGE,
+                version: NEW_PACKAGE_VERSION,
+            },
+            tree,
+        );
         context.addTask(new NodePackageInstallTask());
-
-        fileSystem.commitEdits();
-        saveActiveProject();
 
         !options['skip-logs'] && titleLog(`${FINISH_SYMBOL} successfully migrated \n`);
     };

--- a/projects/cdk/schematics/ng-update/v4/index.ts
+++ b/projects/cdk/schematics/ng-update/v4/index.ts
@@ -5,6 +5,7 @@ import {chain} from '@angular-devkit/schematics';
 import {NodePackageInstallTask} from '@angular-devkit/schematics/tasks';
 import {saveActiveProject} from 'ng-morph';
 
+import cdkPackage from '../../../package.json';
 import {TAIGA_VERSION} from '../../ng-add/constants/versions';
 import type {TuiSchema} from '../../ng-add/schema';
 import {FINISH_SYMBOL, START_SYMBOL, titleLog} from '../../utils/colored-log';
@@ -14,6 +15,7 @@ import {
     renameTypes,
     replaceEnums,
     replaceIdentifiers,
+    replacePackageName,
     showWarnings,
 } from '../steps';
 import {getFileSystem} from '../utils/get-file-system';
@@ -60,6 +62,23 @@ function main(options: TuiSchema): Rule {
 
         fileSystem.commitEdits();
         saveActiveProject();
+
+        replacePackageName(
+            '@tinkoff/ng-polymorpheus',
+            {
+                name: '@taiga-ui/polymorpheus',
+                version: cdkPackage.peerDependencies['@taiga-ui/polymorpheus'],
+            },
+            tree,
+        );
+        replacePackageName(
+            '@tinkoff/ng-event-plugins',
+            {
+                name: '@taiga-ui/event-plugins',
+                version: cdkPackage.peerDependencies['@taiga-ui/event-plugins'],
+            },
+            tree,
+        );
 
         context.addTask(new NodePackageInstallTask());
     };

--- a/projects/cdk/schematics/ng-update/v4/tests/migrate-destroy-service/utils.ts
+++ b/projects/cdk/schematics/ng-update/v4/tests/migrate-destroy-service/utils.ts
@@ -19,6 +19,7 @@ export async function runMigration(before: string): Promise<string> {
 
     setActiveProject(createProject(host));
     createSourceFile('test/app/test.component.ts', before);
+    createSourceFile('package.json', '{}');
     saveActiveProject();
 
     const tree = await runner.runSchematic(

--- a/projects/cdk/schematics/ng-update/v4/tests/schematic-migrate-all-country-iso-codes.spec.ts
+++ b/projects/cdk/schematics/ng-update/v4/tests/schematic-migrate-all-country-iso-codes.spec.ts
@@ -53,6 +53,7 @@ describe('ng-update', () => {
         setActiveProject(createProject(host));
 
         createSourceFile('test/app/test.component.ts', BEFORE);
+        createSourceFile('package.json', '{}');
 
         saveActiveProject();
     });

--- a/projects/cdk/schematics/ng-update/v4/tests/schematic-migrate-button.spec.ts
+++ b/projects/cdk/schematics/ng-update/v4/tests/schematic-migrate-button.spec.ts
@@ -120,6 +120,6 @@ describe('ng-update', () => {
 
 function createMainFiles(): void {
     createSourceFile('test/app/test.component.ts', COMPONENT_BEFORE);
-
     createSourceFile('test/app/test.template.html', TEMPLATE_BEFORE);
+    createSourceFile('package.json', '{}');
 }

--- a/projects/cdk/schematics/ng-update/v4/tests/schematic-migrate-enums.spec.ts
+++ b/projects/cdk/schematics/ng-update/v4/tests/schematic-migrate-enums.spec.ts
@@ -93,4 +93,5 @@ describe('ng-update enums', () => {
 
 function createMainFiles(): void {
     createSourceFile('test/app/test.component.ts', COMPONENT_BEFORE);
+    createSourceFile('package.json', '{}');
 }

--- a/projects/cdk/schematics/ng-update/v4/tests/schematic-migrate-hosted-dropdown.spec.ts
+++ b/projects/cdk/schematics/ng-update/v4/tests/schematic-migrate-hosted-dropdown.spec.ts
@@ -121,6 +121,6 @@ describe('ng-update', () => {
 
 function createMainFiles(): void {
     createSourceFile('test/app/test.component.ts', COMPONENT_BEFORE);
-
     createSourceFile('test/app/test.template.html', TEMPLATE_BEFORE);
+    createSourceFile('package.json', '{}');
 }

--- a/projects/cdk/schematics/ng-update/v4/tests/schematic-migrate-labeled.spec.ts
+++ b/projects/cdk/schematics/ng-update/v4/tests/schematic-migrate-labeled.spec.ts
@@ -103,4 +103,5 @@ function createMainFiles(): void {
     createSourceFile('test/app/test.component.ts', COMPONENT_BEFORE);
 
     createSourceFile('test/app/test.template.html', TEMPLATE_BEFORE);
+    createSourceFile('package.json', '{}');
 }

--- a/projects/cdk/schematics/ng-update/v4/tests/schematic-migrate-legacy-mask.spec.ts
+++ b/projects/cdk/schematics/ng-update/v4/tests/schematic-migrate-legacy-mask.spec.ts
@@ -73,6 +73,7 @@ describe('ng-update', () => {
         setActiveProject(createProject(host));
 
         createSourceFile('test/app/test.component.ts', BEFORE);
+        createSourceFile('package.json', '{}');
 
         saveActiveProject();
     });

--- a/projects/cdk/schematics/ng-update/v4/tests/schematic-migrate-package-names.spec.ts
+++ b/projects/cdk/schematics/ng-update/v4/tests/schematic-migrate-package-names.spec.ts
@@ -11,6 +11,8 @@ import {
     setActiveProject,
 } from 'ng-morph';
 
+import cdkPackage from '../../../../package.json';
+
 const collectionPath = join(__dirname, '../../../migration.json');
 
 const TS_FILE_BEFORE = `
@@ -42,8 +44,8 @@ const PACKAGE_JSON_AFTER = {
     dependencies: {
         '@angular/core': '~13.0.0',
         '@taiga-ui/addon-commerce': '~3.42.0',
-        '@taiga-ui/event-plugins': '^4.0.1',
-        '@taiga-ui/polymorpheus': '^4.6.3',
+        '@taiga-ui/event-plugins': cdkPackage.peerDependencies['@taiga-ui/event-plugins'],
+        '@taiga-ui/polymorpheus': cdkPackage.peerDependencies['@taiga-ui/polymorpheus'],
     },
 };
 

--- a/projects/cdk/schematics/ng-update/v4/tests/schematic-migrate-package-names.spec.ts
+++ b/projects/cdk/schematics/ng-update/v4/tests/schematic-migrate-package-names.spec.ts
@@ -1,0 +1,89 @@
+import {join} from 'node:path';
+
+import {HostTree} from '@angular-devkit/schematics';
+import {SchematicTestRunner, UnitTestTree} from '@angular-devkit/schematics/testing';
+import type {TuiSchema} from '@taiga-ui/cdk/schematics/ng-add/schema';
+import {
+    createProject,
+    createSourceFile,
+    resetActiveProject,
+    saveActiveProject,
+    setActiveProject,
+} from 'ng-morph';
+
+const collectionPath = join(__dirname, '../../../migration.json');
+
+const TS_FILE_BEFORE = `
+import {Component} from '@angular/core';
+import {PolymorpheusComponent} from '@tinkoff/ng-polymorpheus';
+import {shouldCall} from '@tinkoff/ng-event-plugins';
+import {NG_EVENT_PLUGINS} from '@tinkoff/ng-event-plugins';
+import {TUI_VERSION} from '@taiga-ui/cdk';
+`.trim();
+
+const TS_FILE_AFTER = `
+import {Component} from '@angular/core';
+import {PolymorpheusComponent} from '@taiga-ui/polymorpheus';
+import {shouldCall} from '@taiga-ui/event-plugins';
+import {NG_EVENT_PLUGINS} from '@taiga-ui/event-plugins';
+import {TUI_VERSION} from '@taiga-ui/cdk';
+`.trim();
+
+const PACKAGE_JSON_BEFORE = {
+    dependencies: {
+        '@angular/core': '~13.0.0',
+        '@taiga-ui/addon-commerce': '~3.42.0',
+        '@tinkoff/ng-polymorpheus': '1.2.3',
+        '@tinkoff/ng-event-plugins': '4.5.6',
+    },
+};
+
+const PACKAGE_JSON_AFTER = {
+    dependencies: {
+        '@angular/core': '~13.0.0',
+        '@taiga-ui/addon-commerce': '~3.42.0',
+        '@taiga-ui/event-plugins': '^4.0.1',
+        '@taiga-ui/polymorpheus': '^4.6.3',
+    },
+};
+
+describe('ng-update', () => {
+    let host: UnitTestTree;
+    let runner: SchematicTestRunner;
+
+    beforeEach(() => {
+        host = new UnitTestTree(new HostTree());
+        runner = new SchematicTestRunner('schematics', collectionPath);
+
+        setActiveProject(createProject(host));
+
+        createSourceFile('test/app/test.component.ts', TS_FILE_BEFORE);
+        createSourceFile('package.json', JSON.stringify(PACKAGE_JSON_BEFORE));
+
+        saveActiveProject();
+    });
+
+    it('replace imports inside all *.ts files', async () => {
+        const tree = await runner.runSchematic(
+            'updateToV4',
+            {'skip-logs': process.env['TUI_CI'] === 'true'} as Partial<TuiSchema>,
+            host,
+        );
+
+        expect(tree.readContent('test/app/test.component.ts')).toEqual(TS_FILE_AFTER);
+    });
+
+    it('replace package names inside all package.json files', async () => {
+        const tree = await runner.runSchematic(
+            'updateToV4',
+            {'skip-logs': process.env['TUI_CI'] === 'true'} as Partial<TuiSchema>,
+            host,
+        );
+
+        expect(JSON.parse(tree.readContent('package.json'))).toEqual(PACKAGE_JSON_AFTER);
+    });
+
+    afterEach(() => {
+        resetActiveProject();
+    });
+});

--- a/projects/cdk/schematics/ng-update/v4/tests/schematic-migrate-progress-segmented.spec.ts
+++ b/projects/cdk/schematics/ng-update/v4/tests/schematic-migrate-progress-segmented.spec.ts
@@ -106,6 +106,6 @@ describe('ng-update', () => {
 
 function createMainFiles(): void {
     createSourceFile('test/app/test.component.ts', COMPONENT_BEFORE);
-
     createSourceFile('test/app/test.template.html', TEMPLATE_BEFORE);
+    createSourceFile('package.json', '{}');
 }

--- a/projects/cdk/schematics/ng-update/v4/tests/schematic-migrate-providers.spec.ts
+++ b/projects/cdk/schematics/ng-update/v4/tests/schematic-migrate-providers.spec.ts
@@ -65,4 +65,5 @@ describe('ng-update', () => {
 
 function createMainFiles(): void {
     createSourceFile('test/app/component.ts', COMPONENT_BEFORE);
+    createSourceFile('package.json', '{}');
 }

--- a/projects/cdk/schematics/ng-update/v4/tests/schematic-migrate-restore-tui-mapper.spec.ts
+++ b/projects/cdk/schematics/ng-update/v4/tests/schematic-migrate-restore-tui-mapper.spec.ts
@@ -167,5 +167,5 @@ function createMainFiles(): void {
     createSourceFile('test/app/tui-typed-mapper.component.html', TEMPLATE_BEFORE);
 
     createAngularJson();
-    createSourceFile('package.json');
+    createSourceFile('package.json', '{}');
 }

--- a/projects/cdk/schematics/ng-update/v4/tests/schematic-migrate-restore-tui-matcher.spec.ts
+++ b/projects/cdk/schematics/ng-update/v4/tests/schematic-migrate-restore-tui-matcher.spec.ts
@@ -167,5 +167,5 @@ function createMainFiles(): void {
     createSourceFile('test/app/tui-typed-matcher.component.html', TEMPLATE_BEFORE);
 
     createAngularJson();
-    createSourceFile('package.json');
+    createSourceFile('package.json', '{}');
 }

--- a/projects/cdk/schematics/ng-update/v4/tests/schematic-migrate-styles.spec.ts
+++ b/projects/cdk/schematics/ng-update/v4/tests/schematic-migrate-styles.spec.ts
@@ -69,4 +69,5 @@ describe('ng-update', () => {
 
 function createMainFiles(): void {
     createSourceFile('test/styles.less', STYLES_BEFORE);
+    createSourceFile('package.json', '{}');
 }


### PR DESCRIPTION
1. Use `main` branch of https://github.com/taiga-family/maskito
2. Run 
    ```
    nx migrate @taiga-ui/cdk@next
    ```
    ```
    npm_config_legacy_peer_deps=false nx migrate --run-migrations
    ```
    ```
    npm start
    ```

    It throws
    
    ```
    Error: projects/demo/src/pages/stackblitz/stackblitz.service.ts:7:37[[39m0m - error TS2307: Cannot find module '@tinkoff/ng-polymorpheus' or its corresponding type declarations.
    
      import {PolymorpheusComponent} from '@tinkoff/ng-polymorpheus';
                                          ~~~~~~~~~~~~~~~~~~~~~~~~~~
    ```