### PR TITLE
fix(experimental) `Badge` fix img width in Safari

### DIFF
--- a/projects/experimental/components/badge/badge.style.less
+++ b/projects/experimental/components/badge/badge.style.less
@@ -97,6 +97,7 @@
 
 img[tuiBadge] {
     padding: 0;
+    width: var(--t-size);
 }
 
 tui-icon[tuiBadge] {


### PR DESCRIPTION
Closes # <!-- link to a relevant issue. -->
