### PR TITLE
fix(experimental): `InputPhoneInternational` detects `countryIsoCode` on control update with complete phone

### DIFF
--- a/projects/demo-cypress/src/tests/input-phone-international.cy.ts
+++ b/projects/demo-cypress/src/tests/input-phone-international.cy.ts
@@ -34,6 +34,7 @@ import {createOutputSpy} from 'cypress/angular';
                     [countries]="countries"
                     [formControl]="control"
                     [(countryIsoCode)]="countryIsoCode"
+                    (countryIsoCodeChange)="countryIsoCodeChange.emit($event)"
                 />
 
                 <tui-icon icon="@tui.sun" />
@@ -63,6 +64,9 @@ export class Test implements OnInit {
 
     @Output()
     public readonly valueChange = new EventEmitter<string>();
+
+    @Output()
+    public readonly countryIsoCodeChange = new EventEmitter<string>();
 
     public ngOnInit(): void {
         this.control.valueChanges
@@ -238,6 +242,7 @@ describe('InputPhoneInternational', () => {
                         countryIsoCode: 'KZ',
                         control,
                         valueChange: createOutputSpy('valueChange'),
+                        countryIsoCodeChange: createOutputSpy('countryIsoCodeChange'),
                     },
                 });
 
@@ -265,6 +270,15 @@ describe('InputPhoneInternational', () => {
                     name: 'phone-18n-formatted-value',
                     cypressScreenshotOptions: {padding: 8},
                 });
+            });
+
+            it('automatically detects new [countryIsoCode] for complete phone', () => {
+                cy.get('@input').focus();
+
+                control.patchValue('+375123456789');
+
+                cy.get('@input').should('have.value', '+375 12 345-67-89');
+                cy.get('@countryIsoCodeChange').should('have.been.calledWith', 'BY');
             });
         });
     });

--- a/projects/experimental/components/input-phone-international/input-phone-international.component.ts
+++ b/projects/experimental/components/input-phone-international/input-phone-international.component.ts
@@ -190,6 +190,12 @@ export class TuiInputPhoneInternational extends TuiControl<string> {
     }
 
     public override writeValue(unmasked: string): void {
+        const code = this.getCountryCode(unmasked);
+
+        if (code) {
+            this.code.set(code);
+        }
+
         super.writeValue(unmasked);
         this.masked.set(
             maskitoTransform(this.value() ?? '', this.mask() || MASKITO_DEFAULT_OPTIONS),
@@ -202,21 +208,18 @@ export class TuiInputPhoneInternational extends TuiControl<string> {
     }
 
     protected onPaste(event: Event): void {
-        const metadata = this.metadata();
         const data = tuiIsInputEvent(event) && event.data;
 
         if (
             !data ||
-            !metadata ||
             (!event.inputType.includes('Drop') && !event.inputType.includes('Paste'))
         ) {
             return;
         }
 
-        const value = data.startsWith(CHAR_PLUS) ? data : CHAR_PLUS + data;
-        const code = maskitoGetCountryFromNumber(value, metadata);
+        const code = this.getCountryCode(data);
 
-        if (code && validatePhoneNumberLength(value) !== 'TOO_SHORT') {
+        if (code) {
             this.code.set(code);
         }
     }
@@ -258,5 +261,14 @@ export class TuiInputPhoneInternational extends TuiControl<string> {
         const value = maskedValue.replaceAll(NOT_FORM_CONTROL_SYMBOLS, '');
 
         return value === tuiGetCallingCode(this.code(), this.metadata()) ? '' : value;
+    }
+
+    private getCountryCode(value: string): TuiCountryIsoCode | null {
+        const metadata = this.metadata();
+        const phone = value.startsWith(CHAR_PLUS) ? value : CHAR_PLUS + value;
+
+        return metadata && validatePhoneNumberLength(phone) !== 'TOO_SHORT'
+            ? (maskitoGetCountryFromNumber(phone, metadata) ?? null)
+            : null;
     }
 }

--- a/projects/experimental/components/input-phone-international/input-phone-international.component.ts
+++ b/projects/experimental/components/input-phone-international/input-phone-international.component.ts
@@ -189,8 +189,8 @@ export class TuiInputPhoneInternational extends TuiControl<string> {
         this.code.set(code);
     }
 
-    public override writeValue(unmasked: string): void {
-        const code = this.getCountryCode(unmasked);
+    public override writeValue(unmasked: string | null): void {
+        const code = this.getCountryCode(unmasked ?? '');
 
         if (code) {
             this.code.set(code);


### PR DESCRIPTION
 Fixes #10351
