### PR TITLE
#9966 - Fix documentation Name & Description, Type columns overlapping.

### DIFF
--- a/projects/addon-doc/components/documentation/documentation.style.less
+++ b/projects/addon-doc/components/documentation/documentation.style.less
@@ -159,3 +159,7 @@
         max-inline-size: 22.5rem;
     }
 }
+
+.t-no-overflow {
+    overflow: hidden !important;
+}

--- a/projects/addon-doc/components/documentation/documentation.template.html
+++ b/projects/addon-doc/components/documentation/documentation.template.html
@@ -25,7 +25,7 @@
             class="t-row"
             [class.t-deprecated]="propertyConnector.documentationPropertyDeprecated"
         >
-            <td class="t-cell">
+            <td class="t-cell t-no-overflow">
                 <div
                     automation-id="tui-documentation__property-name"
                     class="t-property t-additional-info"
@@ -54,7 +54,7 @@
                 </div>
                 <ng-container [ngTemplateOutlet]="propertyConnector.template" />
             </td>
-            <td class="t-cell">
+            <td class="t-cell t-no-overflow">
                 <span class="type">
                     <code class="t-code-type">
                         <ng-container


### PR DESCRIPTION
Fixes #9966 

Changes Description :
1. Fixes type column overlapping.
2. Fixes Name & description column overlapping (This one we found while unit testing, fixed it within the same PR).
