### PR TITLE
fix(core): fix tuiDialog typings for classes with constructor parameters

### DIFF
--- a/projects/core/components/dialog/dialog.factory.ts
+++ b/projects/core/components/dialog/dialog.factory.ts
@@ -21,10 +21,10 @@ type ContextKeys<T> = {
 }[keyof T];
 
 type AssertNotMultipleContexts<T, K extends keyof T> = [K] extends [never]
-    ? new () => T
+    ? new (...args: any[]) => T
     : [SingleUnionOrNever<K>] extends [never]
       ? 'Component has multiple context. Cannot determine the type...'
-      : new () => T;
+      : new (...args: any[]) => T;
 
 type ExtractDialogData<T, K extends keyof T = ContextKeys<T>> = [K] extends [never]
     ? void

--- a/projects/core/components/dialog/test/dialog.factory.spec.ts
+++ b/projects/core/components/dialog/test/dialog.factory.spec.ts
@@ -99,6 +99,23 @@ const tuiDialogMock: typeof tuiDialog = jest.fn(() => jest.fn(() => EMPTY));
     dialog('test');
 }
 
+{
+    // component with constructor parameters
+    class TestComponent {
+        constructor(public readonly context: TuiDialogContext<string, number>) {}
+    }
+
+    const dialog = tuiDialogMock(TestComponent);
+
+    dialog(123).subscribe((_value: string) => {});
+    // @ts-expect-error TS2554: Expected 1 arguments, but got 0
+    dialog();
+    // @ts-expect-error TS2345: Argument of type `string` is not assignable to parameter of type `number`
+    dialog('');
+    // @ts-expect-error TS2345: Argument of type `string` is not assignable to parameter of type `number`
+    dialog(123).subscribe((_value: number) => {});
+}
+
 describe('tuiDialog', () => {
     it('stub', () => {
         expect(true).toBeTruthy();


### PR DESCRIPTION
Fixes # <!-- link to a relevant issue. -->
