### PR TITLE
chore: use less strict dep constraints for deprecated `@taiga-ui/{addon-preview,addon-tablebars}`

### DIFF
--- a/projects/addon-preview/package.json
+++ b/projects/addon-preview/package.json
@@ -15,11 +15,11 @@
     "peerDependencies": {
         "@angular/common": ">=12.0.0",
         "@angular/core": ">=12.0.0",
-        "@ng-web-apis/mutation-observer": "^3.1.0",
-        "@taiga-ui/cdk": "^3.88.0",
-        "@taiga-ui/core": "^3.88.0",
-        "@taiga-ui/i18n": "^3.88.0",
-        "@taiga-ui/kit": "^3.88.0",
+        "@ng-web-apis/mutation-observer": ">=3.1.0",
+        "@taiga-ui/cdk": ">=3.88.0",
+        "@taiga-ui/core": ">=3.88.0",
+        "@taiga-ui/i18n": ">=3.88.0",
+        "@taiga-ui/kit": ">=3.88.0",
         "@tinkoff/ng-polymorpheus": "^4.3.0",
         "rxjs": ">=6.0.0",
         "tslib": "^2.6.2"

--- a/projects/addon-tablebars/package.json
+++ b/projects/addon-tablebars/package.json
@@ -15,8 +15,8 @@
     "peerDependencies": {
         "@angular/common": ">=12.0.0",
         "@angular/core": ">=12.0.0",
-        "@taiga-ui/cdk": "^3.88.0",
-        "@taiga-ui/core": "^3.88.0",
+        "@taiga-ui/cdk": ">=3.88.0",
+        "@taiga-ui/core": ">=3.88.0",
         "@tinkoff/ng-polymorpheus": "^4.3.0",
         "rxjs": ">=6.0.0",
         "tslib": "^2.6.2"


### PR DESCRIPTION
Use project **WITHOUT** `--legacy-peer-deps` config.

```
nx migrate @taiga-ui/cdk@next
npm i
```

it throws
```
~/WebstormProjects/twfm-ui-2 git:[test-taiga-migrations]
npm i
npm error code ERESOLVE
npm error ERESOLVE unable to resolve dependency tree
npm error
npm error While resolving: twfm@0.0.0
npm error Found: @taiga-ui/cdk@4.0.0-rc.8
npm error node_modules/@taiga-ui/cdk
npm error   @taiga-ui/cdk@"4.0.0-rc.8" from the root project
npm error
npm error Could not resolve dependency:
npm error peer @taiga-ui/cdk@"^3.83.0" from @taiga-ui/addon-tablebars@3.83.0
npm error node_modules/@taiga-ui/addon-tablebars
npm error   @taiga-ui/addon-tablebars@"3.83.0" from the root project
npm error
npm error Fix the upstream dependency conflict, or retry
npm error this command with --force or --legacy-peer-deps
npm error to accept an incorrect (and potentially broken) dependency resolution.
npm error
npm error
npm error For a full report see:
npm error /Users/n.barsukov/.npm/_logs/2024-08-05T14_45_53_945Z-eresolve-report.txt

npm error A complete log of this run can be found in: /Users/n.barsukov/.npm/_logs/2024-08-05T14_45_53_945Z-debug-0.log
```