### PR TITLE
Feature/9721 migrate tui table classes

### DIFF
--- a/projects/demo/src/modules/directives/dropdown-context/examples/2/index.html
+++ b/projects/demo/src/modules/directives/dropdown-context/examples/2/index.html
@@ -1,25 +1,26 @@
 <p>Right-click any table row.</p>
 
-<table class="tui-table">
-    <tbody>
-        <tr class="tui-table__tr tui-table__tr_hover_disabled">
+<table tuiTable>
+    <thead tuiTHead>
+        <tr tuiThGroup>
             <th
                 *ngFor="let column of tableColumns"
-                class="tui-table__th"
+                tuiTh
             >
                 {{ column }}
             </th>
         </tr>
+    </thead>
+    <tbody tuiTbody>
         <tr
             *ngFor="let rowInfo of tableData"
             #dropdown="tuiDropdown"
             tuiDropdownContext
-            class="tui-table__tr"
             [tuiDropdown]="contextMenu"
         >
             <td
                 *ngFor="let value of getObjectValues(rowInfo)"
-                class="tui-table__td"
+                tuiTd
             >
                 {{ value }}
             </td>

--- a/projects/demo/src/modules/directives/dropdown-context/examples/2/index.less
+++ b/projects/demo/src/modules/directives/dropdown-context/examples/2/index.less
@@ -5,3 +5,13 @@
 .icon {
     border-width: 0.25rem;
 }
+
+[tuiTable] {
+    inline-size: 100%;
+}
+
+[tuiTh],
+[tuiTd] {
+    border-inline-start: none;
+    border-inline-end: none;
+}

--- a/projects/demo/src/modules/directives/dropdown-context/examples/2/index.ts
+++ b/projects/demo/src/modules/directives/dropdown-context/examples/2/index.ts
@@ -2,12 +2,34 @@ import {NgForOf} from '@angular/common';
 import {Component, inject} from '@angular/core';
 import {changeDetection} from '@demo/emulate/change-detection';
 import {encapsulation} from '@demo/emulate/encapsulation';
+import {
+    TuiTable,
+    TuiTableHead,
+    TuiTableTbody,
+    TuiTableTd,
+    TuiTableTh,
+    TuiTableThGroup,
+    TuiTableTr,
+} from '@taiga-ui/addon-table';
 import {TuiDataList, TuiDialogService, TuiDropdown, TuiIcon} from '@taiga-ui/core';
 import {TuiDataListDropdownManager} from '@taiga-ui/kit';
 
 @Component({
     standalone: true,
-    imports: [NgForOf, TuiDataList, TuiDataListDropdownManager, TuiDropdown, TuiIcon],
+    imports: [
+        NgForOf,
+        TuiDataList,
+        TuiDataListDropdownManager,
+        TuiDropdown,
+        TuiIcon,
+        TuiTable,
+        TuiTableHead,
+        TuiTableTbody,
+        TuiTableTd,
+        TuiTableTh,
+        TuiTableThGroup,
+        TuiTableTr,
+    ],
     templateUrl: './index.html',
     styleUrls: ['./index.less'],
     encapsulation,

--- a/projects/demo/src/modules/info/browsers/index.html
+++ b/projects/demo/src/modules/info/browsers/index.html
@@ -1,17 +1,16 @@
 <tui-doc-page header="Browser support">
     <h2 class="tui-text_h4 tui-space_top-0 tui-space_bottom-3">Desktop</h2>
-    <table class="tui-table">
-        <tbody>
-            <tr class="tui-table__tr">
-                <th class="tui-table__th">Browser</th>
-                <th class="tui-table__th">Version</th>
+    <table tuiTable>
+        <thead tuiThead>
+            <tr tuiThGroup>
+                <th tuiTh>Browser</th>
+                <th tuiTh>Version</th>
             </tr>
-            <tr
-                *ngFor="let browser of desktopBrowsers"
-                class="tui-table__tr"
-            >
-                <td class="tui-table__td">{{ browser.name }}</td>
-                <td class="tui-table__td">
+        </thead>
+        <tbody tuiTbody>
+            <tr *ngFor="let browser of desktopBrowsers">
+                <td tuiTd>{{ browser.name }}</td>
+                <td tuiTd>
                     <ng-container *ngIf="browser.version; else notSupported">
                         {{ browser.version }}
                     </ng-container>
@@ -20,18 +19,17 @@
         </tbody>
     </table>
     <h2 class="tui-text_h4 tui-space_top-6 tui-space_bottom-3">Mobile</h2>
-    <table class="tui-table">
-        <tbody>
-            <tr class="tui-table__tr">
-                <th class="tui-table__th">Browser</th>
-                <th class="tui-table__th">Version</th>
+    <table tuiTable>
+        <thead tuiThead>
+            <tr tuiThGroup>
+                <th tuiTh>Browser</th>
+                <th tuiTh>Version</th>
             </tr>
-            <tr
-                *ngFor="let browser of mobileBrowsers"
-                class="tui-table__tr"
-            >
-                <td class="tui-table__td">{{ browser.name }}</td>
-                <td class="tui-table__td">{{ browser.version }}</td>
+        </thead>
+        <tbody tuiTbody>
+            <tr *ngFor="let browser of mobileBrowsers">
+                <td tuiTd>{{ browser.name }}</td>
+                <td tuiTd>{{ browser.version }}</td>
             </tr>
         </tbody>
     </table>

--- a/projects/demo/src/modules/info/browsers/index.less
+++ b/projects/demo/src/modules/info/browsers/index.less
@@ -1,13 +1,5 @@
 @import '@taiga-ui/core/styles/taiga-ui-local';
 
-.context-menu {
-    inline-size: 8rem;
-}
-
-.icon {
-    border-width: 0.25rem;
-}
-
 [tuiTable] {
     inline-size: 100%;
 }
@@ -20,4 +12,8 @@
 
 [tuiTd] {
     font: var(--tui-font-text-m) !important;
+}
+
+td {
+    inline-size: 18.75rem;
 }

--- a/projects/demo/src/modules/info/browsers/index.ts
+++ b/projects/demo/src/modules/info/browsers/index.ts
@@ -1,11 +1,29 @@
 import {ChangeDetectionStrategy, Component} from '@angular/core';
 import {TuiDemo} from '@demo/utils';
+import {
+    TuiTable,
+    TuiTableHead,
+    TuiTableTbody,
+    TuiTableTd,
+    TuiTableTh,
+    TuiTableThGroup,
+    TuiTableTr,
+} from '@taiga-ui/addon-table';
 
 @Component({
     standalone: true,
-    imports: [TuiDemo],
+    imports: [
+        TuiDemo,
+        TuiTable,
+        TuiTableHead,
+        TuiTableTbody,
+        TuiTableTd,
+        TuiTableTh,
+        TuiTableThGroup,
+        TuiTableTr,
+    ],
     templateUrl: './index.html',
-    styles: ['td {width: 18.75rem}'],
+    styleUrls: ['./index.less'],
     changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export default class Page {

--- a/projects/demo/src/modules/pipes/filter/examples/1/index.html
+++ b/projects/demo/src/modules/pipes/filter/examples/1/index.html
@@ -1,12 +1,17 @@
-<table class="tui-table table">
-    <thead>
-        <tr>
-            <th class="tui-table__th cell_name">Name</th>
-            <th class="tui-table__th cell_sum">Sum, $</th>
-        </tr>
-        <tr *ngFor="let item of items | tuiFilter: matcher : 300">
-            <td class="tui-table__td cell_name">{{ item.name }}</td>
-            <td class="tui-table__td cell_sum">{{ item.price }}</td>
+<table
+    tuiTable
+    [style.width.rem]="17"
+>
+    <thead tuiThead>
+        <tr tuiThGroup>
+            <th tuiTh>Name</th>
+            <th tuiTh>Sum, $</th>
         </tr>
     </thead>
+    <tbody tuiTbody>
+        <tr *ngFor="let item of items | tuiFilter: matcher : 300">
+            <td tuiTd>{{ item.name }}</td>
+            <td tuiTd>{{ item.price }}</td>
+        </tr>
+    </tbody>
 </table>

--- a/projects/demo/src/modules/pipes/filter/examples/1/index.less
+++ b/projects/demo/src/modules/pipes/filter/examples/1/index.less
@@ -1,0 +1,10 @@
+@import '@taiga-ui/core/styles/taiga-ui-local';
+
+[tuiTh],
+[tuiTd] {
+    border: none;
+}
+
+[tuiTd] {
+    font: var(--tui-font-text-m) !important;
+}

--- a/projects/demo/src/modules/pipes/filter/examples/1/index.ts
+++ b/projects/demo/src/modules/pipes/filter/examples/1/index.ts
@@ -2,6 +2,14 @@ import {NgForOf} from '@angular/common';
 import {Component} from '@angular/core';
 import {changeDetection} from '@demo/emulate/change-detection';
 import {encapsulation} from '@demo/emulate/encapsulation';
+import {
+    TuiTable,
+    TuiTableHead,
+    TuiTableTbody,
+    TuiTableTd,
+    TuiTableTh,
+    TuiTableThGroup,
+} from '@taiga-ui/addon-table';
 import {TuiFilterPipe} from '@taiga-ui/cdk';
 
 export interface Item {
@@ -11,8 +19,18 @@ export interface Item {
 
 @Component({
     standalone: true,
-    imports: [NgForOf, TuiFilterPipe],
+    imports: [
+        NgForOf,
+        TuiFilterPipe,
+        TuiTable,
+        TuiTableHead,
+        TuiTableThGroup,
+        TuiTableTh,
+        TuiTableTbody,
+        TuiTableTd,
+    ],
     templateUrl: './index.html',
+    styleUrls: ['./index.less'],
     encapsulation,
     changeDetection,
 })


### PR DESCRIPTION
Fixes #9721

Changes Description
1. Migrated tui-form classes from the below pages.
 - [Dropdown Context > Context Menu Example](https://taiga-ui.dev/directives/dropdown-context)
 - [Browser Support](https://taiga-ui.dev/browser-support)
 - [Filter Pipe Usage](https://taiga-ui.dev/pipes/filter)
 

