### PR TITLE
chore(schematics): fix migration for `TuiDocExample`

### DIFF
--- a/projects/cdk/schematics/ng-update/interfaces/replacement-type.ts
+++ b/projects/cdk/schematics/ng-update/interfaces/replacement-type.ts
@@ -4,5 +4,5 @@ export interface ReplacementType {
     readonly preserveGenerics?: boolean;
     readonly to?: string;
     readonly removeImport?: boolean;
-    readonly newImports?: {name: string; moduleSpecifier: string}[];
+    readonly newImports?: Array<{name: string; moduleSpecifier: string}>;
 }

--- a/projects/cdk/schematics/ng-update/interfaces/replacement-type.ts
+++ b/projects/cdk/schematics/ng-update/interfaces/replacement-type.ts
@@ -4,4 +4,5 @@ export interface ReplacementType {
     readonly preserveGenerics?: boolean;
     readonly to?: string;
     readonly removeImport?: boolean;
+    readonly newImports?: {name: string; moduleSpecifier: string}[];
 }

--- a/projects/cdk/schematics/ng-update/v4/steps/constants/types.ts
+++ b/projects/cdk/schematics/ng-update/v4/steps/constants/types.ts
@@ -3,9 +3,12 @@ import type {ReplacementType} from '../../../interfaces';
 export const TYPES_TO_RENAME: readonly ReplacementType[] = [
     {
         from: 'TuiDocExample',
-        to: 'Record<string, string | Promise<unknown>>',
+        to: 'Record<string, TuiRawLoaderContent>',
         moduleSpecifier: ['@taiga-ui/addon-doc'],
         removeImport: true,
+        newImports: [
+            {name: 'TuiRawLoaderContent', moduleSpecifier: '@taiga-ui/addon-doc'},
+        ],
     },
     {
         from: 'TuiBrightness',

--- a/projects/cdk/schematics/ng-update/v4/tests/schematic-migrate-money.spec.ts
+++ b/projects/cdk/schematics/ng-update/v4/tests/schematic-migrate-money.spec.ts
@@ -33,6 +33,7 @@ export class Test {
 }`;
 
 const COMPONENT_AFTER = `import { TuiNumberFormat } from "@taiga-ui/core";
+import { TuiRawLoaderContent } from "@taiga-ui/addon-doc";
 import { TuiAmountPipe } from "@taiga-ui/addon-commerce";
 
 @Component({
@@ -41,7 +42,7 @@ import { TuiAmountPipe } from "@taiga-ui/addon-commerce";
     imports: [TuiAmountPipe, TuiNumberFormat]
 })
 export class Test {
-    example: Record<string, string | Promise<unknown>> = {
+    example: Record<string, TuiRawLoaderContent> = {
         [DocExamplePrimaryTab.MaskitoOptions]: import(
             './examples/1-high-precision/mask.ts?raw'
         )


### PR DESCRIPTION
Relates to:
* https://github.com/taiga-family/taiga-ui/pull/7904


## Problem description
1. Run migration schematics in Maskito repo
2. Run `nx build`

The following lines 
```ts
protected readonly textareaExample1: Record<string, Promise<unknown> | string> = {
    [DocExamplePrimaryTab.MaskitoOptions]: import('./examples/1-latin/mask.ts?raw'),
};
```

throws
```
Error: projects/demo/src/pages/recipes/textarea/textarea-doc.template.html:33:10 - 
error TS2322: 
Type 'Record<string, string | Promise<unknown>>' is not assignable to type 'Record<string, TuiRawLoaderContent>'.

33         [content]="textareaExample1"
            ~~~~~~~
```