### PR TITLE
fix(core): show empty content in correct detect changes cycle

### DIFF
--- a/projects/core/components/data-list/data-list.component.ts
+++ b/projects/core/components/data-list/data-list.component.ts
@@ -7,6 +7,7 @@ import {
     forwardRef,
     inject,
     Input,
+    signal,
     ViewEncapsulation,
 } from '@angular/core';
 import {toSignal} from '@angular/core/rxjs-interop';
@@ -63,7 +64,7 @@ export class TuiDataListComponent<T>
     private readonly el = tuiInjectElement();
 
     protected readonly fallback = toSignal(inject(TUI_NOTHING_FOUND_MESSAGE));
-    protected empty = true;
+    protected readonly empty = signal(false);
 
     @Input()
     public emptyContent: PolymorpheusContent;
@@ -85,7 +86,7 @@ export class TuiDataListComponent<T>
 
     public ngAfterContentChecked(): void {
         // TODO: Refactor to :has after Safari support bumped to 15
-        this.empty = !this.el.querySelector('[tuiOption]');
+        this.empty.set(!this.options.length);
     }
 
     public getOptions(includeDisabled = false): readonly T[] {

--- a/projects/core/components/data-list/data-list.template.html
+++ b/projects/core/components/data-list/data-list.template.html
@@ -1,6 +1,6 @@
 <ng-content />
 <div
-    *ngIf="empty"
+    *ngIf="empty()"
     class="t-empty"
 >
     <ng-container *polymorpheusOutlet="emptyContent || fallback() as text">


### PR DESCRIPTION
# Before

https://github.com/user-attachments/assets/28f1a9a1-be92-43dd-b646-427758831d47




# After


https://github.com/user-attachments/assets/81772ae1-cc00-4fe1-b0b7-de5c823fb280

