### PR TITLE
fix(core): add `type=button` to `textfield` for ignore submit event

### DIFF
--- a/projects/core/components/textfield/textfield.template.html
+++ b/projects/core/components/textfield/textfield.template.html
@@ -11,6 +11,7 @@
         appearance="icon"
         size="xs"
         tabindex="-1"
+        type="button"
         tuiIconButton
         class="t-clear"
         [iconStart]="icons.close"


### PR DESCRIPTION
При обнулении значения в textfield, происходит submit формы. Добавил type="button", чтобы этого не происходило