### PR TITLE
fix(addon-mobile): `InputDateRange` throws error on single date selection

### DIFF
--- a/projects/addon-mobile/components/mobile-calendar-dropdown/mobile-calendar-dropdown.component.ts
+++ b/projects/addon-mobile/components/mobile-calendar-dropdown/mobile-calendar-dropdown.component.ts
@@ -131,11 +131,13 @@ export class TuiMobileCalendarDropdown {
     }
 
     protected confirm(value: any): void {
+        const normalizedValue = this.range ? this.selectedPeriod : value;
+
         if (this.control) {
-            this.control.value = value;
+            this.control.value = normalizedValue;
         }
 
-        this.observer?.next(value);
+        this.observer?.next(normalizedValue);
         this.close();
     }
 

--- a/projects/demo-playwright/utils/page-objects/calendar-sheet.po.ts
+++ b/projects/demo-playwright/utils/page-objects/calendar-sheet.po.ts
@@ -1,13 +1,17 @@
 import type {Locator} from '@playwright/test';
 
-export class TuiCalendarPO {
+export class TuiCalendarSheetPO {
     constructor(private readonly host: Locator) {}
 
     public async getDays(): Promise<Locator[]> {
-        return this.host.locator('[automation-id="tui-calendar-sheet__cell"]').all();
+        return this.host
+            .locator(
+                '[automation-id="tui-calendar-sheet__cell"], [automation-id="tui-primitive-calendar-mobile__cell"]',
+            )
+            .all();
     }
 
-    public async clickOnCalendarDay(day: number): Promise<void> {
+    public async clickOnDay(day: number): Promise<void> {
         const cells = await this.getDays();
 
         for (const cell of cells) {

--- a/projects/demo-playwright/utils/page-objects/index.ts
+++ b/projects/demo-playwright/utils/page-objects/index.ts
@@ -1,5 +1,5 @@
-export * from './calendar.po';
 export * from './calendar-range.po';
+export * from './calendar-sheet.po';
 export * from './combo-box.po';
 export * from './documentation-api-page.po';
 export * from './documentation-page.po';
@@ -14,6 +14,7 @@ export * from './input-range.po';
 export * from './input-slider.po';
 export * from './input-tag.po';
 export * from './input-time.po';
+export * from './mobile-calendar.po';
 export * from './multi-select.po';
 export * from './range.po';
 export * from './select.po';

--- a/projects/demo-playwright/utils/page-objects/input-date-range.po.ts
+++ b/projects/demo-playwright/utils/page-objects/input-date-range.po.ts
@@ -3,18 +3,22 @@ import {expect} from '@playwright/test';
 
 export class TuiInputDateRangePO {
     public readonly textfield: Locator = this.host.getByRole('textbox');
-    public readonly calendarRange: Locator = this.host
-        .page()
-        .locator('tui-calendar-range');
+    public readonly textfieldIcon: Locator = this.host.getByTestId(
+        'tui-input-date-range__icon',
+    );
 
-    public readonly items = this.calendarRange.locator(
+    public readonly calendar: Locator = this.host
+        .page()
+        .locator('tui-calendar-range, tui-mobile-calendar');
+
+    public readonly items = this.calendar.locator(
         '[automation-id="tui-calendar-range__menu"]',
     );
 
     constructor(private readonly host: Locator) {}
 
     public async getItems(): Promise<Locator[]> {
-        const dataList = this.calendarRange.locator(
+        const dataList = this.calendar.locator(
             '[automation-id="tui-calendar-range__menu"]',
         );
 

--- a/projects/demo-playwright/utils/page-objects/mobile-calendar.po.ts
+++ b/projects/demo-playwright/utils/page-objects/mobile-calendar.po.ts
@@ -1,0 +1,18 @@
+import {TuiCalendarSheetPO} from '@demo-playwright/utils';
+import type {Locator} from '@playwright/test';
+
+export class TuiMobileCalendarPO {
+    public cancelButton = this.host.getByTestId('tui-mobile-calendar__cancel');
+    public confirmButton = this.host.getByTestId('tui-mobile-calendar__confirm');
+
+    constructor(private readonly host: Locator) {}
+
+    public async getCalendarSheets(): Promise<TuiCalendarSheetPO[]> {
+        const locators = await this.host
+            .page()
+            .locator('tui-calendar-sheet, tui-mobile-calendar-sheet')
+            .all();
+
+        return locators.map((x) => new TuiCalendarSheetPO(x));
+    }
+}


### PR DESCRIPTION
Relates:
* https://github.com/taiga-family/taiga-ui/pull/8265/files#diff-0cce1811277c4e753fd5df47a281d07366b8fa48a46c1dbf8bd54de38d457a34L221-R248

Fixes #9351
