### PR TITLE
fix(core): support provide empty icon value

### DIFF
--- a/projects/core/tokens/icon-resolver.ts
+++ b/projects/core/tokens/icon-resolver.ts
@@ -23,12 +23,10 @@ export function tuiInjectIconResolver(): TuiStringHandler<string> {
     const icons = inject(TUI_ICON_REGISTRY);
     const resolver = inject(TUI_ICON_RESOLVER);
 
-    return (icon) => (!icon || icon.includes('/') ? icon : icons[icon] || resolver(icon));
+    return (icon) =>
+        !icon || icon.includes('/') ? icon : (icons[icon] ?? resolver(icon));
 }
 
 export function tuiIconResolverProvider(useValue: TuiStringHandler<string>): Provider {
-    return {
-        provide: TUI_ICON_RESOLVER,
-        useValue,
-    };
+    return {provide: TUI_ICON_RESOLVER, useValue};
 }


### PR DESCRIPTION
I want pass empty icons for screenshot testing

```ts
tuiIconsProvider({
  '@tui.heart': ''
})
```