### PR TITLE
fix(kit): `Segmented` fix shadow clipping in Safari

### DIFF
--- a/projects/kit/components/segmented/segmented.style.less
+++ b/projects/kit/components/segmented/segmented.style.less
@@ -6,6 +6,8 @@ tui-segmented {
     color: var(--tui-background-base);
     background: var(--tui-background-neutral-1);
     overflow: hidden;
+    /* Safari bug https://bugs.webkit.org/show_bug.cgi?id=68196 */
+    mask-image: linear-gradient(black, black);
 
     &[data-size='s'] {
         --t-padding: 0.5rem;


### PR DESCRIPTION
Fixes # <!-- link to a relevant issue. -->
