### PR TITLE
chore(demo): `TuiLegendItem` change activeItemIndex when unhover legend item

### DIFF
--- a/projects/demo/src/modules/components/legend-item/examples/1/index.ts
+++ b/projects/demo/src/modules/components/legend-item/examples/1/index.ts
@@ -26,6 +26,6 @@ export default class Example {
     }
 
     protected onHover(index: number, hovered: boolean): void {
-        this.activeItemIndex = hovered ? index : 0;
+        this.activeItemIndex = hovered ? index : NaN;
     }
 }


### PR DESCRIPTION
This PR fixed error , when hover in `TuiLegendItem` set false , activeItemIndex set 0 
[link to Docs](https://taiga-ui.dev/charts/legend-item#ring)

https://github.com/user-attachments/assets/0cc82c20-1384-4033-bcb2-f6906cd2bbe3

