### PR TITLE
chore(demo-playwright): improve stability of `tabs.pw.spec.ts` for proprietary repo

### DIFF
--- a/projects/demo-playwright/tests/kit/tabs/tabs.pw.spec.ts
+++ b/projects/demo-playwright/tests/kit/tabs/tabs.pw.spec.ts
@@ -63,7 +63,7 @@ describe('Tabs', () => {
             test('shows only a single dropdown for the nested item (with [tuiDropdown]) inside more section', async ({
                 page,
             }) => {
-                await page.setViewportSize({width: 600, height: 700});
+                await page.setViewportSize({width: 550, height: 700});
 
                 await expect(tabsPO.more).toBeVisible();
 


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/6b4d49f0-a0b6-46fd-9e5f-365f155ab626)

But

<img width="533" alt="Снимок экрана 2024-11-13 в 12 47 11" src="https://github.com/user-attachments/assets/a3cb925c-1247-40d6-9de6-d2da5042f4a1">


