### PR TITLE
fix(legacy): add `styles` entrypoint to `exports` of `package.json`

### DIFF
--- a/projects/legacy/package.json
+++ b/projects/legacy/package.json
@@ -10,6 +10,9 @@
     "homepage": "https://github.com/taiga-family/taiga-ui",
     "repository": "https://github.com/taiga-family/taiga-ui",
     "license": "Apache-2.0",
+    "exports": {
+        "./styles/*": "./styles/*"
+    },
     "peerDependencies": {
         "@angular/core": ">=16.0.0",
         "tslib": ">=2.8.1"


### PR DESCRIPTION
The same logic as inside `@taiga-ui/core`

https://github.com/taiga-family/taiga-ui/blob/dc916bc9a5e6efe81b9943e6d075cf6220ef4a81/projects/core/package.json#L17-L19