### PR TITLE
chore(schematics): migration for `MaskitoModule`

### DIFF
--- a/projects/cdk/schematics/ng-update/v4/steps/constants/identifiers-to-replace.ts
+++ b/projects/cdk/schematics/ng-update/v4/steps/constants/identifiers-to-replace.ts
@@ -2640,9 +2640,6 @@ export const IDENTIFIERS_TO_REPLACE: ReplacementIdentifierMulti[] = [
     },
     {
         from: {name: 'MaskitoModule', moduleSpecifier: '@maskito/angular'},
-        to: [
-            {name: 'MaskitoDirective', moduleSpecifier: '@maskito/angular'},
-            {name: 'MaskitoPipe', moduleSpecifier: '@maskito/angular'},
-        ],
+        to: {name: 'MaskitoDirective', moduleSpecifier: '@maskito/angular'},
     },
 ];


### PR DESCRIPTION
**Previous behavior:**
```ts
import {Component} from '@angular/core';
import {MaskitoModule} from '@maskito/angular';
import type {MaskitoOptions} from '@maskito/core';

@Component({
    standalone: true,
    selector: 'app',
    imports: [MaskitoModule],
    template: `
        <input [maskito]="options" />
    `,
})
export class App {
    public readonly options: MaskitoOptions = {
        mask: /^\d+$/,
    };
}
```
<p align="center">⬇️ </p>

**New behavior**:
```ts
import {Component} from '@angular/core';
import {MaskitoDirective, MaskitoPipe} from '@maskito/angular';
import type {MaskitoOptions} from '@maskito/core';

@Component({
    standalone: true,
    selector: 'app',
    imports: [MaskitoDirective], // <--- standalone entity
    template: `
        <input [maskito]="options" />
    `,
})
export class App {
    public readonly options: MaskitoOptions = {
        mask: /^\d+$/,
    };
}
```

Learn more:
* https://github.com/taiga-family/maskito/releases/tag/v3.0.0