### PR TITLE
docs: add sticky search bar to custom data list

### DIFF
--- a/projects/demo/src/modules/components/data-list/examples/4/custom-list/index.html
+++ b/projects/demo/src/modules/components/data-list/examples/4/custom-list/index.html
@@ -1,15 +1,14 @@
-<tui-textfield
-    iconStart="@tui.search"
-    class="tui-space_all-2"
->
-    <input
-        placeholder="Search categories"
-        tuiAutoFocus
-        tuiTextfield
-        [focused]="true"
-        [(ngModel)]="value"
-    />
-</tui-textfield>
+<div class="t-list-search">
+    <tui-textfield iconStart="@tui.search">
+        <input
+            placeholder="Search categories"
+            tuiAutoFocus
+            tuiTextfield
+            [focused]="true"
+            [(ngModel)]="value"
+        />
+    </tui-textfield>
+</div>
 <hr />
 <tui-data-list
     emptyContent="No results found"

--- a/projects/demo/src/modules/components/data-list/examples/4/custom-list/index.less
+++ b/projects/demo/src/modules/components/data-list/examples/4/custom-list/index.less
@@ -1,0 +1,13 @@
+@import '@taiga-ui/core/styles/taiga-ui-local';
+
+.t-list-search {
+    position: sticky;
+    top: 0;
+    z-index: 1;
+    background: var(--tui-background-elevation-3);
+    padding: 0.375rem 0.375rem 0;
+
+    input {
+        .tui-prevent-ios-scroll();
+    }
+}

--- a/projects/demo/src/modules/components/data-list/examples/4/custom-list/index.ts
+++ b/projects/demo/src/modules/components/data-list/examples/4/custom-list/index.ts
@@ -37,6 +37,7 @@ interface Items<T> {
         TuiTextfield,
     ],
     templateUrl: './index.html',
+    styleUrls: ['./index.less'],
     changeDetection,
 })
 export class CustomListComponent<T> {


### PR DESCRIPTION
Custom data list now has sticky search bar like [input-phone-international](https://taiga-ui.dev/components/input-phone-international#countries) example.
