### PR TITLE
fix(core): `TuiDataList` attr(data-label) not correct working in Chrome

### DIFF
--- a/projects/core/components/data-list/data-list.style.less
+++ b/projects/core/components/data-list/data-list.style.less
@@ -105,6 +105,7 @@ tui-opt-group {
 
     &[data-label='']:before,
     &:not([data-label]):before {
+        content: '';
         padding: 0;
         margin: 0;
     }


### PR DESCRIPTION
Fixes #10456 

`attr()` not correct working when `data-label` is not defined since Chrome 133
https://developer.chrome.com/blog/advanced-attr
```
&::before {
        content: attr(data-label);
        ...
    }
```
<img width="450" alt="image" src="https://github.com/user-attachments/assets/c40c6fec-93a4-4fbc-b6a2-3f485cdb0dda" />

