### PR TITLE
fix(legacy): `InputDateTime` has incorrect typings for control value

### DIFF
--- a/projects/demo/src/modules/components/input-date-time/examples/4/index.ts
+++ b/projects/demo/src/modules/components/input-date-time/examples/4/index.ts
@@ -8,14 +8,12 @@ import {TuiInputDateTimeModule} from '@taiga-ui/legacy';
 
 @Injectable()
 class ExampleDateTimeTransformer extends TuiValueTransformer<
-    [TuiDay | null, TuiTime | null] | null,
+    [TuiDay, TuiTime | null] | null,
     string
 > {
     private readonly separator = ', ';
 
-    public fromControlValue(
-        controlValue: string,
-    ): [TuiDay | null, TuiTime | null] | null {
+    public fromControlValue(controlValue: string): [TuiDay, TuiTime | null] | null {
         const [day, time = ''] = controlValue.split(this.separator);
 
         return day
@@ -23,7 +21,9 @@ class ExampleDateTimeTransformer extends TuiValueTransformer<
             : null;
     }
 
-    public toControlValue([day, time]: [TuiDay | null, TuiTime | null]): string {
+    public toControlValue(internalValue: [TuiDay, TuiTime | null] | null): string {
+        const [day, time] = internalValue ?? [];
+
         return day
             ? day.toString() + (time ? `${this.separator}${time.toString()}` : '')
             : '';

--- a/projects/demo/src/modules/components/input-date-time/index.html
+++ b/projects/demo/src/modules/components/input-date-time/index.html
@@ -38,7 +38,7 @@
             </dt>
             <dd>
                 custom format of control output (
-                <code>[TuiDay | null, TuiTime | null] | null</code>
+                <code>[TuiDay, TuiTime | null] | null</code>
                 is default).
                 <p>
                     <a

--- a/projects/demo/src/modules/components/input-date-time/index.ts
+++ b/projects/demo/src/modules/components/input-date-time/index.ts
@@ -97,7 +97,7 @@ export default class PageComponent extends AbstractExampleTuiControl {
 
     public override cleaner = false;
 
-    public readonly control = new FormControl<[TuiDay | null, TuiTime | null] | null>(
+    public readonly control = new FormControl<[TuiDay, TuiTime | null] | null>(
         null,
         Validators.required,
     );

--- a/projects/kit/tokens/calendar-date-stream.ts
+++ b/projects/kit/tokens/calendar-date-stream.ts
@@ -28,7 +28,7 @@ export function tuiDateStreamWithTransformer(
 }
 
 function tuiControlValueFactory<
-    T extends TuiDay | TuiDayRange | [TuiDay | null, TuiTime | null],
+    T extends TuiDay | TuiDayRange | [TuiDay, TuiTime | null],
 >(
     control: NgControl | null,
     transformer?: TuiValueTransformer<T> | null,

--- a/projects/kit/tokens/date-inputs-value-transformers.ts
+++ b/projects/kit/tokens/date-inputs-value-transformers.ts
@@ -20,7 +20,7 @@ export const TUI_DATE_RANGE_VALUE_TRANSFORMER =
  * Control value transformer for InputDateTime component
  */
 export const TUI_DATE_TIME_VALUE_TRANSFORMER =
-    tuiCreateToken<TuiValueTransformer<[TuiDay | null, TuiTime | null]>>();
+    tuiCreateToken<TuiValueTransformer<[TuiDay, TuiTime | null]>>();
 
 /**
  * Control value transformer for InputTime component

--- a/projects/legacy/components/input-date-time/input-date-time.component.ts
+++ b/projects/legacy/components/input-date-time/input-date-time.component.ts
@@ -70,7 +70,7 @@ const DATE_TIME_SEPARATOR = ', ';
     },
 })
 export class TuiInputDateTimeComponent
-    extends AbstractTuiControl<[TuiDay | null, TuiTime | null] | null>
+    extends AbstractTuiControl<[TuiDay, TuiTime | null] | null>
     implements TuiFocusableElementAccessor
 {
     @ViewChild(TuiPrimitiveTextfieldComponent)
@@ -86,7 +86,7 @@ export class TuiInputDateTimeComponent
     protected readonly timeTexts$ = inject(TUI_TIME_TEXTS);
     protected readonly dateTexts$ = inject(TUI_DATE_TEXTS);
     protected override readonly valueTransformer: TuiValueTransformer<
-        [TuiDay | null, TuiTime | null]
+        [TuiDay, TuiTime | null]
     > | null = inject(TUI_DATE_TIME_VALUE_TRANSFORMER, {optional: true});
 
     protected readonly type!: TuiContext<TuiActiveZone>;
@@ -164,7 +164,7 @@ export class TuiInputDateTimeComponent
         this.open = false;
     }
 
-    public override writeValue(value: [TuiDay | null, TuiTime | null] | null): void {
+    public override writeValue(value: [TuiDay, TuiTime | null] | null): void {
         if (this.value === null && value === this.value) {
             return;
         }
@@ -331,13 +331,13 @@ export class TuiInputDateTimeComponent
         this.value = !parsedDate || !parsedTime ? null : [parsedDate, parsedTime];
     }
 
-    protected getFallbackValue(): [TuiDay | null, TuiTime | null] | null {
+    protected getFallbackValue(): [TuiDay, TuiTime | null] | null {
         return null;
     }
 
     protected override valueIdenticalComparator(
-        oldValue: [TuiDay | null, TuiTime | null] | null,
-        newValue: [TuiDay | null, TuiTime | null] | null,
+        oldValue: [TuiDay, TuiTime | null] | null,
+        newValue: [TuiDay, TuiTime | null] | null,
     ): boolean {
         return (
             tuiNullableSame(oldValue?.[0] ?? null, newValue?.[0] ?? null, (a, b) =>

--- a/projects/legacy/components/input-date-time/input-date-time.directive.ts
+++ b/projects/legacy/components/input-date-time/input-date-time.directive.ts
@@ -15,7 +15,7 @@ export class TuiInputDateTimeDirective extends AbstractTuiTextfieldHost<TuiInput
         return this.host.computedValue;
     }
 
-    public get rawValue(): [TuiDay | null, TuiTime | null] | null {
+    public get rawValue(): [TuiDay, TuiTime | null] | null {
         return this.host.value ?? null;
     }
 
@@ -23,7 +23,7 @@ export class TuiInputDateTimeDirective extends AbstractTuiTextfieldHost<TuiInput
         this.host.onValueChange(value);
     }
 
-    public writeValue(value: [TuiDay | null, TuiTime | null] | null): void {
+    public writeValue(value: [TuiDay, TuiTime | null] | null): void {
         this.host.writeValue(value);
     }
 

--- a/projects/legacy/components/input-date-time/test/input-date-time.component.spec.ts
+++ b/projects/legacy/components/input-date-time/test/input-date-time.component.spec.ts
@@ -368,14 +368,14 @@ describe('InputDateTime', () => {
 
     describe('InputDateTime + TUI_DATE_TIME_VALUE_TRANSFORMER', () => {
         class ExampleDateTimeTransformer extends TuiValueTransformer<
-            [TuiDay | null, TuiTime | null] | null,
+            [TuiDay, TuiTime | null] | null,
             string
         > {
             private readonly separator = ', ';
 
             public fromControlValue(
                 controlValue: string,
-            ): [TuiDay | null, TuiTime | null] | null {
+            ): [TuiDay, TuiTime | null] | null {
                 const [day, time = ''] = controlValue.split(this.separator);
 
                 if (!day) {
@@ -388,7 +388,11 @@ describe('InputDateTime', () => {
                 ];
             }
 
-            public toControlValue([day, time]: [TuiDay | null, TuiTime | null]): string {
+            public toControlValue(
+                internalValue: [TuiDay, TuiTime | null] | null,
+            ): string {
+                const [day, time] = internalValue ?? [];
+
                 if (!day) {
                     return '';
                 }


### PR DESCRIPTION
Relates:
* https://github.com/taiga-family/taiga-ui/pull/10164/files?diff=unified&w=0#diff-bf6d631859b74c2247e3dadaf259e66d650b62abe660f1ffe4765c2535fa6635L186-R191


https://github.com/taiga-family/taiga-ui/blob/d63c214a12e8b21ebbe5b3aed7a348145329062c/projects/legacy/components/input-date-time/input-date-time.component.ts#L194-L195