### PR TITLE
fix(core): `Dropdown` fix initial width

### DIFF
--- a/projects/core/directives/dropdown/dropdown.style.less
+++ b/projects/core/directives/dropdown/dropdown.style.less
@@ -27,6 +27,7 @@
 .t-scroll {
     flex-grow: 1;
     max-inline-size: 100%;
+    inline-size: max-content;
     overscroll-behavior: none;
 }
 

--- a/projects/demo-playwright/tests/core/dropdown/dropdown.pw.spec.ts
+++ b/projects/demo-playwright/tests/core/dropdown/dropdown.pw.spec.ts
@@ -55,6 +55,16 @@ test.describe('Dropdown', () => {
         await expect(page).toHaveScreenshot('05-dropdown.png');
     });
 
+    test('Hosted dropdown initial width', async ({page}) => {
+        await tuiGoto(page, DemoRoute.Viewport);
+        const example = new TuiDocumentationPagePO(page).getExample('#portal');
+
+        await example.scrollIntoViewIfNeeded();
+        await example.locator('.t2').click({force: true});
+
+        await expect(page).toHaveScreenshot('13-dropdown.png');
+    });
+
     test('Esc -> Hosted Dropdown', async ({page}) => {
         await tuiGoto(page, DemoRoute.DropdownOpen);
         const example = new TuiDocumentationPagePO(page).getExample('#tui-dropdown-host');


### PR DESCRIPTION
Fixes #9683

el.getBoundingClientRect() returns wrong initial width

https://github.com/taiga-family/taiga-ui/blob/a28e79b34814f312ad1ef8398ebe5070e0120ed5/projects/core/services/position.service.ts#L25

 because of this `left` is not calculated correctly 