### PR TITLE
chore(demo-cypress): provide `NG_EVENT_PLUGINS` for all component tests by default

### DIFF
--- a/projects/demo-cypress/src/support/component.ts
+++ b/projects/demo-cypress/src/support/component.ts
@@ -1,3 +1,4 @@
+import {NG_EVENT_PLUGINS} from '@taiga-ui/event-plugins';
 import {mount} from 'cypress/angular';
 import addCompareSnapshotCommand from 'cypress-image-diff-js/command';
 
@@ -12,8 +13,11 @@ declare global {
     }
 }
 
-export const stableMount: typeof mount = (...mountArgs) =>
-    mount(...mountArgs).then((mountResponse) =>
+export const stableMount: typeof mount = (component, config) =>
+    mount(component, {
+        ...config,
+        providers: [...(config?.providers || []), NG_EVENT_PLUGINS],
+    }).then((mountResponse) =>
         cy
             .get('body')
             .find('[data-cy-root]')

--- a/projects/demo-cypress/src/tests/elastic-sticky.cy.ts
+++ b/projects/demo-cypress/src/tests/elastic-sticky.cy.ts
@@ -1,6 +1,5 @@
 import {ChangeDetectionStrategy, Component, EventEmitter, Output} from '@angular/core';
 import {TuiElasticSticky} from '@taiga-ui/addon-mobile';
-import {NG_EVENT_PLUGINS} from '@taiga-ui/event-plugins';
 import {createOutputSpy} from 'cypress/angular';
 
 describe('ElasticSticky', () => {
@@ -37,8 +36,6 @@ describe('ElasticSticky', () => {
 
     beforeEach(() =>
         cy.mount(Test, {
-            imports: [TuiElasticSticky],
-            providers: [NG_EVENT_PLUGINS],
             componentProperties: {
                 change: createOutputSpy<number>('changeSpy'),
             },

--- a/projects/demo-cypress/src/tests/hint.cy.ts
+++ b/projects/demo-cypress/src/tests/hint.cy.ts
@@ -2,7 +2,6 @@ import {NgIf} from '@angular/common';
 import {ChangeDetectionStrategy, Component, Input} from '@angular/core';
 import {NoopAnimationsModule} from '@angular/platform-browser/animations';
 import {TuiHintDirective, TuiRoot} from '@taiga-ui/core';
-import {NG_EVENT_PLUGINS} from '@taiga-ui/event-plugins';
 import type {MountResponse} from 'cypress/angular';
 
 describe('TuiHint', () => {
@@ -47,7 +46,6 @@ describe('TuiHint', () => {
         cy
             .mount(Test, {
                 imports: [NoopAnimationsModule, Host],
-                providers: [NG_EVENT_PLUGINS],
             })
             .then((wrap) => {
                 component = wrap.component;

--- a/projects/demo-cypress/src/tests/lazy-loading.cy.ts
+++ b/projects/demo-cypress/src/tests/lazy-loading.cy.ts
@@ -1,5 +1,4 @@
 import {ChangeDetectionStrategy, Component} from '@angular/core';
-import {NG_EVENT_PLUGINS} from '@taiga-ui/event-plugins';
 import {TuiImgLazyLoading} from '@taiga-ui/kit';
 
 describe('LazyLoading', () => {
@@ -29,7 +28,6 @@ describe('LazyLoading', () => {
 
     beforeEach(() =>
         cy.mount(Test, {
-            providers: [NG_EVENT_PLUGINS],
             componentProperties: {
                 src: '',
             },

--- a/projects/demo-cypress/src/tests/mobile-calendar.cy.ts
+++ b/projects/demo-cypress/src/tests/mobile-calendar.cy.ts
@@ -7,7 +7,6 @@ import {
     TuiDay,
     TuiDayRange,
 } from '@taiga-ui/cdk';
-import {NG_EVENT_PLUGINS} from '@taiga-ui/event-plugins';
 import {TUI_CALENDAR_DATE_STREAM} from '@taiga-ui/kit';
 import {createOutputSpy} from 'cypress/angular';
 import {of} from 'rxjs';
@@ -53,8 +52,6 @@ describe('Mobile calendar', () => {
 
     it('the back button emits a cancel event', () => {
         cy.mount(Test, {
-            imports: [TuiMobileCalendar],
-            providers: [NG_EVENT_PLUGINS],
             componentProperties: {
                 onCancel: createOutputSpy('onCancelSpy'),
             },
@@ -65,9 +62,7 @@ describe('Mobile calendar', () => {
     });
 
     it('single === true', () => {
-        cy.mount(Test, {
-            imports: [TuiMobileCalendar],
-        });
+        cy.mount(Test);
 
         cy.get('[automation-id="tui-mobile-calendar__label"]').should(
             'contain.text',
@@ -77,7 +72,6 @@ describe('Mobile calendar', () => {
 
     it('single === false', () => {
         cy.mount(Test, {
-            imports: [TuiMobileCalendar],
             componentProperties: {
                 single: false,
             },
@@ -92,7 +86,6 @@ describe('Mobile calendar', () => {
     describe('when the done button emits', () => {
         it('confirm event with selected day', () => {
             cy.mount(Test, {
-                imports: [TuiMobileCalendar],
                 componentProperties: {
                     onConfirm: createOutputSpy('onConfirmSpy'),
                 },
@@ -107,7 +100,6 @@ describe('Mobile calendar', () => {
 
         it('confirm event at selected interval', () => {
             cy.mount(Test, {
-                imports: [TuiMobileCalendar],
                 componentProperties: {
                     single: false,
                     onConfirm: createOutputSpy('onConfirmSpy'),
@@ -127,7 +119,6 @@ describe('Mobile calendar', () => {
         // TODO: why failed after https://github.com/taiga-family/taiga-ui/pull/8961
         xit('year selection scrolls through months', () => {
             cy.mount(Test, {
-                imports: [TuiMobileCalendar],
                 componentProperties: {
                     onConfirm: createOutputSpy('onConfirmSpy'),
                 },

--- a/projects/demo-cypress/src/tests/pan.cy.ts
+++ b/projects/demo-cypress/src/tests/pan.cy.ts
@@ -1,6 +1,5 @@
 import {ChangeDetectionStrategy, Component} from '@angular/core';
 import {TuiPan} from '@taiga-ui/cdk';
-import {NG_EVENT_PLUGINS} from '@taiga-ui/event-plugins';
 
 describe('TuiPan', () => {
     let component: Test;
@@ -22,14 +21,9 @@ describe('TuiPan', () => {
     }
 
     beforeEach(() =>
-        cy
-            .mount(Test, {
-                imports: [TuiPan],
-                providers: [NG_EVENT_PLUGINS],
-            })
-            .then((wrapper) => {
-                component = wrapper.component;
-            }),
+        cy.mount(Test).then((wrapper) => {
+            component = wrapper.component;
+        }),
     );
 
     it('emits delta', () => {

--- a/projects/demo-cypress/src/tests/range.cy.ts
+++ b/projects/demo-cypress/src/tests/range.cy.ts
@@ -1,7 +1,6 @@
 import {ChangeDetectionStrategy, Component, ElementRef, ViewChild} from '@angular/core';
 import type {ComponentFixture} from '@angular/core/testing';
 import {FormControl, ReactiveFormsModule} from '@angular/forms';
-import {NG_EVENT_PLUGINS} from '@taiga-ui/event-plugins';
 import type {TuiKeySteps} from '@taiga-ui/kit';
 import {TuiRange} from '@taiga-ui/kit';
 
@@ -44,10 +43,7 @@ describe('TuiRange', () => {
     }
 
     beforeEach(() => {
-        cy.mount(Test, {
-            imports: [TuiRange, ReactiveFormsModule],
-            providers: [NG_EVENT_PLUGINS],
-        }).then((wrapper) => {
+        cy.mount(Test).then((wrapper) => {
             component = wrapper.component;
             fixture = wrapper.fixture;
         });

--- a/projects/demo-cypress/src/tests/swipe.cy.ts
+++ b/projects/demo-cypress/src/tests/swipe.cy.ts
@@ -1,7 +1,6 @@
 import {ChangeDetectionStrategy, Component} from '@angular/core';
 import type {TuiSwipeEvent} from '@taiga-ui/cdk';
 import {TuiSwipe} from '@taiga-ui/cdk';
-import {NG_EVENT_PLUGINS} from '@taiga-ui/event-plugins';
 
 describe('TuiSwipe', () => {
     let component: Test;
@@ -26,14 +25,9 @@ describe('TuiSwipe', () => {
     }
 
     beforeEach(() =>
-        cy
-            .mount(Test, {
-                imports: [TuiSwipe],
-                providers: [NG_EVENT_PLUGINS],
-            })
-            .then((wrapper) => {
-                component = wrapper.component;
-            }),
+        cy.mount(Test).then((wrapper) => {
+            component = wrapper.component;
+        }),
     );
 
     it('emits events bottom', () => {

--- a/projects/demo-cypress/src/tests/tabs.cy.ts
+++ b/projects/demo-cypress/src/tests/tabs.cy.ts
@@ -1,5 +1,4 @@
 import {ChangeDetectionStrategy, Component} from '@angular/core';
-import {NG_EVENT_PLUGINS} from '@taiga-ui/event-plugins';
 import {TuiTabs} from '@taiga-ui/kit';
 
 describe('Tabs', () => {
@@ -44,14 +43,9 @@ describe('Tabs', () => {
     }
 
     beforeEach(() =>
-        cy
-            .mount(Test, {
-                imports: [TuiTabs],
-                providers: [NG_EVENT_PLUGINS],
-            })
-            .then((wrapper) => {
-                component = wrapper.component;
-            }),
+        cy.mount(Test).then((wrapper) => {
+            component = wrapper.component;
+        }),
     );
 
     it('navigation by arrows works when going right', () => {

--- a/projects/demo-cypress/src/tests/zoom.cy.ts
+++ b/projects/demo-cypress/src/tests/zoom.cy.ts
@@ -1,7 +1,6 @@
 import {ChangeDetectionStrategy, Component} from '@angular/core';
 import type {TuiZoomEvent} from '@taiga-ui/cdk';
 import {tuiFloor, TuiZoom} from '@taiga-ui/cdk';
-import {NG_EVENT_PLUGINS} from '@taiga-ui/event-plugins';
 
 describe('TuiZoom', () => {
     let component: Test;
@@ -26,14 +25,9 @@ describe('TuiZoom', () => {
     }
 
     beforeEach(() =>
-        cy
-            .mount(Test, {
-                imports: [TuiZoom],
-                providers: [NG_EVENT_PLUGINS],
-            })
-            .then((wrapper) => {
-                component = wrapper.component;
-            }),
+        cy.mount(Test).then((wrapper) => {
+            component = wrapper.component;
+        }),
     );
 
     it('pinch', () => {


### PR DESCRIPTION
<img width="1489" alt="console-error" src="https://github.com/user-attachments/assets/45b52821-92de-40b6-b0a4-6d47e212c01c">
