### PR TITLE
fix(addon-commerce): `InputCardGroup` safari autofill focus

### DIFF
--- a/projects/addon-commerce/components/input-card-group/input-card-group.component.ts
+++ b/projects/addon-commerce/components/input-card-group/input-card-group.component.ts
@@ -152,7 +152,7 @@ export class TuiInputCardGroup
                   switchMap(() => timer(100)),
                   takeUntilDestroyed(),
               )
-              .subscribe(() => this.focusExpire())
+              .subscribe(() => (this.expire ? this.focusCVC() : this.focusExpire()))
         : EMPTY;
 
     protected readonly m = tuiAppearanceMode(this.mode);


### PR DESCRIPTION
Fixes #9410 
