### PR TITLE
fix(legacy): `InputDateRange` should not distinguish ranges with same dates and different names

### DIFF
--- a/projects/demo-playwright/tests/kit/input-date-range/input-date-range.spec.ts
+++ b/projects/demo-playwright/tests/kit/input-date-range/input-date-range.spec.ts
@@ -13,6 +13,7 @@ import {
 test.describe('InputDateRange', () => {
     let example!: Locator;
     let inputDateRange!: TuiInputDateRangePO;
+    let documentationPage!: TuiDocumentationPagePO;
 
     test.use({
         viewport: {width: 650, height: 650},
@@ -21,7 +22,8 @@ test.describe('InputDateRange', () => {
     test.beforeEach(async ({page}) => {
         await tuiGoto(page, DemoRoute.InputDateRange);
 
-        example = new TuiDocumentationPagePO(page).apiPageExample;
+        documentationPage = new TuiDocumentationPagePO(page);
+        example = documentationPage.apiPageExample;
 
         inputDateRange = new TuiInputDateRangePO(example.locator('tui-input-date-range'));
     });
@@ -158,6 +160,28 @@ test.describe('InputDateRange', () => {
             );
             await expect(example).toHaveScreenshot(
                 '07-item-and-calendar-interactions.png',
+            );
+        });
+    });
+
+    test.describe('Examples', () => {
+        test('Select second same range => after close/open calendar displays selected period displays correctly', async () => {
+            const example = documentationPage.getExample('#custom-period');
+
+            const inputDateRange = new TuiInputDateRangePO(
+                example.locator('tui-input-date-range'),
+            );
+
+            await inputDateRange.textfield.click();
+            await inputDateRange.selectItem(2);
+            await inputDateRange.textfield.click();
+
+            expect(await inputDateRange.itemHasCheckmark(1)).toBeFalsy();
+            expect(await inputDateRange.itemHasCheckmark(2)).toBeTruthy();
+
+            await expect(inputDateRange.textfield).toHaveValue('Yet another yesterday');
+            await expect(inputDateRange.calendarRange).toHaveScreenshot(
+                '08-calendar-correct-selected-period-after-close-open.png',
             );
         });
     });

--- a/projects/demo-playwright/utils/page-objects/input-date-range.po.ts
+++ b/projects/demo-playwright/utils/page-objects/input-date-range.po.ts
@@ -28,4 +28,14 @@ export class TuiInputDateRangePO {
 
         await items[index].click();
     }
+
+    public async itemHasCheckmark(index: number): Promise<boolean> {
+        const items = await this.getItems();
+
+        const itemCheckmark = await items[index]
+            .locator('[automation-id="tui-calendar-range__checkmark"]')
+            .count();
+
+        return !!itemCheckmark;
+    }
 }

--- a/projects/demo/src/modules/components/input-date-range/examples/5/index.ts
+++ b/projects/demo/src/modules/components/input-date-range/examples/5/index.ts
@@ -30,5 +30,10 @@ export default class Example {
             'Yesterday',
             ({$implicit}) => `Yesterday (${$implicit.from})`,
         ),
+        new TuiDayRangePeriod(
+            new TuiDayRange(yesterday, yesterday),
+            'Yet another yesterday',
+            ({$implicit}) => `Yet another yesterday (${$implicit.from})`,
+        ),
     ];
 }

--- a/projects/kit/components/calendar-range/calendar-range.component.ts
+++ b/projects/kit/components/calendar-range/calendar-range.component.ts
@@ -45,6 +45,7 @@ import type {TuiDayRangePeriod} from './day-range-period';
 export class TuiCalendarRange implements OnChanges {
     protected readonly otherDateText$ = inject(TUI_OTHER_DATE_TEXT);
     protected readonly icons = inject(TUI_COMMON_ICONS);
+    protected readonly cdr = inject(ChangeDetectorRef);
     protected previousValue: TuiDayRange | null = null;
     protected hoveredItem: TuiDay | null = null;
     protected selectedActivePeriod: TuiDayRangePeriod | null = null;
@@ -82,7 +83,7 @@ export class TuiCalendarRange implements OnChanges {
 
     constructor() {
         inject<Observable<TuiDayRange | null>>(TUI_CALENDAR_DATE_STREAM, {optional: true})
-            ?.pipe(tuiWatch(inject(ChangeDetectorRef)), takeUntilDestroyed())
+            ?.pipe(tuiWatch(this.cdr), takeUntilDestroyed())
             .subscribe(value => {
                 this.value = value;
             });
@@ -143,11 +144,11 @@ export class TuiCalendarRange implements OnChanges {
 
     protected onItemSelect(item: TuiDayRangePeriod | string): void {
         if (!tuiIsString(item)) {
-            this.updateValue(item.range.dayLimit(this.min, this.max));
             this.selectedActivePeriod = item;
+            this.updateValue(item.range.dayLimit(this.min, this.max));
         } else if (this.activePeriod !== null) {
-            this.updateValue(null);
             this.selectedActivePeriod = null;
+            this.updateValue(null);
         }
     }
 

--- a/projects/legacy/components/input-date-range/test/input-date-range.component.spec.ts
+++ b/projects/legacy/components/input-date-range/test/input-date-range.component.spec.ts
@@ -13,10 +13,10 @@ import {
 } from '@taiga-ui/cdk';
 import {TUI_DATE_FORMAT, TuiRoot} from '@taiga-ui/core';
 import {NG_EVENT_PLUGINS} from '@taiga-ui/event-plugins';
-import type {TuiDayRangePeriod} from '@taiga-ui/kit';
 import {
     TUI_DATE_RANGE_VALUE_TRANSFORMER,
     TUI_DATE_VALUE_TRANSFORMER,
+    TuiDayRangePeriod,
 } from '@taiga-ui/kit';
 import {
     TuiInputDateRangeComponent,
@@ -91,6 +91,28 @@ describe('InputDateRangeComponent', () => {
             TestBed.configureTestingModule({imports: [Test]});
             await TestBed.compileComponents();
             initializeEnvironment();
+        });
+
+        it('When switching between ranges with same date, displays appropriate input value', async () => {
+            const today = TuiDay.currentLocal();
+            const previousMonth = today.append({month: -1});
+            const first = '1';
+            const second = '2';
+
+            testComponent.items = [
+                new TuiDayRangePeriod(new TuiDayRange(previousMonth, today), first),
+                new TuiDayRangePeriod(new TuiDayRange(previousMonth, today), second),
+            ];
+            fixture.detectChanges();
+
+            clickOnTextfield();
+
+            getCalendarItems()[1]?.nativeElement.click();
+            fixture.detectChanges();
+
+            await fixture.whenStable();
+
+            expect(inputPO.value).toBe(second);
         });
 
         describe('Click on the input field', () => {
@@ -440,6 +462,10 @@ describe('InputDateRangeComponent', () => {
 
     function getCalendarsWrapper(): DebugElement | null {
         return fixture.debugElement.query(By.css('tui-calendar-range'));
+    }
+
+    function getCalendarItems(): DebugElement[] {
+        return pageObject.getAllByAutomationId('tui-calendar-range__menu__item');
     }
 
     function getTextfield(): DebugElement | null {


### PR DESCRIPTION
Closes #7909 
