### PR TITLE
fix(core): emit tuiDropdownOpenChange on distinct values

### DIFF
--- a/projects/core/directives/dropdown/dropdown-open-legacy.directive.ts
+++ b/projects/core/directives/dropdown/dropdown-open-legacy.directive.ts
@@ -1,5 +1,5 @@
 import {Directive, Input, Output} from '@angular/core';
-import {BehaviorSubject} from 'rxjs';
+import {distinctUntilChanged, Subject} from 'rxjs';
 
 /**
  * @deprecated TODO: remove in v.5 when legacy controls are dropped
@@ -10,11 +10,19 @@ import {BehaviorSubject} from 'rxjs';
         '[tuiDropdownOpen]:not([tuiDropdown]),[tuiDropdownOpenChange]:not([tuiDropdown])',
 })
 export class TuiDropdownOpenLegacy {
+    private readonly openStateSub = new Subject<boolean>();
+
     @Output()
-    public readonly tuiDropdownOpenChange = new BehaviorSubject(false);
+    public readonly tuiDropdownOpenChange = this.openStateSub
+        .asObservable()
+        .pipe(distinctUntilChanged());
 
     @Input()
     public set tuiDropdownOpen(open: boolean) {
-        this.tuiDropdownOpenChange.next(open);
+        this.emitOpenChange(open);
+    }
+
+    public emitOpenChange(open: boolean): void {
+        this.openStateSub.next(open);
     }
 }

--- a/projects/core/directives/dropdown/dropdown-open-legacy.directive.ts
+++ b/projects/core/directives/dropdown/dropdown-open-legacy.directive.ts
@@ -13,9 +13,8 @@ export class TuiDropdownOpenLegacy {
     private readonly openStateSub = new Subject<boolean>();
 
     @Output()
-    public readonly tuiDropdownOpenChange = this.openStateSub
-        .asObservable()
-        .pipe(distinctUntilChanged());
+    public readonly tuiDropdownOpenChange =
+        this.openStateSub.pipe(distinctUntilChanged());
 
     @Input()
     public set tuiDropdownOpen(open: boolean) {

--- a/projects/legacy/directives/legacy-dropdown-open-monitor/legacy-dropdown-open-monitor.ts
+++ b/projects/legacy/directives/legacy-dropdown-open-monitor/legacy-dropdown-open-monitor.ts
@@ -34,6 +34,6 @@ export class TuiLegacyDropdownOpenMonitorDirective implements AfterViewInit {
 
         this.host.driver
             .pipe(distinctUntilChanged(), takeUntilDestroyed(this.destroyRef))
-            .subscribe((open) => this.external?.tuiDropdownOpenChange.next(open));
+            .subscribe((open) => this.external?.emitOpenChange(open));
     }
 }


### PR DESCRIPTION
Fixes #9609

Description : 
1. We used `Subject` because we are concerned about the latest value compared to maintaining the last state.
2. Created the `emitOpenChange` method to centralize & handle responsibility for emitting values.
3. Replaced previous value emission logic with the currently integrated flow.