### PR TITLE
fix(legacy): return possibility to use any data type in `TUI_DATE_TIME_VALUE_TRANSFORMER`

### DIFF
--- a/projects/legacy/components/input-date-time/input-date-time.component.ts
+++ b/projects/legacy/components/input-date-time/input-date-time.component.ts
@@ -169,7 +169,11 @@ export class TuiInputDateTimeComponent
             return;
         }
 
-        if (value?.[0]) {
+        const transformed = this.valueTransformer
+            ? this.valueTransformer.fromControlValue(value)
+            : value;
+
+        if (transformed?.[0]) {
             super.writeValue(value);
         } else {
             super.writeValue(null);


### PR DESCRIPTION
Fixes #10770
