### PR TITLE
chore(schematics): valid migration for `tui-primitive-textfield`

### DIFF
--- a/projects/cdk/schematics/ng-update/v4/steps/constants/attr-to-directive-replace.ts
+++ b/projects/cdk/schematics/ng-update/v4/steps/constants/attr-to-directive-replace.ts
@@ -68,5 +68,6 @@ export const ATTRS_TO_DIRECTIVE_REPLACE: ReplacementAttributeToDirective[] = [
             name: 'TuiAppearance',
             moduleSpecifier: '@taiga-ui/core',
         },
+        filterFn: (el) => !['tui-primitive-textfield'].includes(el.tagName),
     },
 ];

--- a/projects/cdk/schematics/ng-update/v4/tests/schematic-migrate-blocked.spec.ts
+++ b/projects/cdk/schematics/ng-update/v4/tests/schematic-migrate-blocked.spec.ts
@@ -86,6 +86,8 @@ const TEMPLATE_BEFORE = `
 >
     {{ fruit }}
 </tui-radio-block>
+
+<tui-primitive-textfield [(value)]="value" [pseudoFocus]="pseudoFocus">Type something</tui-primitive-textfield>
 `.trim();
 
 const TEMPLATE_AFTER = `
@@ -138,6 +140,8 @@ const TEMPLATE_AFTER = `
 >
     {{ fruit }}
 </label>
+
+<tui-primitive-textfield [(value)]="value" [pseudoFocus]="pseudoFocus">Type something</tui-primitive-textfield>
 `.trim();
 
 describe('ng-update', () => {


### PR DESCRIPTION
Part of #10017 