### PR TITLE
fix(addon-charts): bar color

### DIFF
--- a/projects/addon-charts/components/arc-chart/arc-chart.template.html
+++ b/projects/addon-charts/components/arc-chart/arc-chart.template.html
@@ -19,7 +19,7 @@
         vector-effect="non-scaling-stroke"
         class="t-value"
         [class.t-value_inactive]="isInactive(index)"
-        [style.stroke]="'var(--tui-chart-categorical-0' + index + ')'"
+        [style.stroke]="'var(--tui-chart-categorical-' + index.toString().padStart(2, '0') + ')'"
         [style.strokeDasharray.em]="getLength(index)"
         [style.strokeDashoffset.em]="initialized() ? getOffset(index) : getLength(index)"
     />

--- a/projects/addon-charts/components/bar-set/bar-set.template.html
+++ b/projects/addon-charts/components/bar-set/bar-set.template.html
@@ -28,7 +28,7 @@
         [class.t-bar_flexible]="flexible"
         [class.t-bar_negative]="item < 0"
         [size]="computedSize"
-        [style.background]="'var(--tui-chart-categorical-0' + index + ')'"
+        [style.background]="'var(--tui-chart-categorical-' + index.toString().padStart(2, '0') + ')'"
         [style.height.%]="getHeight(item)"
         [value]="computedSegments"
     />

--- a/projects/addon-charts/components/bar/bar.template.html
+++ b/projects/addon-charts/components/bar/bar.template.html
@@ -1,6 +1,6 @@
 <div
     *ngFor="let item of value; let index = index"
     automation-id="tui-bar__bar"
-    [style.background]="'var(--tui-chart-categorical-0' + index + ')'"
+    [style.background]="'var(--tui-chart-categorical-' + index.toString().padStart(2, '0') + ')'"
     [style.height.%]="getHeight(item)"
 ></div>

--- a/projects/addon-charts/components/pie-chart/pie-chart.template.html
+++ b/projects/addon-charts/components/pie-chart/pie-chart.template.html
@@ -37,7 +37,7 @@
             tuiHintPointer
             class="t-segment"
             [attr.transform]="getTransform(index)"
-            [style.color]="'var(--tui-chart-categorical-0' + index + ')'"
+            [style.color]="'var(--tui-chart-categorical-' + index.toString().padStart(2, '0') + ')'"
             [tuiHint]="hintContent"
             [tuiHintContext]="{$implicit: index}"
             [tuiPieChart]="segments[index] || [0, 0]"


### PR DESCRIPTION
Fixes https://github.com/taiga-family/taiga-ui/issues/10674
change "'var(--tui-chart-categorical-0' + index + ')'" to"'var(--tui-chart-categorical-' + index.toString().padStart(2, '0')+ ')'" 
Now bar color work good