### PR TITLE
chore(addon-doc): add `./styles/*` to `exports` config of `package.json`

### DIFF
--- a/projects/addon-doc/package.json
+++ b/projects/addon-doc/package.json
@@ -13,6 +13,9 @@
     "homepage": "https://github.com/taiga-family/taiga-ui",
     "repository": "https://github.com/taiga-family/taiga-ui",
     "license": "Apache-2.0",
+    "exports": {
+        "./styles/*": "./styles/*"
+    },
     "dependencies": {
         "markdown-it": "14.1.0",
         "marked": "13.0.2",

--- a/projects/demo/src/modules/info/changelog/index.less
+++ b/projects/demo/src/modules/info/changelog/index.less
@@ -1,4 +1,4 @@
-@import '@taiga-ui/addon-doc/styles';
+@import '@taiga-ui/addon-doc/styles/index';
 
 .t-changelog {
     .markdown();


### PR DESCRIPTION
## Problem description
Use the following import inside any external project (e.g. Maskito):
```less
@import '@taiga-ui/addon-doc/styles/index';
```

Try to build project – it'll throw:

```shell
./projects/demo/src/pages/documentation/changelog/changelog.style.less?ngResource - Error: Module build failed (from ./node_modules/less-loader/dist/cjs.js):


@import '@taiga-ui/addon-doc/styles/index';
^
Less resolver error:
'@taiga-ui/addon-doc/styles/index' wasn't found. Tried -
/maskito/projects/demo/src/pages/documentation/changelog/@taiga-ui/addon-doc/styles/index.less,
npm://@taiga-ui/addon-doc/styles/index,
npm://@taiga-ui/addon-doc/styles/index.less,
@taiga-ui/addon-doc/styles/index.less

Webpack resolver error details:
undefined

Webpack resolver error missing:
undefined


Error in /maskito/projects/demo/src/pages/documentation/changelog/changelog.style.less (line 1, column 0)
```

## Solution
Use the same approach as inside `@taiga-ui/core`: 
https://github.com/taiga-family/taiga-ui/blob/1d63a76935d1483b07cfb07029087c74ec24081e/projects/core/package.json#L17-L19