### PR TITLE
fix(legacy): `InputTime` has missing zero padding on blur for `HH:MM` mode

### DIFF
--- a/projects/cdk/date-time/time.ts
+++ b/projects/cdk/date-time/time.ts
@@ -114,7 +114,7 @@ export class TuiTime implements TuiTimeLike {
      */
     public static fromString(time: string): TuiTime {
         const hours = Number(time.slice(0, 2));
-        const minutes = Number(time.slice(3, 5));
+        const minutes = Number(time.slice(3, 5)) || 0;
         const seconds = Number(time.slice(6, 8)) || 0;
         const ms = Number(time.slice(9, 12)) || 0;
 

--- a/projects/demo-playwright/tests/kit/input-time/input-time.spec.ts
+++ b/projects/demo-playwright/tests/kit/input-time/input-time.spec.ts
@@ -192,9 +192,12 @@ test.describe('InputTime', () => {
             const check = (typedCharacters: string, expectedFinalValue: string): void => {
                 test(`Type ${typedCharacters} => Blur => ${expectedFinalValue}`, async () => {
                     await inputTime.textfield.clear();
+
                     await expect(inputTime.textfield).toHaveValue('');
+
                     await inputTime.textfield.pressSequentially(typedCharacters);
                     await inputTime.textfield.blur();
+
                     await expect(inputTime.textfield).toHaveValue(expectedFinalValue);
                 });
             };

--- a/projects/demo-playwright/tests/kit/input-time/input-time.spec.ts
+++ b/projects/demo-playwright/tests/kit/input-time/input-time.spec.ts
@@ -187,5 +187,66 @@ test.describe('InputTime', () => {
                 );
             });
         });
+
+        test.describe('zero padding on blur', () => {
+            const check = (typedCharacters: string, expectedFinalValue: string): void => {
+                test(`Type ${typedCharacters} => Blur => ${expectedFinalValue}`, async () => {
+                    await inputTime.textfield.clear();
+                    await expect(inputTime.textfield).toHaveValue('');
+                    await inputTime.textfield.pressSequentially(typedCharacters);
+                    await inputTime.textfield.blur();
+                    await expect(inputTime.textfield).toHaveValue(expectedFinalValue);
+                });
+            };
+
+            test.describe('HH:MM', () => {
+                test.beforeEach(async ({page}) => {
+                    await tuiGoto(page, 'components/input-time/API?mode=HH:MM');
+                });
+
+                check('1', '01:00');
+                check('12', '12:00');
+                check('12:', '12:00');
+                check('123', '12:03');
+                check('12:3', '12:03');
+                check('12:34', '12:34');
+            });
+
+            test.describe('HH:MM:SS', () => {
+                test.beforeEach(async ({page}) => {
+                    await tuiGoto(page, 'components/input-time/API?mode=HH:MM:SS');
+                });
+
+                check('1', '01:00:00');
+                check('12', '12:00:00');
+                check('12:', '12:00:00');
+                check('123', '12:03:00');
+                check('12:3', '12:03:00');
+                check('12:34', '12:34:00');
+                check('12:34:', '12:34:00');
+                check('12:34:5', '12:34:05');
+                check('12:34:56', '12:34:56');
+            });
+
+            test.describe('HH:MM:SS.MSS', () => {
+                test.beforeEach(async ({page}) => {
+                    await tuiGoto(page, 'components/input-time/API?mode=HH:MM:SS.MSS');
+                });
+
+                check('1', '01:00:00.000');
+                check('12', '12:00:00.000');
+                check('12:', '12:00:00.000');
+                check('123', '12:03:00.000');
+                check('12:3', '12:03:00.000');
+                check('12:34', '12:34:00.000');
+                check('12:34:', '12:34:00.000');
+                check('12:34:5', '12:34:05.000');
+                check('12:34:56', '12:34:56.000');
+                check('12:34:56.', '12:34:56.000');
+                check('12:34:56.7', '12:34:56.007');
+                check('12:34:56.78', '12:34:56.078');
+                check('12:34:56.789', '12:34:56.789');
+            });
+        });
     });
 });

--- a/projects/legacy/components/input-time/input-time.component.ts
+++ b/projects/legacy/components/input-time/input-time.component.ts
@@ -219,12 +219,7 @@ export class TuiInputTimeComponent
     protected onFocused(focused: boolean): void {
         this.updateFocused(focused);
 
-        if (
-            focused ||
-            this.value !== null ||
-            this.nativeValue === '' ||
-            this.mode === 'HH:MM'
-        ) {
+        if (focused || this.value !== null || this.nativeValue === '') {
             return;
         }
 


### PR DESCRIPTION
Closes #8450
