### PR TITLE
chore(demo-cypress): mock current date for `MobileCalendar` tests

### DIFF
--- a/projects/demo-cypress/src/tests/mobile-calendar.cy.ts
+++ b/projects/demo-cypress/src/tests/mobile-calendar.cy.ts
@@ -12,8 +12,12 @@ import {createOutputSpy} from 'cypress/angular';
 import {of} from 'rxjs';
 
 describe('Mobile calendar', () => {
-    const today = TuiDay.currentLocal();
+    const today = new TuiDay(2020, 8, 20);
     const tomorrow = today.append({day: 1});
+
+    beforeEach(() => {
+        cy.clock(today.toLocalNativeDate(), ['Date']);
+    });
 
     @Component({
         standalone: true,


### PR DESCRIPTION
See failed jobs in other PRs.

For example: https://github.com/taiga-family/taiga-ui/actions/runs/13586033007/job/37981123699?pr=10480