### PR TITLE
fix(kit): `InputNumber` should handle initial `ngModel` phantom `null` value

### DIFF
--- a/projects/kit/components/input-number/input-number.component.ts
+++ b/projects/kit/components/input-number/input-number.component.ts
@@ -179,7 +179,7 @@ export class TuiInputNumber extends TuiControl<number | null> {
 
     public override writeValue(value: number | null): void {
         super.writeValue(value);
-        this.textfieldValue.set(this.formatNumber(value));
+        this.textfieldValue.set(this.formatNumber(this.value()));
     }
 
     protected onBlur(): void {


### PR DESCRIPTION
Relates:
* https://github.com/angular/angular/issues/14988

https://github.com/taiga-family/taiga-ui/blob/768f1ffbf67d3ea7fe7f0d47cdf14e6825a4c338/projects/cdk/classes/control.ts#L122-L126

![tabs](https://github.com/user-attachments/assets/4aba28ff-5343-4479-89f7-9dd8576b96ec)
See: https://github.com/taiga-family/taiga-ui/pull/10166#discussion_r1914741942
