### PR TITLE
fix(kit): `CalendarRange` should not require extra click to start new range after same day range

### DIFF
--- a/projects/addon-mobile/components/mobile-calendar-dropdown/mobile-calendar-dropdown.component.ts
+++ b/projects/addon-mobile/components/mobile-calendar-dropdown/mobile-calendar-dropdown.component.ts
@@ -66,7 +66,8 @@ export class TuiMobileCalendarDropdown {
     protected readonly range = this.is('tui-input-date-range');
     protected readonly multi = this.data.multi || this.is('tui-input-date[multiple]');
     protected readonly single =
-        this.data.single || this.is('tui-input-date:not([multiple])');
+        this.data.single || // TODO(v5): use `rangeMode` from DI token `TUI_CALENDAR_SHEET_DEFAULT_OPTIONS`
+        this.is('tui-input-date:not([multiple])');
 
     constructor() {
         this.keyboard.hide();

--- a/projects/addon-mobile/components/mobile-calendar/mobile-calendar.component.ts
+++ b/projects/addon-mobile/components/mobile-calendar/mobile-calendar.component.ts
@@ -37,6 +37,7 @@ import {TuiMapperPipe} from '@taiga-ui/cdk/pipes/mapper';
 import {TUI_IS_E2E, TUI_IS_IOS} from '@taiga-ui/cdk/tokens';
 import type {TuiBooleanHandler, TuiMapper} from '@taiga-ui/cdk/types';
 import {TuiButton} from '@taiga-ui/core/components/button';
+import {TUI_CALENDAR_SHEET_OPTIONS} from '@taiga-ui/core/components/calendar';
 import {TuiLink} from '@taiga-ui/core/components/link';
 import {TuiMonthPipe} from '@taiga-ui/core/pipes/month';
 import {TuiOrderWeekDaysPipe} from '@taiga-ui/core/pipes/order-week-days';
@@ -153,8 +154,15 @@ export class TuiMobileCalendar implements AfterViewInit {
             ),
     );
 
+    /**
+     * @deprecated use static DI options instead
+     * ```
+     * tuiCalendarSheetOptionsProvider({rangeMode: boolean})
+     * ```
+     * TODO(v5): delete it
+     */
     @Input()
-    public single = true;
+    public single = !inject(TUI_CALENDAR_SHEET_OPTIONS).rangeMode;
 
     @Input()
     public multi = false;
@@ -180,7 +188,7 @@ export class TuiMobileCalendar implements AfterViewInit {
     public readonly valueChange = this.value$.pipe(
         skip(1),
         distinctUntilChanged((a, b) => a?.toString() === b?.toString()),
-        takeUntilDestroyed(),
+        map((x) => (!this.single && x instanceof TuiDay ? new TuiDayRange(x, x) : x)),
     );
 
     constructor() {
@@ -245,10 +253,8 @@ export class TuiMobileCalendar implements AfterViewInit {
             this.value = tuiToggleDay(this.value, day);
         } else if (this.value instanceof TuiDay) {
             this.value = TuiDayRange.sort(this.value, day);
-        } else if (this.value instanceof TuiDayRange && !this.value.isSingleDay) {
-            this.value = day;
         } else if (this.value instanceof TuiDayRange) {
-            this.value = TuiDayRange.sort(this.value.from, day);
+            this.value = day;
         } else if (!this.value) {
             this.value = day;
         }

--- a/projects/addon-mobile/components/mobile-calendar/mobile-calendar.template.html
+++ b/projects/addon-mobile/components/mobile-calendar/mobile-calendar.template.html
@@ -84,6 +84,7 @@
             class="t-calendar"
             [disabledItemHandler]="disabledItemHandler | tuiMapper: disabledItemHandlerMapper : min : max"
             [month]="month"
+            [single]="single"
             [value]="value"
             (dayClick)="onDayClick($event)"
         />

--- a/projects/cdk/date-time/day-range.ts
+++ b/projects/cdk/date-time/day-range.ts
@@ -102,4 +102,19 @@ export class TuiDayRange extends TuiMonthRange {
     ): string {
         return this.getFormattedDayRange(dateFormat, dateSeparator);
     }
+
+    public toArray(): readonly TuiDay[] {
+        const {from, to} = this;
+        const arr = [];
+
+        for (
+            const day = from.toUtcNativeDate();
+            day <= to.toUtcNativeDate();
+            day.setDate(day.getDate() + 1)
+        ) {
+            arr.push(TuiDay.fromLocalNativeDate(day));
+        }
+
+        return arr;
+    }
 }

--- a/projects/cdk/date-time/test/day-range.spec.ts
+++ b/projects/cdk/date-time/test/day-range.spec.ts
@@ -183,6 +183,24 @@ describe('TuiDayRange', () => {
         });
     });
 
+    describe('toArray', () => {
+        it('returns array with all dates between `from` and `to` (including `from` and `to` day)', () => {
+            const range = new TuiDayRange(
+                new TuiDay(2024, 11, 29),
+                new TuiDay(2025, 0, 3),
+            );
+
+            expect(range.toArray()).toEqual([
+                new TuiDay(2024, 11, 29),
+                new TuiDay(2024, 11, 30),
+                new TuiDay(2024, 11, 31),
+                new TuiDay(2025, 0, 1),
+                new TuiDay(2025, 0, 2),
+                new TuiDay(2025, 0, 3),
+            ]);
+        });
+    });
+
     describe('dayLimit', () => {
         it('limits from one side if the other is null', () => {
             const y2000m0d1 = new TuiDay(2000, 0, 1);

--- a/projects/core/components/calendar/calendar-sheet.component.ts
+++ b/projects/core/components/calendar/calendar-sheet.component.ts
@@ -18,6 +18,8 @@ import {tuiNullableSame, tuiPure} from '@taiga-ui/cdk/utils/miscellaneous';
 import {TuiCalendarSheetPipe, TuiOrderWeekDaysPipe} from '@taiga-ui/core/pipes';
 import {TUI_DAY_TYPE_HANDLER, TUI_SHORT_WEEK_DAYS} from '@taiga-ui/core/tokens';
 
+import {TUI_CALENDAR_SHEET_OPTIONS} from './calendar-sheet.options';
+
 export type TuiMarkerHandler = TuiHandler<TuiDay, [] | [string, string] | [string]>;
 
 @Component({
@@ -36,10 +38,11 @@ export type TuiMarkerHandler = TuiHandler<TuiDay, [] | [string, string] | [strin
     styleUrls: ['./calendar-sheet.style.less'],
     changeDetection: ChangeDetectionStrategy.OnPush,
     host: {
-        '[class._picking]': 'isSingleDayRange',
+        '[class._picking]': 'isRangePicking',
     },
 })
 export class TuiCalendarSheet {
+    private readonly options = inject(TUI_CALENDAR_SHEET_OPTIONS);
     private readonly today = TuiDay.currentLocal();
 
     protected readonly unorderedWeekDays$ = inject(TUI_SHORT_WEEK_DAYS);
@@ -63,12 +66,25 @@ export class TuiCalendarSheet {
     @Input()
     public showAdjacent = true;
 
+    /**
+     * @deprecated use static DI options instead
+     * ```
+     * tuiCalendarSheetOptionsProvider({rangeMode: true})
+     * ```
+     * TODO(v5): delete it
+     */
+    @Input()
+    public single = true;
+
     @Output()
     public readonly hoveredItemChange = new EventEmitter<TuiDay | null>();
 
     @Output()
     public readonly dayClick = new EventEmitter<TuiDay>();
 
+    /**
+     * @deprecated TODO(v5): delete it. It is used nowhere except unit tests
+     */
     public itemIsInterval(day: TuiDay): boolean {
         const {value, hoveredItem} = this;
 
@@ -96,17 +112,25 @@ export class TuiCalendarSheet {
     public getItemRange(item: TuiDay): 'active' | 'end' | 'middle' | 'start' | null {
         const {value, hoveredItem} = this;
 
-        if (value instanceof TuiDay) {
+        if (!value) {
+            return null;
+        }
+
+        if (value instanceof TuiDay && !this.computedRangeMode) {
             return value.daySame(item) ? 'active' : null;
         }
 
-        if (!value || !(value instanceof TuiDayRange)) {
-            return value?.find((day) => day.daySame(item)) ? 'active' : null;
+        if (value instanceof TuiDayRange && value.isSingleDay) {
+            return value.from.daySame(item) ? 'active' : null;
+        }
+
+        if (!(value instanceof TuiDay) && !(value instanceof TuiDayRange)) {
+            return value.find((day) => day.daySame(item)) ? 'active' : null;
         }
 
         const range = this.getRange(value, hoveredItem);
 
-        if (value.isSingleDay && range.isSingleDay && value.from.daySame(item)) {
+        if (range.isSingleDay && range.from.daySame(item)) {
             return 'active';
         }
 
@@ -121,8 +145,18 @@ export class TuiCalendarSheet {
         return range.from.dayBefore(item) && range.to.dayAfter(item) ? 'middle' : null;
     }
 
-    protected get isSingleDayRange(): boolean {
-        return this.value instanceof TuiDayRange && this.value.isSingleDay;
+    protected get computedRangeMode(): boolean {
+        return !this.single || this.options.rangeMode;
+    }
+
+    protected get isRangePicking(): boolean {
+        return this.computedRangeMode
+            ? this.value instanceof TuiDay
+            : /**
+               * Only for backward compatibility!
+               * TODO(v5): replace with `this.options.rangeMode && this.value instanceof TuiDay`
+               */
+              this.value instanceof TuiDayRange && this.value.isSingleDay;
     }
 
     protected readonly toMarkers = (
@@ -157,7 +191,14 @@ export class TuiCalendarSheet {
     }
 
     @tuiPure
-    private getRange(value: TuiDayRange, hoveredItem: TuiDay | null): TuiDayRange {
+    private getRange(
+        value: TuiDay | TuiDayRange,
+        hoveredItem: TuiDay | null,
+    ): TuiDayRange {
+        if (value instanceof TuiDay) {
+            return TuiDayRange.sort(value, hoveredItem ?? value);
+        }
+
         return value.isSingleDay
             ? TuiDayRange.sort(value.from, hoveredItem ?? value.to)
             : value;
@@ -173,20 +214,10 @@ export class TuiCalendarSheet {
     }
 
     private rangeHasDisabledDay(item: TuiDay): boolean {
-        if (this.value instanceof TuiDayRange) {
-            const range = this.getRange(this.value, item);
-
-            for (
-                const day = range.from.toUtcNativeDate();
-                day <= range.to.toUtcNativeDate();
-                day.setDate(day.getDate() + 1)
-            ) {
-                const tuiDay = TuiDay.fromLocalNativeDate(day);
-
-                if (this.disabledItemHandler(tuiDay)) {
-                    return true;
-                }
-            }
+        if (this.isRangePicking && this.value instanceof TuiDay) {
+            return this.getRange(this.value, item)
+                .toArray()
+                .some((x) => this.disabledItemHandler(x));
         }
 
         return false;

--- a/projects/core/components/calendar/calendar-sheet.options.ts
+++ b/projects/core/components/calendar/calendar-sheet.options.ts
@@ -1,0 +1,24 @@
+import type {Provider} from '@angular/core';
+import {tuiCreateToken, tuiProvideOptions} from '@taiga-ui/cdk/utils/miscellaneous';
+
+export interface TuiCalendarSheetOptions {
+    readonly rangeMode: boolean;
+}
+
+export const TUI_CALENDAR_SHEET_DEFAULT_OPTIONS: TuiCalendarSheetOptions = {
+    rangeMode: false,
+};
+
+export const TUI_CALENDAR_SHEET_OPTIONS = tuiCreateToken(
+    TUI_CALENDAR_SHEET_DEFAULT_OPTIONS,
+);
+
+export function tuiCalendarSheetOptionsProvider(
+    options: Partial<TuiCalendarSheetOptions>,
+): Provider {
+    return tuiProvideOptions(
+        TUI_CALENDAR_SHEET_OPTIONS,
+        options,
+        TUI_CALENDAR_SHEET_DEFAULT_OPTIONS,
+    );
+}

--- a/projects/core/components/calendar/index.ts
+++ b/projects/core/components/calendar/index.ts
@@ -1,4 +1,5 @@
 export * from './calendar.component';
 export * from './calendar-sheet.component';
+export * from './calendar-sheet.options';
 export * from './calendar-spin.component';
 export * from './calendar-year.component';

--- a/projects/demo-playwright/tests/kit/calendar-range/calendar-range.pw.spec.ts
+++ b/projects/demo-playwright/tests/kit/calendar-range/calendar-range.pw.spec.ts
@@ -7,7 +7,10 @@ import {
 import type {Locator} from '@playwright/test';
 import {expect, test} from '@playwright/test';
 
-test.describe('CalendarRange', () => {
+const {describe, beforeEach} = test;
+
+describe('CalendarRange', () => {
+    const today = new Date(2020, 8, 25);
     let example!: Locator;
     let calendarRange!: TuiCalendarRangePO;
     let documentationPage!: TuiDocumentationPagePO;
@@ -16,24 +19,22 @@ test.describe('CalendarRange', () => {
         viewport: {width: 650, height: 650},
     });
 
-    test.beforeEach(async ({page}) => {
-        await tuiGoto(page, DemoRoute.CalendarRange, {
-            date: new Date(2020, 8, 25),
-        });
-
+    beforeEach(({page}) => {
         documentationPage = new TuiDocumentationPagePO(page);
-        example = documentationPage.apiPageExample;
-
-        calendarRange = new TuiCalendarRangePO(example.locator('tui-calendar-range'));
     });
 
-    test.describe('Examples', () => {
+    describe('Examples', () => {
+        beforeEach(async ({page}) => {
+            await tuiGoto(page, DemoRoute.CalendarRange, {
+                date: today,
+            });
+        });
+
         test('With another range switcher', async () => {
             example = documentationPage.getExample('#with-another-range-switcher');
             calendarRange = new TuiCalendarRangePO(example.locator('tui-calendar-range'));
 
-            const getRangeSwitcher = (): Locator =>
-                example.locator('p button[data-appearance="action"]');
+            const resetButton = example.locator('p button[data-appearance="action"]');
 
             await expect(example).toHaveScreenshot(
                 '05-calendar-range-correct-display-defaults-items-and-values-1.png',
@@ -46,36 +47,33 @@ test.describe('CalendarRange', () => {
                 '05-calendar-range-correct-display-range-switcher-after-select-week.png',
             );
 
-            await getRangeSwitcher().click();
+            await resetButton.click();
 
             await expect(example).toHaveScreenshot(
                 '05-calendar-range-correct-display-items-and-values-after-click-on-month-range-switcher.png',
             );
 
-            await getRangeSwitcher().click();
+            await resetButton.click();
 
             await expect(example).toHaveScreenshot(
                 '05-calendar-range-correct-display-items-and-values-after-click-on-quarter-range-switcher.png',
             );
 
-            await getRangeSwitcher().click();
+            await resetButton.click();
 
             await expect(example).toHaveScreenshot(
                 '05-calendar-range-correct-display-defaults-items-and-values-2.png',
             );
         });
 
-        test.describe('With value', () => {
+        describe('With value', () => {
             test('Month switching via chevron', async ({page}) => {
                 example = documentationPage.getExample('#with-value');
                 calendarRange = new TuiCalendarRangePO(
                     example.locator('tui-calendar-range'),
                 );
 
-                const getPreviousMonthChevron = (): Locator =>
-                    example.locator('tui-spin-button > button').first();
-
-                await getPreviousMonthChevron().click();
+                await calendarRange.previousMonth.click();
 
                 await page.mouse.click(100, 100); // clear focus
 
@@ -86,7 +84,18 @@ test.describe('CalendarRange', () => {
         });
     });
 
-    test.describe('API', () => {
+    describe('API', () => {
+        beforeEach(async ({page}) => {
+            await tuiGoto(page, DemoRoute.CalendarRange, {
+                date: today,
+            });
+
+            documentationPage = new TuiDocumentationPagePO(page);
+            example = documentationPage.apiPageExample;
+
+            calendarRange = new TuiCalendarRangePO(example.locator('tui-calendar-range'));
+        });
+
         test('Maximum month when items not empty', async ({page}) => {
             await tuiGoto(page, `${DemoRoute.CalendarRange}/API?items$=1&max$=4`);
 
@@ -118,6 +127,90 @@ test.describe('CalendarRange', () => {
             await page.mouse.click(100, 100); // clear focus
 
             await expect(example).toHaveScreenshot('08-disabled-dates-5-click-to.png');
+        });
+
+        describe('Selecting range consisting of the same start/end date', () => {
+            let alert!: Locator;
+
+            beforeEach(({page}) => {
+                alert = page.locator('tui-alerts tui-notification');
+            });
+
+            test('double click on the same day - selects single-day range', async ({
+                page,
+            }) => {
+                await tuiGoto(page, `${DemoRoute.CalendarRange}/API`);
+
+                const [calendarSheet] = await calendarRange
+                    .getCalendars()
+                    .then(async ([x]) => x.getCalendarSheets());
+
+                await calendarSheet.clickOnDay(15);
+
+                await expect(alert).not.toBeAttached();
+
+                await calendarSheet.clickOnDay(15);
+
+                await expect(alert).toContainText(
+                    '{from: {year: 2020, month: 8, day: 15}, to: {year: 2020, month: 8, day: 15}}',
+                );
+                await expect(example).toHaveScreenshot(
+                    '07-double-click-on-the-same-day.png',
+                );
+            });
+
+            test('allows to select new range start after double click on the same day', async ({
+                page,
+            }) => {
+                await tuiGoto(page, `${DemoRoute.CalendarRange}/API`);
+
+                const [calendarSheet] = await calendarRange
+                    .getCalendars()
+                    .then(async ([x]) => x.getCalendarSheets());
+
+                await calendarSheet.clickOnDay(15);
+                await calendarSheet.clickOnDay(15);
+
+                await calendarSheet.clickOnDay(22);
+
+                await expect(alert).not.toBeAttached();
+
+                await calendarSheet.clickOnDay(25);
+
+                await expect(alert).toContainText(
+                    '{from: {year: 2020, month: 8, day: 22}, to: {year: 2020, month: 8, day: 25}}',
+                );
+                await expect(example).toHaveScreenshot(
+                    '08-new-range-after-double-click-on-the-same-day.png',
+                );
+            });
+
+            test('no highlighting hover effect after double click on the same day', async ({
+                page,
+            }) => {
+                await tuiGoto(page, `${DemoRoute.CalendarRange}/API`);
+
+                const [calendarSheet] = await calendarRange
+                    .getCalendars()
+                    .then(async ([x]) => x.getCalendarSheets());
+
+                await calendarSheet.clickOnDay(15);
+                await calendarSheet.getCalendarDay(20).then(async (x) => x!.hover());
+
+                await expect(example).toHaveScreenshot('09-1-has-hover-effect.png');
+
+                await calendarSheet.clickOnDay(15);
+
+                await calendarSheet.getCalendarDay(22).then(async (x) => x!.hover());
+
+                await expect(example).toHaveScreenshot('09-2-no-hover-effect.png');
+
+                await calendarSheet.clickOnDay(22);
+
+                await calendarSheet.getCalendarDay(25).then(async (x) => x!.hover());
+
+                await expect(example).toHaveScreenshot('09-3-has-hover-effect.png');
+            });
         });
     });
 });

--- a/projects/demo-playwright/tests/legacy/input-date-range/input-date-range.pw.spec.ts
+++ b/projects/demo-playwright/tests/legacy/input-date-range/input-date-range.pw.spec.ts
@@ -13,7 +13,9 @@ import {
     TuiMobileCalendarPO,
 } from '../../../utils';
 
-test.describe('InputDateRange', () => {
+const {describe, beforeEach} = test;
+
+describe('InputDateRange', () => {
     let inputDateRange!: TuiInputDateRangePO;
     let documentationPage!: TuiDocumentationPagePO;
 
@@ -21,16 +23,16 @@ test.describe('InputDateRange', () => {
         viewport: {width: 650, height: 650},
     });
 
-    test.beforeEach(({page}) => {
+    beforeEach(({page}) => {
         documentationPage = new TuiDocumentationPagePO(page);
     });
 
-    test.describe('API', () => {
+    describe('API', () => {
         let example!: Locator;
 
         let calendar!: TuiCalendarPO;
 
-        test.beforeEach(() => {
+        beforeEach(() => {
             example = documentationPage.apiPageExample;
 
             inputDateRange = new TuiInputDateRangePO(
@@ -120,7 +122,7 @@ test.describe('InputDateRange', () => {
             );
         });
 
-        test.describe('prevents changes if you enter an invalid date', () => {
+        describe('prevents changes if you enter an invalid date', () => {
             test('day > 31', async ({page}) => {
                 await tuiGoto(page, `${DemoRoute.InputDateRange}/API`);
 
@@ -183,6 +185,7 @@ test.describe('InputDateRange', () => {
 
             await inputDateRange.textfield.click();
             await calendarSheet.clickOnDay(21);
+            await calendarSheet.clickOnDay(25);
 
             await expect(inputDateRange.textfield).toHaveValue(
                 `21.09.2020${CHAR_NO_BREAK_SPACE}–${CHAR_NO_BREAK_SPACE}25.09.2020`,
@@ -230,12 +233,12 @@ test.describe('InputDateRange', () => {
             );
         });
 
-        test.describe('Mobile emulation', () => {
+        describe('Mobile emulation', () => {
             test.use(TUI_PLAYWRIGHT_MOBILE);
 
             let mobileCalendar!: TuiMobileCalendarPO;
 
-            test.beforeEach(() => {
+            beforeEach(() => {
                 mobileCalendar = new TuiMobileCalendarPO(inputDateRange.calendar);
             });
 
@@ -255,10 +258,108 @@ test.describe('InputDateRange', () => {
                 );
             });
         });
+
+        describe('Selecting range consisting of the same start/end date', () => {
+            test('double click on the same day - selects single-day range', async ({
+                page,
+            }) => {
+                await tuiGoto(page, `${DemoRoute.InputDateRange}/API`);
+
+                await inputDateRange.textfield.click();
+
+                const calendarSheet = new TuiCalendarSheetPO(
+                    inputDateRange.calendar.locator('tui-calendar-sheet'),
+                );
+
+                await calendarSheet.clickOnDay(15);
+
+                await expect(inputDateRange.textfield).toHaveValue('');
+
+                await calendarSheet.clickOnDay(15);
+
+                await expect(inputDateRange.textfield).toHaveValue(
+                    '15.09.2020 – 15.09.2020',
+                );
+            });
+
+            test('allows to select new range start after double click on the same day', async ({
+                page,
+            }) => {
+                await tuiGoto(page, `${DemoRoute.InputDateRange}/API`);
+
+                await inputDateRange.textfield.click();
+
+                const calendarSheet = new TuiCalendarSheetPO(
+                    inputDateRange.calendar.locator('tui-calendar-sheet'),
+                );
+
+                await calendarSheet.clickOnDay(15);
+                await calendarSheet.clickOnDay(15);
+
+                await expect(inputDateRange.calendar).not.toBeAttached();
+
+                await inputDateRange.textfield.click();
+
+                await expect(inputDateRange.calendar).toBeAttached();
+
+                await calendarSheet.clickOnDay(22);
+
+                await expect(inputDateRange.textfield).toHaveValue(
+                    '15.09.2020 – 15.09.2020',
+                );
+
+                await calendarSheet.clickOnDay(25);
+
+                await expect(inputDateRange.textfield).toHaveValue(
+                    '22.09.2020 – 25.09.2020',
+                );
+            });
+
+            test('no highlighting hover effect after double click on the same day', async ({
+                page,
+            }) => {
+                await tuiGoto(page, `${DemoRoute.InputDateRange}/API`);
+
+                await inputDateRange.textfield.click();
+
+                const calendarSheet = new TuiCalendarSheetPO(
+                    inputDateRange.calendar.locator('tui-calendar-sheet'),
+                );
+
+                await calendarSheet.clickOnDay(15);
+                await calendarSheet.getCalendarDay(20).then(async (x) => x!.hover());
+
+                await expect(inputDateRange.calendar).toHaveScreenshot(
+                    '12-1-has-hover-effect.png',
+                );
+
+                await calendarSheet.clickOnDay(15);
+
+                await expect(inputDateRange.textfield).toHaveValue(
+                    '15.09.2020 – 15.09.2020',
+                );
+                await expect(inputDateRange.calendar).not.toBeAttached();
+
+                await inputDateRange.textfield.click();
+                await calendarSheet.getCalendarDay(22).then(async (x) => x!.hover());
+
+                await expect(inputDateRange.calendar).toHaveScreenshot(
+                    '12-2-no-hover-effect.png',
+                );
+
+                await calendarSheet.clickOnDay(22);
+
+                await calendarSheet.getCalendarDay(25).then(async (x) => x!.hover());
+
+                await expect(inputDateRange.calendar).toHaveScreenshot(
+                    '12-3-has-hover-effect.png',
+                );
+            });
+        });
     });
 
-    test.describe('Examples', () => {
-        test.beforeEach(async ({page}) => {
+    describe('Examples', () => {
+        beforeEach(async ({page}) => {
             await tuiGoto(page, DemoRoute.InputDateRange);
         });
 

--- a/projects/demo-playwright/utils/page-objects/calendar-range.po.ts
+++ b/projects/demo-playwright/utils/page-objects/calendar-range.po.ts
@@ -1,8 +1,28 @@
 import type {Locator} from '@playwright/test';
 import {expect} from '@playwright/test';
 
+import {TuiCalendarPO} from './calendar.po';
+
 export class TuiCalendarRangePO {
+    public previousMonth = this.host
+        .locator('tui-calendar-spin tui-spin-button > button')
+        .first();
+
+    public nextMonth = this.host
+        .locator('tui-calendar-spin tui-spin-button > button')
+        .last();
+
     constructor(private readonly host: Locator) {}
+
+    public async getCalendars(): Promise<
+        [TuiCalendarPO, TuiCalendarPO] | [TuiCalendarPO]
+    > {
+        const calendars = await this.host.locator('tui-calendar').all();
+
+        return calendars.map((x) => new TuiCalendarPO(x)) as
+            | [TuiCalendarPO, TuiCalendarPO]
+            | [TuiCalendarPO];
+    }
 
     public async getItems(): Promise<Locator[]> {
         const dataList = this.host.locator('[automation-id="tui-calendar-range__menu"]');

--- a/projects/demo-playwright/utils/page-objects/calendar-sheet.po.ts
+++ b/projects/demo-playwright/utils/page-objects/calendar-sheet.po.ts
@@ -11,15 +11,21 @@ export class TuiCalendarSheetPO {
             .all();
     }
 
-    public async clickOnDay(day: number): Promise<void> {
+    public async getCalendarDay(day: number): Promise<Locator | null> {
         const cells = await this.getDays();
 
         for (const cell of cells) {
             if ((await cell.textContent())?.trim() === day.toString()) {
-                await cell.click();
-
-                break;
+                return cell;
             }
         }
+
+        return null;
+    }
+
+    public async clickOnDay(day: number): Promise<void> {
+        const element = await this.getCalendarDay(day);
+
+        return element!.click();
     }
 }

--- a/projects/demo-playwright/utils/page-objects/calendar.po.ts
+++ b/projects/demo-playwright/utils/page-objects/calendar.po.ts
@@ -9,12 +9,17 @@ export class TuiCalendarPO {
 
     constructor(private readonly host: Locator) {}
 
-    public async getCalendarSheets(): Promise<TuiCalendarSheetPO[]> {
+    public async getCalendarSheets(): Promise<
+        [TuiCalendarSheetPO, ...TuiCalendarSheetPO[]]
+    > {
         const locators = await this.host
             .page()
             .locator('tui-calendar-sheet, tui-mobile-calendar-sheet')
             .all();
 
-        return locators.map((x) => new TuiCalendarSheetPO(x));
+        return locators.map((x) => new TuiCalendarSheetPO(x)) as [
+            TuiCalendarSheetPO,
+            ...TuiCalendarSheetPO[],
+        ];
     }
 }

--- a/projects/demo/src/modules/components/mobile-calendar/examples/2/index.html
+++ b/projects/demo/src/modules/components/mobile-calendar/examples/2/index.html
@@ -2,6 +2,5 @@
     <tui-mobile-calendar
         [max]="max"
         [min]="min"
-        [single]="false"
     />
 </div>

--- a/projects/demo/src/modules/components/mobile-calendar/examples/2/index.ts
+++ b/projects/demo/src/modules/components/mobile-calendar/examples/2/index.ts
@@ -3,6 +3,7 @@ import {changeDetection} from '@demo/emulate/change-detection';
 import {encapsulation} from '@demo/emulate/encapsulation';
 import {TuiMobileCalendar} from '@taiga-ui/addon-mobile';
 import {TuiDay} from '@taiga-ui/cdk';
+import {tuiCalendarSheetOptionsProvider} from '@taiga-ui/core';
 
 @Component({
     standalone: true,
@@ -11,6 +12,7 @@ import {TuiDay} from '@taiga-ui/cdk';
     styleUrls: ['./index.less'],
     encapsulation,
     changeDetection,
+    providers: [tuiCalendarSheetOptionsProvider({rangeMode: true})],
 })
 export default class Example {
     protected min = new TuiDay(new Date().getFullYear(), new Date().getMonth(), 1);

--- a/projects/demo/src/modules/components/mobile-calendar/examples/import/template.md
+++ b/projects/demo/src/modules/components/mobile-calendar/examples/import/template.md
@@ -2,7 +2,6 @@
 <tui-mobile-calendar
   [min]="min"
   [max]="max"
-  [single]="false"
   [disabledItemHandler]="disabledItemHandler"
 ></tui-mobile-calendar>
 ```

--- a/projects/demo/src/modules/components/mobile-calendar/index.html
+++ b/projects/demo/src/modules/components/mobile-calendar/index.html
@@ -123,14 +123,6 @@
             </ng-template>
             <ng-template
                 documentationPropertyMode="input"
-                documentationPropertyName="single"
-                documentationPropertyType="boolean"
-                [(documentationPropertyValue)]="single"
-            >
-                Single date or a range
-            </ng-template>
-            <ng-template
-                documentationPropertyMode="input"
                 documentationPropertyName="multi"
                 documentationPropertyType="boolean"
                 [(documentationPropertyValue)]="multi"
@@ -152,6 +144,21 @@
                 documentationPropertyType="TuiDayRange | TuiDay"
             >
                 "Confirm" button clicked
+            </ng-template>
+            <ng-template
+                documentationPropertyMode="input"
+                documentationPropertyName="single"
+                documentationPropertyType="boolean"
+                [documentationPropertyDeprecated]="true"
+                [(documentationPropertyValue)]="single"
+            >
+                Single date or a range
+
+                <p>
+                    Use
+                    <code>tuiCalendarSheetOptionsProvider(&#123;rangeMode: boolean"&#125;)</code>
+                    instead
+                </p>
             </ng-template>
         </tui-doc-documentation>
     </ng-template>

--- a/projects/demo/src/modules/components/mobile-calendar/index.less
+++ b/projects/demo/src/modules/components/mobile-calendar/index.less
@@ -1,3 +1,3 @@
 .calendar {
-    block-size: 28.75rem;
+    block-size: min(28.75rem, 60vh);
 }

--- a/projects/kit/components/calendar-range/calculate-disabled-item-handler.ts
+++ b/projects/kit/components/calendar-range/calculate-disabled-item-handler.ts
@@ -1,20 +1,21 @@
-import type {TuiDay, TuiDayLike, TuiDayRange} from '@taiga-ui/cdk/date-time';
+import type {TuiDay, TuiDayLike} from '@taiga-ui/cdk/date-time';
+import {TuiDayRange} from '@taiga-ui/cdk/date-time';
 import type {TuiBooleanHandler} from '@taiga-ui/cdk/types';
 
 export const calculateDisabledItemHandler: (
     disabledItemHandler: TuiBooleanHandler<TuiDay>,
-    value: TuiDayRange | null,
+    value: TuiDay | TuiDayRange | null,
     minLength: TuiDayLike | null,
 ) => TuiBooleanHandler<TuiDay> = (disabledItemHandler, value, minLength) => (item) => {
-    if (!value?.isSingleDay || !minLength) {
+    if (!value || value instanceof TuiDayRange || !minLength) {
         return disabledItemHandler(item);
     }
 
     const negativeMinLength = Object.fromEntries(
         Object.entries(minLength).map(([key, value]) => [key, -value]),
     );
-    const disabledBefore = value.from.append(negativeMinLength).append({day: 1});
-    const disabledAfter = value.from.append(minLength).append({day: -1});
+    const disabledBefore = value.append(negativeMinLength).append({day: 1});
+    const disabledAfter = value.append(minLength).append({day: -1});
     const inDisabledRange =
         disabledBefore.dayBefore(item) && disabledAfter.dayAfter(item);
 

--- a/projects/kit/components/calendar-range/day-caps-mapper.ts
+++ b/projects/kit/components/calendar-range/day-caps-mapper.ts
@@ -1,12 +1,12 @@
-import type {TuiDay, TuiDayLike, TuiDayRange} from '@taiga-ui/cdk/date-time';
-import {TUI_FIRST_DAY, TUI_LAST_DAY} from '@taiga-ui/cdk/date-time';
+import type {TuiDayLike, TuiDayRange} from '@taiga-ui/cdk/date-time';
+import {TUI_FIRST_DAY, TUI_LAST_DAY, TuiDay} from '@taiga-ui/cdk/date-time';
 import type {TuiMapper} from '@taiga-ui/cdk/types';
 
 export const TUI_DAY_CAPS_MAPPER: TuiMapper<
-    [TuiDay | null, TuiDayRange | null, TuiDayLike | null, boolean],
+    [TuiDay | null, TuiDay | TuiDayRange | null, TuiDayLike | null, boolean],
     TuiDay
 > = (current, value, maxLength, backwards) => {
-    if (!value?.isSingleDay || !maxLength) {
+    if (value instanceof TuiDay || !value?.isSingleDay || !maxLength) {
         return backwards ? current || TUI_FIRST_DAY : current || TUI_LAST_DAY;
     }
 


### PR DESCRIPTION
Fixes #7550

### Problem 
Low-level component `TuiCalendarSheet` decides if user completes selection of range period or not:
https://github.com/taiga-family/taiga-ui/blob/031f55054aec8f856f61f37461d7690ef1aaca99/projects/core/components/calendar/calendar-sheet.component.ts#L38-L39
https://github.com/taiga-family/taiga-ui/blob/031f55054aec8f856f61f37461d7690ef1aaca99/projects/core/components/calendar/calendar-sheet.component.ts#L124-L125

`TuiCalendarSheet` is dumb and does not have any internal state – it only depends on input property `this.value` 
https://github.com/taiga-family/taiga-ui/blob/031f55054aec8f856f61f37461d7690ef1aaca99/projects/core/components/calendar/calendar-sheet.component.ts#L57-L58
and emits output event `dayClick` on any day click
https://github.com/taiga-family/taiga-ui/blob/031f55054aec8f856f61f37461d7690ef1aaca99/projects/core/components/calendar/calendar-sheet.component.ts#L69-L70

However, at the present time (if `TuiCalendarSheet` is used inside `CalendarRange`) `this.value` is always `TuiDayRange | null` (higher-level component `CalendarRange` always sends only the such kinds of value). So, **it is impossible to distinguish if `this.value` with same day period** (e.g. `TuiDayRange(today, today)`) **is finished selection of range period** (it happens if user clicks twice on the same day) **or it is just an intermediate value for incomplete selection**.

### Could we just listen to `click` event inside `TuiCalendarSheet` to solve issue?
No. `CalendarRange` includes two `TuiCalendarSheet`-s. User can start selection on the 1st sheet and finish it on the second one. I am not sure that different instances of `TuiCalendarSheet` should "communicate" between each others.

### New proposed approach
Don't use `TuiDayRange(sameDay, sameDay)` for incomplete date range.
Incomplete date range – `TuiDay`.
Complete date range with the same day (user clicks twice on the same day) – `TuiDayRange`.

So, `CalendarRange` / `MobileCalendar[single=true]` can pass `TuiDay` inside `TuiCalendarSheet` to indicate incomplete range selection.