### PR TITLE
fix(legacy): `Textarea` displays emoji in Safari

### DIFF
--- a/projects/legacy/components/textarea/textarea.style.less
+++ b/projects/legacy/components/textarea/textarea.style.less
@@ -204,10 +204,12 @@
     :host[data-size='s'] &,
     :host[data-size='m'] & {
         padding: 0 0.75rem;
+        font: var(--tui-font-text-s);
     }
 
     :host[data-size='l'] & {
         padding: 0 1rem;
+        font: var(--tui-font-text-m);
     }
 
     /* Safari 9+, < 13.1 */


### PR DESCRIPTION
Closes #7786 
