### PR TITLE
fix(core): `InputMonth` should hide Android text select handle

### DIFF
--- a/projects/core/components/textfield/select-like.directive.ts
+++ b/projects/core/components/textfield/select-like.directive.ts
@@ -8,6 +8,7 @@ import {Directive} from '@angular/core';
         // Click on cleaner icon does not trigger `beforeinput` event --> handle all kind of deletion in input event
         '(beforeinput)': '$event.inputType.includes("delete") || $event.preventDefault()',
         '(input.capture)': '$event.inputType?.includes("delete") && clear($event.target)',
+        '(pointerdown.prevent)': '0', // Hide Android text select handle (bubble marker below transparent caret)
     },
 })
 export class TuiSelectLike {

--- a/projects/core/components/textfield/select-like.directive.ts
+++ b/projects/core/components/textfield/select-like.directive.ts
@@ -8,7 +8,7 @@ import {Directive} from '@angular/core';
         // Click on cleaner icon does not trigger `beforeinput` event --> handle all kind of deletion in input event
         '(beforeinput)': '$event.inputType.includes("delete") || $event.preventDefault()',
         '(input.capture)': '$event.inputType?.includes("delete") && clear($event.target)',
-        '(pointerdown.prevent)': '0', // Hide Android text select handle (bubble marker below transparent caret)
+        '(mousedown.prevent)': '$event.target.focus()', // Hide Android text select handle (bubble marker below transparent caret)
     },
 })
 export class TuiSelectLike {

--- a/projects/core/components/textfield/select-like.directive.ts
+++ b/projects/core/components/textfield/select-like.directive.ts
@@ -1,4 +1,5 @@
-import {Directive} from '@angular/core';
+import {Directive, inject} from '@angular/core';
+import {TUI_IS_ANDROID} from '@taiga-ui/cdk/tokens';
 
 @Directive({
     standalone: true,
@@ -8,11 +9,21 @@ import {Directive} from '@angular/core';
         // Click on cleaner icon does not trigger `beforeinput` event --> handle all kind of deletion in input event
         '(beforeinput)': '$event.inputType.includes("delete") || $event.preventDefault()',
         '(input.capture)': '$event.inputType?.includes("delete") && clear($event.target)',
-        '(mousedown.prevent)': '$event.target.focus()', // Hide Android text select handle (bubble marker below transparent caret)
+        // Hide Android text select handle (bubble marker below transparent caret)
+        '(mousedown)': 'prevent($event, $event.target)',
     },
 })
 export class TuiSelectLike {
+    private readonly isAndroid = inject(TUI_IS_ANDROID);
+
     protected clear(element: HTMLInputElement): void {
         element.value = '';
+    }
+
+    protected prevent(event: MouseEvent, element: HTMLInputElement): void {
+        if (this.isAndroid) {
+            event.preventDefault();
+            element.focus();
+        }
     }
 }


### PR DESCRIPTION
https://taiga-ui.dev/components/input-month

<img width="334" alt="android-text-select-handle" src="https://github.com/user-attachments/assets/e724343a-e900-4fcb-81b9-1248adce5882" />
