### PR TITLE
fix(core): `Dialog` should hide close icon if `closeable` equals to `Observable<false>`

### DIFF
--- a/projects/core/components/dialog/dialog.component.ts
+++ b/projects/core/components/dialog/dialog.component.ts
@@ -22,7 +22,7 @@ import {
 import {TuiDialogSize} from '@taiga-ui/core/types';
 import {POLYMORPHEUS_CONTEXT, PolymorpheusContent} from '@tinkoff/ng-polymorpheus';
 import {isObservable, merge, Observable, of, Subject} from 'rxjs';
-import {filter, map, switchMap, takeUntil} from 'rxjs/operators';
+import {filter, map, share, switchMap, takeUntil} from 'rxjs/operators';
 
 import {TUI_DIALOGS_CLOSE} from './dialog.tokens';
 import {TuiDialogCloseService} from './dialog-close.service';
@@ -64,6 +64,7 @@ export class TuiDialogComponent<O, I> {
     } as const;
 
     readonly close$ = new Subject();
+    readonly closeable$ = toObservable(this.context.closeable).pipe(share());
 
     constructor(
         @Inject(TUI_ANIMATIONS_DURATION) private readonly duration: number,
@@ -76,7 +77,7 @@ export class TuiDialogComponent<O, I> {
         @Inject(TUI_COMMON_ICONS) readonly icons: TuiCommonIcons,
     ) {
         merge(
-            this.close$.pipe(switchMap(() => toObservable(context.closeable))),
+            this.close$.pipe(switchMap(() => this.closeable$)),
             dialogClose$.pipe(switchMap(() => toObservable(context.dismissible))),
             close$.pipe(map(ALWAYS_TRUE_HANDLER)),
         )

--- a/projects/core/components/dialog/dialog.template.html
+++ b/projects/core/components/dialog/dialog.template.html
@@ -32,7 +32,7 @@
 </div>
 <div class="t-filler"></div>
 <div
-    *ngIf="context.closeable"
+    *ngIf="closeable$ | async"
     class="t-wrapper"
 >
     <button

--- a/projects/demo/src/modules/components/dialog/examples/8/index.ts
+++ b/projects/demo/src/modules/components/dialog/examples/8/index.ts
@@ -28,6 +28,8 @@ export class TuiDialogExampleComponent8 {
     onClick(content: PolymorpheusContent): void {
         const closeable = this.dialogForm.withPrompt({
             label: 'Are you sure?',
+            closeable: false,
+            dismissible: false,
             data: {
                 content: 'Your data will be <strong>lost</strong>',
             },


### PR DESCRIPTION
https://taiga-ui.dev/components/dialog#prompt

https://github.com/taiga-family/taiga-ui/blob/96c56561cd1af077aca7a88d87f66bca06bb592c/projects/core/interfaces/dialog-options.ts#L20

Closes #8204
