### PR TITLE
fix(kit): `Textarea` use balance text-wrap in safari (#8666)

### DIFF
--- a/projects/kit/components/textarea/textarea.style.less
+++ b/projects/kit/components/textarea/textarea.style.less
@@ -41,6 +41,13 @@
     &[data-size='l']._has-counter {
         --tui-textarea-height: @heightCounter;
     }
+
+    // https://bugs.webkit.org/show_bug.cgi?id=278558
+    .safari-only({
+        .t-pseudo-content, .t-input {
+            text-wrap: balance;
+        }
+    });
 }
 
 .t-outline {


### PR DESCRIPTION
(cherry picked from commit cbaac1b1c87b884cb692f979b44094ebb583ef1a)

Close #8608
