### PR TITLE
fix(core): `Dialog` should hide close icon if `closeable` equals to `Observable<false>`

### DIFF
--- a/projects/core/components/dialog/dialog.component.ts
+++ b/projects/core/components/dialog/dialog.component.ts
@@ -71,10 +71,11 @@ export class TuiDialogComponent<O, I> {
 
     protected readonly closeWord$ = inject(TUI_CLOSE_WORD);
     protected readonly icons = inject(TUI_COMMON_ICONS);
+    protected closeable$ = toObservable(this.context.closeable);
 
     constructor() {
         merge(
-            this.close$.pipe(switchMap(() => toObservable(this.context.closeable))),
+            this.close$.pipe(switchMap(() => this.closeable$)),
             inject(TuiDialogCloseService).pipe(
                 switchMap(() => toObservable(this.context.dismissible)),
             ),

--- a/projects/core/components/dialog/dialog.component.ts
+++ b/projects/core/components/dialog/dialog.component.ts
@@ -17,7 +17,7 @@ import {tuiGetDuration} from '@taiga-ui/core/utils';
 import type {PolymorpheusContent} from '@taiga-ui/polymorpheus';
 import {POLYMORPHEUS_CONTEXT, PolymorpheusOutlet} from '@taiga-ui/polymorpheus';
 import type {Observable} from 'rxjs';
-import {filter, isObservable, map, merge, of, Subject, switchMap} from 'rxjs';
+import {filter, isObservable, map, merge, of, share, Subject, switchMap} from 'rxjs';
 
 import type {TuiDialogOptions, TuiDialogSize} from './dialog.interfaces';
 import {TUI_DIALOGS_CLOSE} from './dialog.tokens';
@@ -71,7 +71,7 @@ export class TuiDialogComponent<O, I> {
 
     protected readonly closeWord$ = inject(TUI_CLOSE_WORD);
     protected readonly icons = inject(TUI_COMMON_ICONS);
-    protected closeable$ = toObservable(this.context.closeable);
+    protected closeable$ = toObservable(this.context.closeable).pipe(share());
 
     constructor() {
         merge(

--- a/projects/core/components/dialog/dialog.template.html
+++ b/projects/core/components/dialog/dialog.template.html
@@ -31,7 +31,7 @@
 </div>
 <div class="t-filler"></div>
 <div
-    *ngIf="context.closeable"
+    *ngIf="closeable$ | async"
     class="t-wrapper"
 >
     <button

--- a/projects/demo/src/modules/components/dialog/examples/8/index.ts
+++ b/projects/demo/src/modules/components/dialog/examples/8/index.ts
@@ -29,6 +29,8 @@ export default class Example {
     protected onClick(content: PolymorpheusContent): void {
         const closeable = this.confirm.withConfirm({
             label: 'Are you sure?',
+            closeable: false,
+            dismissible: false,
             data: {
                 content: 'Your data will be <strong>lost</strong>',
             },


### PR DESCRIPTION
https://taiga-ui.dev/components/dialog#prompt

https://github.com/taiga-family/taiga-ui/blob/8f071226dcb9e4893b2d2a4bcf23fd6490e01456/projects/core/components/dialog/dialog.interfaces.ts#L22

Closes #8204
