### PR TITLE
fix(legacy): fix scroll jumping on readonly input focusing in safari

### DIFF
--- a/projects/legacy/styles/mixins/textfield.less
+++ b/projects/legacy/styles/mixins/textfield.less
@@ -161,7 +161,6 @@
     :host-context(tui-primitive-textfield._hidden) {
         opacity: 0;
         text-indent: -10em; // Hide blinking caret even in IE
-        -webkit-user-select: none; // Hide blinking caret in mobile safari
     }
 }
 


### PR DESCRIPTION
Close #7443

when trying to focus with a tab (or programmatically) on a readonly input with the `-webkit-user-select: none` property, desktop safari unexpectedly resets the scroll

https://stackblitz.com/edit/vitejs-vite-drvcag?file=index.html,style.css,main.js&terminal=dev