### PR TITLE
fix(addon-doc): strange behavior on safari

### DIFF
--- a/projects/addon-doc/components/code/index.less
+++ b/projects/addon-doc/components/code/index.less
@@ -29,11 +29,11 @@
 
         td {
             white-space: pre;
-        }
 
-        tr:hover {
-            outline: 1px solid var(--tui-border-normal);
-            border-radius: 0.25rem;
+            &:not(.hljs-ln-numbers):hover {
+                outline: 1px solid var(--tui-border-normal);
+                border-radius: 0.25rem;
+            }
         }
     }
 }


### PR DESCRIPTION
# Before

<img width="742" alt="image" src="https://github.com/user-attachments/assets/0c093b40-4fe6-4de2-8422-4baa24262d4e">


# After

<img width="736" alt="image" src="https://github.com/user-attachments/assets/357ec8ca-7482-474d-81de-d8734b2122f1">
