### PR TITLE
feat(cdk): add `TuiRepeatTimes` pipe

### DIFF
--- a/projects/cdk/pipes/index.ts
+++ b/projects/cdk/pipes/index.ts
@@ -2,5 +2,6 @@ export * from '@taiga-ui/cdk/pipes/filter';
 export * from '@taiga-ui/cdk/pipes/is-present';
 export * from '@taiga-ui/cdk/pipes/keys';
 export * from '@taiga-ui/cdk/pipes/mapper';
+export * from '@taiga-ui/cdk/pipes/repeat-times';
 export * from '@taiga-ui/cdk/pipes/replace';
 export * from '@taiga-ui/cdk/pipes/to-array';

--- a/projects/cdk/pipes/repeat-times/index.ts
+++ b/projects/cdk/pipes/repeat-times/index.ts
@@ -1,0 +1,12 @@
+import {Pipe, type PipeTransform} from '@angular/core';
+import {tuiClamp} from '@taiga-ui/cdk/utils';
+
+@Pipe({
+    standalone: true,
+    name: 'tuiRepeatTimes',
+})
+export class TuiRepeatTimesPipe implements PipeTransform {
+    public transform(n: number): number[] {
+        return Array.from({length: tuiClamp(n, 0, n)}, (_, i) => i);
+    }
+}

--- a/projects/cdk/pipes/repeat-times/ng-package.json
+++ b/projects/cdk/pipes/repeat-times/ng-package.json
@@ -1,0 +1,5 @@
+{
+    "lib": {
+        "entryFile": "index.ts"
+    }
+}

--- a/projects/cdk/pipes/repeat-times/test/repeat-times.pipe.spec.ts
+++ b/projects/cdk/pipes/repeat-times/test/repeat-times.pipe.spec.ts
@@ -1,0 +1,16 @@
+import {TuiRepeatTimesPipe} from '@taiga-ui/cdk';
+
+describe('TuiRepeatTimes pipe', () => {
+    const pipe = new TuiRepeatTimesPipe();
+
+    it('works', () => {
+        expect(pipe.transform(-2)).toEqual([]);
+        expect(pipe.transform(-1)).toEqual([]);
+        expect(pipe.transform(0)).toEqual([]);
+        expect(pipe.transform(1)).toEqual([0]);
+        expect(pipe.transform(2)).toEqual([0, 1]);
+        expect(pipe.transform(3)).toEqual([0, 1, 2]);
+        expect(pipe.transform(4)).toEqual([0, 1, 2, 3]);
+        expect(pipe.transform(5)).toEqual([0, 1, 2, 3, 4]);
+    });
+});

--- a/projects/demo/src/modules/app/app.routes.ts
+++ b/projects/demo/src/modules/app/app.routes.ts
@@ -971,6 +971,11 @@ export const ROUTES: Routes = [
         title: 'Mapper',
     }),
     route({
+        path: DemoRoute.RepeatTimes,
+        loadComponent: async () => import('../pipes/repeat-times'),
+        title: 'RepeatTimes',
+    }),
+    route({
         path: DemoRoute.Stringify,
         loadComponent: async () => import('../pipes/stringify'),
         title: 'Stringify',

--- a/projects/demo/src/modules/app/demo-routes.ts
+++ b/projects/demo/src/modules/app/demo-routes.ts
@@ -192,6 +192,7 @@ export const DemoRoute = {
     FormatNumber: '/pipes/format-number',
     IsPresent: '/pipes/is-present',
     Mapper: '/pipes/mapper',
+    RepeatTimes: '/pipes/repeat-times',
     Stringify: '/pipes/stringify',
     StringifyContent: '/pipes/stringify-content',
     Alert: '/components/alert',

--- a/projects/demo/src/modules/app/pages.ts
+++ b/projects/demo/src/modules/app/pages.ts
@@ -1370,6 +1370,12 @@ export const pages: TuiDocRoutePages = [
             },
             {
                 section: 'Tools',
+                title: 'RepeatTimes',
+                keywords: 'повторение, repeat, пайп, pipe',
+                route: DemoRoute.RepeatTimes,
+            },
+            {
+                section: 'Tools',
                 title: 'FieldError',
                 keywords: 'error, field, hint, ошибка, преобразование, пайп, pipe',
                 route: DemoRoute.FieldError,

--- a/projects/demo/src/modules/pipes/repeat-times/examples/1/index.html
+++ b/projects/demo/src/modules/pipes/repeat-times/examples/1/index.html
@@ -1,0 +1,3 @@
+<ng-container *ngFor="let index of 5 | tuiRepeatTimes">
+    {{ index }}
+</ng-container>

--- a/projects/demo/src/modules/pipes/repeat-times/examples/1/index.ts
+++ b/projects/demo/src/modules/pipes/repeat-times/examples/1/index.ts
@@ -1,0 +1,14 @@
+import {NgForOf} from '@angular/common';
+import {Component} from '@angular/core';
+import {changeDetection} from '@demo/emulate/change-detection';
+import {encapsulation} from '@demo/emulate/encapsulation';
+import {TuiRepeatTimesPipe} from '@taiga-ui/cdk';
+
+@Component({
+    standalone: true,
+    imports: [NgForOf, TuiRepeatTimesPipe],
+    templateUrl: './index.html',
+    encapsulation,
+    changeDetection,
+})
+export default class Example {}

--- a/projects/demo/src/modules/pipes/repeat-times/examples/import/import.md
+++ b/projects/demo/src/modules/pipes/repeat-times/examples/import/import.md
@@ -1,0 +1,15 @@
+```ts
+import {TuiRepeatTimesPipe} from '@taiga-ui/cdk';
+
+//...
+
+@Component({
+  standalone: true,
+  imports: [
+    // ...
+    TuiRepeatTimesPipe,
+  ],
+  //  ...
+})
+export class Example {}
+```

--- a/projects/demo/src/modules/pipes/repeat-times/examples/import/template.md
+++ b/projects/demo/src/modules/pipes/repeat-times/examples/import/template.md
@@ -1,0 +1,5 @@
+```html
+@for (index of 3 | tuiRepeatTimes; track index) {
+<div class="t-cell"></div>
+}
+```

--- a/projects/demo/src/modules/pipes/repeat-times/index.html
+++ b/projects/demo/src/modules/pipes/repeat-times/index.html
@@ -1,0 +1,17 @@
+<tui-doc-page
+    header="RepeatTimes"
+    package="CDK"
+    type="pipes"
+>
+    <ng-template pageTab>
+        <tui-doc-example
+            id="base"
+            description="Pipe for making an array of elements by length"
+            heading="Base"
+            [component]="1 | tuiComponent"
+            [content]="1 | tuiExample"
+        />
+    </ng-template>
+
+    <tui-setup *pageTab="'Setup'" />
+</tui-doc-page>

--- a/projects/demo/src/modules/pipes/repeat-times/index.ts
+++ b/projects/demo/src/modules/pipes/repeat-times/index.ts
@@ -1,0 +1,11 @@
+import {Component} from '@angular/core';
+import {changeDetection} from '@demo/emulate/change-detection';
+import {TuiDemo} from '@demo/utils';
+
+@Component({
+    standalone: true,
+    imports: [TuiDemo],
+    templateUrl: './index.html',
+    changeDetection,
+})
+export default class Page {}


### PR DESCRIPTION
@waterplea I want to use `@for` in Angular 18 and I don't want use `*tuiRepeatTimes`

I can happy with it

<img width="534" alt="image" src="https://github.com/user-attachments/assets/f559a8b3-1fc8-4fff-a0bc-49f2ca844aef">


+ strict types

<img width="553" alt="image" src="https://github.com/user-attachments/assets/d319e53c-04fc-46a7-a3bd-5e1c65a83517">
