### PR TITLE
fix(experimental): increase css-specificity for select's styles inside `TuiInputPhoneInternational`

### DIFF
--- a/projects/experimental/components/input-phone-international/input-phone-international.style.less
+++ b/projects/experimental/components/input-phone-international/input-phone-international.style.less
@@ -39,7 +39,7 @@ tui-textfield[data-size='l'] {
     }
 }
 
-.t-ipi-select {
+tui-textfield .t-ipi-select {
     position: absolute;
     left: 0;
     border-radius: inherit;


### PR DESCRIPTION
## Reproduction 1
Open StackBlitz of this documentation example:
https://taiga-ui.dev/components/input-phone-international#metadata

<img width="491" alt="stakblitz" src="https://github.com/user-attachments/assets/7cb3300e-c75e-45e7-8cfb-a9879880a110" />


## Reproduction 2
Use Cypress Component Testing with `TuiInputPhoneInternational`:
<img width="1488" alt="cypress" src="https://github.com/user-attachments/assets/a111ead7-d9de-4c11-a8c4-bce2a44c40f9" />
