### PR TITLE
fix(legacy): placeholder in multiselect disappears while hovering options

### DIFF
--- a/projects/legacy/components/input-tag/input-tag.style.less
+++ b/projects/legacy/components/input-tag/input-tag.style.less
@@ -64,7 +64,7 @@
         overflow: hidden;
     }
 
-    &_empty {
+    &_empty:not(.t-with-placeholder) {
         height: 0;
     }
 

--- a/projects/legacy/components/input-tag/input-tag.template.html
+++ b/projects/legacy/components/input-tag/input-tag.template.html
@@ -48,6 +48,7 @@
                     <div
                         class="t-tags"
                         [class.t-tags_empty]="(!focused || inputHidden) && !value.length && !search?.trim()?.length"
+                        [class.t-with-placeholder]="placeholder"
                     >
                         <ng-container *ngIf="labelOutside; else text">
                             <tui-tag


### PR DESCRIPTION
https://github.com/taiga-family/taiga-ui/issues/8233