### PR TITLE
fix(core): do not override passed empty id

### DIFF
--- a/projects/core/components/textfield/textfield.component.ts
+++ b/projects/core/components/textfield/textfield.component.ts
@@ -120,7 +120,7 @@ export class TuiTextfieldComponent<T> implements TuiDataListHost<T> {
     }
 
     public get id(): string {
-        return this.input?.nativeElement.id || this.autoId;
+        return this.input?.nativeElement.id ?? this.autoId;
     }
 
     public get size(): TuiSizeL | TuiSizeS {


### PR DESCRIPTION
In my tests I wanna use empty id, but now it doesn't work as expected

```html
<input id="" />
```