### PR TITLE
fix(core): `tuiIsEditingKey` safe argument for autofill empty key

### DIFF
--- a/projects/core/utils/miscellaneous/is-editing-key.ts
+++ b/projects/core/utils/miscellaneous/is-editing-key.ts
@@ -3,6 +3,6 @@ import {tuiEditingKeys} from '@taiga-ui/core/constants';
 /**
  * Check if pressed key is interactive in terms of input field
  */
-export function tuiIsEditingKey(key: string): boolean {
+export function tuiIsEditingKey(key = ''): boolean {
     return key.length === 1 || tuiEditingKeys.includes(key);
 }

--- a/projects/core/utils/miscellaneous/test/is-editing-key.spec.ts
+++ b/projects/core/utils/miscellaneous/test/is-editing-key.spec.ts
@@ -1,0 +1,21 @@
+import {tuiEditingKeys} from '@taiga-ui/core/constants';
+
+import {tuiIsEditingKey} from '../is-editing-key';
+
+describe('tuiIsEditingKey', () => {
+    it('returns false for undefined', () => {
+        expect(tuiIsEditingKey(undefined)).toBe(false);
+    });
+
+    it('returns false for empty string', () => {
+        expect(tuiIsEditingKey('')).toBe(false);
+    });
+
+    it('returns true for single character', () => {
+        expect(tuiIsEditingKey('a')).toBe(true);
+    });
+
+    it('returns true for defined editing key', () => {
+        expect(tuiIsEditingKey(tuiEditingKeys[0])).toBe(true);
+    });
+});


### PR DESCRIPTION
Add a default parameter value to `tuiIsEditingKey` to handle cases where `key` might be an `undefined` (e.g., from autofill events). This prevents potential runtime errors.

Added unit tests to verify:
- Handling of `undefined` and empty string inputs.
- Correct true for single-character keys.
- Correct true for `tuiEditingKeys` values.