### PR TITLE
fix(core): `DropdownOpen` has CD problems after switching of `tuiDropdownEnabled` (`false`=>`true`)

### DIFF
--- a/projects/core/directives/dropdown/dropdown-open.directive.ts
+++ b/projects/core/directives/dropdown/dropdown-open.directive.ts
@@ -99,7 +99,7 @@ export class TuiDropdownOpen implements OnChanges {
     public readonly driver = inject(TuiDropdownDriver);
 
     public ngOnChanges(): void {
-        this.update(!!this.tuiDropdownOpen && this.tuiDropdownEnabled);
+        this.update(!!this.tuiDropdownOpen);
     }
 
     public toggle(open: boolean): void {
@@ -171,7 +171,7 @@ export class TuiDropdownOpen implements OnChanges {
 
     private update(open: boolean): void {
         if (open && !this.tuiDropdownEnabled) {
-            return;
+            return this.drive();
         }
 
         this.tuiDropdownOpen = open;

--- a/projects/demo-cypress/src/support/component.ts
+++ b/projects/demo-cypress/src/support/component.ts
@@ -1,5 +1,6 @@
 import 'cypress-plugin-tab';
 
+import {provideNoopAnimations} from '@angular/platform-browser/animations';
 import {NG_EVENT_PLUGINS} from '@taiga-ui/event-plugins';
 import {mount} from 'cypress/angular';
 import addCompareSnapshotCommand from 'cypress-image-diff-js/command';
@@ -29,7 +30,11 @@ export const stableMount: typeof mount = (component, config) => {
 
     return mount(component, {
         ...config,
-        providers: [...(config?.providers || []), NG_EVENT_PLUGINS],
+        providers: [
+            ...(config?.providers || []),
+            provideNoopAnimations(),
+            NG_EVENT_PLUGINS,
+        ],
     }).then((mountResponse) =>
         cy
             .get('body')

--- a/projects/demo-cypress/src/tests/input-with-datalist.cy.ts
+++ b/projects/demo-cypress/src/tests/input-with-datalist.cy.ts
@@ -1,0 +1,58 @@
+import {AsyncPipe, NgIf} from '@angular/common';
+import {ChangeDetectionStrategy, Component} from '@angular/core';
+import {FormControl, ReactiveFormsModule} from '@angular/forms';
+import {TuiDataList, TuiRoot} from '@taiga-ui/core';
+import {TuiInputModule} from '@taiga-ui/legacy';
+
+@Component({
+    standalone: true,
+    imports: [AsyncPipe, NgIf, ReactiveFormsModule, TuiDataList, TuiInputModule, TuiRoot],
+    template: `
+        <tui-root>
+            <tui-input [formControl]="control">
+                Enter 3 characters
+
+                <ng-container *ngIf="(control.valueChanges | async)?.length > 2">
+                    <tui-data-list *tuiDataList>Taiga UI</tui-data-list>
+                </ng-container>
+            </tui-input>
+        </tui-root>
+    `,
+    changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class TestInputWithDatalist {
+    protected readonly control = new FormControl('');
+}
+
+describe('Input + Datalist', () => {
+    describe('Shows dropdown only textfield contains >2 characters', () => {
+        beforeEach(() => {
+            cy.mount(TestInputWithDatalist, {
+                componentProperties: {
+                    filler: 'HH:MM',
+                },
+            });
+
+            cy.get('tui-input input').as('textfield');
+        });
+
+        it('Type 12 => no dropdown', () => {
+            cy.get('@textfield').type('12');
+
+            cy.get('tui-dropdown').should('not.exist');
+        });
+
+        it('Type 123 => dropdown appears', () => {
+            cy.get('@textfield').type('123');
+
+            cy.get('tui-dropdown').should('be.visible');
+        });
+
+        it('Type 123 => Press Backspace => dropdown disappears', () => {
+            cy.get('@textfield').type('123');
+            cy.get('tui-dropdown').should('be.visible');
+            cy.get('@textfield').type('{backspace}');
+            cy.get('tui-dropdown').should('not.exist');
+        });
+    });
+});

--- a/projects/demo-cypress/src/tests/input-with-datalist.cy.ts
+++ b/projects/demo-cypress/src/tests/input-with-datalist.cy.ts
@@ -25,7 +25,7 @@ export class TestInputWithDatalist {
 }
 
 describe('Input + Datalist', () => {
-    describe('Shows dropdown only textfield contains >2 characters', () => {
+    describe('Shows dropdown only if textfield contains >2 characters', () => {
         beforeEach(() => {
             cy.mount(TestInputWithDatalist, {
                 componentProperties: {


### PR DESCRIPTION
### Reproduction
```html
<tui-input [formControl]="control">
  Enter 3 characters
  
  @if (control.value.length > 2) {
    <tui-data-list *tuiDataList> Blah blah </tui-data-list>
  }
</tui-input>
```

Enter `123`

**Expected behavior**: dropdown appears
**Actual behavior**: no dropdown

Explore more:
https://stackblitz.com/edit/input-with-datalist-v4-bug?file=src%2Fapp%2Fapp.template.html