### PR TITLE
chore: add progress log for identifiers migration

### DIFF
--- a/projects/cdk/schematics/ng-update/steps/replace-identifier.ts
+++ b/projects/cdk/schematics/ng-update/steps/replace-identifier.ts
@@ -11,8 +11,8 @@ import {
 } from '../../utils/colored-log';
 import {getNamedImportReferences} from '../../utils/get-named-import-references';
 import {removeImport} from '../../utils/import-manipulations';
-import type {ReplacementIdentifierMulti} from '../interfaces/replacement-identifier';
 import {setupProgressLogger} from '../../utils/progress';
+import type {ReplacementIdentifierMulti} from '../interfaces/replacement-identifier';
 
 export function replaceIdentifiers(
     options: TuiSchema,

--- a/projects/cdk/schematics/ng-update/steps/replace-identifier.ts
+++ b/projects/cdk/schematics/ng-update/steps/replace-identifier.ts
@@ -12,6 +12,7 @@ import {
 import {getNamedImportReferences} from '../../utils/get-named-import-references';
 import {removeImport} from '../../utils/import-manipulations';
 import type {ReplacementIdentifierMulti} from '../interfaces/replacement-identifier';
+import {setupProgressLogger} from '../../utils/progress';
 
 export function replaceIdentifiers(
     options: TuiSchema,
@@ -20,7 +21,17 @@ export function replaceIdentifiers(
     !options['skip-logs'] &&
         infoLog(`${SMALL_TAB_SYMBOL}${REPLACE_SYMBOL} replacing identifiers...`);
 
-    constants.forEach(replaceIdentifier);
+    const progressLog = setupProgressLogger({
+        total: constants.length,
+    });
+
+    constants.forEach((item, index) => {
+        replaceIdentifier(item);
+
+        const last = index === constants.length - 1;
+
+        !options['skip-logs'] && progressLog(item.from.name, last);
+    });
 
     !options['skip-logs'] &&
         successLog(`${SMALL_TAB_SYMBOL}${SUCCESS_SYMBOL} identifiers replaced \n`);


### PR DESCRIPTION
`replace Identifiers` can be a too long step, we need to add progress indicator