### PR TITLE
feat(addon-doc): add aria-label for dark mode button

### DIFF
--- a/projects/addon-doc/components/main/main.template.html
+++ b/projects/addon-doc/components/main/main.template.html
@@ -11,6 +11,7 @@
         <ng-content select="tuiDocHeader" />
         <button
             appearance="secondary"
+            aria-label="Switch between dark and light mode"
             size="s"
             tuiIconButton
             type="button"


### PR DESCRIPTION
## Before

<img width="582" alt="image" src="https://github.com/user-attachments/assets/71a63693-f306-4b4d-933b-f91dc3f71d18">


## After

<img width="594" alt="image" src="https://github.com/user-attachments/assets/75dee82a-6f2d-4fcb-b0bf-269d226f4107">
