### PR TITLE
fix(kit): `Stepper` fix flashing styles

### DIFF
--- a/projects/kit/components/stepper/stepper.component.ts
+++ b/projects/kit/components/stepper/stepper.component.ts
@@ -77,9 +77,11 @@ export class TuiStepperComponent {
     }
 
     public indexOf(step: HTMLElement): number {
-        return tuiGetOriginalArrayFromQueryList(this.steps).findIndex(
+        const index = tuiGetOriginalArrayFromQueryList(this.steps).findIndex(
             ({nativeElement}) => nativeElement === step,
         );
+
+        return index < 0 ? NaN : index;
     }
 
     public isActive(index: number): boolean {


### PR DESCRIPTION
Fixes #9632 

The first time, when the query list is empty yet, indexOf for all steps returns `-1`

<img width="351" alt="Снимок экрана 2024-10-30 в 10 58 07" src="https://github.com/user-attachments/assets/0ae6aec7-f96d-4e65-b34c-d918b4dd217c">

If we set `-1` to the `[activeItemIndex]` input of the stepper, it will cause the styles to flash since all steps are active for a millisecond.


https://github.com/user-attachments/assets/308f054e-abae-4457-8d02-18a0b1316cf6

