### PR TITLE
fix(kit): fix `CalendarRange` typing and checks `otherDateText` in `mapper` function

### DIFF
--- a/projects/kit/components/calendar-range/calendar-range.component.ts
+++ b/projects/kit/components/calendar-range/calendar-range.component.ts
@@ -122,7 +122,7 @@ export class TuiCalendarRangeComponent implements TuiWithOptionalMinMax<TuiDay> 
         valueChanges: Observable<TuiDayRange | null> | null,
         @Inject(ChangeDetectorRef) readonly cdr: ChangeDetectorRef,
         @Self() @Inject(TuiDestroyService) destroy$: TuiDestroyService,
-        @Inject(TUI_OTHER_DATE_TEXT) readonly otherDateText$: Observable<string>,
+        @Inject(TUI_OTHER_DATE_TEXT) readonly otherDateText$: Observable<string | null>,
         @Inject(TUI_COMMON_ICONS) readonly icons: TuiCommonIcons,
     ) {
         if (!valueChanges) {
@@ -153,10 +153,10 @@ export class TuiCalendarRangeComponent implements TuiWithOptionalMinMax<TuiDay> 
             TuiDay | null,
             TuiDay | null,
             TuiDayLike | null,
-            string?,
+            string | null | undefined,
         ],
         ReadonlyArray<TuiDayRangePeriod | string>
-    > = (items, min, max, minLength, otherDateText = '') => [
+    > = (items, min, max, minLength, otherDateText) => [
         ...items.filter(
             item =>
                 (minLength === null ||
@@ -164,7 +164,7 @@ export class TuiCalendarRangeComponent implements TuiWithOptionalMinMax<TuiDay> 
                 (min === null || item.range.to.daySameOrAfter(min)) &&
                 (max === null || item.range.from.daySameOrBefore(max)),
         ),
-        otherDateText,
+        otherDateText ?? '',
     ];
 
     get calculatedDisabledItemHandler(): TuiBooleanHandler<TuiDay> {


### PR DESCRIPTION
Closes #8621
