### PR TITLE
fix(core): `Textfield` with initial value has change detection problems with `filler`

### DIFF
--- a/projects/core/components/textfield/select.directive.ts
+++ b/projects/core/components/textfield/select.directive.ts
@@ -1,6 +1,5 @@
 import {CommonModule} from '@angular/common';
 import {ChangeDetectionStrategy, Component, inject, Input} from '@angular/core';
-import {NgControl} from '@angular/forms';
 import {WA_NAVIGATOR} from '@ng-web-apis/common';
 import {TuiNativeValidator} from '@taiga-ui/cdk/directives/native-validator';
 import {tuiProvide} from '@taiga-ui/cdk/utils/miscellaneous';
@@ -34,13 +33,12 @@ import {TuiTextfieldBase, TuiTextfieldDirective} from './textfield.directive';
 })
 export class TuiSelect<T> extends TuiTextfieldBase<T> {
     private readonly nav = inject(WA_NAVIGATOR);
-    private readonly control = inject(NgControl);
 
     @Input()
     public placeholder = '';
 
     public override setValue(value: T): void {
-        this.control.control?.setValue(value);
+        this.control?.control?.setValue(value);
         this.el.dispatchEvent(new Event('input', {bubbles: true}));
     }
 
@@ -51,7 +49,7 @@ export class TuiSelect<T> extends TuiTextfieldBase<T> {
     }
 
     protected get value(): string {
-        return this.textfield.stringify(this.control.value ?? '');
+        return this.textfield.stringify(this.control?.value ?? '');
     }
 
     protected async onCopy(): Promise<void> {

--- a/projects/demo-cypress/src/tests/textfield.cy.ts
+++ b/projects/demo-cypress/src/tests/textfield.cy.ts
@@ -1,16 +1,16 @@
 import {ChangeDetectionStrategy, Component, Input} from '@angular/core';
-import {FormControl, ReactiveFormsModule} from '@angular/forms';
+import {FormsModule} from '@angular/forms';
 import {TUI_ANIMATIONS_SPEED, TuiRoot, TuiTextfield} from '@taiga-ui/core';
 
 @Component({
     standalone: true,
-    imports: [ReactiveFormsModule, TuiRoot, TuiTextfield],
+    imports: [FormsModule, TuiRoot, TuiTextfield],
     template: `
         <tui-root>
             <tui-textfield [filler]="filler">
                 <input
                     tuiTextfield
-                    [formControl]="control"
+                    [(ngModel)]="initialValue"
                 />
             </tui-textfield>
         </tui-root>
@@ -20,7 +20,7 @@ import {TUI_ANIMATIONS_SPEED, TuiRoot, TuiTextfield} from '@taiga-ui/core';
 })
 export class TestTextfield {
     @Input()
-    public control = new FormControl('', {nonNullable: true});
+    public initialValue = '';
 
     @Input()
     public filler = '';
@@ -35,7 +35,7 @@ describe('Textfield', () => {
                 it(initialValue, () => {
                     cy.mount(TestTextfield, {
                         componentProperties: {
-                            control: new FormControl(initialValue, {nonNullable: true}),
+                            initialValue,
                             filler: 'HH:MM',
                         },
                     });
@@ -43,33 +43,6 @@ describe('Textfield', () => {
                     cy.get('input[tuiTextfield]').focus();
                     cy.get('tui-textfield').compareSnapshot(
                         `[filler]-initial-value_${initialValue}`,
-                    );
-                });
-            });
-        });
-
-        describe('programmatic patch of form control', () => {
-            let control!: FormControl<string>;
-
-            beforeEach(() => {
-                control = new FormControl('', {nonNullable: true});
-
-                cy.mount(TestTextfield, {
-                    componentProperties: {
-                        control,
-                        filler: 'HH:MM',
-                    },
-                });
-
-                cy.get('input[tuiTextfield]').focus();
-            });
-
-            ['2', '23', '23:', '23:5', '23:59'].forEach((value) => {
-                it(value, () => {
-                    control.patchValue(value);
-
-                    cy.get('tui-textfield').compareSnapshot(
-                        `[filler]-patch-value_${value}`,
                     );
                 });
             });

--- a/projects/demo-cypress/src/tests/textfield.cy.ts
+++ b/projects/demo-cypress/src/tests/textfield.cy.ts
@@ -1,0 +1,100 @@
+import {ChangeDetectionStrategy, Component, Input} from '@angular/core';
+import {FormControl, ReactiveFormsModule} from '@angular/forms';
+import {TUI_ANIMATIONS_SPEED, TuiRoot, TuiTextfield} from '@taiga-ui/core';
+
+@Component({
+    standalone: true,
+    imports: [ReactiveFormsModule, TuiRoot, TuiTextfield],
+    template: `
+        <tui-root>
+            <tui-textfield [filler]="filler">
+                <input
+                    tuiTextfield
+                    [formControl]="control"
+                />
+            </tui-textfield>
+        </tui-root>
+    `,
+    changeDetection: ChangeDetectionStrategy.OnPush,
+    providers: [{provide: TUI_ANIMATIONS_SPEED, useValue: 0}],
+})
+export class TestTextfield {
+    @Input()
+    public control = new FormControl('', {nonNullable: true});
+
+    @Input()
+    public filler = '';
+}
+
+describe('Textfield', () => {
+    describe('[filler] property', () => {
+        beforeEach(() => cy.viewport(200, 150));
+
+        describe('with initial value', () => {
+            ['2', '23', '23:', '23:5', '23:59'].forEach((initialValue) => {
+                it(initialValue, () => {
+                    cy.mount(TestTextfield, {
+                        componentProperties: {
+                            control: new FormControl(initialValue, {nonNullable: true}),
+                            filler: 'HH:MM',
+                        },
+                    });
+
+                    cy.get('input[tuiTextfield]').focus();
+                    cy.get('tui-textfield').compareSnapshot(
+                        `[filler]-initial-value_${initialValue}`,
+                    );
+                });
+            });
+        });
+
+        describe('programmatic patch of form control', () => {
+            let control!: FormControl<string>;
+
+            beforeEach(() => {
+                control = new FormControl('', {nonNullable: true});
+
+                cy.mount(TestTextfield, {
+                    componentProperties: {
+                        control,
+                        filler: 'HH:MM',
+                    },
+                });
+
+                cy.get('input[tuiTextfield]').focus();
+            });
+
+            ['2', '23', '23:', '23:5', '23:59'].forEach((value) => {
+                it(value, () => {
+                    control.patchValue(value);
+
+                    cy.get('tui-textfield').compareSnapshot(
+                        `[filler]-patch-value_${value}`,
+                    );
+                });
+            });
+        });
+
+        describe('user types new value', () => {
+            beforeEach(() => {
+                cy.mount(TestTextfield, {
+                    componentProperties: {
+                        filler: 'HH:MM',
+                    },
+                });
+
+                cy.get('input[tuiTextfield]').focus();
+            });
+
+            ['2', '23', '23:', '23:5', '23:59'].forEach((value) => {
+                it(value, () => {
+                    cy.get('input[tuiTextfield]').type(value);
+
+                    cy.get('tui-textfield').compareSnapshot(
+                        `[filler]-user-types_${value}`,
+                    );
+                });
+            });
+        });
+    });
+});


### PR DESCRIPTION
### Previous behavior

**textfield.cy.ts-[filler]-initial-value_23:.png**
![textfield cy ts- filler -initial-value_23:](https://github.com/user-attachments/assets/1eaea737-9669-4036-993d-5d9cc19fd79a)


### New behavior

**textfield.cy.ts-[filler]-initial-value_23:.png**
![textfield cy ts- filler -initial-value_23:](https://github.com/user-attachments/assets/9d573104-2b66-4215-8491-bb36e5e2c7c5)
