### PR TITLE
chore(schematics): fix migration for one line usage of `<tui-checkbox-labeled />` / `<tui-radio-labeled />`

### DIFF
--- a/projects/cdk/schematics/ng-update/v4/steps/templates/migrate-labeled.ts
+++ b/projects/cdk/schematics/ng-update/v4/steps/templates/migrate-labeled.ts
@@ -58,16 +58,13 @@ export function migrateLabeled({
             templateOffset + (sourceCodeLocation.startTag?.startOffset || 1) - 1,
             '<label tuiLabel>',
         );
-        recorder.insertRight(
-            templateOffset + (sourceCodeLocation.endTag?.startOffset || 1) - 1,
-            '\n</label>',
-        );
-
         recorder.remove(
             templateOffset + (sourceCodeLocation.endTag?.startOffset ?? 0),
-            tagName === 'tui-checkbox-labeled'
-                ? '<tui-checkbox-labeled/>'.length
-                : '<tui-radio-labeled/>'.length,
+            `<${tagName}/>`.length,
+        );
+        recorder.insertRight(
+            templateOffset + (sourceCodeLocation.endTag?.startOffset || 1),
+            '</label>',
         );
     });
 }

--- a/projects/cdk/schematics/ng-update/v4/tests/schematic-migrate-labeled.spec.ts
+++ b/projects/cdk/schematics/ng-update/v4/tests/schematic-migrate-labeled.spec.ts
@@ -39,6 +39,8 @@ const TEMPLATE_BEFORE = `<tui-checkbox-labeled [(ngModel)]="value">
   Label
 </tui-checkbox-labeled>
 
+<tui-checkbox-labeled [(ngModel)]="value">Content</tui-checkbox-labeled>
+
 <tui-radio-labeled size="l" [formControl]="control" [item]="value" [identityMatcher]="matcher">
   Label
 </tui-radio-labeled>
@@ -47,12 +49,12 @@ const TEMPLATE_BEFORE = `<tui-checkbox-labeled [(ngModel)]="value">
 const TEMPLATE_AFTER = `<label tuiLabel><input tuiCheckbox type="checkbox" [(ngModel)]="value">
   Label
 </label>
-
+<label tuiLabel>
+<input tuiCheckbox type="checkbox" [(ngModel)]="value">Content</label>
 <label tuiLabel>
 <input tuiRadio type="radio" size="m" [formControl]="control" [value]="value" [identityMatcher]="matcher">
   Label
 </label>
-
 `;
 
 describe('ng-update', () => {


### PR DESCRIPTION
### Previous behavior

```html
<tui-checkbox-labeled [(ngModel)]="value">Content</tui-checkbox-labeled>
```

⬇️ 

```html
<label tuiLabel>
<input tuiCheckbox type="checkbox" [(ngModel)]="value">Conten
</label>t
```