### PR TITLE
feat(addon-doc): improve active zone for copy button

### DIFF
--- a/projects/addon-doc/components/code/index.html
+++ b/projects/addon-doc/components/code/index.html
@@ -12,8 +12,8 @@
     <div class="t-code-actions">
         <button type="button"
             tuiIconButton
-            appearance="icon"
-            size="xs"
+            appearance="whiteblock"
+            size="s"
             class="t-copy-button"
             [iconStart]="icon()"
             [cdkCopyToClipboard]="content"

--- a/projects/addon-doc/components/code/tests/code.component.spec.ts
+++ b/projects/addon-doc/components/code/tests/code.component.spec.ts
@@ -55,7 +55,7 @@ describe('TuiDocCodeComponent', () => {
         expect(fixture.nativeElement.querySelector('.t-code')?.innerHTML.trim()).toEqual(
             `<code class="hljs"><span class="hljs-keyword">const</span> a = <span class="hljs-number">5</span>;</code>
     <div class="t-code-actions">
-        <button tuiappearance="" tuiicons="" type="button" tuiiconbutton="" appearance="icon" size="xs" class="t-copy-button" data-appearance="icon" style="--t-icon-start: url(assets/taiga-ui/icons/copy.svg);" data-size="xs">
+        <button tuiappearance="" tuiicons="" type="button" tuiiconbutton="" appearance="whiteblock" size="s" class="t-copy-button" data-appearance="whiteblock" style="--t-icon-start: url(assets/taiga-ui/icons/copy.svg);" data-size="s">
         </button>
 \t
     </div>`.replace('\t', '        '), // prettier problem
@@ -71,7 +71,7 @@ describe('TuiDocCodeComponent', () => {
         expect(fixture.nativeElement.querySelector('.t-code')?.innerHTML.trim()).toEqual(
             `<code class="hljs"><span class="hljs-keyword">const</span> a = <span class="hljs-number">10</span>;</code>
     <div class="t-code-actions">
-        <button tuiappearance="" tuiicons="" type="button" tuiiconbutton="" appearance="icon" size="xs" class="t-copy-button" data-appearance="icon" style="--t-icon-start: url(assets/taiga-ui/icons/copy.svg);" data-size="xs">
+        <button tuiappearance="" tuiicons="" type="button" tuiiconbutton="" appearance="whiteblock" size="s" class="t-copy-button" data-appearance="whiteblock" style="--t-icon-start: url(assets/taiga-ui/icons/copy.svg);" data-size="s">
         </button>
 \t
     </div>`.replace('\t', '        '), // prettier problem
@@ -89,7 +89,7 @@ describe('TuiDocCodeComponent', () => {
         expect(fixture.nativeElement.querySelector('.t-code')?.innerHTML.trim()).toEqual(
             `<code class="hljs"><span class="hljs-keyword">const</span> a = <span class="hljs-number">15</span>;</code>
     <div class="t-code-actions">
-        <button tuiappearance="" tuiicons="" type="button" tuiiconbutton="" appearance="icon" size="xs" class="t-copy-button" data-appearance="icon" style="--t-icon-start: url(assets/taiga-ui/icons/copy.svg);" data-size="xs">
+        <button tuiappearance="" tuiicons="" type="button" tuiiconbutton="" appearance="whiteblock" size="s" class="t-copy-button" data-appearance="whiteblock" style="--t-icon-start: url(assets/taiga-ui/icons/copy.svg);" data-size="s">
         </button>
 \t
     </div>`.replace('\t', '        '), // prettier problem


### PR DESCRIPTION
### Before

<img width="854" alt="image" src="https://github.com/user-attachments/assets/32cca5d6-a095-4b3a-8e9f-f1be0a7faeb7">


### After

<img width="820" alt="image" src="https://github.com/user-attachments/assets/f2b95d16-fa20-4e8b-b409-0271d19aa462">
