### PR TITLE
fix(addon-doc): `DocAPIItem` throws error for signal-based output handlers

### DIFF
--- a/projects/addon-doc/components/api/api-item.component.ts
+++ b/projects/addon-doc/components/api/api-item.component.ts
@@ -1,5 +1,5 @@
 import {Location, NgForOf, NgIf, NgSwitch, NgSwitchCase} from '@angular/common';
-import type {OnInit} from '@angular/core';
+import type {AfterViewInit} from '@angular/core';
 import {
     ChangeDetectionStrategy,
     Component,
@@ -49,7 +49,7 @@ const SERIALIZED_SUFFIX = '$';
     styleUrls: ['./api-item.style.less'],
     changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class TuiDocAPIItem<T> implements OnInit {
+export class TuiDocAPIItem<T> implements AfterViewInit {
     private readonly locationRef = inject(Location);
     private readonly activatedRoute = inject(ActivatedRoute);
     private readonly urlSerializer = inject(UrlSerializer);
@@ -71,7 +71,7 @@ export class TuiDocAPIItem<T> implements OnInit {
     @Output()
     public readonly valueChange = new EventEmitter<T>();
 
-    public ngOnInit(): void {
+    public ngAfterViewInit(): void {
         this.parseParams(this.activatedRoute.snapshot.queryParams);
     }
 


### PR DESCRIPTION
## Reproduction 

Add the following code to any API documentation page:

```ts
protected debug = signal('');
```

```html
<tr
    name="[debug]"
    tuiDocAPIItem
    type="string"
    [value]="debug()"
    (valueChange)="debug.set($event)"
>
    DEBUG
</tr>
```

Open http://localhost:3333/components/any/API?debug=42
It throws

```
ERROR Error: ASSERTION ERROR: Updating a signal during template or host binding execution is not allowed. [Expected=> null != null <=Actual]
    at throwError (core.mjs:328:11)
    at assertDefined (core.mjs:324:9)
    at Object.consumerMarkedDirty (core.mjs:11722:13)
    at consumerMarkDirty (core.mjs:2547:29)
    at producerNotifyConsumers (core.mjs:2529:17)
    at signalValueChanged (core.mjs:2837:5)
    at Function.signalSetFn [as set] (core.mjs:2847:9)
    at Page_ng_template_2_Template_tr_valueChange_11_listener (index.html:40:32)
    at executeListenerWithErrorHandling (core.mjs:16795:16)
    at Object.wrapListenerIn_markDirtyAndPreventDefault [as next] (core.mjs:16828:22)
```