### PR TITLE
feat(core): add margin right for left icons in small textfield

### DIFF
--- a/projects/core/styles/mixins/textfield.less
+++ b/projects/core/styles/mixins/textfield.less
@@ -321,6 +321,7 @@
         &_left {
             :host[data-size='s'] & {
                 margin-inline-start: -0.375rem;
+                margin-inline-end: 0.125rem;
             }
 
             :host[data-size='m'] & {


### PR DESCRIPTION
Fixes #9806