### PR TITLE
chore(demo): add missing `tuiDropdownHost` reference to example

### DIFF
--- a/projects/demo/src/modules/directives/dropdown-hover/examples/4/index.html
+++ b/projects/demo/src/modules/directives/dropdown-hover/examples/4/index.html
@@ -12,6 +12,7 @@
         Won't open here
     </button>
     <button
+        #tuiDropdownHost
         tuiButton
         type="button"
     >


### PR DESCRIPTION
**Before:**

https://github.com/user-attachments/assets/48bc4c34-124c-43b6-97c1-e5e945dd4973

**After:**

https://github.com/user-attachments/assets/5c55dcee-6d2c-497a-bda4-c29be7d79018

