### PR TITLE
feat(legacy): limit `tui-tag` width to `80%` to avoid wrapping in selects

### DIFF
--- a/projects/demo/src/modules/components/multi-select/examples/1/index.ts
+++ b/projects/demo/src/modules/components/multi-select/examples/1/index.ts
@@ -9,7 +9,7 @@ import {TuiDataListWrapper} from '@taiga-ui/kit';
 import {TuiMultiSelectModule, TuiTextfieldControllerModule} from '@taiga-ui/legacy';
 
 const ITEMS: readonly string[] = [
-    'Luke Skywalker',
+    'Luke Skywalker and a long time ago in a galaxy far, far away..',
     'Leia Organa Solo',
     'Darth Vader',
     'Han Solo',

--- a/projects/demo/src/modules/pipes/filter-by-input/examples/3/index.ts
+++ b/projects/demo/src/modules/pipes/filter-by-input/examples/3/index.ts
@@ -20,7 +20,7 @@ import {TuiMultiSelectModule, TuiTextfieldControllerModule} from '@taiga-ui/lega
 })
 export default class Example {
     protected readonly items = [
-        'Luke Skywalker',
+        'Luke Skywalker and a long time ago in a galaxy far, far away..',
         'Leia Organa Solo',
         'Darth Vader',
         'Han Solo',

--- a/projects/legacy/components/input-tag/input-tag.style.less
+++ b/projects/legacy/components/input-tag/input-tag.style.less
@@ -82,6 +82,10 @@
     :host[data-size='l']:not(._label-outside) & {
         padding: 0;
     }
+
+    tui-tag:last-of-type {
+        max-inline-size: 80%;
+    }
 }
 
 .t-content {


### PR DESCRIPTION
Fixes #4255

### Before

<img width="621" alt="image" src="https://github.com/user-attachments/assets/b269e0c6-a4f3-4e4d-a73a-7b399d407eae">


### After

<img width="598" alt="image" src="https://github.com/user-attachments/assets/5b6c7265-7103-407a-8609-888fb6578200">
