### PR TITLE
fix(kit): increase css-specificity for step button's styles inside `TuiInputNumber`

### DIFF
--- a/projects/kit/components/input-number/input-number.style.less
+++ b/projects/kit/components/input-number/input-number.style.less
@@ -3,45 +3,43 @@ TODO: if :has() is supported by all browsers
  - use tui-textfield:has([tuiInputNumber]) .t-input-number {...}
  - rename .t-input-number-buttons => .t-buttons
  */
-.t-input-number {
-    &-buttons {
-        position: absolute;
-        right: 0;
-        display: flex;
-        block-size: var(--t-height);
-        flex-direction: column;
-        gap: 0.125rem;
-        border-radius: inherit;
+.t-input-number-buttons.t-input-number-buttons {
+    position: absolute;
+    right: 0;
+    display: flex;
+    block-size: var(--t-height);
+    flex-direction: column;
+    gap: 0.125rem;
+    border-radius: inherit;
 
-        tui-textfield[data-size='s'] & {
-            flex-direction: row-reverse;
+    tui-textfield[data-size='s'] & {
+        flex-direction: row-reverse;
+    }
+
+    & > * {
+        flex: 1 1 0;
+        border-radius: 0;
+
+        &:first-child {
+            border-start-end-radius: inherit;
         }
 
-        & > * {
-            flex: 1 1 0;
-            border-radius: 0;
+        &:last-child {
+            border-end-end-radius: inherit;
+        }
 
+        tui-textfield[data-size='l'] & {
+            inline-size: var(--tui-height-m);
+        }
+
+        tui-textfield[data-size='s'] & {
             &:first-child {
                 border-start-end-radius: inherit;
-            }
-
-            &:last-child {
                 border-end-end-radius: inherit;
             }
 
-            tui-textfield[data-size='l'] & {
-                inline-size: var(--tui-height-m);
-            }
-
-            tui-textfield[data-size='s'] & {
-                &:first-child {
-                    border-start-end-radius: inherit;
-                    border-end-end-radius: inherit;
-                }
-
-                &:last-child {
-                    border-radius: 0;
-                }
+            &:last-child {
+                border-radius: 0;
             }
         }
     }


### PR DESCRIPTION
## Reproduction 1
Open StackBlitz of this documentation example:
https://taiga-ui.dev/next/components/input-number#step

<img width="421" alt="Снимок экрана 2025-01-27 в 10 21 21" src="https://github.com/user-attachments/assets/486f37da-37da-4f74-9d78-5e4ebdd1bf04" />



## Reproduction 2
Use Cypress Component Testing with `TuiInputNumber`:

<img width="802" alt="Снимок экрана 2025-01-27 в 10 18 46" src="https://github.com/user-attachments/assets/dfea4e64-3241-48aa-89df-7e0d901ee863" />


