### PR TITLE
chore(cdk): migrate TuiMobileCalendarDialogModule to provider

### DIFF
--- a/projects/cdk/schematics/ng-update/v4/index.ts
+++ b/projects/cdk/schematics/ng-update/v4/index.ts
@@ -35,7 +35,9 @@ import {
     MIGRATION_WARNINGS,
     MODULES_TO_REMOVE,
 } from './steps/constants';
+import {MODULES_TO_REPLACE_WITH_PROVIDERS} from './steps/constants/modules-to-replace';
 import {TYPES_TO_RENAME} from './steps/constants/types';
+import {replaceModulesWithProviders} from './steps/utils/replace-modules-with-providers';
 
 function main(options: TuiSchema): Rule {
     return (tree: Tree, context: SchematicContext) => {
@@ -43,6 +45,7 @@ function main(options: TuiSchema): Rule {
 
         replaceIdentifiers(options, IDENTIFIERS_TO_REPLACE);
         removeModules(options, MODULES_TO_REMOVE);
+        replaceModulesWithProviders(options, MODULES_TO_REPLACE_WITH_PROVIDERS);
         renameTypes(options, TYPES_TO_RENAME);
         restoreTuiMapper(options);
         restoreTuiMatcher(options);

--- a/projects/cdk/schematics/ng-update/v4/steps/constants/modules-to-replace.ts
+++ b/projects/cdk/schematics/ng-update/v4/steps/constants/modules-to-replace.ts
@@ -1,0 +1,17 @@
+interface ModuleToReplace {
+    from: {name: string; moduleSpecifier: string};
+    to: {name: string; providerSpecifier: string};
+}
+
+export const MODULES_TO_REPLACE_WITH_PROVIDERS: ModuleToReplace[] = [
+    {
+        from: {
+            name: 'TuiMobileCalendarDialogModule',
+            moduleSpecifier: '@taiga-ui/addon-mobile',
+        },
+        to: {
+            name: 'tuiProvideMobileCalendar',
+            providerSpecifier: '@taiga-ui/addon-mobile',
+        },
+    },
+];

--- a/projects/cdk/schematics/ng-update/v4/steps/utils/replace-modules-with-providers.ts
+++ b/projects/cdk/schematics/ng-update/v4/steps/utils/replace-modules-with-providers.ts
@@ -1,0 +1,80 @@
+import {
+    addProviderToComponent,
+    addProviderToNgModule,
+    getNgComponents,
+    getNgModules,
+    Node,
+} from 'ng-morph';
+
+import type {TuiSchema} from '../../../../ng-add/schema';
+import {addUniqueImport} from '../../../../utils/add-unique-import';
+import {
+    infoLog,
+    REPLACE_SYMBOL,
+    SMALL_TAB_SYMBOL,
+    SUCCESS_SYMBOL,
+    successLog,
+} from '../../../../utils/colored-log';
+import {getNamedImportReferences} from '../../../../utils/get-named-import-references';
+import {removeImport} from '../../../../utils/import-manipulations';
+
+interface ModuleToReplace {
+    from: {name: string; moduleSpecifier: string};
+    to: {name: string; providerSpecifier: string};
+}
+
+export const replaceModulesWithProviders = (
+    options: TuiSchema,
+    list: ModuleToReplace[],
+): void => {
+    !options['skip-logs'] &&
+        infoLog(
+            `${SMALL_TAB_SYMBOL}${REPLACE_SYMBOL} replacing modules with providers...`,
+        );
+
+    list.forEach(replaceModule);
+
+    !options['skip-logs'] &&
+        successLog(`${SMALL_TAB_SYMBOL}${SUCCESS_SYMBOL} modules replaced \n`);
+};
+
+function replaceModule({from, to}: ModuleToReplace): void {
+    const references = getNamedImportReferences(from.name, from.moduleSpecifier);
+
+    references.forEach(ref => {
+        if (ref.wasForgotten()) {
+            return;
+        }
+
+        const parent = ref.getParent();
+
+        if (Node.isImportSpecifier(parent)) {
+            removeImport(parent);
+            addImport(to, parent.getSourceFile().getFilePath());
+        } else if (Node.isArrayLiteralExpression(parent)) {
+            parent.removeElement(ref.getChildIndex());
+
+            addProvider(to, parent.getSourceFile().getFilePath());
+        }
+    });
+}
+
+function addImport(identifier: ModuleToReplace['to'], filePath: string): void {
+    addUniqueImport(filePath, identifier.name, identifier.providerSpecifier);
+}
+
+function addProvider(identifier: ModuleToReplace['to'], filePath: string): void {
+    const provider = `${identifier.name}()`;
+
+    const componentClass = getNgComponents(filePath)[0];
+
+    if (componentClass) {
+        addProviderToComponent(componentClass, provider);
+    }
+
+    const moduleClass = getNgModules(filePath)[0];
+
+    if (moduleClass) {
+        addProviderToNgModule(moduleClass, provider);
+    }
+}

--- a/projects/cdk/schematics/ng-update/v4/tests/replace-modules-with-providers.spec.ts
+++ b/projects/cdk/schematics/ng-update/v4/tests/replace-modules-with-providers.spec.ts
@@ -1,0 +1,121 @@
+import {join} from 'node:path';
+
+import {HostTree} from '@angular-devkit/schematics';
+import {SchematicTestRunner, UnitTestTree} from '@angular-devkit/schematics/testing';
+import type {TuiSchema} from '@taiga-ui/cdk/schematics/ng-add/schema';
+import {
+    createProject,
+    createSourceFile,
+    resetActiveProject,
+    saveActiveProject,
+    setActiveProject,
+} from 'ng-morph';
+
+import {createAngularJson} from '../../../utils/create-angular-json';
+import {MODULES_TO_REPLACE_WITH_PROVIDERS} from '../steps/constants/modules-to-replace';
+
+const collectionPath = join(__dirname, '../../../migration.json');
+
+const MODULE_BEFORE = `import { TuiMobileCalendarDialogModule } from "@taiga-ui/addon-mobile";
+import { OldModule } from "@namespace/cdk";
+
+@NgModule({
+    imports: [ TuiMobileCalendarDialogModule, OldModule ]
+})
+export class Test {
+}`;
+
+const MODULE_AFTER = `import { newProvider } from "@namespace/new";
+import { tuiProvideMobileCalendar } from "@taiga-ui/addon-mobile";
+
+@NgModule({
+    imports: [ ],
+    providers: [tuiProvideMobileCalendar(), newProvider()]
+})
+export class Test {
+}`;
+
+const COMPONENT_BEFORE = `import { TuiMobileCalendarDialogModule } from "@taiga-ui/addon-mobile";
+import { OldModule } from "@namespace/cdk";
+
+@Component({
+    selector: 'app-my-component',
+    standalone: true,
+    template: '',
+    imports: [
+        TuiMobileCalendarDialogModule,
+        OldModule
+    ]
+})
+export class Test {
+}`;
+
+const COMPONENT_AFTER = `import { newProvider } from "@namespace/new";
+import { tuiProvideMobileCalendar } from "@taiga-ui/addon-mobile";
+
+@Component({
+    selector: 'app-my-component',
+    standalone: true,
+    template: '',
+    imports: [
+],
+    providers: [tuiProvideMobileCalendar(), newProvider()]
+})
+export class Test {
+}`;
+
+describe('ng-update', () => {
+    let host: UnitTestTree;
+    let runner: SchematicTestRunner;
+
+    beforeEach(() => {
+        host = new UnitTestTree(new HostTree());
+        runner = new SchematicTestRunner('schematics', collectionPath);
+
+        MODULES_TO_REPLACE_WITH_PROVIDERS.push({
+            from: {name: 'OldModule', moduleSpecifier: '@namespace/cdk'},
+            to: {name: 'newProvider', providerSpecifier: '@namespace/new'},
+        });
+
+        setActiveProject(createProject(host));
+
+        createMainFiles();
+
+        saveActiveProject();
+    });
+
+    it('should migrate module', async () => {
+        const tree = await runner.runSchematic(
+            'updateToV4',
+            {'skip-logs': process.env['TUI_CI'] === 'true'} as Partial<TuiSchema>,
+            host,
+        );
+
+        expect(tree.readContent('test/app/test.module.ts')).toEqual(MODULE_AFTER);
+    });
+
+    it('should migrate component', async () => {
+        const tree = await runner.runSchematic(
+            'updateToV4',
+            {'skip-logs': process.env['TUI_CI'] === 'true'} as Partial<TuiSchema>,
+            host,
+        );
+
+        expect(tree.readContent('test/app/test.component.ts')).toEqual(COMPONENT_AFTER);
+    });
+
+    afterEach(() => {
+        resetActiveProject();
+    });
+});
+
+function createMainFiles(): void {
+    createSourceFile('test/app/test.module.ts', MODULE_BEFORE);
+    createSourceFile('test/app/test.component.ts', COMPONENT_BEFORE);
+
+    createAngularJson();
+    createSourceFile(
+        'package.json',
+        '{"dependencies": {"@angular/core": "~13.0.0", "@taiga-ui/addon-commerce": "~3.42.0"}}',
+    );
+}


### PR DESCRIPTION
Closes #5808

Not sure if `replaceModulesWithProviders` and it's interface with moving to `ng-update/steps` from `ng-update/v4/steps`