### PR TITLE
fix(addon-mobile): `PullToRefresh` do not trigger pulled if dialog is inside

### DIFF
--- a/projects/addon-mobile/components/pull-to-refresh/pull-to-refresh.service.ts
+++ b/projects/addon-mobile/components/pull-to-refresh/pull-to-refresh.service.ts
@@ -33,6 +33,7 @@ export class TuiPullToRefreshService extends Observable<number> {
         startWith(null),
         switchMap(() =>
             tuiTypedFromEvent(this.element, 'touchstart', {passive: true}).pipe(
+                filter(() => !this.el.nativeElement.querySelector('tui-dialog')),
                 filter(() => !this.scrollTop),
                 map(({touches}) => touches[0].clientY),
                 switchMap(start =>

--- a/projects/addon-mobile/components/pull-to-refresh/pull-to-refresh.service.ts
+++ b/projects/addon-mobile/components/pull-to-refresh/pull-to-refresh.service.ts
@@ -22,6 +22,7 @@ import {
 } from './pull-to-refresh.providers';
 
 export const MICRO_OFFSET = 10 ** -6;
+const EXCLUSION_SELECTORS = 'tui-dialog, tui-dropdown, tui-dropdown-mobile';
 
 @Injectable()
 export class TuiPullToRefreshService extends Observable<number> {
@@ -33,8 +34,11 @@ export class TuiPullToRefreshService extends Observable<number> {
         startWith(null),
         switchMap(() =>
             tuiTypedFromEvent(this.element, 'touchstart', {passive: true}).pipe(
-                filter(() => !this.el.nativeElement.querySelector('tui-dialog')),
-                filter(() => !this.scrollTop),
+                filter(
+                    () =>
+                        !this.scrollTop &&
+                        !this.el.nativeElement.querySelector(EXCLUSION_SELECTORS),
+                ),
                 map(({touches}) => touches[0].clientY),
                 switchMap(start =>
                     tuiTypedFromEvent(this.element, 'touchmove').pipe(


### PR DESCRIPTION

Closes # <!-- link to a relevant issue. -->
