### PR TITLE
fix(core): it's not possible to scroll container elements on safari

### DIFF
--- a/projects/core/components/dialog/dialogs.style.less
+++ b/projects/core/components/dialog/dialogs.style.less
@@ -5,11 +5,12 @@
     .scrollbar-hidden();
 
     pointer-events: none;
-    overflow: auto;
+    overflow: hidden;
     overscroll-behavior: none;
 
     &:has(section) {
         pointer-events: auto;
+        overflow: auto;
     }
 
     &:before {


### PR DESCRIPTION
Closes https://github.com/taiga-family/taiga-ui/issues/8166
