### PR TITLE
chore(demo-cypress): delete forbidden character `:` from snapshot names

### DIFF
--- a/projects/demo-cypress/src/tests/textfield.cy.ts
+++ b/projects/demo-cypress/src/tests/textfield.cy.ts
@@ -42,7 +42,7 @@ describe('Textfield', () => {
 
                     cy.get('input[tuiTextfield]').focus();
                     cy.get('tui-textfield').compareSnapshot(
-                        `[filler]-initial-value_${initialValue}`,
+                        `[filler]-initial-value_${initialValue.replaceAll(':', '-')}`,
                     );
                 });
             });
@@ -64,7 +64,7 @@ describe('Textfield', () => {
                     cy.get('input[tuiTextfield]').type(value);
 
                     cy.get('tui-textfield').compareSnapshot(
-                        `[filler]-user-types_${value}`,
+                        `[filler]-user-types_${value.replaceAll(':', '-')}`,
                     );
                 });
             });


### PR DESCRIPTION

![telegram-cloud-photo-size-2-5199489109800903172-w](https://github.com/user-attachments/assets/5363dcb3-11dd-40bb-ae73-8a647fb83663)
