### PR TITLE
fix(kit): `InputTime` should hide icon if it equals to empty string

### DIFF
--- a/projects/kit/components/input-time/input-time.template.html
+++ b/projects/kit/components/input-time/input-time.template.html
@@ -20,7 +20,7 @@
         [pseudoHover]="pseudoHover"
         [readOnly]="readOnly"
         [tuiTextfieldFiller]="(getFiller$(mode) | async) || ''"
-        [tuiTextfieldIcon]="iconContent"
+        [tuiTextfieldIcon]="icon && iconContent"
         [value]="computedValue"
         (keydown.arrowDown)="onArrowDown($event)"
         (keydown.arrowUp)="onArrowUp($event)"


### PR DESCRIPTION
Fixes # <!-- link to a relevant issue. -->
