### PR TITLE
feat(addon-table): disable column sorting on demand

### DIFF
--- a/projects/addon-table/components/table/th/th.template.html
+++ b/projects/addon-table/components/table/th/th.template.html
@@ -1,5 +1,5 @@
 <button
-    *ngIf="sorter && table; else content"
+    *ngIf="requiredSort && table; else content"
     type="button"
     class="t-sort"
     [class.t-sort_sorted]="isCurrent"

--- a/projects/demo/src/modules/components/table/examples/4/index.html
+++ b/projects/demo/src/modules/components/table/examples/4/index.html
@@ -53,7 +53,6 @@
             <tr tuiThGroup>
                 <th
                     *tuiHead="'name'"
-                    tuiSortable
                     tuiTh
                 >
                     Name
@@ -62,6 +61,7 @@
                     *tuiHead="'dob'"
                     tuiSortable
                     tuiTh
+                    [requiredSort]="true"
                 >
                     Date of Birth
                 </th>


### PR DESCRIPTION
Fixes https://github.com/taiga-family/taiga-ui/issues/8244

![image](https://github.com/user-attachments/assets/1b299963-677d-4347-abb7-c1f1c63ad0b2)
The idea is to enable sorting only for columns where the `[requiredSort]="true"` is provided