### PR TITLE
fix(kit): `Textarea` displays emoji in Safari

### DIFF
--- a/projects/kit/components/textarea/textarea.style.less
+++ b/projects/kit/components/textarea/textarea.style.less
@@ -206,10 +206,12 @@
     :host[data-size='s'] &,
     :host[data-size='m'] & {
         padding: 0 0.75rem;
+        font: var(--tui-font-text-s);
     }
 
     :host[data-size='l'] & {
         padding: 0 1rem;
+        font: var(--tui-font-text-m);
     }
 
     :host[data-mode='onDark']._disabled & {


### PR DESCRIPTION
Closes #7786 
