### PR TITLE
fix(legacy): `InputPhone` incorrectly parses paste of the shorten phone number

### DIFF
--- a/projects/legacy/components/input-phone/utils/complete-phone-insertion-preprocessor.ts
+++ b/projects/legacy/components/input-phone/utils/complete-phone-insertion-preprocessor.ts
@@ -40,13 +40,12 @@ export function tuiCreateCompletePhoneInsertionPreprocessor(
                      * and mask are ready to reject "extra" characters.
                      * We should cut leading country prefix to save trailing characters!
                      */
-                    countDigits(value) > completePhoneLength ||
-                    value.startsWith(countryCode)
+                    countDigits(value) > completePhoneLength
                         ? trimCountryPrefix(value)
                         : value,
             },
             data:
-                countDigits(data) >= completePhoneLength || value.startsWith(countryCode)
+                countDigits(data) >= completePhoneLength || data.startsWith(countryCode)
                     ? /**
                        * User tries to insert/drop the complete phone number (with country prefix).
                        * We should drop already existing non-removable prefix.

--- a/projects/legacy/components/input-phone/utils/complete-phone-insertion-preprocessor.ts
+++ b/projects/legacy/components/input-phone/utils/complete-phone-insertion-preprocessor.ts
@@ -40,12 +40,13 @@ export function tuiCreateCompletePhoneInsertionPreprocessor(
                      * and mask are ready to reject "extra" characters.
                      * We should cut leading country prefix to save trailing characters!
                      */
-                    countDigits(value) > completePhoneLength
+                    countDigits(value) > completePhoneLength ||
+                    value.startsWith(countryCode)
                         ? trimCountryPrefix(value)
                         : value,
             },
             data:
-                countDigits(data) >= completePhoneLength
+                countDigits(data) >= completePhoneLength || value.startsWith(countryCode)
                     ? /**
                        * User tries to insert/drop the complete phone number (with country prefix).
                        * We should drop already existing non-removable prefix.


### PR DESCRIPTION
Fixes #9834 

Changes Description:-
1. Consider trimming the number with `trimCountryPrefix` in [`tuiCreateCompletePhoneInsertionPreprocessor`](https://github.com/taiga-family/taiga-ui/blob/main/projects/legacy/components/input-phone/utils/complete-phone-insertion-preprocessor.ts)  when the pasted phone number is with country code.