### PR TITLE
chore(legacy): `Date` should support native date picker even without providing of `TUI_MOBILE_CALENDAR`

### DIFF
--- a/projects/legacy/components/input-date/input-date.component.ts
+++ b/projects/legacy/components/input-date/input-date.component.ts
@@ -194,7 +194,7 @@ export class TuiInputDateComponent
     }
 
     protected get nativePicker(): boolean {
-        return this.options.nativePicker && !!this.mobileCalendar && this.isMobile;
+        return this.options.nativePicker && this.isMobile;
     }
 
     protected get calendarIcon(): TuiInputDateOptions['icon'] {

--- a/projects/legacy/components/input-date/input-date.template.html
+++ b/projects/legacy/components/input-date/input-date.template.html
@@ -3,7 +3,7 @@
     class="t-hosted"
     [tuiDropdown]="dropdown"
     [tuiDropdownEnabled]="interactive && !nativePicker"
-    [tuiDropdownOpen]="open && interactive && !nativePicker"
+    [tuiDropdownOpen]="open"
     (tuiDropdownOpenChange)="onOpenChange($event)"
 >
     <tui-primitive-textfield


### PR DESCRIPTION
Problem reproduction:
https://stackblitz.com/edit/angular-gfcprx?file=src%2Fapp%2Fapp.component.ts
