### PR TITLE
fix(kit,legacy): all textfield controls should handle initial `ngModel` phantom `null` value

### DIFF
--- a/projects/kit/components/input-phone-international/input-phone-international.component.ts
+++ b/projects/kit/components/input-phone-international/input-phone-international.component.ts
@@ -201,8 +201,8 @@ export class TuiInputPhoneInternational extends TuiControl<string> {
         const maskOptions = this.mask();
 
         this.textfieldValue = maskOptions
-            ? maskitoTransform(unmaskedValue, maskOptions)
-            : unmaskedValue; // it will be calibrated later when mask is ready (by maskitoInitialCalibrationPlugin)
+            ? maskitoTransform(this.value(), maskOptions)
+            : this.value(); // it will be calibrated later when mask is ready (by maskitoInitialCalibrationPlugin)
         this.cdr.detectChanges();
     }
 

--- a/projects/legacy/components/input-date/input-date.component.ts
+++ b/projects/legacy/components/input-date/input-date.component.ts
@@ -184,7 +184,7 @@ export class TuiInputDateComponent
 
     public override writeValue(value: TuiDay | null): void {
         super.writeValue(value);
-        this.nativeValue.set(value ? this.computedValue : '');
+        this.nativeValue.set(this.value ? this.computedValue : '');
     }
 
     protected get size(): TuiSizeL | TuiSizeS {

--- a/projects/legacy/components/input-phone/input-phone.component.ts
+++ b/projects/legacy/components/input-phone/input-phone.component.ts
@@ -161,7 +161,7 @@ export class TuiInputPhoneComponent
 
     public override writeValue(value: string | null): void {
         super.writeValue(value);
-        this.nativeValue = maskitoTransform(value || '', this.maskOptions);
+        this.nativeValue = maskitoTransform(this.value || '', this.maskOptions);
         this.updateSearch('');
     }
 

--- a/projects/legacy/components/input-time/input-time.component.ts
+++ b/projects/legacy/components/input-time/input-time.component.ts
@@ -139,7 +139,7 @@ export class TuiInputTimeComponent
 
     public override writeValue(value: TuiTime | null): void {
         super.writeValue(value);
-        this.nativeValue = value ? this.computedValue : '';
+        this.nativeValue = this.value ? this.computedValue : '';
     }
 
     public onValueChange(value: string): void {

--- a/projects/legacy/components/input-year/input-year.component.ts
+++ b/projects/legacy/components/input-year/input-year.component.ts
@@ -74,7 +74,7 @@ export class TuiInputYearComponent
 
     public override writeValue(value: number | null): void {
         super.writeValue(value);
-        this.updateNativeValue(value);
+        this.updateNativeValue(this.value);
     }
 
     protected get size(): TuiSizeL | TuiSizeS {


### PR DESCRIPTION
Learn more (read body description of this PR):
* https://github.com/taiga-family/taiga-ui/pull/10168