### PR TITLE
fix(legacy): `InputTime` has broken support of `<input tuiTextfieldLegacy />` projection

### DIFF
--- a/projects/demo/src/modules/components/input-time/examples/1/index.html
+++ b/projects/demo/src/modules/components/input-time/examples/1/index.html
@@ -9,9 +9,13 @@
         formControlName="testValue"
         tuiTextfieldSize="m"
         class="tui-space_top-2"
-        [tuiTextfieldLabelOutside]="true"
     >
-        Input time
+        I am a label
+
+        <input
+            placeholder="I am a placeholder"
+            tuiTextfieldLegacy
+        />
     </tui-input-time>
     <p>
         If field is not required, but you want to mark it invalid if user did not complete it, use

--- a/projects/demo/src/modules/components/input-time/examples/1/index.ts
+++ b/projects/demo/src/modules/components/input-time/examples/1/index.ts
@@ -5,6 +5,7 @@ import {encapsulation} from '@demo/emulate/encapsulation';
 import {TuiTime} from '@taiga-ui/cdk';
 import {
     TuiInputTimeModule,
+    TuiPrimitiveTextfieldModule,
     TuiTextfieldControllerModule,
     TuiUnfinishedValidator,
 } from '@taiga-ui/legacy';
@@ -14,6 +15,7 @@ import {
     imports: [
         ReactiveFormsModule,
         TuiInputTimeModule,
+        TuiPrimitiveTextfieldModule,
         TuiTextfieldControllerModule,
         TuiUnfinishedValidator,
     ],

--- a/projects/legacy/components/input-time/input-time.style.less
+++ b/projects/legacy/components/input-time/input-time.style.less
@@ -24,3 +24,7 @@
 .t-icon_small {
     border-width: 0.25rem;
 }
+
+tui-primitive-textfield input:not(:first-of-type) {
+    display: none;
+}

--- a/projects/legacy/components/input-time/input-time.template.html
+++ b/projects/legacy/components/input-time/input-time.template.html
@@ -25,6 +25,11 @@
         (valueChange)="onValueChange($event)"
     >
         <ng-content />
+        <ng-content
+            ngProjectAs="input"
+            select="input"
+        />
+        <!-- TODO: don't set it by default in a new version of this component -->
         <input
             inputmode="numeric"
             tuiTextfieldLegacy

--- a/projects/legacy/components/primitive-textfield/primitive-textfield.component.ts
+++ b/projects/legacy/components/primitive-textfield/primitive-textfield.component.ts
@@ -128,7 +128,7 @@ export class TuiPrimitiveTextfieldComponent
 
         const {nativeElement} = this.focusableElement;
 
-        return (nativeElement.previousElementSibling ||
+        return (nativeElement.parentElement?.firstElementChild ||
             nativeElement) as HTMLInputElement | null;
     }
 


### PR DESCRIPTION
### Bug description 

```html
<tui-input-time [formControl]="timeControl">
  InputTime
  <input tuiTextfieldLegacy placeholder="I'm placeholder" />
</tui-input-time>

<tui-input-date [formControl]="dateControl">
  InputDate
  <input tuiTextfieldLegacy placeholder="I'm placeholder" />
</tui-input-date>

<tui-input-date-range [formControl]="dateRangeControl">
  InputDateRange
  <input tuiTextfieldLegacy placeholder="I'm placeholder" />
</tui-input-date-range>
```
<img width="362" alt="bug-demo" src="https://github.com/user-attachments/assets/a0cd8f9c-1528-4330-b402-2c236dc983c3">

Explore more: https://stackblitz.com/edit/input-time-with-input-projection-bug?file=src%2Fapp%2Fapp.template.html

### Why ?
https://github.com/taiga-family/taiga-ui/blob/90fd608ab194a7617671e9e158a47a9615ca3709/projects/legacy/components/input-date/input-date.template.html#L27-L33

https://github.com/taiga-family/taiga-ui/blob/90fd608ab194a7617671e9e158a47a9615ca3709/projects/legacy/components/input-date-range/input-date-range.template.html#L27-L32

but

https://github.com/taiga-family/taiga-ui/blob/90fd608ab194a7617671e9e158a47a9615ca3709/projects/legacy/components/input-time/input-time.template.html#L26-L32
