### PR TITLE
fix(layout): `Card` fix `tuiLabel` title font weight when `tuiLabel` is placed inside a card

### DIFF
--- a/projects/layout/components/card/card.styles.less
+++ b/projects/layout/components/card/card.styles.less
@@ -12,7 +12,7 @@
     overscroll-behavior: contain;
 
     &[tuiTitle],
-    [tuiTitle]:not([tuiCell] *) {
+    [tuiTitle]:not([tuiCell] *):not([tuiLabel] *) {
         font-weight: bold;
     }
 


### PR DESCRIPTION
Fixes `tuiLabel` title font weight in the following case:
```html
<div
    tuiCardLarge
    tuiSurface="elevated"
>
    <label tuiLabel>
        <span tuiTitle>
            <span tuiSubtitle>Foo</span>
            Bar
        </span>
    </label>
</div>
```
