### PR TITLE
fix(kit): do not override white-space for children of line-clamp

### DIFF
--- a/projects/kit/components/line-clamp/line-clamp.style.less
+++ b/projects/kit/components/line-clamp/line-clamp.style.less
@@ -18,8 +18,4 @@
     -webkit-box-orient: vertical;
     overflow: hidden;
     overflow-wrap: anywhere;
-
-    ::ng-deep > * {
-        white-space: initial;
-    }
 }


### PR DESCRIPTION


![image](https://github.com/user-attachments/assets/86f27725-06d6-4666-98ec-66f94e63839f)

<img width="665" alt="image" src="https://github.com/user-attachments/assets/1e1f8dae-8591-4ff5-83cb-a938ffdb5fb9">

When user set `white-space: nowrap` it doesn't work