### PR TITLE
chore(demo): drop `any`

### DIFF
--- a/projects/demo/src/modules/app/metrika/metrika.service.ts
+++ b/projects/demo/src/modules/app/metrika/metrika.service.ts
@@ -1,5 +1,6 @@
 import {DOCUMENT, isPlatformBrowser} from '@angular/common';
 import {inject, Injectable, PLATFORM_ID} from '@angular/core';
+import type {Params} from '@angular/router';
 import {TUI_IS_E2E, tuiCreateOptions} from '@taiga-ui/cdk';
 
 declare global {
@@ -15,8 +16,8 @@ declare global {
 
 interface HitOptions {
     referer?: string;
-    params?: any;
-    title?: any;
+    params?: Params;
+    title?: string;
 }
 
 interface YaMetrikaOptions {

--- a/projects/demo/src/modules/components/abstract/control.ts
+++ b/projects/demo/src/modules/components/abstract/control.ts
@@ -63,7 +63,7 @@ export abstract class AbstractExampleTuiControl
 
     public inputMode = this.inputModeVariants[0]!;
 
-    public maxLength: any = null;
+    public maxLength: unknown = null;
 
     public type = this.typeVariants[0]!;
 

--- a/projects/demo/src/modules/components/radio/examples/2/index.ts
+++ b/projects/demo/src/modules/components/radio/examples/2/index.ts
@@ -2,18 +2,22 @@ import {Component} from '@angular/core';
 import {FormsModule} from '@angular/forms';
 import {changeDetection} from '@demo/emulate/change-detection';
 import {encapsulation} from '@demo/emulate/encapsulation';
-import {TuiPlatform} from '@taiga-ui/cdk';
 import {TuiButton, TuiLabel} from '@taiga-ui/core';
 import {TuiRadio} from '@taiga-ui/kit';
 
+interface TestValue {
+    test: string;
+}
+
 @Component({
     standalone: true,
-    imports: [FormsModule, TuiButton, TuiLabel, TuiPlatform, TuiRadio],
+    imports: [FormsModule, TuiButton, TuiLabel, TuiRadio],
     templateUrl: './index.html',
     encapsulation,
     changeDetection,
 })
 export default class Example {
-    protected value: any = null;
-    protected identityMatcher = (a: any, b: any): boolean => a?.test === b?.test;
+    protected value: TestValue | null = null;
+    protected identityMatcher = (a: TestValue, b: TestValue): boolean =>
+        a?.test === b?.test;
 }

--- a/projects/demo/src/utils/component.pipe.ts
+++ b/projects/demo/src/utils/component.pipe.ts
@@ -11,7 +11,7 @@ import {toKebab} from './kebab.pipe';
 export class TuiComponentPipe implements PipeTransform {
     private readonly page = inject(TuiDocPage);
 
-    public async transform(index: number): Promise<{readonly default: any}> {
+    public async transform(index: number): Promise<{readonly default: unknown}> {
         return import(
             `../modules/${this.page.type}/${toKebab(this.page.header)}/examples/${index}/index.ts`
         );


### PR DESCRIPTION
If you really need to skip type checking, you can use something that Typescript 3.0 introduced: the unknown type. Unlike any, unknown is safer to use in the sense that before actually doing something with data of this type, we must do some sort of checking, whereas any has no restrictions.

https://dev.to/arikaturika/typescript-why-to-use-unknown-instead-of-any-41i8