### PR TITLE
fix(core): `Textfield` has invalid width for `[tuiChevron]`'s icon

### DIFF
--- a/projects/kit/directives/chevron/chevron.style.less
+++ b/projects/kit/directives/chevron/chevron.style.less
@@ -8,7 +8,20 @@ tui-icon[tuiChevron]::after {
 }
 
 [tuiChevron][tuiIcons]::after {
-    font-size: 1rem;
+    block-size: 1rem;
+    inline-size: 1rem;
+
+    [data-size='s']& {
+        margin-inline-end: -0.125rem;
+    }
+
+    [data-size='m']& {
+        margin-inline-end: 0.125rem;
+    }
+
+    [data-size='l']& {
+        margin-inline-end: 0.25rem;
+    }
 }
 
 [tuiChevron][tuiIcons]._chevron-rotated::after,

--- a/projects/kit/directives/chevron/chevron.style.less
+++ b/projects/kit/directives/chevron/chevron.style.less
@@ -9,17 +9,20 @@ tui-icon[tuiChevron]::after {
 
 [tuiChevron][tuiIcons]::after {
     block-size: 1rem;
-    inline-size: 1rem;
 
-    [data-size='s']& {
+    tui-textfield& {
+        font-size: 1rem;
+    }
+
+    tui-textfield[data-size='s']& {
         margin-inline-end: -0.125rem;
     }
 
-    [data-size='m']& {
+    tui-textfield[data-size='m']& {
         margin-inline-end: 0.125rem;
     }
 
-    [data-size='l']& {
+    tui-textfield[data-size='l']& {
         margin-inline-end: 0.25rem;
     }
 }

--- a/projects/kit/directives/chevron/chevron.style.less
+++ b/projects/kit/directives/chevron/chevron.style.less
@@ -8,7 +8,7 @@ tui-icon[tuiChevron]::after {
 }
 
 [tuiChevron][tuiIcons]::after {
-    block-size: 1rem;
+    font-size: 1rem;
 }
 
 [tuiChevron][tuiIcons]._chevron-rotated::after,


### PR DESCRIPTION
### Previous behavior
<img width="295" alt="before" src="https://github.com/user-attachments/assets/f6fdd570-0e1e-4ef6-b448-5799dcb30d5a" />


### New behavior
<img width="295" alt="after" src="https://github.com/user-attachments/assets/b8619499-db43-4d52-a508-2758ebd16143" />

