### PR TITLE
chore(demo-playwright): fix invalid order of actions for `InputNumber` test (again)

### DIFF
--- a/projects/demo-playwright/tests/legacy/input-number/input-number.pw.spec.ts
+++ b/projects/demo-playwright/tests/legacy/input-number/input-number.pw.spec.ts
@@ -53,8 +53,10 @@ test.describe('InputNumber', () => {
 
             await expect(example).toHaveScreenshot('02-input-number.png');
 
+            await input.focus();
             await input.clear();
 
+            await expect(input).toHaveValue('$ GBP');
             await expect(example).toHaveScreenshot('03-input-number.png');
         });
 
@@ -479,9 +481,10 @@ test.describe('InputNumber', () => {
                 .all();
 
             for (const [i, input] of inputs.entries()) {
-                await input.clear();
                 await input.focus();
+                await input.clear();
 
+                await expect(input).toHaveValue(/\D/);
                 await expect(example).toHaveScreenshot(`06-input-number-${i}.png`);
             }
         });


### PR DESCRIPTION
Relates:
- https://github.com/taiga-family/taiga-ui/pull/10485

![image](https://github.com/user-attachments/assets/e812375e-0953-4363-aa77-59a60a430473)

![image](https://github.com/user-attachments/assets/00e32042-f723-420d-90e6-3dd09132ce1b)
