### PR TITLE
fix(legacy): `InputDate` incorrect value after backspace

### DIFF
--- a/projects/cdk/constants/regexp.ts
+++ b/projects/cdk/constants/regexp.ts
@@ -1,3 +1,4 @@
 export const TUI_DIGIT_REGEXP = /\d/;
 export const TUI_NON_DIGIT_REGEXP = /\D/;
 export const TUI_NON_DIGITS_REGEXP = /\D+/g;
+export const TUI_LETTER_REGEXP = /\p{L}/u;

--- a/projects/cdk/constants/regexp.ts
+++ b/projects/cdk/constants/regexp.ts
@@ -1,4 +1,3 @@
 export const TUI_DIGIT_REGEXP = /\d/;
 export const TUI_NON_DIGIT_REGEXP = /\D/;
 export const TUI_NON_DIGITS_REGEXP = /\D+/g;
-export const TUI_LETTER_REGEXP = /\p{L}/u;

--- a/projects/demo-playwright/tests/legacy/input-date/input-date.spec.ts
+++ b/projects/demo-playwright/tests/legacy/input-date/input-date.spec.ts
@@ -181,17 +181,42 @@ test.describe('InputDate', () => {
             await expect(inputDate.textfield).toHaveScreenshot('10-input-date.png');
         });
 
-        test('Click `Until today`', async ({page}) => {
-            await tuiGoto(page, 'components/input-date/API?items$=1');
+        test('Click `Until today`, calendar not switched to large date', async ({
+            page,
+        }) => {
+            await tuiGoto(page, `${DemoRoute.InputDate}/API?items$=1`);
 
             await inputDate.textfield.click();
             await calendar.itemButton.click();
 
             await inputDate.textfield.click();
 
-            await expect(inputDate.calendar).toHaveScreenshot(
-                '02-input-date-calendar.png',
-            );
+            await expect(inputDate.calendar).toHaveScreenshot('11-input-date.png');
+        });
+
+        test('Press backspace to remove `Until today`, textfield is empty', async ({
+            page,
+        }) => {
+            await tuiGoto(page, `${DemoRoute.InputDate}/API?items$=1`);
+
+            await inputDate.textfield.click();
+            await calendar.itemButton.click();
+
+            await inputDate.textfield.focus();
+            await inputDate.textfield.press('Backspace');
+
+            await expect(inputDate.textfield).toHaveValue('');
+            await expect(inputDate.textfield).toHaveScreenshot('12-input-date.png');
+        });
+
+        test('Enter item date, it converts to item name', async ({page}) => {
+            await tuiGoto(page, `${DemoRoute.InputDate}/API?items$=1`);
+
+            await inputDate.textfield.focus();
+            await inputDate.textfield.fill('31.12.9998');
+
+            await expect(inputDate.textfield).toHaveValue('Until today');
+            await expect(inputDate.textfield).toHaveScreenshot('13-input-date.png');
         });
     });
 

--- a/projects/legacy/components/input-date/input-date.component.ts
+++ b/projects/legacy/components/input-date/input-date.component.ts
@@ -8,10 +8,10 @@ import {
 } from '@angular/core';
 import {takeUntilDestroyed} from '@angular/core/rxjs-interop';
 import type {MaskitoOptions} from '@maskito/core';
-import {MASKITO_DEFAULT_OPTIONS} from '@maskito/core';
+import {MASKITO_DEFAULT_OPTIONS, maskitoTransform} from '@maskito/core';
 import {maskitoDateOptionsGenerator} from '@maskito/kit';
 import {tuiAsControl} from '@taiga-ui/cdk/classes';
-import {TUI_FALSE_HANDLER} from '@taiga-ui/cdk/constants';
+import {TUI_FALSE_HANDLER, TUI_LETTER_REGEXP} from '@taiga-ui/cdk/constants';
 import type {TuiDateMode} from '@taiga-ui/cdk/date-time';
 import {
     DATE_FILLER_LENGTH,
@@ -174,9 +174,13 @@ export class TuiInputDateComponent
         }
 
         this.value =
-            value.length !== DATE_FILLER_LENGTH
+            value.length !== DATE_FILLER_LENGTH || TUI_LETTER_REGEXP.test(value)
                 ? null
                 : TuiDay.normalizeParse(value, this.dateFormat.mode);
+
+        if (TUI_LETTER_REGEXP.test(this.nativeValue)) {
+            this.nativeValue = maskitoTransform(this.nativeValue, this.computedMask);
+        }
     }
 
     public override setDisabledState(): void {

--- a/projects/legacy/components/input-date/input-date.component.ts
+++ b/projects/legacy/components/input-date/input-date.component.ts
@@ -11,7 +11,7 @@ import type {MaskitoOptions} from '@maskito/core';
 import {MASKITO_DEFAULT_OPTIONS} from '@maskito/core';
 import {maskitoDateOptionsGenerator} from '@maskito/kit';
 import {tuiAsControl} from '@taiga-ui/cdk/classes';
-import {TUI_FALSE_HANDLER, TUI_LETTER_REGEXP} from '@taiga-ui/cdk/constants';
+import {TUI_FALSE_HANDLER} from '@taiga-ui/cdk/constants';
 import type {TuiDateMode} from '@taiga-ui/cdk/date-time';
 import {
     DATE_FILLER_LENGTH,
@@ -173,14 +173,14 @@ export class TuiInputDateComponent
             this.onOpenChange(true);
         }
 
-        this.value =
-            value.length !== DATE_FILLER_LENGTH || TUI_LETTER_REGEXP.test(value)
-                ? null
-                : TuiDay.normalizeParse(value, this.dateFormat.mode);
-
-        if (TUI_LETTER_REGEXP.test(this.nativeValue)) {
+        if (this.activeItem) {
             this.nativeValue = '';
         }
+
+        this.value =
+            value.length !== DATE_FILLER_LENGTH || this.activeItem
+                ? null
+                : TuiDay.normalizeParse(value, this.dateFormat.mode);
     }
 
     public override setDisabledState(): void {

--- a/projects/legacy/components/input-date/input-date.component.ts
+++ b/projects/legacy/components/input-date/input-date.component.ts
@@ -8,7 +8,7 @@ import {
 } from '@angular/core';
 import {takeUntilDestroyed} from '@angular/core/rxjs-interop';
 import type {MaskitoOptions} from '@maskito/core';
-import {MASKITO_DEFAULT_OPTIONS, maskitoTransform} from '@maskito/core';
+import {MASKITO_DEFAULT_OPTIONS} from '@maskito/core';
 import {maskitoDateOptionsGenerator} from '@maskito/kit';
 import {tuiAsControl} from '@taiga-ui/cdk/classes';
 import {TUI_FALSE_HANDLER, TUI_LETTER_REGEXP} from '@taiga-ui/cdk/constants';
@@ -179,7 +179,7 @@ export class TuiInputDateComponent
                 : TuiDay.normalizeParse(value, this.dateFormat.mode);
 
         if (TUI_LETTER_REGEXP.test(this.nativeValue)) {
-            this.nativeValue = maskitoTransform(this.nativeValue, this.computedMask);
+            this.nativeValue = '';
         }
     }
 

--- a/projects/legacy/components/input-date/test/input-date.component.spec.ts
+++ b/projects/legacy/components/input-date/test/input-date.component.spec.ts
@@ -3,7 +3,7 @@ import {ChangeDetectionStrategy, Component, ViewChild} from '@angular/core';
 import type {ComponentFixture} from '@angular/core/testing';
 import {TestBed} from '@angular/core/testing';
 import {FormControl, ReactiveFormsModule} from '@angular/forms';
-import {TuiDay, TuiValueTransformer} from '@taiga-ui/cdk';
+import {TUI_LAST_DAY, TuiDay, TuiValueTransformer} from '@taiga-ui/cdk';
 import type {TuiSizeL, TuiSizeS} from '@taiga-ui/core';
 import {TUI_DATE_FORMAT, TuiHint, TuiRoot} from '@taiga-ui/core';
 import {NG_EVENT_PLUGINS} from '@taiga-ui/event-plugins';
@@ -13,6 +13,7 @@ import {
     TuiInputDateModule,
     TuiTextfieldControllerModule,
 } from '@taiga-ui/legacy';
+import {TuiNamedDay} from '@taiga-ui/legacy/classes';
 import {TuiNativeInputPO, TuiPageObject} from '@taiga-ui/testing';
 import {of} from 'rxjs';
 
@@ -30,12 +31,14 @@ describe('InputDate', () => {
             <tui-root>
                 <tui-input-date
                     [formControl]="control"
+                    [items]="items"
                     [min]="min"
                     [readOnly]="readOnly"
                     [tuiHintContent]="hintContent"
                     [tuiTextfieldCleaner]="cleaner"
                     [tuiTextfieldLabelOutside]="labelOutside"
                     [tuiTextfieldSize]="size"
+                    [(ngModel)]="value"
                 >
                     Select date
                 </tui-input-date>
@@ -56,6 +59,10 @@ describe('InputDate', () => {
         public min = new TuiDay(1900, 0, 1);
 
         public labelOutside = false;
+
+        public items: TuiNamedDay[] = [];
+
+        public value: TuiDay | null = new TuiDay(2017, 2, 1);
 
         public size: TuiSizeL | TuiSizeS = 'm';
 
@@ -181,6 +188,64 @@ describe('InputDate', () => {
                         });
                     });
                 });
+            });
+        });
+
+        describe('With items', () => {
+            beforeEach(() => {
+                testComponent.items = [
+                    new TuiNamedDay(
+                        new TuiDay(2017, 2, 1),
+                        'Current',
+                        TuiDay.currentLocal(),
+                    ),
+                    new TuiNamedDay(
+                        TUI_LAST_DAY.append({year: -1}),
+                        'Until today',
+                        TuiDay.currentLocal(),
+                    ),
+                ];
+            });
+
+            it('when entering item date, input shows named date', async () => {
+                inputPO.sendText('01.02.2017');
+
+                await fixture.whenStable();
+
+                expect(inputPO.value).toBe('Current');
+            });
+
+            it('when control value updated with item date, input shows named date', async () => {
+                testComponent.control.setValue(TUI_LAST_DAY.append({year: -1}));
+                fixture.detectChanges();
+
+                await fixture.whenStable();
+
+                expect(inputPO.value).toBe('Until today');
+            });
+
+            it('when ngModel value updated with item date, input shows named date', async () => {
+                testComponent.value = TUI_LAST_DAY.append({year: -1});
+                fixture.detectChanges();
+
+                await fixture.whenStable();
+
+                expect(inputPO.value).toBe('Until today');
+            });
+
+            it('when selected item date via calendar, input shows named date', async () => {
+                mouseDownOnTextfield();
+
+                expect(getCalendar()).not.toBeNull();
+
+                const calendarCell = getCalendarCell(1);
+
+                calendarCell?.nativeElement.click();
+
+                fixture.detectChanges();
+                await fixture.whenStable();
+
+                expect(inputPO.value).toBe('Current');
             });
         });
     });

--- a/projects/legacy/components/input-date/test/input-date.component.spec.ts
+++ b/projects/legacy/components/input-date/test/input-date.component.spec.ts
@@ -117,6 +117,14 @@ describe('InputDate', () => {
             expect(inputPO.value).toBe('14.03.2017');
         });
 
+        it('if there is min and an initial value and an initial value less than min - keep the initial value', () => {
+            testComponent.min = new TuiDay(2023, 5, 17);
+
+            fixture.detectChanges();
+
+            expect(inputPO.value).toBe('01.03.2017');
+        });
+
         describe('Keyboard input', () => {
             it('the passed date is inserted into the field', () => {
                 inputPO.sendText('01.03.2017');


### PR DESCRIPTION
When `value.length === DATE_FILLER_LENGTH (10)`, value may contain not only date string, but also letters string. 

```
this.value =
            value.length !== DATE_FILLER_LENGTH
                ? null
                : TuiDay.normalizeParse(value, this.dateFormat.mode);
```

This was not taken into account and as a result, an attempt was made to parse the date from the string and the value `01.01.0000` was obtained 


https://github.com/user-attachments/assets/92334503-3034-4294-b132-fc2bf195819c
