### PR TITLE
chore(schematics): migrate `@tinkoff/{ng-polymorpheus|ng-event-plugins}` even if they are not installed directly

### DIFF
--- a/projects/cdk/schematics/ng-update/steps/replace-package-name.ts
+++ b/projects/cdk/schematics/ng-update/steps/replace-package-name.ts
@@ -15,16 +15,14 @@ export function replacePackageName(
     newPackage: {name: string; version: string},
     tree: Tree,
 ): void {
-    if (!getPackageJsonDependency(tree, oldPackage)) {
-        return;
-    }
-
     const fileSystem = getFileSystem(tree);
 
     replaceText([{from: oldPackage, to: newPackage.name}], ALL_TS_FILES);
-    removePackageJsonDependency(tree, oldPackage);
 
-    addPackageJsonDependency(tree, newPackage);
+    if (getPackageJsonDependency(tree, oldPackage)) {
+        removePackageJsonDependency(tree, oldPackage);
+        addPackageJsonDependency(tree, newPackage);
+    }
 
     fileSystem.commitEdits();
     saveActiveProject();

--- a/projects/cdk/schematics/ng-update/v4/steps/migrate-styles.ts
+++ b/projects/cdk/schematics/ng-update/v4/steps/migrate-styles.ts
@@ -1,5 +1,5 @@
 /// <reference lib="es2021" />
-import {getActiveProject} from 'ng-morph';
+import {getActiveProject, saveActiveProject} from 'ng-morph';
 
 export const TUI_RATING_WARNING =
     '// TODO: (Taiga UI migration): use css to customize rating gap and size. See https://taiga-ui.dev/components/rating#basic';
@@ -19,4 +19,6 @@ export function migrateStyles(): void {
 
             sourceFile.replaceWithText(fullText);
         });
+
+    saveActiveProject();
 }


### PR DESCRIPTION
Use any project **WITHOUT** `legacy-peer-deps`.
For example: https://github.com/taiga-family/maskito

This project does not install `@taiga-ui/polymorpheus` directly (this dependency is installed automatically because it is peer dependency of `@taiga-ui/cdk`  package).


This project after schematic migrations:
<img width="1309" alt="Снимок экрана 2024-07-15 в 14 52 15" src="https://github.com/user-attachments/assets/eefb15ec-d99f-48cd-a9bf-0a2e3de84631">
