### PR TITLE
chore(schematics): migrations for `@ViewChild` / `@ContentChild` + `TuiCheckboxComponent` || `TuiCheckboxLabeledComponent` || `TuiRadioLabeledComponent`

### DIFF
--- a/projects/cdk/schematics/ng-update/v4/steps/constants/identifiers-to-replace.ts
+++ b/projects/cdk/schematics/ng-update/v4/steps/constants/identifiers-to-replace.ts
@@ -653,12 +653,24 @@ export const IDENTIFIERS_TO_REPLACE: ReplacementIdentifierMulti[] = [
         to: {name: 'TuiIcon', moduleSpecifier: '@taiga-ui/core'},
     },
     {
+        from: {name: 'TuiCheckboxComponent', moduleSpecifier: '@taiga-ui/kit'},
+        to: {name: 'TuiCheckbox', moduleSpecifier: '@taiga-ui/kit'},
+    },
+    {
+        from: {name: 'TuiCheckboxLabeledComponent', moduleSpecifier: '@taiga-ui/kit'},
+        to: {name: 'TuiCheckbox', moduleSpecifier: '@taiga-ui/kit'},
+    },
+    {
         from: {name: 'TuiCheckboxLabeledModule', moduleSpecifier: '@taiga-ui/kit'},
         to: {name: 'TuiLabel', moduleSpecifier: '@taiga-ui/core'},
     },
     {
         from: {name: 'TuiRadioLabeledModule', moduleSpecifier: '@taiga-ui/kit'},
         to: {name: 'TuiLabel', moduleSpecifier: '@taiga-ui/core'},
+    },
+    {
+        from: {name: 'TuiRadioLabeledComponent', moduleSpecifier: '@taiga-ui/kit'},
+        to: {name: 'TuiRadioComponent', moduleSpecifier: '@taiga-ui/kit'},
     },
     {
         from: {name: 'TuiCheckboxBlockModule', moduleSpecifier: '@taiga-ui/kit'},
@@ -671,7 +683,7 @@ export const IDENTIFIERS_TO_REPLACE: ReplacementIdentifierMulti[] = [
         from: {name: 'TuiRadioBlockModule', moduleSpecifier: '@taiga-ui/kit'},
         to: [
             {name: 'TuiBlock', moduleSpecifier: '@taiga-ui/kit'},
-            {name: 'TuiRadio', moduleSpecifier: '@taiga-ui/kit'},
+            {name: 'TuiRadio', moduleSpecifier: '@taiga-ui/kit', spreadInModule: true},
         ],
     },
     {


### PR DESCRIPTION
Relates:
* https://github.com/taiga-family/taiga-ui/issues/8162