### PR TITLE
chore(demo): fix re-creating main portal twice

### DIFF
--- a/projects/demo/src/modules/app/app.component.ts
+++ b/projects/demo/src/modules/app/app.component.ts
@@ -9,7 +9,7 @@ import {WA_LOCAL_STORAGE} from '@ng-web-apis/common';
 import {ResizeObserverService} from '@ng-web-apis/resize-observer';
 import {TuiDocLanguageSwitcher} from '@taiga-ui/addon-doc';
 import {TuiSheetModule, TuiTextfieldControllerModule} from '@taiga-ui/legacy';
-import {distinctUntilChanged, filter, map} from 'rxjs';
+import {distinctUntilChanged, filter, map, startWith} from 'rxjs';
 
 import {CustomHost} from '../customization/portals/examples/1/portal';
 import {AbstractDemo, DEMO_PAGE_LOADED_PROVIDER} from './abstract.app';
@@ -59,8 +59,10 @@ export class App extends AbstractDemo implements OnInit {
     protected readonly routes = DemoRoute;
 
     protected readonly isLanding$ = this.router.events.pipe(
+        filter((event) => event instanceof NavigationEnd),
         map(() => this.url === '' || this.url === '/'),
         distinctUntilChanged(),
+        startWith(true),
     );
 
     public override async ngOnInit(): Promise<void> {


### PR DESCRIPTION
### before:

1. main portal creating twice when navigating to somewhere except landing-page route
<img width="1428" alt="Снимок экрана 2024-09-23 в 11 57 11" src="https://github.com/user-attachments/assets/984c8154-5c67-465e-b9e2-d7c596084157">

2. main-portal unexpected creating on landing-page route
<img width="1565" alt="Снимок экрана 2024-09-23 в 11 57 44" src="https://github.com/user-attachments/assets/6f4efe34-347f-49a9-9b1d-888c5280c571">



