### PR TITLE
fix(core): redundant padding around title when header block exists

### DIFF
--- a/projects/core/components/dialog/dialog.template.html
+++ b/projects/core/components/dialog/dialog.template.html
@@ -9,7 +9,7 @@
 <div class="t-content">
     <h2
         class="t-heading"
-        [class.t-heading_closable]="context.closeable"
+        [class.t-heading_closable]="context.closeable && !header"
         [id]="context.id"
         [textContent]="context.label"
     ></h2>


### PR DESCRIPTION
Fixes #10381
