### PR TITLE
chore: make StackBlitz great again for `v3` documentation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18329,7 +18329,7 @@
             "license": "BSD-2-Clause"
         },
         "node_modules/dompurify": {
-            "version": "3.1.6",
+            "version": "3.1.7",
             "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.1.6.tgz",
             "integrity": "sha512-cTOAhc36AalkjtBpfG6O8JimdTMWNXjiePT2xQH/ppBGi/4uIpmj8eKyIkMJErXWARyINV/sB38yf8JCLF5pbQ==",
             "license": "(MPL-2.0 OR Apache-2.0)"
@@ -44025,7 +44025,7 @@
                 "@tinkoff/angular-contenteditable-accessor": "^2.0.0",
                 "@tinkoff/ng-dompurify": "^4.0.0",
                 "date-fns": "^2.30.0",
-                "dompurify": "^3.1.6",
+                "dompurify": "3.1.7",
                 "ngx-markdown": "^10.1.1"
             },
             "devDependencies": {

--- a/projects/demo/package.json
+++ b/projects/demo/package.json
@@ -8,7 +8,7 @@
         "@tinkoff/angular-contenteditable-accessor": "^2.0.0",
         "@tinkoff/ng-dompurify": "^4.0.0",
         "date-fns": "^2.30.0",
-        "dompurify": "^3.1.6",
+        "dompurify": "3.1.7",
         "ngx-markdown": "^10.1.1"
     },
     "devDependencies": {


### PR DESCRIPTION
Open https://taiga-ui.dev/v3/stackblitz

It throws:
```
Error in turbo_modules/dompurify@3.2.2/dist/purify.cjs.d.ts (434:15)
',' expected.
```

Relates:
* https://github.com/taiga-family/ng-dompurify/pull/596