### PR TITLE
fix(legacy): `InputDateTime` fix native option for empty value

### DIFF
--- a/projects/legacy/components/input-date-time/input-date-time.directive.ts
+++ b/projects/legacy/components/input-date-time/input-date-time.directive.ts
@@ -16,7 +16,7 @@ export class TuiInputDateTimeDirective extends AbstractTuiTextfieldHost<TuiInput
     }
 
     public get rawValue(): [TuiDay | null, TuiTime | null] {
-        return this.host.value;
+        return this.host.value ?? [null, null];
     }
 
     public onValueChange(value: string): void {


### PR DESCRIPTION
Fixes # <!-- link to a relevant issue. -->
