### PR TITLE
ci(demo): fix prerender of `API` & `Setup` pages of legacy components

### DIFF
--- a/scripts/generate-demo-routes-file.ts
+++ b/scripts/generate-demo-routes-file.ts
@@ -61,7 +61,7 @@ const EXCEPTIONS = [
              * use ng-morph (DemoRoute + `app.routes.ts` file + `*pageTab` directive) to create more accurate algorithm.
              *
              */
-            /^\/(components|directives|pipes|services|utils|layout|navigation|charts|experimental)/.exec(
+            /^\/(components|directives|pipes|services|utils|layout|navigation|charts|experimental|legacy)/.exec(
                 route,
             )
         ) {


### PR DESCRIPTION
Open:
* https://taiga-ui.dev/legacy/input-number/API
* https://taiga-ui.dev/legacy/input-number/Setup

See console logs
<img width="863" alt="logs" src="https://github.com/user-attachments/assets/d8be969a-e9e4-4df5-890b-9b6fffcb99db" />
