### PR TITLE
feat(addon-mobile): `SheetDialog` add `fullscreen`

### DIFF
--- a/projects/addon-mobile/components/sheet-dialog/sheet-dialog.component.ts
+++ b/projects/addon-mobile/components/sheet-dialog/sheet-dialog.component.ts
@@ -5,7 +5,6 @@ import {
     Component,
     ElementRef,
     inject,
-    ViewChild,
     ViewChildren,
 } from '@angular/core';
 import {EMPTY_QUERY} from '@taiga-ui/cdk/constants';
@@ -37,8 +36,6 @@ function isCloseable(this: TuiSheetDialogComponent<unknown>): boolean {
     host: {
         '[@tuiSlideInTop]': 'slideInTop',
         '[style.--tui-offset.px]': 'context.offset',
-        '[style.--t-bar.px]': 'bar?.nativeElement.clientHeight',
-        '[style.--t-heading.px]': 'heading?.nativeElement.clientHeight',
         '[class._closeable]': 'context.closeable === true',
         '[class._fullscreen]': 'context.fullscreen === true',
         '(document:touchstart.passive.zoneless)': 'onPointerChange(1)',
@@ -54,12 +51,6 @@ export class TuiSheetDialogComponent<I> implements AfterViewInit {
 
     private readonly el = tuiInjectElement();
     private pointers = 0;
-
-    @ViewChild('bar')
-    protected readonly bar?: ElementRef<HTMLElement>;
-
-    @ViewChild('heading')
-    protected readonly heading?: ElementRef<HTMLElement>;
 
     protected readonly slideInTop = {
         value: '',

--- a/projects/addon-mobile/components/sheet-dialog/sheet-dialog.component.ts
+++ b/projects/addon-mobile/components/sheet-dialog/sheet-dialog.component.ts
@@ -40,7 +40,7 @@ function isCloseable(this: TuiSheetDialogComponent<unknown>): boolean {
         '[style.--t-bar.px]': 'bar?.nativeElement.clientHeight',
         '[style.--t-heading.px]': 'heading?.nativeElement.clientHeight',
         '[class._closeable]': 'context.closeable === true',
-        '[class._fullsize]': 'context.fullsize === true',
+        '[class._fullscreen]': 'context.fullscreen === true',
         '(document:touchstart.passive.zoneless)': 'onPointerChange(1)',
         '(document:touchend.zoneless)': 'onPointerChange(-1)',
         '(document:touchcancel.zoneless)': 'onPointerChange(-1)',

--- a/projects/addon-mobile/components/sheet-dialog/sheet-dialog.component.ts
+++ b/projects/addon-mobile/components/sheet-dialog/sheet-dialog.component.ts
@@ -5,6 +5,7 @@ import {
     Component,
     ElementRef,
     inject,
+    ViewChild,
     ViewChildren,
 } from '@angular/core';
 import {EMPTY_QUERY} from '@taiga-ui/cdk/constants';
@@ -36,7 +37,10 @@ function isCloseable(this: TuiSheetDialogComponent<unknown>): boolean {
     host: {
         '[@tuiSlideInTop]': 'slideInTop',
         '[style.--tui-offset.px]': 'context.offset',
+        '[style.--t-bar.px]': 'bar?.nativeElement.clientHeight',
+        '[style.--t-heading.px]': 'heading?.nativeElement.clientHeight',
         '[class._closeable]': 'context.closeable === true',
+        '[class._fullsize]': 'context.fullsize === true',
         '(document:touchstart.passive.zoneless)': 'onPointerChange(1)',
         '(document:touchend.zoneless)': 'onPointerChange(-1)',
         '(document:touchcancel.zoneless)': 'onPointerChange(-1)',
@@ -50,6 +54,12 @@ export class TuiSheetDialogComponent<I> implements AfterViewInit {
 
     private readonly el = tuiInjectElement();
     private pointers = 0;
+
+    @ViewChild('bar')
+    protected readonly bar?: ElementRef<HTMLElement>;
+
+    @ViewChild('heading')
+    protected readonly heading?: ElementRef<HTMLElement>;
 
     protected readonly slideInTop = {
         value: '',

--- a/projects/addon-mobile/components/sheet-dialog/sheet-dialog.options.ts
+++ b/projects/addon-mobile/components/sheet-dialog/sheet-dialog.options.ts
@@ -12,7 +12,7 @@ export interface TuiSheetDialogOptions<I = undefined> {
     readonly offset: number;
     readonly stops: readonly string[];
     readonly bar: boolean;
-    readonly fullsize: boolean;
+    readonly fullscreen: boolean;
 }
 
 export const TUI_SHEET_DIALOG_DEFAULT_OPTIONS: TuiSheetDialogOptions = {
@@ -23,7 +23,7 @@ export const TUI_SHEET_DIALOG_DEFAULT_OPTIONS: TuiSheetDialogOptions = {
     closeable: true,
     data: undefined,
     bar: true,
-    fullsize: false,
+    fullscreen: false,
 };
 
 /**

--- a/projects/addon-mobile/components/sheet-dialog/sheet-dialog.options.ts
+++ b/projects/addon-mobile/components/sheet-dialog/sheet-dialog.options.ts
@@ -12,6 +12,7 @@ export interface TuiSheetDialogOptions<I = undefined> {
     readonly offset: number;
     readonly stops: readonly string[];
     readonly bar: boolean;
+    readonly fullsize: boolean;
 }
 
 export const TUI_SHEET_DIALOG_DEFAULT_OPTIONS: TuiSheetDialogOptions = {
@@ -22,6 +23,7 @@ export const TUI_SHEET_DIALOG_DEFAULT_OPTIONS: TuiSheetDialogOptions = {
     closeable: true,
     data: undefined,
     bar: true,
+    fullsize: false,
 };
 
 /**

--- a/projects/addon-mobile/components/sheet-dialog/sheet-dialog.style.less
+++ b/projects/addon-mobile/components/sheet-dialog/sheet-dialog.style.less
@@ -40,7 +40,7 @@
             display: flex;
             min-block-size: calc(var(--t-sheet-height) - var(--t-bar, 0px) - var(--t-heading, 0px));
             flex-direction: column;
-            box-sizing: border-box;
+            // box-sizing: border-box;
         }
 
         &._closeable {
@@ -128,6 +128,7 @@
     isolation: isolate;
     padding-block-end: calc(1.5rem + env(safe-area-inset-bottom));
     border-radius: inherit;
+    box-sizing: border-box;
 
     &::after {
         content: '';

--- a/projects/addon-mobile/components/sheet-dialog/sheet-dialog.style.less
+++ b/projects/addon-mobile/components/sheet-dialog/sheet-dialog.style.less
@@ -123,7 +123,6 @@
     isolation: isolate;
     padding-block-end: calc(1.5rem + env(safe-area-inset-bottom));
     border-radius: inherit;
-    box-sizing: border-box;
 
     &::after {
         content: '';

--- a/projects/addon-mobile/components/sheet-dialog/sheet-dialog.style.less
+++ b/projects/addon-mobile/components/sheet-dialog/sheet-dialog.style.less
@@ -40,7 +40,6 @@
             display: flex;
             min-block-size: calc(var(--t-sheet-height) - var(--t-bar, 0px) - var(--t-heading, 0px));
             flex-direction: column;
-            // box-sizing: border-box;
         }
 
         &._closeable {

--- a/projects/addon-mobile/components/sheet-dialog/sheet-dialog.style.less
+++ b/projects/addon-mobile/components/sheet-dialog/sheet-dialog.style.less
@@ -38,6 +38,7 @@
             min-block-size: 100%;
         }
 
+        // TODO: make default in v5
         .t-content {
             display: flex;
             flex-direction: column;

--- a/projects/addon-mobile/components/sheet-dialog/sheet-dialog.style.less
+++ b/projects/addon-mobile/components/sheet-dialog/sheet-dialog.style.less
@@ -29,7 +29,7 @@
         }
     }
 
-    &._fullsize {
+    &._fullscreen {
         --t-sheet-height: calc(var(--tui-viewport-height) - var(--tui-offset) - env(safe-area-inset-bottom));
 
         .t-sheet {
@@ -38,8 +38,8 @@
 
         .t-content {
             display: flex;
-            min-block-size: calc(var(--t-sheet-height) - var(--t-bar, 0px) - var(--t-heading, 0px));
             flex-direction: column;
+            min-block-size: calc(var(--t-sheet-height) - var(--t-bar, 0px) - var(--t-heading, 0px));
         }
 
         &._closeable {

--- a/projects/addon-mobile/components/sheet-dialog/sheet-dialog.style.less
+++ b/projects/addon-mobile/components/sheet-dialog/sheet-dialog.style.less
@@ -30,22 +30,18 @@
     }
 
     &._fullscreen {
-        --t-sheet-height: calc(var(--tui-viewport-height) - var(--tui-offset) - env(safe-area-inset-bottom));
+        display: block;
 
         .t-sheet {
-            flex-grow: 1;
+            display: flex;
+            flex-direction: column;
+            min-block-size: 100%;
         }
 
         .t-content {
             display: flex;
             flex-direction: column;
-            min-block-size: calc(var(--t-sheet-height) - var(--t-bar, 0px) - var(--t-heading, 0px));
-        }
-
-        &._closeable {
-            .t-sheet {
-                min-block-size: var(--t-sheet-height);
-            }
+            flex-grow: 1;
         }
     }
 }

--- a/projects/addon-mobile/components/sheet-dialog/sheet-dialog.style.less
+++ b/projects/addon-mobile/components/sheet-dialog/sheet-dialog.style.less
@@ -28,6 +28,27 @@
             display: flex;
         }
     }
+
+    &._fullsize {
+        --t-sheet-height: calc(var(--tui-viewport-height) - var(--tui-offset) - env(safe-area-inset-bottom));
+
+        .t-sheet {
+            flex-grow: 1;
+        }
+
+        .t-content {
+            display: flex;
+            min-block-size: calc(var(--t-sheet-height) - var(--t-bar, 0px) - var(--t-heading, 0px));
+            flex-direction: column;
+            box-sizing: border-box;
+        }
+
+        &._closeable {
+            .t-sheet {
+                min-block-size: var(--t-sheet-height);
+            }
+        }
+    }
 }
 
 .t-stops {

--- a/projects/addon-mobile/components/sheet-dialog/sheet-dialog.template.html
+++ b/projects/addon-mobile/components/sheet-dialog/sheet-dialog.template.html
@@ -9,10 +9,12 @@
 <div class="t-sheet">
     <div
         *ngIf="context.bar"
+        #bar
         class="t-top"
     ></div>
     <h2
         *ngIf="context.label"
+        #heading
         class="t-heading"
         [id]="context.id"
     >

--- a/projects/addon-mobile/components/sheet-dialog/sheet-dialog.template.html
+++ b/projects/addon-mobile/components/sheet-dialog/sheet-dialog.template.html
@@ -9,12 +9,10 @@
 <div class="t-sheet">
     <div
         *ngIf="context.bar"
-        #bar
         class="t-top"
     ></div>
     <h2
         *ngIf="context.label"
-        #heading
         class="t-heading"
         [id]="context.id"
     >

--- a/projects/demo/src/modules/components/sheet-dialog/examples/7/index.html
+++ b/projects/demo/src/modules/components/sheet-dialog/examples/7/index.html
@@ -1,0 +1,69 @@
+<button
+    tuiButton
+    type="button"
+    (click)="open = true"
+>
+    Show
+</button>
+<ng-template
+    let-observer
+    [tuiSheetDialogOptions]="options"
+    [(tuiSheetDialog)]="open"
+>
+    <span>
+        <a
+            appearance="secondary"
+            href="mailto:alexander@inkin.ru"
+            iconStart="@tui.mail"
+            size="m"
+            tuiIconButton
+            class="tui-space_right-2"
+        >
+            Email
+        </a>
+        <a
+            appearance="secondary"
+            href="https://t.me/waterplea"
+            iconStart="@tui.phone-forwarded"
+            size="m"
+            tuiIconButton
+            class="tui-space_right-2"
+        >
+            Telegram
+        </a>
+        <a
+            appearance="secondary"
+            href="https://waterplea.bandcamp.com/"
+            iconStart="@tui.music"
+            size="m"
+            tuiIconButton
+        >
+            Music
+        </a>
+    </span>
+    <p
+        *tuiRepeatTimes="let i of 1"
+        [style.flex-grow]="1"
+    >
+        Passionate Angular dev, musician and OSS author.
+    </p>
+    <footer class="footer">
+        <button
+            size="m"
+            tuiButton
+            type="button"
+            (click)="observer.complete()"
+        >
+            Give a raise
+        </button>
+        <button
+            appearance="secondary"
+            size="m"
+            tuiButton
+            type="button"
+            (click)="observer.complete()"
+        >
+            Fire
+        </button>
+    </footer>
+</ng-template>

--- a/projects/demo/src/modules/components/sheet-dialog/examples/7/index.less
+++ b/projects/demo/src/modules/components/sheet-dialog/examples/7/index.less
@@ -1,9 +1,7 @@
-.label {
-    display: flex;
-    gap: 0.75rem;
-}
-
 .footer {
     position: sticky;
     bottom: calc(1.5rem - env(safe-area-inset-bottom));
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
 }

--- a/projects/demo/src/modules/components/sheet-dialog/examples/7/index.ts
+++ b/projects/demo/src/modules/components/sheet-dialog/examples/7/index.ts
@@ -8,7 +8,7 @@ import {TuiButton} from '@taiga-ui/core';
 
 @Component({
     standalone: true,
-    imports: [TuiButton, TuiSheetDialog, TuiRepeatTimes],
+    imports: [TuiButton, TuiRepeatTimes, TuiSheetDialog],
     templateUrl: './index.html',
     styleUrls: ['./index.less'],
     encapsulation,

--- a/projects/demo/src/modules/components/sheet-dialog/examples/7/index.ts
+++ b/projects/demo/src/modules/components/sheet-dialog/examples/7/index.ts
@@ -1,0 +1,25 @@
+import {Component} from '@angular/core';
+import {changeDetection} from '@demo/emulate/change-detection';
+import {encapsulation} from '@demo/emulate/encapsulation';
+import type {TuiSheetDialogOptions} from '@taiga-ui/addon-mobile';
+import {TuiSheetDialog} from '@taiga-ui/addon-mobile';
+import {TuiRepeatTimes} from '@taiga-ui/cdk';
+import {TuiButton} from '@taiga-ui/core';
+
+@Component({
+    standalone: true,
+    imports: [TuiButton, TuiSheetDialog, TuiRepeatTimes],
+    templateUrl: './index.html',
+    styleUrls: ['./index.less'],
+    encapsulation,
+    changeDetection,
+})
+export default class Example {
+    protected open = false;
+
+    protected readonly options: Partial<TuiSheetDialogOptions> = {
+        label: 'Alexander Inkin',
+        closeable: true,
+        fullsize: true,
+    };
+}

--- a/projects/demo/src/modules/components/sheet-dialog/examples/7/index.ts
+++ b/projects/demo/src/modules/components/sheet-dialog/examples/7/index.ts
@@ -20,6 +20,6 @@ export default class Example {
     protected readonly options: Partial<TuiSheetDialogOptions> = {
         label: 'Alexander Inkin',
         closeable: true,
-        fullsize: true,
+        fullscreen: true,
     };
 }

--- a/projects/demo/src/modules/components/sheet-dialog/index.html
+++ b/projects/demo/src/modules/components/sheet-dialog/index.html
@@ -55,10 +55,8 @@
             >
                 <p [style.flex-grow]="1">
                     Karl Gambolputty de von
-                    Ausfern-schplenden-schlitter-crasscrenbon-fried-digger-dingle-dangle-dongle-dungle-burstein-von-knacker-thrasher-apple-banger-horowitz-ticolensic-grander-knotty-spelltinkle-grandlich-grumblemeyer-spelterwasser-kurstlich-himbleeisen-bahnwagen-gutenabend-bitte-ein-nürnburger-bratwustle-gerspurten-mitzweimache-luber-hundsfut-gumberaber-shönendanker-kalbsfleisch-mittler-aucher
-                    von Hautkopft of Ulm was the last-surviving relative of Johann Gambolputty de von
-                    Ausfern-schplenden-schlitter-crasscrenbon-fried-digger-dingle-dangle-dongle-dungle-burstein-von-knacker-thrasher-apple-banger-horowitz-ticolensic-grander-knotty-spelltinkle-grandlich-grumblemeyer-spelterwasser-kurstlich-himbleeisen-bahnwagen-gutenabend-bitte-ein-nürnburger-bratwustle-gerspurten-mitzweimache-luber-hundsfut-gumberaber-shönendanker-kalbsfleisch-mittler-aucher
-                    von Hautkopft of Ulm.
+                    Ausfern-schplenden-schlitter-crasscrenbon-fried-digger-dingle-dangle-dongle-dungle-burstein-von-knacker-thrasher-apple-banger-horowitz-ticolensic-grander-knotty-spelltinkle-grandlich-grumblemeyer-spelterwasser-kurstlich-himbleeisen-bahnwagen-gutenabend-bitte-ein-nürnburger-bratwustle-gerspurten-mitzweimache-luber
+                    von Hautkopft of Ulm was the last-surviving relative of Johann Gambolputty de von.
                 </p>
                 <footer class="footer">
                     <button

--- a/projects/demo/src/modules/components/sheet-dialog/index.html
+++ b/projects/demo/src/modules/components/sheet-dialog/index.html
@@ -45,7 +45,7 @@
                 [tuiSheetDialogOptions]="{
                     label: label === 'Template' ? template : label,
                     closeable: closeable,
-                    fullsize: fullsize,
+                    fullscreen: fullscreen,
                     stops: stops,
                     initial: initial,
                     bar: bar,
@@ -79,9 +79,9 @@
                 Whether or not a sheet can be closed by user.
             </ng-template>
             <ng-template
-                documentationPropertyName="fullsize"
+                documentationPropertyName="fullscreen"
                 documentationPropertyType="boolean"
-                [(documentationPropertyValue)]="fullsize"
+                [(documentationPropertyValue)]="fullscreen"
             >
                 Fullsize
             </ng-template>

--- a/projects/demo/src/modules/components/sheet-dialog/index.html
+++ b/projects/demo/src/modules/components/sheet-dialog/index.html
@@ -45,25 +45,31 @@
                 [tuiSheetDialogOptions]="{
                     label: label === 'Template' ? template : label,
                     closeable: closeable,
+                    fullsize: fullsize,
                     stops: stops,
                     initial: initial,
+                    bar: bar,
+                    offset: offset,
                 }"
                 [(tuiSheetDialog)]="open"
             >
-                Karl Gambolputty de von
-                Ausfern-schplenden-schlitter-crasscrenbon-fried-digger-dingle-dangle-dongle-dungle-burstein-von-knacker-thrasher-apple-banger-horowitz-ticolensic-grander-knotty-spelltinkle-grandlich-grumblemeyer-spelterwasser-kurstlich-himbleeisen-bahnwagen-gutenabend-bitte-ein-nürnburger-bratwustle-gerspurten-mitzweimache-luber-hundsfut-gumberaber-shönendanker-kalbsfleisch-mittler-aucher
-                von Hautkopft of Ulm was the last-surviving relative of Johann Gambolputty de von
-                Ausfern-schplenden-schlitter-crasscrenbon-fried-digger-dingle-dangle-dongle-dungle-burstein-von-knacker-thrasher-apple-banger-horowitz-ticolensic-grander-knotty-spelltinkle-grandlich-grumblemeyer-spelterwasser-kurstlich-himbleeisen-bahnwagen-gutenabend-bitte-ein-nürnburger-bratwustle-gerspurten-mitzweimache-luber-hundsfut-gumberaber-shönendanker-kalbsfleisch-mittler-aucher
-                von Hautkopft of Ulm.
-                <div class="tui-space_top-4">
+                <p [style.flex-grow]="1">
+                    Karl Gambolputty de von
+                    Ausfern-schplenden-schlitter-crasscrenbon-fried-digger-dingle-dangle-dongle-dungle-burstein-von-knacker-thrasher-apple-banger-horowitz-ticolensic-grander-knotty-spelltinkle-grandlich-grumblemeyer-spelterwasser-kurstlich-himbleeisen-bahnwagen-gutenabend-bitte-ein-nürnburger-bratwustle-gerspurten-mitzweimache-luber-hundsfut-gumberaber-shönendanker-kalbsfleisch-mittler-aucher
+                    von Hautkopft of Ulm was the last-surviving relative of Johann Gambolputty de von
+                    Ausfern-schplenden-schlitter-crasscrenbon-fried-digger-dingle-dangle-dongle-dungle-burstein-von-knacker-thrasher-apple-banger-horowitz-ticolensic-grander-knotty-spelltinkle-grandlich-grumblemeyer-spelterwasser-kurstlich-himbleeisen-bahnwagen-gutenabend-bitte-ein-nürnburger-bratwustle-gerspurten-mitzweimache-luber-hundsfut-gumberaber-shönendanker-kalbsfleisch-mittler-aucher
+                    von Hautkopft of Ulm.
+                </p>
+                <footer class="footer">
                     <button
                         tuiButton
                         type="button"
+                        [style.inline-size.%]="100"
                         (click)="toggle()"
                     >
                         Close
                     </button>
-                </div>
+                </footer>
             </ng-template>
         </tui-doc-demo>
         <tui-doc-documentation>
@@ -73,6 +79,20 @@
                 [(documentationPropertyValue)]="closeable"
             >
                 Whether or not a sheet can be closed by user.
+            </ng-template>
+            <ng-template
+                documentationPropertyName="fullsize"
+                documentationPropertyType="boolean"
+                [(documentationPropertyValue)]="fullsize"
+            >
+                Fullsize
+            </ng-template>
+            <ng-template
+                documentationPropertyName="bar"
+                documentationPropertyType="boolean"
+                [(documentationPropertyValue)]="bar"
+            >
+                Show bar
             </ng-template>
             <ng-template
                 documentationPropertyName="data"
@@ -104,6 +124,15 @@
                 Initial stop index to open on. Index exceeding
                 <code>stops</code>
                 means to stop on top of the sheet's content.
+            </ng-template>
+            <ng-template
+                documentationPropertyName="offset"
+                documentationPropertyType="number"
+                [(documentationPropertyValue)]="offset"
+            >
+                Top offset px (
+                <code>--tui-offset</code>
+                )
             </ng-template>
         </tui-doc-documentation>
     </ng-template>

--- a/projects/demo/src/modules/components/sheet-dialog/index.ts
+++ b/projects/demo/src/modules/components/sheet-dialog/index.ts
@@ -21,12 +21,16 @@ export default class Page {
         'Sticky elements',
         'Responsive',
         'AppBar',
+        'Fullsize',
     ];
 
     protected closeable = TUI_SHEET_DIALOG_DEFAULT_OPTIONS.closeable;
+    protected fullsize = TUI_SHEET_DIALOG_DEFAULT_OPTIONS.fullsize;
+    protected bar = TUI_SHEET_DIALOG_DEFAULT_OPTIONS.bar;
     protected initial = TUI_SHEET_DIALOG_DEFAULT_OPTIONS.initial;
     protected stops = TUI_SHEET_DIALOG_DEFAULT_OPTIONS.stops;
     protected label = TUI_SHEET_DIALOG_DEFAULT_OPTIONS.label;
+    protected offset = TUI_SHEET_DIALOG_DEFAULT_OPTIONS.offset;
 
     protected open = false;
 

--- a/projects/demo/src/modules/components/sheet-dialog/index.ts
+++ b/projects/demo/src/modules/components/sheet-dialog/index.ts
@@ -21,11 +21,11 @@ export default class Page {
         'Sticky elements',
         'Responsive',
         'AppBar',
-        'Fullsize',
+        'Fullscreen',
     ];
 
     protected closeable = TUI_SHEET_DIALOG_DEFAULT_OPTIONS.closeable;
-    protected fullsize = TUI_SHEET_DIALOG_DEFAULT_OPTIONS.fullsize;
+    protected fullscreen = TUI_SHEET_DIALOG_DEFAULT_OPTIONS.fullscreen;
     protected bar = TUI_SHEET_DIALOG_DEFAULT_OPTIONS.bar;
     protected initial = TUI_SHEET_DIALOG_DEFAULT_OPTIONS.initial;
     protected stops = TUI_SHEET_DIALOG_DEFAULT_OPTIONS.stops;


### PR DESCRIPTION
`SheetDialog` add `fullscreen` option, add example and update API page

<img width="971" alt="image" src="https://github.com/user-attachments/assets/94f34bb3-452a-43d9-8cdc-82932694552c" />
<img width="992" alt="image" src="https://github.com/user-attachments/assets/b70ce3bf-8e40-4d48-8bdf-aa2e9a5be072" />

