### PR TITLE
chore(demo): remove redundant `inputmode=decimal` from documentation examples of new `InputNumber`

### DIFF
--- a/projects/demo/src/modules/components/input-number/examples/1/index.html
+++ b/projects/demo/src/modules/components/input-number/examples/1/index.html
@@ -2,7 +2,6 @@
     <label tuiLabel>Enter a number</label>
 
     <input
-        inputmode="decimal"
         tuiInputNumber
         [formControl]="control"
     />

--- a/projects/demo/src/modules/components/input-number/examples/2/index.html
+++ b/projects/demo/src/modules/components/input-number/examples/2/index.html
@@ -5,7 +5,6 @@
     <label tuiLabel>I am a label</label>
 
     <input
-        inputmode="decimal"
         placeholder="I am placeholder"
         tuiInputNumber
         [(ngModel)]="value"

--- a/projects/demo/src/modules/components/input-number/examples/3/index.html
+++ b/projects/demo/src/modules/components/input-number/examples/3/index.html
@@ -2,7 +2,6 @@
     <label tuiLabel>Type number like a German</label>
 
     <input
-        inputmode="decimal"
         tuiInputNumber
         [tuiNumberFormat]="numberFormat"
         [(ngModel)]="value"

--- a/projects/demo/src/modules/components/input-number/examples/4/index.html
+++ b/projects/demo/src/modules/components/input-number/examples/4/index.html
@@ -2,7 +2,6 @@
     <label tuiLabel>Price</label>
 
     <input
-        inputmode="decimal"
         tuiInputNumber
         [min]="0"
         [prefix]="'USD' | tuiCurrency"

--- a/projects/demo/src/modules/components/input-number/examples/5/index.html
+++ b/projects/demo/src/modules/components/input-number/examples/5/index.html
@@ -2,7 +2,6 @@
     <label tuiLabel>Percentage</label>
 
     <input
-        inputmode="decimal"
         postfix="%"
         tuiInputNumber
         [max]="100"


### PR DESCRIPTION
https://github.com/taiga-family/taiga-ui/blob/9244f1a1f24cc28049e1b8ed0e7731e22ae8ebda/projects/kit/components/input-number/input-number.component.ts#L119-L125
