### PR TITLE
fix(kit): removed redundant space

### DIFF
--- a/projects/kit/components/action-bar/action-bar.style.less
+++ b/projects/kit/components/action-bar/action-bar.style.less
@@ -60,6 +60,7 @@
     justify-content: flex-end;
     gap: 0.5rem;
     margin-inline-start: auto;
+    text-indent: 0;
 
     :host-context(tui-root._mobile) & {
         flex: 1;


### PR DESCRIPTION
Fixes https://github.com/taiga-family/taiga-ui/issues/9700
Removed space at the start of button
![image](https://github.com/user-attachments/assets/d08024fa-d6fe-4e0a-8e70-87bfdcd1d1b6)
