### PR TITLE
chore(schematics): migration for `<tui-radio-block [item]="1" />` => `<input tuiRadio type=radio [value]="1" />`

### DIFF
--- a/projects/cdk/schematics/ng-update/v4/steps/constants/attrs-to-replace.ts
+++ b/projects/cdk/schematics/ng-update/v4/steps/constants/attrs-to-replace.ts
@@ -47,14 +47,14 @@ export const ATTRS_TO_REPLACE: ReplacementAttribute[] = [
     {
         from: {
             attrName: 'item',
-            withTagNames: ['tui-radio'],
+            withTagNames: ['tui-radio', 'tui-radio-labeled', 'tui-radio-block'],
         },
         to: {attrName: 'value'},
     },
     {
         from: {
             attrName: '[item]',
-            withTagNames: ['tui-radio'],
+            withTagNames: ['tui-radio', 'tui-radio-labeled', 'tui-radio-block'],
         },
         to: {attrName: '[value]'},
     },
@@ -71,20 +71,6 @@ export const ATTRS_TO_REPLACE: ReplacementAttribute[] = [
             withTagNames: ['*'],
         },
         to: {attrName: '(waResizeObserver)'},
-    },
-    {
-        from: {
-            attrName: 'item',
-            withTagNames: ['tui-radio-labeled'],
-        },
-        to: {attrName: 'value'},
-    },
-    {
-        from: {
-            attrName: '[item]',
-            withTagNames: ['tui-radio-labeled'],
-        },
-        to: {attrName: '[value]'},
     },
     // Hosted dropdown
     {


### PR DESCRIPTION
Relates:
* https://github.com/taiga-family/taiga-ui/issues/8162