### PR TITLE
feat(i18n): improve literal string union

### DIFF
--- a/projects/i18n/types/language-names.ts
+++ b/projects/i18n/types/language-names.ts
@@ -1,5 +1,4 @@
 export type TuiLanguageName =
-    | string
     | 'belarusian'
     | 'chinese'
     | 'dutch'
@@ -17,4 +16,5 @@ export type TuiLanguageName =
     | 'spanish'
     | 'turkish'
     | 'ukrainian'
-    | 'vietnamese';
+    | 'vietnamese'
+    | (Record<never, never> & string);


### PR DESCRIPTION
### Before

<img width="812" alt="image" src="https://github.com/user-attachments/assets/bfdedac3-0519-4c02-94a4-873e2605c367">


### After

<img width="1411" alt="image" src="https://github.com/user-attachments/assets/eaef4ad9-0b9a-49df-9d58-384036d67676">


More information: https://github.com/microsoft/TypeScript/issues/29729