### PR TITLE
chore(demo): fix icons in StackBlitz

### DIFF
--- a/projects/demo/src/modules/app/stackblitz/project-files/src/main.ts.md
+++ b/projects/demo/src/modules/app/stackblitz/project-files/src/main.ts.md
@@ -3,7 +3,7 @@ import 'zone.js';
 import {bootstrapApplication} from '@angular/platform-browser';
 import {provideAnimations} from '@angular/platform-browser/animations';
 import {Component} from '@angular/core';
-import {TuiRoot} from '@taiga-ui/core';
+import {TuiRoot, tuiAssetsPathProvider} from '@taiga-ui/core';
 
 import {App} from './app/app.component';
 
@@ -16,6 +16,13 @@ import {App} from './app/app.component';
 class Root {}
 
 bootstrapApplication(Root, {
-  providers: [provideAnimations()],
+  providers: [
+    provideAnimations(),
+    /**
+     * A workaround for StackBlitz only (it does not support assets).
+     * Don't use this approach in real-world applications!
+     */
+    tuiAssetsPathProvider('https://taiga-ui.dev/next/assets/taiga-ui/icons'),
+  ],
 });
 ```

--- a/projects/demo/src/modules/app/stackblitz/project-files/src/main.ts.md
+++ b/projects/demo/src/modules/app/stackblitz/project-files/src/main.ts.md
@@ -22,6 +22,7 @@ bootstrapApplication(Root, {
      * A workaround for StackBlitz only (it does not support assets).
      * Don't use this approach in real-world applications!
      */
+    // TODO: remove `next/` after 4.0 release
     tuiAssetsPathProvider('https://taiga-ui.dev/next/assets/taiga-ui/icons'),
   ],
 });


### PR DESCRIPTION
## Previous behavior
https://taiga-ui.dev/next/components/accordion#base

<img width="449" alt="before" src="https://github.com/user-attachments/assets/9538cfef-0748-4383-8b77-08004ac767f3">

## New behavior
<img width="449" alt="after" src="https://github.com/user-attachments/assets/e13a0649-871e-4bd6-8826-6366bf88a544">
