### PR TITLE
fix(core): prevent scrolling by arrow keys the whole page in safari

### DIFF
--- a/projects/core/components/data-list/data-list.component.ts
+++ b/projects/core/components/data-list/data-list.component.ts
@@ -55,8 +55,8 @@ export function tuiInjectDataListSize(): TuiSizeL | TuiSizeS {
         '(mouseleave)': 'handleFocusLossIfNecessary($event.target)',
         '(keydown.tab)': 'handleFocusLossIfNecessary()',
         '(keydown.shift.tab)': 'handleFocusLossIfNecessary()',
-        '(keydown.arrowDown.prevent)': 'onKeyDownArrow($event.target, 1)',
-        '(keydown.arrowUp.prevent)': 'onKeyDownArrow($event.target, -1)',
+        '(document:keydown.arrowDown.prevent)': 'onKeyDownArrow($event.target, 1)',
+        '(document:keydown.arrowUp.prevent)': 'onKeyDownArrow($event.target, -1)',
     },
 })
 export class TuiDataListComponent<T>


### PR DESCRIPTION
Fixes #9837
