### PR TITLE
feat(addon-docs): support custom tags

### DIFF
--- a/projects/addon-doc/components/page/page.component.ts
+++ b/projects/addon-doc/components/page/page.component.ts
@@ -27,6 +27,9 @@ export class TuiDocPageComponent {
     package = '';
 
     @Input()
+    tags: string[] = [];
+
+    @Input()
     type = '';
 
     @Input()

--- a/projects/addon-doc/components/page/page.template.html
+++ b/projects/addon-doc/components/page/page.template.html
@@ -14,6 +14,13 @@
             [autoColor]="true"
             [value]="package"
         ></tui-tag>
+        <tui-tag
+            *ngFor="let tag of tags"
+            status="custom"
+            class="t-tag t-tag_package"
+            [autoColor]="true"
+            [value]="tag"
+        ></tui-tag>
     </h1>
     <tui-tabs-with-more
         *ngIf="tabConnectors.length"

--- a/projects/demo/src/modules/experimental/appearance/appearance.template.html
+++ b/projects/demo/src/modules/experimental/appearance/appearance.template.html
@@ -2,6 +2,7 @@
     header="Appearance"
     package="EXPERIMENTAL"
     type="directives"
+    [tags]="['stable']"
 >
     <ng-template pageTab>
         <tui-notification status="warning">


### PR DESCRIPTION
<img width="804" alt="image" src="https://github.com/taiga-family/taiga-ui/assets/12021443/cc354fe3-3bfb-4966-b447-4802ba869061">
