### PR TITLE
fix(kit): `Chip` as text input is not properly clickable

### DIFF
--- a/projects/kit/styles/components/chip.less
+++ b/projects/kit/styles/components/chip.less
@@ -107,8 +107,12 @@ tui-chip,
     & > input[tuiChip] {
         .fullsize();
 
-        z-index: -1;
         margin: 0;
+
+        &[type='checkbox'],
+        &[type='radio'] {
+            z-index: -1;
+        }
     }
 
     &[tuiAppearance][data-appearance='error'], /* TODO @deprecated remove in v5 */


### PR DESCRIPTION
Fixes https://github.com/taiga-family/taiga-ui/issues/10513