### PR TITLE
fix(addon-commerce): `InputCardGroup` should remove browser autofill styles for Chrome on IOS

### DIFF
--- a/projects/addon-commerce/components/input-card-group/input-card-group.style.less
+++ b/projects/addon-commerce/components/input-card-group/input-card-group.style.less
@@ -123,6 +123,7 @@
         color: var(--tui-text-primary);
     }
 
+    &[chrome-autofilled], /* Chrome on IOS */
     &:-webkit-autofill {
         -webkit-text-fill-color: var(--tui-text-primary) !important;
         caret-color: var(--tui-text-primary) !important;

--- a/projects/core/styles/theme/appearance/textfield.less
+++ b/projects/core/styles/theme/appearance/textfield.less
@@ -58,6 +58,7 @@
         outline-color: var(--tui-border-normal) !important;
     }
 
+    &[chrome-autofilled], /* Chrome on IOS */
     &:-webkit-autofill {
         -webkit-text-fill-color: var(--tui-text-primary) !important;
         caret-color: var(--tui-text-primary) !important;


### PR DESCRIPTION

<img width="983" alt="ios-chrome" src="https://github.com/user-attachments/assets/8f9332ad-97d6-44fc-8967-7853636f1582" />


Fixes #10475
