### PR TITLE
fix(kit): `CalendarRange` defaultViewedMonth shows correct calendars months

### DIFF
--- a/projects/kit/components/calendar-range/calendar-range.component.ts
+++ b/projects/kit/components/calendar-range/calendar-range.component.ts
@@ -120,6 +120,9 @@ export class TuiCalendarRangeComponent implements TuiWithOptionalMinMax<TuiDay> 
         this.value = this.previousValue;
     }
 
+    readonly monthOffset: TuiTypedMapper<[TuiMonth, number], TuiMonth> = (value, month) =>
+        value.append({month});
+
     readonly mapper: TuiTypedMapper<
         [
             readonly TuiDayRangePeriod[],

--- a/projects/kit/components/calendar-range/calendar-range.template.html
+++ b/projects/kit/components/calendar-range/calendar-range.template.html
@@ -3,6 +3,7 @@
     automation-id="tui-calendar-range__calendars"
     tuiPreventDefault="mousedown"
     [defaultViewedMonthFirst]="defaultViewedMonth"
+    [defaultViewedMonthSecond]="defaultViewedMonth | tuiMapper: monthOffset : 1"
     [disabledItemHandler]="calculatedDisabledItemHandler"
     [markerHandler]="markerHandler"
     [max]="computedMax | tuiMapper: maxLengthMapper : value : maxLength : false"

--- a/projects/kit/internal/primitive-calendar-range/test/primitive-calendar-range.component.spec.ts
+++ b/projects/kit/internal/primitive-calendar-range/test/primitive-calendar-range.component.spec.ts
@@ -62,6 +62,15 @@ describe('PrimitiveRangeCalendar component', () => {
             component.ngOnInit();
             expect(component.userViewedMonthFirst).toEqual(minDate);
         });
+
+        it('When initialized input defaultViewedMonthFirst, shows defaultViewedMonthFirst', () => {
+            const month = new TuiMonth(2020, 5);
+
+            component.defaultViewedMonthFirst = month;
+            component.ngOnInit();
+
+            expect(component.userViewedMonthFirst).toBe(month);
+        });
     });
 
     describe('viewedMonthSecond', () => {
@@ -104,6 +113,15 @@ describe('PrimitiveRangeCalendar component', () => {
             component.ngOnInit();
 
             expect(component.userViewedMonthSecond).toEqual(minDate.append({month: 1}));
+        });
+
+        it('When initialized input defaultViewedMonthSecond, shows defaultViewedMonthSecond', () => {
+            const month = new TuiMonth(2020, 5);
+
+            component.defaultViewedMonthSecond = month;
+            component.ngOnInit();
+
+            expect(component.userViewedMonthSecond).toBe(month);
         });
     });
 


### PR DESCRIPTION
Closes #8331 

When set input [defaultViewedMonth]:

**As Is:** 

![image](https://github.com/user-attachments/assets/4642fa9f-21ba-4b87-a5dc-fe34f5faacbc)

**To Be:**

<img width="790" alt="image" src="https://github.com/user-attachments/assets/9f2b8788-e7ec-4fe3-acee-3206d69f2a4e">