### PR TITLE
fix(addon-table): TuiTableDirective Content Security Policy error

### DIFF
--- a/projects/addon-table/components/table/directives/table.directive.ts
+++ b/projects/addon-table/components/table/directives/table.directive.ts
@@ -38,7 +38,6 @@ class TuiTableStylesComponent {}
     host: {
         '($.data-mode.attr)': 'mode$',
         '($.class._stuck)': 'stuck$',
-        style: 'border-collapse: separate',
     },
 })
 export class TuiTableDirective<T extends Partial<Record<keyof T, any>>>

--- a/projects/addon-table/components/table/directives/table.style.less
+++ b/projects/addon-table/components/table/directives/table.style.less
@@ -1,4 +1,6 @@
 table[tuiTable] {
+    border-collapse: separate;
+
     [tuiCell] {
         padding: 0;
     }


### PR DESCRIPTION
TuiTableDirective caused error when adding Content Security Policy with NONCE value.

Error itself:

Refused to apply inline style because it violates the following Content Security Policy directive: "style-src....". Either the 'unsafe-inline' keyword, a hash ('sha256-uprzIeY8iAGlQbI25hI6vVEMS+1jDt6N6C2veKnb2dA='), or a nonce ('nonce-...') is required to enable inline execution. Note that hashes do not apply to event handlers, style attributes and javascript: navigations unless the 'unsafe-hashes' keyword is present. 