### PR TITLE
chore(schematics): migrations for `TuiButtonGroupModule` & `TuiButtonVerticalModule` & `TuiIconsModule`

### DIFF
--- a/projects/cdk/schematics/ng-update/v4/steps/constants/identifiers-to-replace.ts
+++ b/projects/cdk/schematics/ng-update/v4/steps/constants/identifiers-to-replace.ts
@@ -1245,6 +1245,26 @@ export const IDENTIFIERS_TO_REPLACE: ReplacementIdentifierMulti[] = [
     },
     {
         from: {
+            name: 'TuiButtonGroupModule',
+            moduleSpecifier: '@taiga-ui/experimental',
+        },
+        to: {
+            name: 'TuiButtonGroup',
+            moduleSpecifier: '@taiga-ui/kit',
+        },
+    },
+    {
+        from: {
+            name: 'TuiButtonVerticalModule',
+            moduleSpecifier: '@taiga-ui/experimental',
+        },
+        to: {
+            name: 'TuiButtonVertical',
+            moduleSpecifier: '@taiga-ui/kit',
+        },
+    },
+    {
+        from: {
             name: 'TuiPreviewModule',
             moduleSpecifier: '@taiga-ui/addon-preview',
         },

--- a/projects/cdk/schematics/ng-update/v4/steps/constants/modules-to-remove.ts
+++ b/projects/cdk/schematics/ng-update/v4/steps/constants/modules-to-remove.ts
@@ -33,4 +33,8 @@ export const MODULES_TO_REMOVE: RemovedModule[] = [
         name: 'TuiModeModule',
         moduleSpecifier: '@taiga-ui/core',
     },
+    {
+        name: 'TuiIconsModule',
+        moduleSpecifier: '@taiga-ui/experimental',
+    },
 ];


### PR DESCRIPTION
Relates to:
* https://github.com/taiga-family/taiga-ui/issues/8162