### PR TITLE
fix(legacy): `InputDate` ignore null value if internal value is already null

### DIFF
--- a/projects/legacy/components/input-date-range/input-date-range.component.ts
+++ b/projects/legacy/components/input-date-range/input-date-range.component.ts
@@ -212,6 +212,10 @@ export class TuiInputDateRangeComponent
     }
 
     public override writeValue(value: TuiDayRange | null): void {
+        if (this.value === null && value === this.value) {
+            return;
+        }
+
         super.writeValue(value);
         this.nativeValue.set(this.value ? this.computedValue : '');
         this.selectedActivePeriod = this.findActivePeriodBy(this.value);

--- a/projects/legacy/components/input-date-time/input-date-time.component.ts
+++ b/projects/legacy/components/input-date-time/input-date-time.component.ts
@@ -164,6 +164,10 @@ export class TuiInputDateTimeComponent
     }
 
     public override writeValue(value: [TuiDay | null, TuiTime | null] | null): void {
+        if (this.value === null && value === this.value) {
+            return;
+        }
+
         super.writeValue(value);
 
         this.nativeValue.set(

--- a/projects/legacy/components/input-date/input-date.component.ts
+++ b/projects/legacy/components/input-date/input-date.component.ts
@@ -183,6 +183,10 @@ export class TuiInputDateComponent
     }
 
     public override writeValue(value: TuiDay | null): void {
+        if (this.value === null && value === this.value) {
+            return;
+        }
+
         super.writeValue(value);
         this.nativeValue.set(this.value ? this.computedValue : '');
     }

--- a/projects/legacy/components/input-date/test/input-date.component.spec.ts
+++ b/projects/legacy/components/input-date/test/input-date.component.spec.ts
@@ -154,6 +154,18 @@ describe('InputDate', () => {
         });
 
         describe('textfield', () => {
+            it('do not clear input value if previous internal value is null', async () => {
+                testComponent.control.setValue(null);
+                fixture.detectChanges();
+                inputPO.sendText('10');
+                fixture.detectChanges();
+                testComponent.control.setValue(null);
+
+                await fixture.whenStable();
+
+                expect(inputPO.nativeElement?.value).toBe('10');
+            });
+
             describe('when mousedown on it', () => {
                 describe('unless the field is locked and not read-only', () => {
                     it('opens the calendar', () => {


### PR DESCRIPTION
…

Fixes #10267
