### PR TITLE
chore(demo-cypress): hide caret for screenshot component testing

### DIFF
--- a/projects/demo-cypress/src/support/component-index.html
+++ b/projects/demo-cypress/src/support/component-index.html
@@ -15,7 +15,7 @@
     <body>
         <div
             data-cy-root
-            style="padding: 1rem"
+            style="padding: 1rem; caret-color: transparent"
         ></div>
     </body>
 </html>


### PR DESCRIPTION
## Previous behavior

**textfield.cy.ts-[filler]-initial-value_2.png:**
![textfield cy ts- filler -initial-value_2](https://github.com/user-attachments/assets/1e0da8aa-32c4-414c-a007-dd7cd0cb0f58)

## New behavior

**textfield.cy.ts-[filler]-initial-value_2.png:**
![textfield cy ts- filler -initial-value_2](https://github.com/user-attachments/assets/831224fb-7cc4-4f19-8e2d-35da517fd7cd)

