### PR TITLE
feat(addon-doc): heading elements are not in a sequentially-descending order

### DIFF
--- a/projects/addon-doc/components/example/example.template.html
+++ b/projects/addon-doc/components/example/example.template.html
@@ -1,5 +1,5 @@
 <div class="t-title-block">
-    <h3
+    <h2
         *ngIf="heading"
         class="t-title"
     >
@@ -7,7 +7,7 @@
             *polymorpheusOutlet="heading as text"
             [textContent]="text"
         ></span>
-    </h3>
+    </h2>
     <a
         *ngIf="id"
         routerLink="."
@@ -23,14 +23,14 @@
         #
     </a>
 </div>
-<h4
+<h3
     *ngIf="description"
     class="t-description"
 >
     <ng-container *polymorpheusOutlet="description as text">
         {{ text }}
     </ng-container>
-</h4>
+</h3>
 
 <div
     *ngIf="processor$ | async as files"


### PR DESCRIPTION
## Before

<img width="567" alt="image" src="https://github.com/user-attachments/assets/395ffe22-fbbc-46eb-a455-578cecd017d0">


## After

<img width="557" alt="image" src="https://github.com/user-attachments/assets/49ce4154-7a54-4d50-9a68-5e0cda466aa2">
