### PR TITLE
fix(kit): `Switch` should have dark knob for the dark theme in web platform

### DIFF
--- a/projects/kit/styles/components/switch.less
+++ b/projects/kit/styles/components/switch.less
@@ -43,7 +43,7 @@
 
         &::after {
             inline-size: 1rem;
-            box-shadow: -2.625rem 0 0 0.5rem currentColor;
+            box-shadow: -2.625rem 0 0 0.5rem var(--tui-background-base);
             outline-width: 0.167rem;
             transform: scale(0.375);
         }
@@ -89,7 +89,7 @@
         right: 0;
         border-radius: 100%;
         transform: scale(0.33333);
-        box-shadow: -4.5rem 0 0 0.75rem currentColor;
+        box-shadow: -4.5rem 0 0 0.75rem var(--tui-background-base);
         outline: 0.375rem solid var(--tui-background-neutral-2-pressed);
         outline-offset: var(--t-checked-icon, 20rem);
     }


### PR DESCRIPTION
### Previous behavior
<img width="360" alt="Снимок экрана 2024-11-01 в 12 24 45" src="https://github.com/user-attachments/assets/a1d77c6e-d910-4945-8bc5-6901488b6463">

### New behavior
<img width="360" alt="Снимок экрана 2024-11-01 в 12 27 37" src="https://github.com/user-attachments/assets/ed10cdb8-c96d-4a0f-af82-598a90d4ac86">

