### PR TITLE
fix(core): background should be filled relatively `tui-root`

### DIFF
--- a/projects/core/components/root/root.style.less
+++ b/projects/core/components/root/root.style.less
@@ -32,7 +32,7 @@ tui-root {
     -webkit-tap-highlight-color: transparent;
 
     &::before {
-        .fullsize(fixed);
+        .fullsize();
 
         content: '';
         background: var(--tui-background-base);


### PR DESCRIPTION
I want add a custom content before or after tui-root

<img width="1214" alt="image" src="https://github.com/user-attachments/assets/69e679a2-cd7e-4dfb-b830-ba9ff27399ff">