### PR TITLE
fix(experimental): correct border-radius for `ButtonGroup` with only child

### DIFF
--- a/projects/experimental/directives/button-group/button-group.style.less
+++ b/projects/experimental/directives/button-group/button-group.style.less
@@ -54,7 +54,7 @@
     }
 
     &:has(button:only-child) {
-        border-radius: var(--tui-radius-l);
+        border-radius: 1rem;
     }
 
     > button:only-child,


### PR DESCRIPTION
Closes #
