### PR TITLE
fix(kit): `Date` should support native date picker even without importing of `TuiMobileCalendarDialogModule`

### DIFF
--- a/projects/kit/components/input-date/input-date.component.ts
+++ b/projects/kit/components/input-date/input-date.component.ts
@@ -170,7 +170,7 @@ export class TuiInputDateComponent
     }
 
     get nativePicker(): boolean {
-        return this.options.nativePicker && !!this.mobileCalendar && this.isMobile;
+        return this.options.nativePicker && this.isMobile;
     }
 
     get calendarIcon(): TuiInputDateOptions['icon'] {

--- a/projects/kit/components/input-date/input-date.template.html
+++ b/projects/kit/components/input-date/input-date.template.html
@@ -2,7 +2,7 @@
     class="t-hosted"
     [canOpen]="interactive && !nativePicker"
     [content]="dropdown"
-    [open]="open && interactive && !nativePicker"
+    [open]="open"
     (openChange)="onOpenChange($event)"
 >
     <tui-primitive-textfield


### PR DESCRIPTION
Problem reproduction:
https://stackblitz.com/edit/angular-gfcprx?file=src%2Fapp%2Fapp.component.ts