### PR TITLE
fix(cdk): `tuiCreateToken` with no arguments should not create token with default `undefined`-value

### DIFF
--- a/projects/cdk/utils/miscellaneous/create-token.ts
+++ b/projects/cdk/utils/miscellaneous/create-token.ts
@@ -1,7 +1,9 @@
 import {InjectionToken} from '@angular/core';
 
 export function tuiCreateToken<T>(defaults?: T): InjectionToken<T> {
-    return tuiCreateTokenFromFactory(() => defaults);
+    return defaults === undefined
+        ? new InjectionToken('')
+        : tuiCreateTokenFromFactory(() => defaults);
 }
 
 export function tuiCreateTokenFromFactory<T>(factory?: () => T): InjectionToken<T> {


### PR DESCRIPTION
https://stackblitz.com/edit/option-content-with-skip-self

`TUI_OPTION_CONTENT` is projected content via `polymorpheusOutlet` (legacy approach) / `createComponent` (modern approach). Both approaches attach parent injector to this projected component.

**Previous behavior:**
`inject(TUI_OPTION_CONTENT, {skipSelf: true))` looks inside local injectors and get default `undefined` (from token factory). Stop exploring DI hierarchy (do not explore "parent" injectors).

**New behavior:**
`inject(TUI_OPTION_CONTENT, {skipSelf: true))` is not found inside "local" injectors - we reach "local" `NullInjector` => Got to "parent" inejctors.