### PR TITLE
fix(legacy): `MultiSelect` empty line when non empty `placeholder` and `valueContent`

### DIFF
--- a/projects/demo-playwright/tests/kit/multi-select/multi-select.spec.ts
+++ b/projects/demo-playwright/tests/kit/multi-select/multi-select.spec.ts
@@ -237,5 +237,26 @@ test.describe('MultiSelect', () => {
 
             await expect(page).toHaveScreenshot('09-multi-select-non-editable.png');
         });
+
+        test('placeholder with value content', async ({page}) => {
+            await tuiGoto(
+                page,
+                'components/multi-select/API?valueContent$=1&placeholder=test',
+            );
+
+            await multiSelect.arrow.click();
+
+            await multiSelect.selectOptions([0]);
+            await multiSelect.closeDropdown();
+
+            await multiSelect.textfield.blur();
+
+            await documentationPage.prepareBeforeScreenshot();
+            await documentationPage.waitStableState();
+
+            await expect(page).toHaveScreenshot(
+                '10-multi-select-placeholder-with-value-content.png',
+            );
+        });
     });
 });

--- a/projects/legacy/components/input-tag/input-tag.component.ts
+++ b/projects/legacy/components/input-tag/input-tag.component.ts
@@ -1,4 +1,4 @@
-import type {AfterContentChecked, AfterContentInit, QueryList} from '@angular/core';
+import type {QueryList} from '@angular/core';
 import {
     ChangeDetectionStrategy,
     Component,
@@ -88,11 +88,7 @@ const TAG_VERTICAL_SPACE_REM = 0.125;
 })
 export class TuiInputTagComponent
     extends AbstractTuiMultipleControl<string>
-    implements
-        TuiFocusableElementAccessor,
-        TuiDataListHost<string>,
-        AfterContentInit,
-        AfterContentChecked
+    implements TuiFocusableElementAccessor, TuiDataListHost<string>
 {
     @ViewChild(TuiDropdownOpen)
     private readonly dropdown?: TuiDropdownOpen;
@@ -235,16 +231,6 @@ export class TuiInputTagComponent
                 !this.placeholder) ||
             !!this.valueContent
         );
-    }
-
-    public ngAfterContentInit(): void {
-        // eslint-disable-next-line
-        console.log(this.valueContent);
-    }
-
-    public ngAfterContentChecked(): void {
-        // eslint-disable-next-line
-        console.log(this.valueContent);
     }
 
     public onTagEdited(value: string, index: number): void {

--- a/projects/legacy/components/input-tag/input-tag.component.ts
+++ b/projects/legacy/components/input-tag/input-tag.component.ts
@@ -1,4 +1,4 @@
-import type {QueryList} from '@angular/core';
+import type {AfterContentChecked, AfterContentInit, QueryList} from '@angular/core';
 import {
     ChangeDetectionStrategy,
     Component,
@@ -88,7 +88,11 @@ const TAG_VERTICAL_SPACE_REM = 0.125;
 })
 export class TuiInputTagComponent
     extends AbstractTuiMultipleControl<string>
-    implements TuiFocusableElementAccessor, TuiDataListHost<string>
+    implements
+        TuiFocusableElementAccessor,
+        TuiDataListHost<string>,
+        AfterContentInit,
+        AfterContentChecked
 {
     @ViewChild(TuiDropdownOpen)
     private readonly dropdown?: TuiDropdownOpen;
@@ -114,8 +118,8 @@ export class TuiInputTagComponent
     @ContentChild(TuiDataListDirective, {read: TemplateRef})
     protected readonly datalist?: TemplateRef<TuiContext<TuiActiveZone>>;
 
-    @ContentChild(PolymorpheusOutlet, {read: ElementRef})
-    protected readonly valueContent?: ElementRef<HTMLSpanElement>;
+    @ContentChild(PolymorpheusOutlet)
+    protected readonly valueContent?: unknown;
 
     @ViewChild('errorIcon')
     protected readonly errorIconTemplate?: TemplateRef<Record<string, unknown>>;
@@ -231,6 +235,16 @@ export class TuiInputTagComponent
                 !this.placeholder) ||
             !!this.valueContent
         );
+    }
+
+    public ngAfterContentInit(): void {
+        // eslint-disable-next-line
+        console.log(this.valueContent);
+    }
+
+    public ngAfterContentChecked(): void {
+        // eslint-disable-next-line
+        console.log(this.valueContent);
     }
 
     public onTagEdited(value: string, index: number): void {

--- a/projects/legacy/components/input-tag/input-tag.component.ts
+++ b/projects/legacy/components/input-tag/input-tag.component.ts
@@ -46,6 +46,7 @@ import {tuiAsFocusableItemAccessor} from '@taiga-ui/legacy/tokens';
 import type {TuiStatus} from '@taiga-ui/legacy/utils';
 import {FIXED_DROPDOWN_CONTROLLER_PROVIDER} from '@taiga-ui/legacy/utils';
 import type {PolymorpheusContent} from '@taiga-ui/polymorpheus';
+import {PolymorpheusOutlet} from '@taiga-ui/polymorpheus';
 import {timer} from 'rxjs';
 
 import {TUI_INPUT_TAG_OPTIONS} from './input-tag.options';
@@ -112,6 +113,9 @@ export class TuiInputTagComponent
 
     @ContentChild(TuiDataListDirective, {read: TemplateRef})
     protected readonly datalist?: TemplateRef<TuiContext<TuiActiveZone>>;
+
+    @ContentChild(PolymorpheusOutlet, {read: ElementRef})
+    protected readonly valueContent?: ElementRef<HTMLSpanElement>;
 
     @ViewChild('errorIcon')
     protected readonly errorIconTemplate?: TemplateRef<Record<string, unknown>>;
@@ -217,6 +221,16 @@ export class TuiInputTagComponent
 
     public get focused(): boolean {
         return tuiIsNativeFocusedIn(this.el) || !!this.dropdown?.tuiDropdownOpen;
+    }
+
+    public get tagsEmpty(): boolean {
+        return (
+            ((!this.focused || this.inputHidden) &&
+                !this.value.length &&
+                !this.search?.trim()?.length &&
+                !this.placeholder) ||
+            !!this.valueContent
+        );
     }
 
     public onTagEdited(value: string, index: number): void {

--- a/projects/legacy/components/input-tag/input-tag.style.less
+++ b/projects/legacy/components/input-tag/input-tag.style.less
@@ -63,7 +63,7 @@
         overflow: hidden;
     }
 
-    &_empty:not(.t-with-placeholder) {
+    &_empty {
         block-size: 0;
     }
 

--- a/projects/legacy/components/input-tag/input-tag.template.html
+++ b/projects/legacy/components/input-tag/input-tag.template.html
@@ -47,8 +47,7 @@
                 >
                     <div
                         class="t-tags"
-                        [class.t-tags_empty]="(!focused || inputHidden) && !value.length && !search?.trim()?.length"
-                        [class.t-with-placeholder]="placeholder"
+                        [class.t-tags_empty]="tagsEmpty"
                     >
                         <ng-container *ngIf="labelOutside; else text">
                             <tui-tag


### PR DESCRIPTION
Close #9112 
