### PR TITLE
fix(addon-doc): support unknown type for `TuiRawLoaderContent`

### DIFF
--- a/projects/addon-doc/types/page.ts
+++ b/projects/addon-doc/types/page.ts
@@ -20,7 +20,7 @@ export interface TuiDocRoutePageGroup extends TuiDocRoutePageBase {
     readonly subPages: readonly TuiDocRoutePage[];
 }
 
-export type TuiRawLoaderContent = Promise<{default: string}> | string;
+export type TuiRawLoaderContent = Promise<{default: string}> | string | unknown;
 
 export const TUI_EXAMPLE_PRIMARY_FILE_NAME = {
     TS: 'TypeScript',


### PR DESCRIPTION
### Current behaviour

<img width="870" alt="image" src="https://github.com/user-attachments/assets/865f3b9c-5453-44be-8230-dc269ec7a4ce">
