### PR TITLE
refactor: use `unknown` instead of `any` for `isMultiValue` util

### DIFF
--- a/projects/addon-mobile/components/mobile-calendar/mobile-calendar.component.ts
+++ b/projects/addon-mobile/components/mobile-calendar/mobile-calendar.component.ts
@@ -329,7 +329,7 @@ export class TuiMobileCalendar implements AfterViewInit {
         );
     }
 
-    private isMultiValue(day: any): day is readonly TuiDay[] | undefined {
+    private isMultiValue(day: unknown): day is readonly TuiDay[] | undefined {
         return !(day instanceof TuiDay) && !(day instanceof TuiDayRange) && this.multi;
     }
 


### PR DESCRIPTION
If you really need to skip type checking, you can use something that Typescript 3.0 introduced: the unknown type. Unlike any, unknown is safer to use in the sense that before actually doing something with data of this type, we must do some sort of checking, whereas any has no restrictions.

https://dev.to/arikaturika/typescript-why-to-use-unknown-instead-of-any-41i8