### PR TITLE
fix(core): `tuiDropdownContext` menu remains open after long tap

### DIFF
--- a/projects/core/directives/dropdown/dropdown-context.directive.ts
+++ b/projects/core/directives/dropdown/dropdown-context.directive.ts
@@ -66,6 +66,7 @@ export class TuiDropdownContextDirective extends TuiDriver implements TuiRectAcc
     @HostListener('document:click.silent', ['$event.target'])
     @HostListener('document:contextmenu.capture.silent', ['$event.target'])
     @HostListener('document:keydown.esc', ['$event.currentTarget'])
+    @HostListener('document:pointerdown.silent', ['$event.target'])
     closeDropdown(): void {
         this.stream$.next(false);
         this.currentRect = EMPTY_CLIENT_RECT;


### PR DESCRIPTION
Fixes #9797

### Before


https://github.com/user-attachments/assets/c1d6c5cb-a176-44cd-b5cd-1c1e3613487c



### After


https://github.com/user-attachments/assets/cf242d93-7a50-440f-ab2b-2f497ed519f1

