### PR TITLE
chore(legacy): `InputDate` add test show actual min/max in `Calendar`

### DIFF
--- a/projects/demo-playwright/tests/legacy/input-date/input-date.pw.spec.ts
+++ b/projects/demo-playwright/tests/legacy/input-date/input-date.pw.spec.ts
@@ -88,6 +88,21 @@ test.describe('InputDate', () => {
                 await expect(inputDate.textfield).toHaveValue('');
             });
         });
+
+        test('Actual min/max in calendar', async () => {
+            const example = documentationPage.getExample('#base');
+
+            const inputDate = new TuiInputDatePO(example.locator('tui-input-date'));
+
+            await inputDate.textfield.click();
+
+            await expect(inputDate.textfield).toHaveScreenshot(
+                '05-input-actual-min-max.png',
+            );
+            await expect(inputDate.calendar).toHaveScreenshot(
+                '05-calendar-actual-min-max.png',
+            );
+        });
     });
 
     test.describe('API', () => {

--- a/projects/demo/src/modules/components/input-date/examples/1/index.html
+++ b/projects/demo/src/modules/components/input-date/examples/1/index.html
@@ -10,6 +10,8 @@
     <tui-input-date
         formControlName="testValue"
         tuiUnfinishedValidator="Finish filling the field"
+        [max]="max"
+        [min]="min"
     >
         Choose a date
     </tui-input-date>

--- a/projects/demo/src/modules/components/input-date/examples/1/index.ts
+++ b/projects/demo/src/modules/components/input-date/examples/1/index.ts
@@ -31,4 +31,7 @@ export default class Example {
     protected readonly testForm = new FormGroup({
         testValue: new FormControl(new TuiDay(2017, 0, 15)),
     });
+
+    protected readonly min = new TuiDay(2017, 0, 21);
+    protected readonly max = new TuiDay(2017, 0, 28);
 }


### PR DESCRIPTION
Fixes #10178 