### PR TITLE
chore(kit): `Stepper` left text align

### DIFF
--- a/projects/kit/components/stepper/step.style.less
+++ b/projects/kit/components/stepper/step.style.less
@@ -12,6 +12,7 @@
     outline: none;
     cursor: pointer;
     counter-increment: steps;
+    text-align: left;
 
     &:disabled {
         pointer-events: none;
@@ -32,7 +33,7 @@
         cursor: default;
     }
 
-    &:focus-visible::before {
+    &:focus-visible:before {
         content: '';
         position: absolute;
         left: 2.75rem;
@@ -68,7 +69,7 @@
     }
 
     &_index {
-        &::before {
+        &:before {
             content: counter(steps);
         }
 

--- a/projects/kit/components/stepper/step.style.less
+++ b/projects/kit/components/stepper/step.style.less
@@ -33,7 +33,7 @@
         cursor: default;
     }
 
-    &:focus-visible:before {
+    &:focus-visible::before {
         content: '';
         position: absolute;
         left: 2.75rem;
@@ -69,7 +69,7 @@
     }
 
     &_index {
-        &:before {
+        &::before {
             content: counter(steps);
         }
 


### PR DESCRIPTION
Closes #

**As Is:** 
<img width="362" alt="image" src="https://github.com/user-attachments/assets/2d57f03f-e4dd-4463-b29d-c02d5b20327b">

**To Be:**
<img width="397" alt="image" src="https://github.com/user-attachments/assets/80b6cb76-c13c-4085-ae97-0331af06cbed">
