### PR TITLE
chore(addon-mobile): improve StackBlitz support for `taiga-ui-mobile.less`

### DIFF
--- a/projects/addon-mobile/styles/taiga-ui-mobile.less
+++ b/projects/addon-mobile/styles/taiga-ui-mobile.less
@@ -1,10 +1,10 @@
-@import './common/search';
+@import './common/search.less';
 
 [data-platform='android'] {
-    @import './android/app-bar';
-    @import './android/checkbox';
-    @import './android/radio';
-    @import './android/switch';
+    @import './android/app-bar.less';
+    @import './android/checkbox.less';
+    @import './android/radio.less';
+    @import './android/switch.less';
 
     tui-badge-notification[data-size='l'] {
         --t-size: 1.375rem;
@@ -12,9 +12,9 @@
 }
 
 [data-platform='ios'] {
-    @import './ios/app-bar';
-    @import './ios/checkbox';
-    @import './ios/switch';
+    @import './ios/app-bar.less';
+    @import './ios/checkbox.less';
+    @import './ios/switch.less';
 
     tui-segmented > *:not(tui-segmented_active):active {
         background-color: var(--tui-background-neutral-1);
@@ -27,12 +27,12 @@
 
 [data-platform='android'],
 [data-platform='ios'] {
-    @import './common/badge';
-    @import './common/badge-notification';
+    @import './common/badge.less';
+    @import './common/badge-notification.less';
     @import './common/block-status';
-    @import './common/button';
-    @import './common/title';
-    @import './common/card-large';
-    @import './common/segmented';
-    @import './common/header';
+    @import './common/button.less';
+    @import './common/title.less';
+    @import './common/card-large.less';
+    @import './common/segmented.less';
+    @import './common/header.less';
 }

--- a/projects/addon-mobile/styles/taiga-ui-mobile.less
+++ b/projects/addon-mobile/styles/taiga-ui-mobile.less
@@ -29,7 +29,7 @@
 [data-platform='ios'] {
     @import './common/badge.less';
     @import './common/badge-notification.less';
-    @import './common/block-status';
+    @import './common/block-status.less';
     @import './common/button.less';
     @import './common/title.less';
     @import './common/card-large.less';


### PR DESCRIPTION
1. Open https://taiga-ui.dev/next/stackblitz
2. Add this line to `global_styles.less`:
```less
@import '@taiga-ui/addon-mobile/styles/taiga-ui-mobile.less';
```

It throws
```
Error in turbo_modules/@taiga-ui/addon-mobile@4.8.1-canary.852a9d9/styles/taiga-ui-mobile.less (35:4)
Could not import ./common/segmented from /~/src/global_styles.less
```