### PR TITLE
fix(core): `Input` with `DataList` never shows dropdown after its 1st closing

### DIFF
--- a/projects/core/components/hosted-dropdown/dropdown-open-monitor.directive.ts
+++ b/projects/core/components/hosted-dropdown/dropdown-open-monitor.directive.ts
@@ -14,15 +14,12 @@ export class TuiDropdownOpenMonitorDirective {
     @Input()
     set tuiDropdownOpenMonitor(open: boolean) {
         this.open?.update(open);
-        this.hosted.updateOpen(open);
     }
 
     constructor(
         @Self() @Inject(TuiDestroyService) destroy$: Observable<unknown>,
         @Inject(TUI_HOSTED_DROPDOWN_COMPONENT)
-        private readonly hosted: TuiInjectionTokenType<
-            typeof TUI_HOSTED_DROPDOWN_COMPONENT
-        >,
+        readonly hosted: TuiInjectionTokenType<typeof TUI_HOSTED_DROPDOWN_COMPONENT>,
         @Self() @Inject(TuiDropdownDirective) dropdown: TuiDropdownDirective,
         @Optional()
         @Inject(TuiDropdownOpenDirective)

--- a/projects/core/components/hosted-dropdown/dropdown-open-monitor.directive.ts
+++ b/projects/core/components/hosted-dropdown/dropdown-open-monitor.directive.ts
@@ -19,7 +19,7 @@ export class TuiDropdownOpenMonitorDirective {
     constructor(
         @Self() @Inject(TuiDestroyService) destroy$: Observable<unknown>,
         @Inject(TUI_HOSTED_DROPDOWN_COMPONENT)
-        readonly hosted: TuiInjectionTokenType<typeof TUI_HOSTED_DROPDOWN_COMPONENT>,
+        hosted: TuiInjectionTokenType<typeof TUI_HOSTED_DROPDOWN_COMPONENT>,
         @Self() @Inject(TuiDropdownDirective) dropdown: TuiDropdownDirective,
         @Optional()
         @Inject(TuiDropdownOpenDirective)


### PR DESCRIPTION
Fixes #9666

### Reproduction 1
1. Open https://taiga-ui.dev/v3
2. Focus search textfield 
3. Enter `acc`
4. Press Backspace
5. Type `c` again

**Expected behavior**: dropdown is shown
**Actual behavior**: you will never see dropdown again

### Reproduction 2

```ts
import { Component } from '@angular/core';
import { FormControl } from '@angular/forms';

@Component({
  selector: `my-app`,
  template: `
    <tui-root>
      <tui-input [formControl]="control">
        Enter 3 characters

        <ng-container *ngIf="control.value.length > 2">
          <tui-data-list *tuiDataList> Blah blah </tui-data-list>
        </ng-container>
      </tui-input>
    </tui-root>
  `,
})
export class AppComponent {
  readonly control = new FormControl('');
}
```

1. Enter any 3 characters
7. Press Backspace
8. Insert any number of additional characters

**Expected behavior**: dropdown is shown
**Actual behavior**: you will never see dropdown again

Explore more:
https://stackblitz.com/edit/input-with-datalist-v3-bug?file=src%2Fapp%2Fapp.component.ts

<div id="reasons"></div>
<br />
<br />

## Why bug happens ?
Everything starts from here:
https://github.com/taiga-family/taiga-ui/blob/7c746b6e9afba48d682d7e4bd236d5437297aa49/projects/kit/components/input/input.template.html#L1-L5

https://github.com/taiga-family/taiga-ui/blob/7c746b6e9afba48d682d7e4bd236d5437297aa49/projects/kit/components/input/input.component.ts#L108-L110

It means that every keystroke opens dropdown.
This method decides should it can it be opened or not
https://github.com/taiga-family/taiga-ui/blob/7c746b6e9afba48d682d7e4bd236d5437297aa49/projects/kit/components/input/input.component.ts#L104-L105

Then props drilling finishes here:
https://github.com/taiga-family/taiga-ui/blob/ab05df0e20c4ab03e100807ecd15908513ea8fa0/projects/core/components/hosted-dropdown/hosted-dropdown.template.html#L7-L8

https://github.com/taiga-family/taiga-ui/blob/7c746b6e9afba48d682d7e4bd236d5437297aa49/projects/core/components/hosted-dropdown/dropdown-open-monitor.directive.ts#L15-L17

`DropdownOpenMonitor` should not update its host (host is controlled outside inside `HostedDropdown` codebase).
`DropdownOpenMonitor` should only update external `DropdownOpen` (if host decides to close dropdown) or vice versa.

**Are there any other solutions ?**
We could listen to `openChange` here and call `this.cdr.detectChanges` on any **UPSTREAM** data-flow (`[open]` should be recalculated after view updates are already finished).
https://github.com/taiga-family/taiga-ui/blob/7c746b6e9afba48d682d7e4bd236d5437297aa49/projects/kit/components/input/input.template.html#L5

It is dangerous solution because it can cause `ExpressionChangedAfterItHasBeenCheckedError`.