### PR TITLE
chore(addon-mobile): stackblitz error for import of `taiga-ui-mobile.less`

### DIFF
--- a/projects/addon-mobile/styles/taiga-ui-mobile.less
+++ b/projects/addon-mobile/styles/taiga-ui-mobile.less
@@ -1,10 +1,10 @@
-@import './common/search.less';
+@import 'common/search.less';
 
 [data-platform='android'] {
-    @import './android/app-bar.less';
-    @import './android/checkbox.less';
-    @import './android/radio.less';
-    @import './android/switch.less';
+    @import 'android/app-bar.less';
+    @import 'android/checkbox.less';
+    @import 'android/radio.less';
+    @import 'android/switch.less';
 
     tui-badge-notification[data-size='l'] {
         --t-size: 1.375rem;
@@ -12,9 +12,9 @@
 }
 
 [data-platform='ios'] {
-    @import './ios/app-bar.less';
-    @import './ios/checkbox.less';
-    @import './ios/switch.less';
+    @import 'ios/app-bar.less';
+    @import 'ios/checkbox.less';
+    @import 'ios/switch.less';
 
     tui-segmented > *:not(tui-segmented_active):active {
         background-color: var(--tui-background-neutral-1);
@@ -27,12 +27,12 @@
 
 [data-platform='android'],
 [data-platform='ios'] {
-    @import './common/badge.less';
-    @import './common/badge-notification.less';
-    @import './common/block-status.less';
-    @import './common/button.less';
-    @import './common/title.less';
-    @import './common/card-large.less';
-    @import './common/segmented.less';
-    @import './common/header.less';
+    @import 'common/badge.less';
+    @import 'common/badge-notification.less';
+    @import 'common/block-status.less';
+    @import 'common/button.less';
+    @import 'common/title.less';
+    @import 'common/card-large.less';
+    @import 'common/segmented.less';
+    @import 'common/header.less';
 }


### PR DESCRIPTION
### Reproduction
1. Open https://taiga-ui.dev/stackblitz
2. Add this line to `global_styles.less`:
    ```less
    @import '@taiga-ui/addon-mobile/styles/taiga-ui-mobile.less';
    ```

It throws:
```
Error in turbo_modules/@taiga-ui/addon-mobile@4.12.0/styles/taiga-ui-mobile.less (37:4)
Could not import ./common/header.less from /~/src/global_styles.less
```

### Why new import style can help ?
Actually, I am not sure. It is just an assumption.
It based on another file (it works in StackBlitz):
https://github.com/taiga-family/taiga-ui/blob/e659f788f71069d77cd9e3eb91ea53d085918840/projects/core/styles/taiga-ui-theme.less#L1-L5

Relates to:
* https://github.com/taiga-family/taiga-ui/pull/9557

