### PR TITLE
fix(addon-mobile): `Card` fix paddings on mobile devices

### DIFF
--- a/projects/addon-mobile/styles/common/card-large.less
+++ b/projects/addon-mobile/styles/common/card-large.less
@@ -1,4 +1,4 @@
-[tuiCardLarge] {
+[tuiCardLarge][data-space] {
     &[data-space='normal'] {
         --t-padding: 1.25rem;
         --t-gap: 1.25rem;


### PR DESCRIPTION
Close #8939

The mobile paddings now look good in the demo. Not sure if they are applied correctly IRL on mobile device.
