### PR TITLE
fix(kit): `Badge` fix img width in Safari

### DIFF
--- a/projects/kit/components/badge/badge.style.less
+++ b/projects/kit/components/badge/badge.style.less
@@ -107,6 +107,7 @@ tui-badge,
 
 img[tuiBadge] {
     padding: 0;
+    width: var(--t-size);
 }
 
 tui-icon[tuiBadge] {


### PR DESCRIPTION
Closes # <!-- link to a relevant issue. -->
