### PR TITLE
fix(legacy): `InputDateRange` double backspace to clear textfield

### DIFF
--- a/projects/demo-playwright/tests/legacy/input-date-range/input-date-range.pw.spec.ts
+++ b/projects/demo-playwright/tests/legacy/input-date-range/input-date-range.pw.spec.ts
@@ -16,7 +16,6 @@ import {
     TuiInputDateRangePO,
     TuiMobileCalendarPO,
 } from '../../../utils';
-// import {TuiDay} from '@taiga-ui/cdk';
 
 test.describe('InputDateRange', () => {
     let inputDateRange!: TuiInputDateRangePO;
@@ -34,10 +33,6 @@ test.describe('InputDateRange', () => {
         let example!: Locator;
 
         let calendar!: TuiCalendarPO;
-
-        // let today = TuiDay.currentLocal();
-        let todayDate = `${new Date().toString()}-${new Date().toString()}`;
-        // const string = `${today.toString()}-${today.toString()}`;
 
         test.beforeEach(() => {
             example = documentationPage.apiPageExample;

--- a/projects/demo-playwright/tests/legacy/input-date-range/input-date-range.pw.spec.ts
+++ b/projects/demo-playwright/tests/legacy/input-date-range/input-date-range.pw.spec.ts
@@ -216,10 +216,10 @@ test.describe('InputDateRange', () => {
             await inputDateRange.textfield.focus();
             await inputDateRange.textfield.press('Backspace');
 
+            await expect(inputDateRange.textfield).toHaveValue('');
             await expect(inputDateRange.textfield).toHaveScreenshot(
                 '10-input-date-range.png',
             );
-            await expect(inputDateRange.textfield).toHaveValue('');
         });
 
         test('Enter item date, it converts to item name', async ({page}) => {
@@ -228,10 +228,10 @@ test.describe('InputDateRange', () => {
             await inputDateRange.textfield.focus();
             await inputDateRange.textfield.fill('25.09.2020 - 25.09.2020');
 
+            await expect(inputDateRange.textfield).toHaveValue('Today');
             await expect(inputDateRange.textfield).toHaveScreenshot(
                 '11-input-date-range.png',
             );
-            await expect(inputDateRange.textfield).toHaveValue('Today');
         });
 
         test.describe('Mobile emulation', () => {

--- a/projects/demo-playwright/tests/legacy/input-date-range/input-date-range.pw.spec.ts
+++ b/projects/demo-playwright/tests/legacy/input-date-range/input-date-range.pw.spec.ts
@@ -9,12 +9,14 @@ import {
 } from '../../../playwright.options';
 import {
     CHAR_NO_BREAK_SPACE,
+    TuiCalendarPO,
     TuiCalendarSheetPO,
     TuiDocumentationPagePO,
     tuiGoto,
     TuiInputDateRangePO,
     TuiMobileCalendarPO,
 } from '../../../utils';
+// import {TuiDay} from '@taiga-ui/cdk';
 
 test.describe('InputDateRange', () => {
     let inputDateRange!: TuiInputDateRangePO;
@@ -31,11 +33,20 @@ test.describe('InputDateRange', () => {
     test.describe('API', () => {
         let example!: Locator;
 
+        let calendar!: TuiCalendarPO;
+
+        // let today = TuiDay.currentLocal();
+        let todayDate = `${new Date().toString()}-${new Date().toString()}`;
+        // const string = `${today.toString()}-${today.toString()}`;
+
         test.beforeEach(() => {
             example = documentationPage.apiPageExample;
+
             inputDateRange = new TuiInputDateRangePO(
                 example.locator('tui-input-date-range'),
             );
+
+            calendar = new TuiCalendarPO(inputDateRange.calendar);
         });
 
         ['s', 'm', 'l'].forEach((size) => {
@@ -199,6 +210,33 @@ test.describe('InputDateRange', () => {
             await inputDateRange.textfield.click();
 
             await expect(example).toHaveScreenshot('09-calendar-shows-end-of-period.png');
+        });
+
+        test('Press backspace to remove item, textfield is empty', async ({page}) => {
+            await tuiGoto(page, `${DemoRoute.InputDateRange}/API?items$=1`);
+
+            await inputDateRange.textfield.click();
+            await calendar.itemButton.first().click();
+
+            await inputDateRange.textfield.focus();
+            await inputDateRange.textfield.press('Backspace');
+
+            await expect(inputDateRange.textfield).toHaveValue('');
+            await expect(inputDateRange.textfield).toHaveScreenshot(
+                '12-input-date-range.png',
+            );
+        });
+
+        test('Enter item date, it converts to item name', async ({page}) => {
+            await tuiGoto(page, `${DemoRoute.InputDateRange}/API?items$=1`);
+
+            await inputDateRange.textfield.focus();
+            await inputDateRange.textfield.fill('25.09.2020 - 25.09.2020');
+
+            await expect(inputDateRange.textfield).toHaveValue('Today');
+            await expect(inputDateRange.textfield).toHaveScreenshot(
+                '13-input-date-range.png',
+            );
         });
 
         test.describe('Mobile emulation', () => {

--- a/projects/demo-playwright/tests/legacy/input-date-range/input-date-range.pw.spec.ts
+++ b/projects/demo-playwright/tests/legacy/input-date-range/input-date-range.pw.spec.ts
@@ -50,7 +50,7 @@ test.describe('InputDateRange', () => {
             }) => {
                 await tuiGoto(
                     page,
-                    `components/input-date-range/API?tuiTextfieldSize=${size}`,
+                    `${DemoRoute.InputDateRange}/API?tuiTextfieldSize=${size}`,
                 );
 
                 await inputDateRange.textfield.click();
@@ -177,7 +177,7 @@ test.describe('InputDateRange', () => {
 
             await tuiGoto(
                 page,
-                'components/input-date-range/API?items$=1&sandboxExpanded=true',
+                `${DemoRoute.InputDateRange}/API?items$=1&sandboxExpanded=true`,
             );
 
             await inputDateRange.textfield.click();
@@ -197,7 +197,7 @@ test.describe('InputDateRange', () => {
         });
 
         test('Calendar shows end of period, when selected any range', async ({page}) => {
-            await tuiGoto(page, 'components/input-date-range/API?items$=1');
+            await tuiGoto(page, `${DemoRoute.InputDateRange}/API?items$=1`);
 
             await inputDateRange.textfield.click();
             await inputDateRange.selectItem(0);
@@ -218,7 +218,7 @@ test.describe('InputDateRange', () => {
 
             await expect(inputDateRange.textfield).toHaveValue('');
             await expect(inputDateRange.textfield).toHaveScreenshot(
-                '12-input-date-range.png',
+                '10-input-date-range.png',
             );
         });
 
@@ -230,7 +230,7 @@ test.describe('InputDateRange', () => {
 
             await expect(inputDateRange.textfield).toHaveValue('Today');
             await expect(inputDateRange.textfield).toHaveScreenshot(
-                '13-input-date-range.png',
+                '11-input-date-range.png',
             );
         });
 

--- a/projects/demo-playwright/tests/legacy/input-date-range/input-date-range.pw.spec.ts
+++ b/projects/demo-playwright/tests/legacy/input-date-range/input-date-range.pw.spec.ts
@@ -216,10 +216,10 @@ test.describe('InputDateRange', () => {
             await inputDateRange.textfield.focus();
             await inputDateRange.textfield.press('Backspace');
 
-            await expect(inputDateRange.textfield).toHaveValue('');
             await expect(inputDateRange.textfield).toHaveScreenshot(
                 '10-input-date-range.png',
             );
+            await expect(inputDateRange.textfield).toHaveValue('');
         });
 
         test('Enter item date, it converts to item name', async ({page}) => {
@@ -228,10 +228,10 @@ test.describe('InputDateRange', () => {
             await inputDateRange.textfield.focus();
             await inputDateRange.textfield.fill('25.09.2020 - 25.09.2020');
 
-            await expect(inputDateRange.textfield).toHaveValue('Today');
             await expect(inputDateRange.textfield).toHaveScreenshot(
                 '11-input-date-range.png',
             );
+            await expect(inputDateRange.textfield).toHaveValue('Today');
         });
 
         test.describe('Mobile emulation', () => {

--- a/projects/legacy/components/input-date-range/input-date-range.component.ts
+++ b/projects/legacy/components/input-date-range/input-date-range.component.ts
@@ -182,8 +182,12 @@ export class TuiInputDateRangeComponent
             this.onOpenChange(true);
         }
 
+        if (this.activePeriod) {
+            this.nativeValue = '';
+        }
+
         this.value =
-            value.length === DATE_RANGE_FILLER_LENGTH
+            value.length === DATE_RANGE_FILLER_LENGTH && !this.activePeriod
                 ? TuiDayRange.normalizeParse(value, this.dateFormat.mode)
                 : null;
 

--- a/projects/legacy/components/input-date-range/test/input-date-range.component.spec.ts
+++ b/projects/legacy/components/input-date-range/test/input-date-range.component.spec.ts
@@ -31,11 +31,11 @@ describe('InputDateRangeComponent', () => {
     @Component({
         standalone: true,
         imports: [
+            FormsModule,
             ReactiveFormsModule,
             TuiInputDateRangeModule,
             TuiRoot,
             TuiTextfieldControllerModule,
-            FormsModule,
         ],
         template: `
             <tui-root>

--- a/projects/legacy/components/input-date-range/test/input-date-range.component.spec.ts
+++ b/projects/legacy/components/input-date-range/test/input-date-range.component.spec.ts
@@ -2,7 +2,7 @@ import type {DebugElement, Type} from '@angular/core';
 import {ChangeDetectionStrategy, Component, Optional, ViewChild} from '@angular/core';
 import type {ComponentFixture} from '@angular/core/testing';
 import {TestBed} from '@angular/core/testing';
-import {FormControl, ReactiveFormsModule} from '@angular/forms';
+import {FormControl, FormsModule, ReactiveFormsModule} from '@angular/forms';
 import {By} from '@angular/platform-browser';
 import {
     RANGE_SEPARATOR_CHAR,
@@ -16,6 +16,7 @@ import {NG_EVENT_PLUGINS} from '@taiga-ui/event-plugins';
 import {
     TUI_DATE_RANGE_VALUE_TRANSFORMER,
     TUI_DATE_VALUE_TRANSFORMER,
+    tuiCreateDefaultDayRangePeriods,
     TuiDayRangePeriod,
 } from '@taiga-ui/kit';
 import {
@@ -34,6 +35,7 @@ describe('InputDateRangeComponent', () => {
             TuiInputDateRangeModule,
             TuiRoot,
             TuiTextfieldControllerModule,
+            FormsModule,
         ],
         template: `
             <tui-root>
@@ -44,6 +46,7 @@ describe('InputDateRangeComponent', () => {
                     [min]="min"
                     [readOnly]="readOnly"
                     [tuiTextfieldCleaner]="cleaner"
+                    [(ngModel)]="value"
                 ></tui-input-date-range>
             </tui-root>
         `,
@@ -59,6 +62,11 @@ describe('InputDateRangeComponent', () => {
                 TuiDay.currentLocal().append({day: -2}),
                 TuiDay.currentLocal().append({day: -2}),
             ),
+        );
+
+        public value: TuiDayRange | [Date, Date] | null = new TuiDayRange(
+            TuiDay.currentLocal().append({day: -2}),
+            TuiDay.currentLocal().append({day: -2}),
         );
 
         public cleaner = false;
@@ -200,6 +208,69 @@ describe('InputDateRangeComponent', () => {
                 fixture.detectChanges();
 
                 expect(component.open).toBe(true);
+            });
+        });
+
+        describe('With items', () => {
+            beforeEach(() => {
+                testComponent.items = tuiCreateDefaultDayRangePeriods();
+            });
+
+            it('when entering item date, input shows named date', async () => {
+                const today = TuiDay.currentLocal();
+
+                inputPO.sendText(
+                    `${today.toString()}${RANGE_SEPARATOR_CHAR}${today.toString()}`,
+                );
+
+                await fixture.whenStable();
+
+                expect(inputPO.value).toBe('Today');
+            });
+
+            it('when control value updated with item date, input shows named date', async () => {
+                const today = TuiDay.currentLocal();
+
+                testComponent.control.setValue(new TuiDayRange(today, today));
+                fixture.detectChanges();
+
+                await fixture.whenStable();
+
+                expect(inputPO.value).toBe('Today');
+            });
+
+            it('when ngModel value updated with item date, input shows named date', async () => {
+                const today = TuiDay.currentLocal();
+
+                testComponent.value = new TuiDayRange(today, today);
+                fixture.detectChanges();
+
+                await fixture.whenStable();
+
+                expect(inputPO.value).toBe('Today');
+            });
+
+            it('when selected item date via calendar, input shows named date', async () => {
+                inputPO.sendText('');
+
+                fixture.detectChanges();
+
+                const [leftCalendar] = getCalendars();
+
+                expect(leftCalendar).toBeTruthy();
+
+                if (leftCalendar) {
+                    getCalendarCell(
+                        leftCalendar,
+                        TuiDay.currentLocal().day,
+                    )?.nativeElement?.click();
+                }
+
+                fixture.detectChanges();
+
+                await fixture.whenStable();
+
+                expect(inputPO.value).toBe('Today');
             });
         });
     });


### PR DESCRIPTION
Fixes #7960 

After press backspace:
**Before (main) ← Diff → After (local)**
![image](https://github.com/user-attachments/assets/a5cbb878-b850-40b9-ad65-b774deda6a50)

