### PR TITLE
fix(addon-doc): `tuiCoerceValue` fails to parse `%` symbol

### DIFF
--- a/projects/addon-doc/utils/coerce-value.ts
+++ b/projects/addon-doc/utils/coerce-value.ts
@@ -35,6 +35,11 @@ export function tuiCoerceValue<T>(
         return Number(prepared);
     }
 
+    if (prepared === '%') {
+        // https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/decodeURIComponent#exceptions
+        return prepared;
+    }
+
     const decodedValue = decodeURIComponent(prepared);
 
     try {

--- a/projects/addon-doc/utils/test/coerce-value.spec.ts
+++ b/projects/addon-doc/utils/test/coerce-value.spec.ts
@@ -5,6 +5,8 @@ describe('coercing values', () => {
         expect(tuiCoerceValue(' +7965')).toBe('+7965');
         expect(tuiCoerceValue('%2B7')).toBe('+7');
         expect(tuiCoerceValue('%20%20%20123%20%20')).toBe('   123  ');
+        expect(tuiCoerceValue('%')).toBe('%');
+        expect(tuiCoerceValue('%25')).toBe('%');
         expect(tuiCoerceValue('Hello world')).toBe('Hello world');
         expect(tuiCoerceValue('2+5')).toBe('2+5');
         expect(tuiCoerceValue('')).toBe('');


### PR DESCRIPTION
## Some context
```
encodeURIComponent('%') // '%25'
```

https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/decodeURIComponent#exceptions

<img width="726" alt="exception" src="https://github.com/user-attachments/assets/f861cd05-057d-4b5d-849f-2bd8eba8757f" />

## Problem
Open https://taiga-ui.dev/components/input-number/API?postfix=%25
It throws 
```
VM25636:1 Uncaught URIError: URI malformed
    at decodeURIComponent (<anonymous>)
    at eval (eval at tuiCoerceValue (coerce-value.ts:38:26), <anonymous>:1:1)
    at tuiCoerceValue (coerce-value.ts:38:26)
    at TuiDocAPIItem.parseParams (api-item.component.ts:107:33)
    at TuiDocAPIItem.ngAfterViewInit (api-item.component.ts:75:14)
    at callHookInternal (core.mjs:4024:14)
    at callHook (core.mjs:4051:13)
    at callHooks (core.mjs:4006:17)
    at executeInitAndCheckHooks (core.mjs:3956:9)
    at refreshView (core.mjs:13569:21)
```