### PR TITLE
fix(kit): new version of `InputNumber` should provide `TuiControl` for DI

### DIFF
--- a/projects/kit/components/input-number/input-number.component.ts
+++ b/projects/kit/components/input-number/input-number.component.ts
@@ -18,7 +18,7 @@ import {
     maskitoNumberOptionsGenerator,
     maskitoParseNumber,
 } from '@maskito/kit';
-import {TuiControl, tuiValueTransformerFrom} from '@taiga-ui/cdk/classes';
+import {tuiAsControl, TuiControl, tuiValueTransformerFrom} from '@taiga-ui/cdk/classes';
 import {CHAR_HYPHEN, CHAR_MINUS, TUI_ALLOW_SIGNAL_WRITES} from '@taiga-ui/cdk/constants';
 import {TUI_IS_IOS, tuiFallbackValueProvider} from '@taiga-ui/cdk/tokens';
 import {tuiInjectElement} from '@taiga-ui/cdk/utils/dom';
@@ -46,6 +46,7 @@ const DEFAULT_MAX_LENGTH = 18;
     encapsulation: ViewEncapsulation.None,
     changeDetection: ChangeDetectionStrategy.OnPush,
     providers: [
+        tuiAsControl(TuiInputNumber),
         tuiFallbackValueProvider(null),
         tuiValueTransformerFrom(TUI_INPUT_NUMBER_OPTIONS),
     ],


### PR DESCRIPTION
https://github.com/taiga-family/taiga-ui/blob/1171fbc3807ece6ec0b5baefa57b3535ebed2b9e/projects/addon-table/components/table/td/td.component.ts#L10-L16
