### PR TITLE
chore(kit): `Stepper` text and icon align

### DIFF
--- a/projects/kit/components/stepper/step/step.style.less
+++ b/projects/kit/components/stepper/step/step.style.less
@@ -11,6 +11,7 @@
     outline: none;
     cursor: pointer;
     counter-increment: steps;
+    text-align: left;
 
     &:disabled {
         pointer-events: none;
@@ -45,6 +46,7 @@
 
 .t-marker {
     .transition(background);
+    position: relative;
     display: flex;
     width: 2rem;
     height: 2rem;
@@ -52,6 +54,7 @@
     margin-right: 0.75rem;
     flex-shrink: 0;
     align-items: center;
+    align-self: flex-start;
     justify-content: center;
     background: var(--tui-secondary);
     color: var(--tui-link);


### PR DESCRIPTION
Closes #

**As Is:**
<img width="316" alt="image" src="https://github.com/user-attachments/assets/b22beb6c-fd68-4bfa-afdd-45f7a21a5caf">


**To Be:**
<img width="345" alt="image" src="https://github.com/user-attachments/assets/b040b797-7ffe-453b-9fa8-f380eee9df0a">

