### PR TITLE
chore(demo): enable `NG_EVENT_PLUGINS` in StackBlitz starter

### DIFF
--- a/projects/demo/src/modules/app/stackblitz/project-files/src/main.ts.md
+++ b/projects/demo/src/modules/app/stackblitz/project-files/src/main.ts.md
@@ -4,6 +4,7 @@ import {bootstrapApplication} from '@angular/platform-browser';
 import {provideAnimations} from '@angular/platform-browser/animations';
 import {Component} from '@angular/core';
 import {TuiRoot, tuiAssetsPathProvider} from '@taiga-ui/core';
+import {NG_EVENT_PLUGINS} from '@taiga-ui/event-plugins';
 
 import {App} from './app/app.component';
 
@@ -18,6 +19,7 @@ class Root {}
 bootstrapApplication(Root, {
   providers: [
     provideAnimations(),
+    NG_EVENT_PLUGINS,
     /**
      * A workaround for StackBlitz only (it does not support assets).
      * Don't use this approach in real-world applications!


### PR DESCRIPTION
See `main.ts` tab in this step:
* https://taiga-ui.dev/next/getting-started#root