### PR TITLE
feat(addon-doc): prevent overflow a long word or URL

### DIFF
--- a/projects/addon-doc/components/demo/index.less
+++ b/projects/addon-doc/components/demo/index.less
@@ -71,6 +71,7 @@
     padding: 1.5rem;
     box-sizing: border-box;
     overflow: hidden;
+    overflow-wrap: anywhere;
 
     :host-context(tui-root._mobile) & {
         padding: 1rem;

--- a/projects/addon-doc/components/example/example.style.less
+++ b/projects/addon-doc/components/example/example.style.less
@@ -78,6 +78,7 @@
     max-width: 100%;
     box-sizing: border-box;
     overflow-x: auto;
+    overflow-wrap: anywhere;
 
     :host-context(tui-root._mobile) & {
         padding: 1rem;


### PR DESCRIPTION
## Before

<img width="1201" alt="image" src="https://github.com/user-attachments/assets/9ac17d2e-6d99-4d1c-aac3-24b642ea31cb">

## After

<img width="1170" alt="image" src="https://github.com/user-attachments/assets/af137fba-525d-43b1-b239-0b5cfa96def1">
