### PR TITLE
fix(addon-commerce): `ThumbnailCard` with blur effect should keep its initial border-radius

### DIFF
--- a/projects/addon-commerce/components/thumbnail-card/thumbnail-card.style.less
+++ b/projects/addon-commerce/components/thumbnail-card/thumbnail-card.style.less
@@ -13,6 +13,7 @@
         .fullsize();
 
         content: '';
+        border-radius: inherit;
     }
 
     &[data-size='s'] {


### PR DESCRIPTION
### Previous behavior
https://taiga-ui.dev/next/components/thumbnail-card#backgrounds

![taiga-ui dev_next_](https://github.com/user-attachments/assets/6d7029a4-a1ea-4dc6-a60a-4f202ede6ad7)

### New behavior
https://taiga-previews--pr9604-thumbnail-card-blur-41buasuc.web.app/components/thumbnail-card#backgrounds
![localhost_3333_components_thumbnail-card](https://github.com/user-attachments/assets/15d3b2ac-26d2-4cfb-978b-353811fbc063)

