### PR TITLE
fix(kit): `InputDate` hold initial value with min/max defined

### DIFF
--- a/projects/core/constants/regexp.ts
+++ b/projects/core/constants/regexp.ts
@@ -6,3 +6,4 @@ export const TUI_MASK_SYMBOLS_REGEXP = /[ \-_()]/g;
 export const TUI_LAST_PUNCTUATION_MARK_REGEXP = /[.,\\/#!$%\\^&\\*;:{}=\\-_`~()]$/;
 export const TUI_LATIN_REGEXP = /[A-z]/;
 export const TUI_LATIN_AND_NUMBERS_REGEXP = /[A-z|0-9]/;
+export const TUI_LETTER_REGEXP = /\p{L}/u;

--- a/projects/core/constants/regexp.ts
+++ b/projects/core/constants/regexp.ts
@@ -6,4 +6,3 @@ export const TUI_MASK_SYMBOLS_REGEXP = /[ \-_()]/g;
 export const TUI_LAST_PUNCTUATION_MARK_REGEXP = /[.,\\/#!$%\\^&\\*;:{}=\\-_`~()]$/;
 export const TUI_LATIN_REGEXP = /[A-z]/;
 export const TUI_LATIN_AND_NUMBERS_REGEXP = /[A-z|0-9]/;
-export const TUI_LETTER_REGEXP = /\p{L}/u;

--- a/projects/demo-cypress/tsconfig.json
+++ b/projects/demo-cypress/tsconfig.json
@@ -4,6 +4,6 @@
         "typeRoots": ["../../node_modules/@types", "../../node_modules/cypress/types", "../../scripts/types"],
         "types": ["cypress", "node", "cypress-real-events", "@testing-library/cypress", "ng-dev-mode"]
     },
-    "include": ["./cypress/**/*.ts"],
+    "include": ["**/*.ts"],
     "exclude": []
 }

--- a/projects/demo-playwright/tests/kit/input-date/input-date.spec.ts
+++ b/projects/demo-playwright/tests/kit/input-date/input-date.spec.ts
@@ -43,7 +43,9 @@ test.describe('InputDate', () => {
             await expect(inputDate.textfield).toHaveScreenshot('01-input-date.png');
         });
 
-        test('Click `Until today`', async ({page}) => {
+        test('Click `Until today`, calendar not switched to large date', async ({
+            page,
+        }) => {
             await tuiGoto(page, 'components/input-date/API?items$=1');
 
             await inputDate.textfield.click();
@@ -51,8 +53,38 @@ test.describe('InputDate', () => {
 
             await inputDate.textfield.click();
 
+            await expect(inputDate.textfield).toHaveValue('Until today');
             await expect(inputDate.calendar).toHaveScreenshot(
                 '02-input-date-calendar.png',
+            );
+        });
+
+        test('Press backspace to remove `Until today`, textfield is empty', async ({
+            page,
+        }) => {
+            await tuiGoto(page, 'components/input-date/API?items$=1');
+
+            await inputDate.textfield.click();
+            await calendar.itemButton.click();
+
+            await inputDate.textfield.focus();
+            await inputDate.textfield.press('Backspace');
+
+            await expect(inputDate.textfield).toHaveValue('');
+            await expect(inputDate.textfield).toHaveScreenshot(
+                '03-input-date-textfield-empty.png',
+            );
+        });
+
+        test('Enter item date, it converts to item date name', async ({page}) => {
+            await tuiGoto(page, 'components/input-date/API?items$=1');
+
+            await inputDate.textfield.focus();
+            await inputDate.textfield.fill('31.12.9998');
+
+            await expect(inputDate.textfield).toHaveValue('Until today');
+            await expect(inputDate.textfield).toHaveScreenshot(
+                '04-input-date-item-name.png',
             );
         });
     });

--- a/projects/kit/components/input-date/input-date.component.ts
+++ b/projects/kit/components/input-date/input-date.component.ts
@@ -14,7 +14,7 @@ import {
     ViewChild,
 } from '@angular/core';
 import {NgControl} from '@angular/forms';
-import {MASKITO_DEFAULT_OPTIONS, MaskitoOptions} from '@maskito/core';
+import {MaskitoOptions} from '@maskito/core';
 import {maskitoDateOptionsGenerator} from '@maskito/kit';
 import {
     AbstractTuiNullableControl,
@@ -217,22 +217,12 @@ export class TuiInputDateComponent
     }
 
     get computedMask(): MaskitoOptions {
-        /**
-         * TODO: we can delete this workaround in v4.0
-         * after solving this issue:
-         * https://github.com/taiga-family/maskito/issues/604
-         */
-        const nativeValueIsNotSynced =
-            this.textfield?.nativeFocusableElement?.value !== this.computedValue;
-
-        return this.activeItem || nativeValueIsNotSynced
-            ? MASKITO_DEFAULT_OPTIONS
-            : this.computeMaskOptions(
-                  this.dateFormat,
-                  this.dateSeparator,
-                  this.computedMin,
-                  this.computedMax,
-              );
+        return this.computeMaskOptions(
+            this.dateFormat,
+            this.dateSeparator,
+            this.computedMin,
+            this.computedMax,
+        );
     }
 
     get activeItem(): TuiNamedDay | null {

--- a/projects/kit/components/input-date/input-date.component.ts
+++ b/projects/kit/components/input-date/input-date.component.ts
@@ -14,7 +14,7 @@ import {
     ViewChild,
 } from '@angular/core';
 import {NgControl} from '@angular/forms';
-import {MaskitoOptions} from '@maskito/core';
+import {MASKITO_DEFAULT_OPTIONS, MaskitoOptions} from '@maskito/core';
 import {maskitoDateOptionsGenerator} from '@maskito/kit';
 import {
     AbstractTuiNullableControl,
@@ -42,6 +42,7 @@ import {
 import {
     TUI_DEFAULT_MARKER_HANDLER,
     TUI_DROPDOWN_COMPONENT,
+    TUI_LETTER_REGEXP,
     TUI_TEXTFIELD_SIZE,
     TuiMarkerHandler,
     TuiPrimitiveTextfieldComponent,
@@ -148,10 +149,28 @@ export class TuiInputDateComponent
     }
 
     get computedMin(): TuiDay {
+        /**
+         * TODO: we can delete this workaround in v4.0
+         * after solving this issue:
+         * https://github.com/taiga-family/maskito/issues/604
+         */
+        if (this.value && this.control?.pristine) {
+            return this.options.min;
+        }
+
         return this.min ?? this.options.min;
     }
 
     get computedMax(): TuiDay {
+        /**
+         * TODO: we can delete this workaround in v4.0
+         * after solving this issue:
+         * https://github.com/taiga-family/maskito/issues/604
+         */
+        if (this.value && this.control?.pristine) {
+            return this.options.max;
+        }
+
         return this.max ?? this.options.max;
     }
 
@@ -217,12 +236,21 @@ export class TuiInputDateComponent
     }
 
     get computedMask(): MaskitoOptions {
-        return this.computeMaskOptions(
-            this.dateFormat,
-            this.dateSeparator,
-            this.computedMin,
-            this.computedMax,
-        );
+        /**
+         * TODO: we can delete this workaround in v4.0
+         * after solving this issue:
+         * https://github.com/taiga-family/maskito/issues/604
+         */
+        const nativeValueIsNotSynced = this.nativeValue !== this.computedValue;
+
+        return this.activeItem || nativeValueIsNotSynced
+            ? MASKITO_DEFAULT_OPTIONS
+            : this.computeMaskOptions(
+                  this.dateFormat,
+                  this.dateSeparator,
+                  this.computedMin,
+                  this.computedMax,
+              );
     }
 
     get activeItem(): TuiNamedDay | null {
@@ -267,7 +295,7 @@ export class TuiInputDateComponent
         }
 
         this.value =
-            value.length !== DATE_FILLER_LENGTH
+            value.length !== DATE_FILLER_LENGTH || TUI_LETTER_REGEXP.test(value)
                 ? null
                 : TuiDay.normalizeParse(value, this.dateFormat);
     }

--- a/projects/kit/components/input-date/input-date.component.ts
+++ b/projects/kit/components/input-date/input-date.component.ts
@@ -44,7 +44,6 @@ import {
 import {
     TUI_DEFAULT_MARKER_HANDLER,
     TUI_DROPDOWN_COMPONENT,
-    TUI_LETTER_REGEXP,
     TUI_TEXTFIELD_SIZE,
     TuiMarkerHandler,
     TuiPrimitiveTextfieldComponent,
@@ -296,8 +295,12 @@ export class TuiInputDateComponent
             this.onOpenChange(true);
         }
 
+        if (this.activeItem) {
+            this.nativeValue = '';
+        }
+
         this.value =
-            value.length !== DATE_FILLER_LENGTH || TUI_LETTER_REGEXP.test(value)
+            value.length !== DATE_FILLER_LENGTH || this.activeItem
                 ? null
                 : TuiDay.normalizeParse(value, this.dateFormat);
     }

--- a/projects/kit/components/input-date/input-date.component.ts
+++ b/projects/kit/components/input-date/input-date.component.ts
@@ -24,7 +24,9 @@ import {
     DATE_FILLER_LENGTH,
     TUI_DATE_FORMAT,
     TUI_DATE_SEPARATOR,
+    TUI_FIRST_DAY,
     TUI_IS_MOBILE,
+    TUI_LAST_DAY,
     TUI_LAST_DISPLAYED_DAY,
     TuiActiveZoneDirective,
     tuiAsControl,
@@ -155,7 +157,7 @@ export class TuiInputDateComponent
          * https://github.com/taiga-family/maskito/issues/604
          */
         if (this.value && this.control?.pristine) {
-            return this.options.min;
+            return TUI_FIRST_DAY;
         }
 
         return this.min ?? this.options.min;
@@ -168,7 +170,7 @@ export class TuiInputDateComponent
          * https://github.com/taiga-family/maskito/issues/604
          */
         if (this.value && this.control?.pristine) {
-            return this.options.max;
+            return TUI_LAST_DAY;
         }
 
         return this.max ?? this.options.max;


### PR DESCRIPTION
Relates to #9582 

When textfield has initial control `value` (less than `min` or more than `max`), mask triggered and value transformed to min/max, what shouldn't be according to https://github.com/taiga-family/maskito/issues/1189#issuecomment-2394981669