### PR TITLE
chore: enable core team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,14 +1,1 @@
-
-# ==================================================================================
-# ==================================================================================
-#                            @taiga-ui codeowners
-# ==================================================================================
-# ==================================================================================
-#
-#  Configuration of code ownership and review approvals for the @taiga-ui repo.
-#
-#  More info: https://help.github.com/articles/about-codeowners/
-#
-
-* @waterplea @MarsiBarsi @vladimirpotekhin @nsbarsukov @mdlufy
-# will be requested for review when someone opens a pull request
+* @taiga-family/core-team


### PR DESCRIPTION
Github support can helped me figure it out, now it will work as it should

auto assignee

<img width="868" alt="image" src="https://github.com/user-attachments/assets/03b808c7-e614-4dc8-8576-720bfc805015">
