### PR TITLE
chore: add migration for `tuiHintAppearance`

### DIFF
--- a/projects/cdk/schematics/ng-update/v4/steps/constants/attr-with-values-to-replace.ts
+++ b/projects/cdk/schematics/ng-update/v4/steps/constants/attr-with-values-to-replace.ts
@@ -32,6 +32,11 @@ export const ATTR_WITH_VALUES_TO_REPLACE: ReplacementAttributeValue[] = [
         ],
     },
     {
+        attrNames: ['tuiHintAppearance'],
+        newAttrName: 'tuiHintAppearance',
+        valueReplacer: [{from: 'onDark', to: 'dark'}],
+    },
+    {
         attrNames: ['[pseudoActive]'],
         newAttrName: '[tuiAppearanceState]',
         withTagNames: hasPseudo,

--- a/projects/cdk/schematics/ng-update/v4/tests/schematic-migrate-avatar.spec.ts
+++ b/projects/cdk/schematics/ng-update/v4/tests/schematic-migrate-avatar.spec.ts
@@ -67,6 +67,7 @@ const TEMPLATE_BEFORE = `
 <tui-avatar
     [src]="src"
     size="xxs"
+    tuiHintAppearance="onDark"
 ></tui-avatar>
 `;
 
@@ -98,6 +99,7 @@ const TEMPLATE_AFTER = `
 <tui-avatar
     [src]="src"
     size="xxs"
+    tuiHintAppearance="dark"
 ></tui-avatar>
 `;
 


### PR DESCRIPTION
Partially solved #8839 

`Missing migration for tuiHintAppearance="onDark". Should be replaced with tuiHintAppearance="dark"`
