### PR TITLE
fix(legacy): `Textarea` use balance text-wrap in safari

### DIFF
--- a/projects/legacy/components/textarea/textarea.style.less
+++ b/projects/legacy/components/textarea/textarea.style.less
@@ -41,6 +41,12 @@
     &[data-size='l']._has-counter {
         --tui-textarea-height: @heightCounter;
     }
+
+    .safari-only({
+        .t-pseudo-content, .t-input {
+            text-wrap: balance;
+        }
+    });
 }
 
 .t-outline {

--- a/projects/legacy/components/textarea/textarea.style.less
+++ b/projects/legacy/components/textarea/textarea.style.less
@@ -42,6 +42,7 @@
         --tui-textarea-height: @heightCounter;
     }
 
+    // https://bugs.webkit.org/show_bug.cgi?id=278558
     .safari-only({
         .t-pseudo-content, .t-input {
             text-wrap: balance;


### PR DESCRIPTION
Close #8608
