### PR TITLE
chore(demo): fix source link for legacy `InputNumber` & `InputMonth`

### DIFF
--- a/projects/demo/src/modules/components/input-month-legacy/index.html
+++ b/projects/demo/src/modules/components/input-month-legacy/index.html
@@ -2,6 +2,7 @@
     deprecated
     header="InputMonthLegacy"
     package="LEGACY"
+    path="legacy/components/input-month"
     type="components"
 >
     <ng-template pageTab>

--- a/projects/demo/src/modules/components/input-number-legacy/index.html
+++ b/projects/demo/src/modules/components/input-number-legacy/index.html
@@ -1,6 +1,7 @@
 <tui-doc-page
     header="InputNumberLegacy"
     package="LEGACY"
+    path="legacy/components/input-number"
     type="components"
     [deprecated]="true"
 >


### PR DESCRIPTION
Open:
* https://taiga-ui.dev/legacy/input-number
* https://taiga-ui.dev/legacy/input-month

<img width="1081" alt="404" src="https://github.com/user-attachments/assets/19da3a28-4244-4fcd-a1a4-9c8066a85b2e" />

It opens 404 page