### PR TITLE
fix(legacy): `InputTime` has broken support of native date picker

### DIFF
--- a/projects/legacy/components/input-time/native-time/native-time.component.ts
+++ b/projects/legacy/components/input-time/native-time/native-time.component.ts
@@ -1,8 +1,7 @@
 import {ChangeDetectionStrategy, Component, inject} from '@angular/core';
 import {tuiInjectId} from '@taiga-ui/cdk/services';
-import {TUI_TEXTFIELD_HOST} from '@taiga-ui/legacy/tokens';
 
-import type {TuiInputTimeDirective} from '../input-time.directive';
+import {TuiInputTimeDirective} from '../input-time.directive';
 
 @Component({
     standalone: false,
@@ -32,7 +31,7 @@ import type {TuiInputTimeDirective} from '../input-time.directive';
     },
 })
 export class TuiNativeTimeComponent {
-    protected readonly host = inject<TuiInputTimeDirective>(TUI_TEXTFIELD_HOST);
+    protected readonly host = inject(TuiInputTimeDirective);
 
     protected readonly autoId = tuiInjectId();
 


### PR DESCRIPTION
### Reproduction 
Open https://taiga-ui.dev/next/components/input-time#native using any mobile device
<img width="1481" alt="bug-demo" src="https://github.com/user-attachments/assets/81e0a049-10e7-41f5-91ea-5b60bcbab148">

Also, there is error inside console:
```
ERROR TypeError: Cannot read properties of undefined (reading 'length')
    at get value (native-time.component.ts:46:58)
    at TuiNativeTimeComponent_HostBindings (native-time.component.ts:34:15)
    at processHostBindingOpCodes (core.mjs:11853:21)
    at refreshView (core.mjs:13544:9)
    at detectChangesInView (core.mjs:13663:9)
    at detectChangesInEmbeddedViews (core.mjs:13606:13)
    at refreshView (core.mjs:13522:9)
    at detectChangesInView (core.mjs:13663:9)
    at detectChangesInEmbeddedViews (core.mjs:13606:13)
    at refreshView (core.mjs:13522:9)
```

## Bug reasons 

https://github.com/taiga-family/taiga-ui/blob/968e4178dc21e030e443fefdddd91702a842292e/projects/legacy/components/input-time/input-time.template.html#L54-L65

is placed inside
https://github.com/taiga-family/taiga-ui/blob/968e4178dc21e030e443fefdddd91702a842292e/projects/legacy/components/input-time/input-time.template.html#L10

For the modern Angular it means that it inherits injector of `<tui-primitive-textfield  />`.
So, the `TEXTFIELD_HOST` for `[inputTime]`-directive is `TuiPrimitiveTextfieldDirective `
https://github.com/taiga-family/taiga-ui/blob/968e4178dc21e030e443fefdddd91702a842292e/projects/legacy/components/primitive-textfield/primitive-textfield.directive.ts#L11-L16

and **not** `TuiInputTimeDirective`
https://github.com/taiga-family/taiga-ui/blob/968e4178dc21e030e443fefdddd91702a842292e/projects/legacy/components/input-time/input-time.directive.ts#L8-L13