### PR TITLE
chore(demo-playwright): `InputDateRange` add test not reset initial value to min/max and show actual in calendar

### DIFF
--- a/projects/demo-playwright/tests/legacy/input-date-range/input-date-range.pw.spec.ts
+++ b/projects/demo-playwright/tests/legacy/input-date-range/input-date-range.pw.spec.ts
@@ -415,6 +415,23 @@ describe('InputDateRange', () => {
                 await expect(inputDateRange.textfield).toHaveValue('');
             });
         });
+
+        test('Actual min/max in calendar', async () => {
+            const example = documentationPage.getExample('#base');
+
+            const inputDateRange = new TuiInputDateRangePO(
+                example.locator('tui-input-date-range'),
+            );
+
+            await inputDateRange.textfield.click();
+
+            await expect(inputDateRange.textfield).toHaveScreenshot(
+                '17-input-date-range-actual-min-max.png',
+            );
+            await expect(inputDateRange.calendar).toHaveScreenshot(
+                '18-input-date-range-calendar-actual-min-max.png',
+            );
+        });
     });
 
     test('check valid active period', async ({page}) => {

--- a/projects/demo/src/modules/components/input-date-range/examples/1/index.ts
+++ b/projects/demo/src/modules/components/input-date-range/examples/1/index.ts
@@ -19,7 +19,6 @@ export default class Example {
         ),
     });
 
-    protected readonly min = new TuiDay(2000, 2, 20);
-
+    protected readonly min = new TuiDay(2018, 2, 25);
     protected readonly max = new TuiDay(2040, 2, 20);
 }


### PR DESCRIPTION
Fixes #10248 
