### PR TITLE
fix(kit): contain width for img in avatar

### DIFF
--- a/projects/kit/components/avatar/avatar.style.less
+++ b/projects/kit/components/avatar/avatar.style.less
@@ -120,6 +120,7 @@
 
     &._svg img {
         padding: 20%;
+        object-fit: contain;
     }
 
     tui-icon {


### PR DESCRIPTION
# Before

<img width="411" alt="image" src="https://github.com/user-attachments/assets/cbcb91b2-8035-41bc-9d20-616c5513150b">


# After

<img width="341" alt="image" src="https://github.com/user-attachments/assets/fcff8d76-4c1c-4891-a8bf-10b0b80633f2">
