### PR TITLE
fix(layout): tui-block-status remove margins for empty t-block-image

### DIFF
--- a/projects/layout/components/block-status/block-status.style.less
+++ b/projects/layout/components/block-status/block-status.style.less
@@ -22,13 +22,13 @@ tui-block-status {
         tui-root._mobile & {
             padding: 1.25rem;
 
-            & .t-block-image {
+            & .t-block-image:not(:empty) {
                 margin-top: 0.75rem;
             }
         }
     }
 
-    .t-block-image {
+    .t-block-image:not(:empty) {
         margin-bottom: 2rem;
 
         tui-root._mobile & {


### PR DESCRIPTION
Removed useless margin for empty t-block-image
Fix UIKIT-7696