### PR TITLE
fix(core): fix open DropdownContext after single touch on iOS

### DIFF
--- a/projects/core/directives/dropdown/dropdown-context.directive.ts
+++ b/projects/core/directives/dropdown/dropdown-context.directive.ts
@@ -95,8 +95,8 @@ export class TuiDropdownContextDirective extends TuiDriver implements TuiRectAcc
             return;
         }
 
-        this.currentRect = tuiPointToClientRect(x, y);
         this.longTapTimeout = setTimeout(() => {
+            this.currentRect = tuiPointToClientRect(x, y);
             this.stream$.next(true);
         }, TAP_DELAY);
     }


### PR DESCRIPTION
Fixes # <!-- link to a relevant issue. -->
