### PR TITLE
chore: import `TuiTextfieldControllerModule` from `@taiga-ui/legacy`

### DIFF
--- a/projects/demo/src/modules/directives/textfield-controller/examples/import/import.md
+++ b/projects/demo/src/modules/directives/textfield-controller/examples/import/import.md
@@ -1,5 +1,5 @@
 ```ts
-import {TuiTextfieldControllerModule} from '@taiga-ui/core';
+import {TuiTextfieldControllerModule} from '@taiga-ui/legacy';
 
 // ...
 


### PR DESCRIPTION
To import `TuiTextfieldControllerModule` from `@taiga-ui/legacy` instead of `@taiga-ui/core`