### PR TITLE
fix(core): `Icon` fix for old safari

### DIFF
--- a/projects/core/styles/components/icon.less
+++ b/projects/core/styles/components/icon.less
@@ -42,7 +42,6 @@ tui-icon {
         content: '';
         display: block;
         mask: var(--t-icon) no-repeat center/contain;
-        mask-composite: intersect;
         background: currentColor;
     }
 }

--- a/projects/kit/directives/icon-badge/icon-badge.style.less
+++ b/projects/kit/directives/icon-badge/icon-badge.style.less
@@ -15,5 +15,6 @@
     &[style*='--t-icon-badge:']::after {
         mask-image: var(--t-icon),
             radial-gradient(circle at bottom 0.1em right 0.1em, transparent calc(0.4em - 0.5px), #000 0.4em);
+        mask-composite: intersect;
     }
 }


### PR DESCRIPTION
### issue 
autoprefixer adds `-webkit-mask-composite: source-in, xor` as a fallback for safari 14 and older, it only works when applying two masks

`mask-composite: intersect` works the same way in safari 15. (only when applying two masks)

### solution:
use `mask-composite: intersect` only when we have two masks on ::after element - in `icon-badge` directive

<img width="1295" alt="Снимок экрана 2024-12-04 в 16 36 05" src="https://github.com/user-attachments/assets/4ef56922-eeac-4bd1-8c32-ee067e79dd0a">
