### PR TITLE
chore: some migration fixes

### DIFF
--- a/projects/cdk/schematics/ng-update/v4/steps/constants/attrs-to-replace.ts
+++ b/projects/cdk/schematics/ng-update/v4/steps/constants/attrs-to-replace.ts
@@ -166,16 +166,44 @@ export const ATTRS_TO_REPLACE: ReplacementAttribute[] = [
     {
         from: {
             attrName: 'icon',
-            withAttrsNames: ['tuiButton'],
+            withAttrsNames: ['tuiButton', 'tuiIconButton'],
         },
         to: {attrName: 'iconStart'},
     },
     {
         from: {
             attrName: '[icon]',
-            withAttrsNames: ['tuiButton'],
+            withAttrsNames: ['tuiButton', 'tuiIconButton'],
         },
         to: {attrName: '[iconStart]'},
+    },
+    {
+        from: {
+            attrName: 'iconLeft',
+            withAttrsNames: ['tuiButton', 'tuiIconButton'],
+        },
+        to: {attrName: 'iconStart'},
+    },
+    {
+        from: {
+            attrName: '[iconLeft]',
+            withAttrsNames: ['tuiButton', 'tuiIconButton'],
+        },
+        to: {attrName: '[iconStart]'},
+    },
+    {
+        from: {
+            attrName: 'iconRight',
+            withAttrsNames: ['tuiButton', 'tuiIconButton'],
+        },
+        to: {attrName: 'iconEnd'},
+    },
+    {
+        from: {
+            attrName: '[iconRight]',
+            withAttrsNames: ['tuiButton', 'tuiIconButton'],
+        },
+        to: {attrName: '[iconEnd]'},
     },
     {
         from: {

--- a/projects/cdk/schematics/ng-update/v4/steps/constants/identifiers-to-replace.ts
+++ b/projects/cdk/schematics/ng-update/v4/steps/constants/identifiers-to-replace.ts
@@ -82,6 +82,18 @@ export const IDENTIFIERS_TO_REPLACE: ReplacementIdentifierMulti[] = [
         to: {name: 'TuiNotification', moduleSpecifier: '@taiga-ui/core'},
     },
     {
+        from: {name: 'TuiNotificationT', moduleSpecifier: '@taiga-ui/core'},
+        to: {name: 'TuiNotificationStatus', moduleSpecifier: '@taiga-ui/core'},
+    },
+    {
+        from: {name: 'TuiFormatPhonePipeModule', moduleSpecifier: '@taiga-ui/core'},
+        to: {name: 'TuiFormatPhonePipe', moduleSpecifier: '@taiga-ui/legacy'},
+    },
+    {
+        from: {name: 'TuiFormatPhonePipe', moduleSpecifier: '@taiga-ui/core'},
+        to: {name: 'TuiFormatPhonePipe', moduleSpecifier: '@taiga-ui/legacy'},
+    },
+    {
         from: {name: 'TuiCalendarModule', moduleSpecifier: '@taiga-ui/core'},
         to: {name: 'TuiCalendar', moduleSpecifier: '@taiga-ui/core'},
     },
@@ -374,11 +386,19 @@ export const IDENTIFIERS_TO_REPLACE: ReplacementIdentifierMulti[] = [
         to: {name: 'TuiAvatar', moduleSpecifier: '@taiga-ui/kit'},
     },
     {
+        from: {name: 'TuiAvatarModule', moduleSpecifier: '@taiga-ui/kit'},
+        to: {name: 'TuiAvatar', moduleSpecifier: '@taiga-ui/kit'},
+    },
+    {
         from: {name: 'TuiToggleModule', moduleSpecifier: '@taiga-ui/experimental'},
         to: {name: 'TuiSwitch', moduleSpecifier: '@taiga-ui/kit'},
     },
     {
         from: {name: 'TuiToggleModule', moduleSpecifier: '@taiga-ui/kit'},
+        to: {name: 'TuiSwitch', moduleSpecifier: '@taiga-ui/kit'},
+    },
+    {
+        from: {name: 'TuiToggleComponent', moduleSpecifier: '@taiga-ui/kit'},
         to: {name: 'TuiSwitch', moduleSpecifier: '@taiga-ui/kit'},
     },
     {
@@ -859,12 +879,12 @@ export const IDENTIFIERS_TO_REPLACE: ReplacementIdentifierMulti[] = [
     },
     {
         from: {
-            name: 'TuiPromptDialogModule',
+            name: 'TuiPromptDialogComponent',
             moduleSpecifier: '@taiga-ui/proprietary-core',
         },
         to: {
-            name: 'TuiPromptDialogComponent',
-            moduleSpecifier: '@taiga-ui/proprietary',
+            name: 'TuiConfirm',
+            moduleSpecifier: '@taiga-ui/kit',
         },
     },
     {
@@ -890,11 +910,12 @@ export const IDENTIFIERS_TO_REPLACE: ReplacementIdentifierMulti[] = [
     {
         from: {
             name: 'TuiNavigationModule',
-            moduleSpecifier: '@taiga-ui/proprietary-navigation',
+            moduleSpecifier: '@taiga-ui/experimental',
         },
         to: {
-            name: 'TuiNavigationComponent',
-            moduleSpecifier: '@taiga-ui/proprietary',
+            name: 'TuiNavigation',
+            moduleSpecifier: '@taiga-ui/experimental',
+            spreadInModule: true,
         },
     },
     {
@@ -1311,12 +1332,36 @@ export const IDENTIFIERS_TO_REPLACE: ReplacementIdentifierMulti[] = [
     },
     {
         from: {
+            name: 'POLYMORPHEUS_CONTEXT',
+            moduleSpecifier: '@tinkoff/ng-polymorpheus',
+        },
+        to: {name: 'POLYMORPHEUS_CONTEXT', moduleSpecifier: '@taiga-ui/polymorpheus'},
+    },
+    {
+        from: {
+            name: 'PolymorpheusComponent',
+            moduleSpecifier: '@tinkoff/ng-polymorpheus',
+        },
+        to: {name: 'PolymorpheusComponent', moduleSpecifier: '@taiga-ui/polymorpheus'},
+    },
+    {
+        from: {
             name: 'tuiDefaultSort',
             moduleSpecifier: '@taiga-ui/addon-table',
         },
         to: {
             name: 'tuiDefaultSort',
             moduleSpecifier: '@taiga-ui/cdk',
+        },
+    },
+    {
+        from: {
+            name: 'AbstractTuiControl',
+            moduleSpecifier: '@taiga-ui/cdk',
+        },
+        to: {
+            name: 'AbstractTuiControl',
+            moduleSpecifier: '@taiga-ui/legacy',
         },
     },
     {
@@ -2175,6 +2220,16 @@ export const IDENTIFIERS_TO_REPLACE: ReplacementIdentifierMulti[] = [
         },
         to: {
             name: 'TuiMultiSelectModule',
+            moduleSpecifier: '@taiga-ui/legacy',
+        },
+    },
+    {
+        from: {
+            name: 'TuiMultiSelectComponent',
+            moduleSpecifier: '@taiga-ui/kit',
+        },
+        to: {
+            name: 'TuiMultiSelectComponent',
             moduleSpecifier: '@taiga-ui/legacy',
         },
     },

--- a/projects/cdk/schematics/ng-update/v4/steps/constants/identifiers-to-replace.ts
+++ b/projects/cdk/schematics/ng-update/v4/steps/constants/identifiers-to-replace.ts
@@ -86,10 +86,6 @@ export const IDENTIFIERS_TO_REPLACE: ReplacementIdentifierMulti[] = [
         to: {name: 'TuiNotificationStatus', moduleSpecifier: '@taiga-ui/core'},
     },
     {
-        from: {name: 'TuiFormatPhonePipeModule', moduleSpecifier: '@taiga-ui/core'},
-        to: {name: 'TuiFormatPhonePipe', moduleSpecifier: '@taiga-ui/legacy'},
-    },
-    {
         from: {name: 'TuiFormatPhonePipe', moduleSpecifier: '@taiga-ui/core'},
         to: {name: 'TuiFormatPhonePipe', moduleSpecifier: '@taiga-ui/legacy'},
     },
@@ -1329,20 +1325,6 @@ export const IDENTIFIERS_TO_REPLACE: ReplacementIdentifierMulti[] = [
             {name: 'PolymorpheusTemplate', moduleSpecifier: '@taiga-ui/polymorpheus'},
             {name: 'PolymorpheusOutlet', moduleSpecifier: '@taiga-ui/polymorpheus'},
         ],
-    },
-    {
-        from: {
-            name: 'POLYMORPHEUS_CONTEXT',
-            moduleSpecifier: '@tinkoff/ng-polymorpheus',
-        },
-        to: {name: 'POLYMORPHEUS_CONTEXT', moduleSpecifier: '@taiga-ui/polymorpheus'},
-    },
-    {
-        from: {
-            name: 'PolymorpheusComponent',
-            moduleSpecifier: '@tinkoff/ng-polymorpheus',
-        },
-        to: {name: 'PolymorpheusComponent', moduleSpecifier: '@taiga-ui/polymorpheus'},
     },
     {
         from: {

--- a/projects/cdk/schematics/ng-update/v4/steps/constants/modules-to-remove.ts
+++ b/projects/cdk/schematics/ng-update/v4/steps/constants/modules-to-remove.ts
@@ -14,6 +14,14 @@ export const MODULES_TO_REMOVE: RemovedModule[] = [
         moduleSpecifier: '@taiga-ui/cdk',
     },
     {
+        name: 'TuiPromptDialogModule',
+        moduleSpecifier: '@taiga-ui/proprietary-core',
+    },
+    {
+        name: 'TuiThemeTinkoff2023NightModule',
+        moduleSpecifier: '@taiga-ui/proprietary-core',
+    },
+    {
         name: 'TuiOverscrollModule',
         moduleSpecifier: '@taiga-ui/cdk',
     },

--- a/projects/cdk/schematics/ng-update/v4/steps/templates/migrate-badge.ts
+++ b/projects/cdk/schematics/ng-update/v4/steps/templates/migrate-badge.ts
@@ -9,6 +9,14 @@ import {
     getTemplateOffset,
 } from '../../../../utils/templates/template-resource';
 import type {TemplateResource} from '../../../interfaces';
+import {replaceSizeAttr} from './toggles/common';
+
+const badgeSizeMap = {
+    xs: 's',
+    s: 'm',
+    m: 'l',
+    l: 'xl',
+};
 
 export function migrateBadge({
     resource,
@@ -28,6 +36,14 @@ export function migrateBadge({
         if (!sourceCodeLocation) {
             return;
         }
+
+        replaceSizeAttr(
+            attrs,
+            sourceCodeLocation,
+            recorder,
+            templateOffset,
+            badgeSizeMap,
+        );
 
         const valueAttr = attrs.find(
             (attr) => attr.name === '[value]' || attr.name === 'value',

--- a/projects/cdk/schematics/ng-update/v4/tests/schematic-migrate-identifiers.spec.ts
+++ b/projects/cdk/schematics/ng-update/v4/tests/schematic-migrate-identifiers.spec.ts
@@ -16,7 +16,7 @@ import {createAngularJson} from '../../../utils/create-angular-json';
 const collectionPath = join(__dirname, '../../../migration.json');
 
 const COMPONENT_BEFORE = `
-import { TuiDialogModule } from "@taiga-ui/core";
+import { TuiDialogModule } from "@taiga-ui/core/components";
 
 @Component({
     standalone: true,

--- a/projects/cdk/schematics/ng-update/v4/tests/schematic-migrate-package-names.spec.ts
+++ b/projects/cdk/schematics/ng-update/v4/tests/schematic-migrate-package-names.spec.ts
@@ -28,9 +28,9 @@ const imports = [TuiEditorModule];
 `.trim();
 
 const TS_FILE_AFTER = `
+import { PolymorpheusComponent } from "@taiga-ui/polymorpheus";
 import { TuiEditor, TuiEditorSocket } from "@taiga-ui/editor";
 import {Component} from '@angular/core';
-import {PolymorpheusComponent} from '@taiga-ui/polymorpheus';
 import {shouldCall} from '@taiga-ui/event-plugins';
 import {NG_EVENT_PLUGINS} from '@taiga-ui/event-plugins';
 import {TUI_VERSION} from '@taiga-ui/cdk';

--- a/projects/cdk/schematics/ng-update/v4/tests/schematic-migrate-package-names.spec.ts
+++ b/projects/cdk/schematics/ng-update/v4/tests/schematic-migrate-package-names.spec.ts
@@ -28,9 +28,9 @@ const imports = [TuiEditorModule];
 `.trim();
 
 const TS_FILE_AFTER = `
-import { PolymorpheusComponent } from "@taiga-ui/polymorpheus";
 import { TuiEditor, TuiEditorSocket } from "@taiga-ui/editor";
 import {Component} from '@angular/core';
+import {PolymorpheusComponent} from '@taiga-ui/polymorpheus';
 import {shouldCall} from '@taiga-ui/event-plugins';
 import {NG_EVENT_PLUGINS} from '@taiga-ui/event-plugins';
 import {TUI_VERSION} from '@taiga-ui/cdk';

--- a/projects/cdk/schematics/ng-update/v4/tests/schematic-migrate-proprietary.spec.ts
+++ b/projects/cdk/schematics/ng-update/v4/tests/schematic-migrate-proprietary.spec.ts
@@ -33,14 +33,14 @@ export class Test {
     readonly icon = tuiIconTdsAbhFlags;
 }`.trim();
 
-const COMPONENT_AFTER = `
-import { TuiBackComponent, TuiFeedItemComponent, TuiNavigationComponent, TuiIllustrationModePipe } from "@taiga-ui/proprietary";
+const COMPONENT_AFTER =
+    `import { TuiBackComponent, TuiFeedItemComponent, TuiIllustrationModePipe, TuiProprietaryNavigation } from "@taiga-ui/proprietary";
 import { tuiIconTdsAbhFlags } from '@taiga-ui/proprietary';
 
 @Component({
     standalone: true,
     templateUrl: './test.template.html',
-    imports: [TuiBackComponent, TuiFeedItemComponent, TuiNavigationComponent, TuiIllustrationModePipe]
+    imports: [TuiBackComponent, TuiFeedItemComponent, TuiProprietaryNavigation, TuiIllustrationModePipe]
 })
 export class Test {
     readonly icon = tuiIconTdsAbhFlags;

--- a/projects/cdk/schematics/utils/get-named-import-references.ts
+++ b/projects/cdk/schematics/utils/get-named-import-references.ts
@@ -5,12 +5,14 @@ import {ALL_TS_FILES} from '../constants';
 
 export function getNamedImportReferences(
     namedImport: string,
-    moduleSpecifier: string[] | string = '**/**',
+    moduleSpecifier: string[] | string = ['**/**'],
     files = ALL_TS_FILES,
 ): Node[] {
     const importDeclarations = getImports(files, {
         namedImports: [namedImport],
-        moduleSpecifier,
+        moduleSpecifier: Array.isArray(moduleSpecifier)
+            ? moduleSpecifier
+            : [moduleSpecifier, `${moduleSpecifier}/**`],
     });
 
     const namedImports = importDeclarations.map((declaration) =>


### PR DESCRIPTION
- [x] TuiPromptDialogComponent from @taiga-ui/proprietary-core  ---> TuiConfirm
- [x] TuiToggleComponent -> TuiSwitch
- [x] TuiNavigationModule (experimental) -> TuiNavigation 
- [x] TuiPromptDialogComponent -> TuiConfirm
- [x] TuiAvatarModule -> TuiAvatar
- [x] TuiFormatPhonePipe -> legacy
- [x] POLYMORPHEUS_CONTEXT, PolymorpheusComponent ---> @taiga-ui/polymorpheus
- [x] TuiBadge sizes
- [x] TuiMultiSelectComponent from kit -> legacy
- [x] AbstractTuiControl -> legacy
- [x] Icon / IconLeft -> iconStart
- [x] TuiNotificationT -> TuiNotificationStatus 
- [x] identifiers with deep imports (from @taiga-ui/core/types)