### PR TITLE
fix(cdk): `ActiveZone` do not exit zone when scrollable container becomes non-scrollable (#8631)

### DIFF
--- a/projects/cdk/tokens/active-element.ts
+++ b/projects/cdk/tokens/active-element.ts
@@ -6,6 +6,7 @@ import {
     tuiCreateTokenFromFactory,
     tuiGetActualTarget,
     tuiGetDocumentOrShadowRoot,
+    tuiIsNativeMouseFocusable,
 } from '@taiga-ui/cdk/utils';
 import type {Observable} from 'rxjs';
 import {
@@ -34,7 +35,9 @@ function isValidFocusout(target: any, removedElement: Element | null = null): bo
         // Not due to button/input becoming disabled or under disabled fieldset
         !target.matches(':disabled') &&
         // Not due to element being removed from DOM
-        !removedElement?.contains(target)
+        !removedElement?.contains(target) &&
+        // Not due to scrollable element became non-scrollable
+        tuiIsNativeMouseFocusable(target)
     );
 }
 


### PR DESCRIPTION
cherry-picked

Closes #8579 
