### PR TITLE
fix(cdk): support `:` inside path segment in  url

### DIFF
--- a/projects/cdk/utils/miscellaneous/is-valid-url.ts
+++ b/projects/cdk/utils/miscellaneous/is-valid-url.ts
@@ -6,7 +6,7 @@ export function tuiIsValidUrl(url: string): boolean {
         String.raw`^([a-zA-Z]+:\/\/)?` + // protocol
             String.raw`((([a-z\d]([a-z\d-]*[a-z\d])*)\.)+[a-z]{2,}|localhost|` + // domain name
             String.raw`((\d{1,3}\.){3}\d{1,3}))` + // OR IP (v4) address
-            String.raw`(\:\d+)?(\/[-a-z\d%_.~+]*)*` + // port and path
+            String.raw`(\:\d+)?(\/[-a-z\d%_.~+\:]*)*` + // port and path
             String.raw`(\?[)(;&a-z\d%_.~+=-]*)?` + // query string
             String.raw`(\#[-a-z\d_]*)?$`, // fragment locator
         'i',

--- a/projects/cdk/utils/miscellaneous/test/is-valid-url.spec.ts
+++ b/projects/cdk/utils/miscellaneous/test/is-valid-url.spec.ts
@@ -11,6 +11,7 @@ describe('tuiIsValidUrl', () => {
         expect(tuiIsValidUrl('127.0.0.1:8080')).toBe(true);
         expect(tuiIsValidUrl('localhost:3333')).toBe(true);
         expect(tuiIsValidUrl('ftp://ftp.example:21/')).toBe(true);
+        expect(tuiIsValidUrl('https://domain.com/path:some:schema:data:test')).toBe(true);
 
         expect(
             tuiIsValidUrl(


### PR DESCRIPTION
Fixes #9521
