### PR TITLE
Revert "fix(core): `Dialog` should hide close icon if `closeable` equals to `Observable<false>` (#8206)"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,9 +17,6 @@ All notable changes to this project will be documented in this file. See
 
 - **cdk:** provided double value is non-finite ([#8161](https://github.com/taiga-family/taiga-ui/issues/8161))
   ([276879b](https://github.com/taiga-family/taiga-ui/commit/276879bf97f2ee5f958477d0f31923ce4b420f87))
-- **core:** `Dialog` should hide close icon if `closeable` equals to `Observable<false>`
-  ([#8206](https://github.com/taiga-family/taiga-ui/issues/8206))
-  ([d0e04f9](https://github.com/taiga-family/taiga-ui/commit/d0e04f926308b89475097077e88de77c1e6b6080))
 - **core:** fix dropdown-context directive on touchscreen laptops
   ([#8223](https://github.com/taiga-family/taiga-ui/issues/8223))
   ([0bb7b5b](https://github.com/taiga-family/taiga-ui/commit/0bb7b5ba2789683af27a979d80609c968b88d323))

--- a/projects/core/components/dialog/dialog.component.ts
+++ b/projects/core/components/dialog/dialog.component.ts
@@ -22,7 +22,7 @@ import {
 import {TuiDialogSize} from '@taiga-ui/core/types';
 import {POLYMORPHEUS_CONTEXT, PolymorpheusContent} from '@tinkoff/ng-polymorpheus';
 import {isObservable, merge, Observable, of, Subject} from 'rxjs';
-import {filter, map, share, switchMap, takeUntil} from 'rxjs/operators';
+import {filter, map, switchMap, takeUntil} from 'rxjs/operators';
 
 import {TUI_DIALOGS_CLOSE} from './dialog.tokens';
 import {TuiDialogCloseService} from './dialog-close.service';
@@ -64,7 +64,6 @@ export class TuiDialogComponent<O, I> {
     } as const;
 
     readonly close$ = new Subject();
-    readonly closeable$ = toObservable(this.context.closeable).pipe(share());
 
     constructor(
         @Inject(TUI_ANIMATIONS_DURATION) private readonly duration: number,
@@ -77,7 +76,7 @@ export class TuiDialogComponent<O, I> {
         @Inject(TUI_COMMON_ICONS) readonly icons: TuiCommonIcons,
     ) {
         merge(
-            this.close$.pipe(switchMap(() => this.closeable$)),
+            this.close$.pipe(switchMap(() => toObservable(context.closeable))),
             dialogClose$.pipe(switchMap(() => toObservable(context.dismissible))),
             close$.pipe(map(ALWAYS_TRUE_HANDLER)),
         )

--- a/projects/core/components/dialog/dialog.template.html
+++ b/projects/core/components/dialog/dialog.template.html
@@ -32,7 +32,7 @@
 </div>
 <div class="t-filler"></div>
 <div
-    *ngIf="closeable$ | async"
+    *ngIf="context.closeable"
     class="t-wrapper"
 >
     <button

--- a/projects/core/components/dialog/dialog.template.html
+++ b/projects/core/components/dialog/dialog.template.html
@@ -31,6 +31,8 @@
     </section>
 </div>
 <div class="t-filler"></div>
+
+<!-- Close button is insensitive to `context.closeable === Observable<false>` by design -->
 <div
     *ngIf="context.closeable"
     class="t-wrapper"

--- a/projects/demo/src/modules/components/dialog/examples/8/index.ts
+++ b/projects/demo/src/modules/components/dialog/examples/8/index.ts
@@ -28,8 +28,6 @@ export class TuiDialogExampleComponent8 {
     onClick(content: PolymorpheusContent): void {
         const closeable = this.dialogForm.withPrompt({
             label: 'Are you sure?',
-            closeable: false,
-            dismissible: false,
             data: {
                 content: 'Your data will be <strong>lost</strong>',
             },


### PR DESCRIPTION
Revert:
* https://github.com/taiga-family/taiga-ui/pull/8206