### PR TITLE
chore(demo): added forgotten import

### DIFF
--- a/projects/demo/src/modules/directives/swipe/examples/2/index.ts
+++ b/projects/demo/src/modules/directives/swipe/examples/2/index.ts
@@ -9,7 +9,7 @@ import {Subject} from 'rxjs';
 
 @Component({
     standalone: true,
-    imports: [AsyncPipe, TuiSwipe, TuiSidebar],
+    imports: [AsyncPipe, TuiSidebar, TuiSwipe],
     templateUrl: './index.html',
     styleUrls: ['./index.less'],
     encapsulation,

--- a/projects/demo/src/modules/directives/swipe/examples/2/index.ts
+++ b/projects/demo/src/modules/directives/swipe/examples/2/index.ts
@@ -2,13 +2,14 @@ import {AsyncPipe} from '@angular/common';
 import {Component} from '@angular/core';
 import {changeDetection} from '@demo/emulate/change-detection';
 import {encapsulation} from '@demo/emulate/encapsulation';
+import {TuiSidebar} from '@taiga-ui/addon-mobile';
 import type {TuiSwipeEvent} from '@taiga-ui/cdk';
 import {TuiSwipe} from '@taiga-ui/cdk';
 import {Subject} from 'rxjs';
 
 @Component({
     standalone: true,
-    imports: [AsyncPipe, TuiSwipe],
+    imports: [AsyncPipe, TuiSwipe, TuiSidebar],
     templateUrl: './index.html',
     styleUrls: ['./index.less'],
     encapsulation,


### PR DESCRIPTION
Fixes [#9977](https://github.com/taiga-family/taiga-ui/issues/9977)

Just forgot to import tuiSidebar during migration process


It's strange but in development mode console have clear errors about import absent

![image](https://github.com/user-attachments/assets/fa875679-74e3-48d4-bc6f-9922edf46af1)
