### PR TITLE
chore(demo-playwright): fix invalid order of actions for `InputNumber` test

### DIFF
--- a/projects/demo-playwright/tests/legacy/input-number/input-number.pw.spec.ts
+++ b/projects/demo-playwright/tests/legacy/input-number/input-number.pw.spec.ts
@@ -455,8 +455,8 @@ test.describe('InputNumber', () => {
                     page,
                     `${DemoRoute.InputNumberLegacy}/API?tuiTextfieldPrefix=$&tuiTextfieldPostfix=kg`,
                 );
-                await input.clear();
                 await input.focus();
+                await input.clear();
 
                 await expect(input).toHaveValue('$ kg');
                 await expect(input).toHaveJSProperty('selectionStart', 1);


### PR DESCRIPTION
Relates:
* https://github.com/taiga-family/taiga-ui/pull/10485

```
  1) [chromium] › projects/demo-playwright/tests/legacy/input-number/input-number.pw.spec.ts:451:17 › InputNumber › API › value formatting on blur › text field does not contain any digit (only prefix + postfix) => clear text field's value on blur 

    Error: Timed out 5000ms waiting for expect(locator).toHaveValue(expected)

    Locator: locator('#demo-content').getByTestId('tui-primitive-textfield__native-input')
    Expected string: "$ kg"
    Received string: "$432 kg"
    Call log:
      - expect.toHaveValue with timeout 5000ms
      - waiting for locator('#demo-content').getByTestId('tui-primitive-textfield__native-input')
        9 × locator resolved to <input tabindex="0" maxlength="23" inputmode="decimal" aria-invalid="false" _ngcontent-ng-c2766531456="" id="tui_interactive_311601061540000" class="t-input ng-untouched ng-valid ng-dirty" automation-id="tui-primitive-textfield__native-input"/>
          - unexpected value "$432 kg"


      459 |                 await input.focus();
      460 |
    > 461 |                 await expect(input).toHaveValue('$ kg');
```