### PR TITLE
feat(addon-mobile): `SheetDialog` add close directive to listen close events

### DIFF
--- a/projects/addon-mobile/components/sheet-dialog/index.ts
+++ b/projects/addon-mobile/components/sheet-dialog/index.ts
@@ -3,3 +3,4 @@ export * from './sheet-dialog.directive';
 export * from './sheet-dialog.module';
 export * from './sheet-dialog.options';
 export * from './sheet-dialog.service';
+export * from './sheet-dialog-close.directive';

--- a/projects/addon-mobile/components/sheet-dialog/sheet-dialog-close.directive.ts
+++ b/projects/addon-mobile/components/sheet-dialog/sheet-dialog-close.directive.ts
@@ -1,0 +1,21 @@
+import {Directive, ElementRef, Inject, NgZone, Output} from '@angular/core';
+import {tuiTypedFromEvent, tuiZonefree} from '@taiga-ui/cdk';
+import {Observable} from 'rxjs';
+
+export const TUI_SHEET_DIALOG_CLOSE = 'tui-sheet-dialog-close';
+
+@Directive({
+    selector: '[tuiSheetDialogClose]',
+})
+export class TuiSheetDialogCloseDirective {
+    @Output()
+    readonly tuiSheetDialogClose: Observable<unknown> = tuiTypedFromEvent(
+        this.el.nativeElement,
+        TUI_SHEET_DIALOG_CLOSE,
+    ).pipe(tuiZonefree(this.zone));
+
+    constructor(
+        @Inject(NgZone) private readonly zone: NgZone,
+        @Inject(ElementRef) private readonly el: ElementRef<HTMLElement>,
+    ) {}
+}

--- a/projects/addon-mobile/components/sheet-dialog/sheet-dialog.module.ts
+++ b/projects/addon-mobile/components/sheet-dialog/sheet-dialog.module.ts
@@ -7,11 +7,20 @@ import {PolymorpheusModule} from '@tinkoff/ng-polymorpheus';
 import {TuiSheetDialogComponent} from './sheet-dialog.component';
 import {TuiSheetDialogDirective} from './sheet-dialog.directive';
 import {TuiSheetDialogService} from './sheet-dialog.service';
+import {TuiSheetDialogCloseDirective} from './sheet-dialog-close.directive';
 
 @NgModule({
     imports: [CommonModule, PolymorpheusModule, TuiClickOutsideModule, TuiButtonModule],
-    declarations: [TuiSheetDialogComponent, TuiSheetDialogDirective],
+    declarations: [
+        TuiSheetDialogComponent,
+        TuiSheetDialogDirective,
+        TuiSheetDialogCloseDirective,
+    ],
     providers: [tuiAsDialog(TuiSheetDialogService)],
-    exports: [TuiSheetDialogComponent, TuiSheetDialogDirective],
+    exports: [
+        TuiSheetDialogComponent,
+        TuiSheetDialogDirective,
+        TuiSheetDialogCloseDirective,
+    ],
 })
 export class TuiSheetDialogModule {}

--- a/projects/addon-mobile/components/sheet-dialog/sheet-dialog.template.html
+++ b/projects/addon-mobile/components/sheet-dialog/sheet-dialog.template.html
@@ -11,6 +11,7 @@
     class="t-sheet"
     [class.t-sheet_small]="isSmall"
     (tuiClickOutside)="close()"
+    (tuiSheetDialogClose)="close()"
 >
     <div
         *ngIf="context.bar"


### PR DESCRIPTION
Add `tuiSheetDialogClose` directive to listen such events from sheet content:

```
elements.dispatchEvent(
    new CustomEvent(TUI_SHEET_DIALOG_CLOSE, {bubbles: true}),
);
```
