### PR TITLE
fix(kit): correct border-radius for `ButtonGroup` with only child

### DIFF
--- a/projects/kit/directives/button-group/button-group.style.less
+++ b/projects/kit/directives/button-group/button-group.style.less
@@ -55,7 +55,7 @@
     }
 
     &:has(button:only-child) {
-        border-radius: var(--tui-radius-l);
+        border-radius: 1rem;
     }
 
     > button:only-child,


### PR DESCRIPTION
Closes #
