### PR TITLE
chore(demo): `Icon` add example inline svg

### DIFF
--- a/projects/demo/src/modules/components/icon/examples/10/index.html
+++ b/projects/demo/src/modules/components/icon/examples/10/index.html
@@ -1,1 +1,0 @@
-<tui-icon [icon]="icon" />

--- a/projects/demo/src/modules/components/icon/examples/10/index.html
+++ b/projects/demo/src/modules/components/icon/examples/10/index.html
@@ -1,0 +1,1 @@
+<tui-icon [icon]="icon" />

--- a/projects/demo/src/modules/components/icon/examples/10/index.ts
+++ b/projects/demo/src/modules/components/icon/examples/10/index.ts
@@ -6,12 +6,12 @@ import {TuiIcon} from '@taiga-ui/core';
 @Component({
     standalone: true,
     imports: [TuiIcon],
-    templateUrl: './index.html',
+    template: '<tui-icon [icon]="icon" />',
     encapsulation,
     changeDetection,
 })
 export default class Example {
     protected readonly icon = `data:image/svg+xml;charset=UTF-8,${encodeURIComponent(
-        '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="#000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m5 12 7-7 7 7"/><path d="M12 19V5"/></svg>',
+        '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m5 12 7-7 7 7"/><path d="M12 19V5"/></svg>',
     )}`;
 }

--- a/projects/demo/src/modules/components/icon/examples/10/index.ts
+++ b/projects/demo/src/modules/components/icon/examples/10/index.ts
@@ -1,0 +1,17 @@
+import {Component} from '@angular/core';
+import {changeDetection} from '@demo/emulate/change-detection';
+import {encapsulation} from '@demo/emulate/encapsulation';
+import {TuiIcon} from '@taiga-ui/core';
+
+@Component({
+    standalone: true,
+    imports: [TuiIcon],
+    templateUrl: './index.html',
+    encapsulation,
+    changeDetection,
+})
+export default class Example {
+    protected readonly icon = `data:image/svg+xml;charset=UTF-8,${encodeURIComponent(
+        '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="#000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m5 12 7-7 7 7"/><path d="M12 19V5"/></svg>',
+    )}`;
+}

--- a/projects/demo/src/modules/components/icon/index.html
+++ b/projects/demo/src/modules/components/icon/index.html
@@ -36,10 +36,10 @@
         />
 
         <tui-doc-example
-            id="dynamic-construct-svg"
-            heading="Dynamic construct svg"
+            id="inline-svg"
+            heading="Inline svg"
             [component]="10 | tuiComponent"
-            [content]="10 | tuiExample: 'html,ts'"
+            [content]="10 | tuiExample: 'ts'"
         />
     </ng-template>
 

--- a/projects/demo/src/modules/components/icon/index.html
+++ b/projects/demo/src/modules/components/icon/index.html
@@ -34,6 +34,13 @@
             [component]="9 | tuiComponent"
             [content]="9 | tuiExample: 'html,ts'"
         />
+
+        <tui-doc-example
+            id="dynamic-construct-svg"
+            heading="Dynamic construct svg"
+            [component]="10 | tuiComponent"
+            [content]="10 | tuiExample: 'html,ts'"
+        />
     </ng-template>
 
     <ng-template pageTab>


### PR DESCRIPTION
Add new example
<img width="956" alt="image" src="https://github.com/user-attachments/assets/35c2fc06-d62d-4030-94cb-0fda000cddc8" />

```
<tui-icon [icon]="icon" />
```

```
protected readonly icon = `data:image/svg+xml;charset=UTF-8,${encodeURIComponent(
        '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="#000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m5 12 7-7 7 7"/><path d="M12 19V5"/></svg>',
)}`;
```
