### PR TITLE
chore(demo): in typography change to bold font-weight on font-heading

### DIFF
--- a/projects/demo/src/modules/markup/typography/index.html
+++ b/projects/demo/src/modules/markup/typography/index.html
@@ -36,7 +36,7 @@
                 <td class="td">
                     <tui-doc-copy cdkCopyToClipboard="var(--tui-font-heading-1)">--tui-font-heading-1</tui-doc-copy>
                 </td>
-                <td class="td">normal</td>
+                <td class="td">bold</td>
                 <td class="td">50px</td>
                 <td class="td">56px (1.12)</td>
             </tr>
@@ -48,7 +48,7 @@
                 <td class="td">
                     <tui-doc-copy cdkCopyToClipboard="var(--tui-font-heading-2)">--tui-font-heading-2</tui-doc-copy>
                 </td>
-                <td class="td">normal</td>
+                <td class="td">bold</td>
                 <td class="td">44px</td>
                 <td class="td">48px (1.1)</td>
             </tr>
@@ -60,7 +60,7 @@
                 <td class="td">
                     <tui-doc-copy cdkCopyToClipboard="var(--tui-font-heading-3)">--tui-font-heading-3</tui-doc-copy>
                 </td>
-                <td class="td">normal</td>
+                <td class="td">bold</td>
                 <td class="td">36px</td>
                 <td class="td">40px (1.11)</td>
             </tr>
@@ -72,7 +72,7 @@
                 <td class="td">
                     <tui-doc-copy cdkCopyToClipboard="var(--tui-font-heading-4)">--tui-font-heading-4</tui-doc-copy>
                 </td>
-                <td class="td">normal</td>
+                <td class="td">bold</td>
                 <td class="td">28px</td>
                 <td class="td">32px (1.14)</td>
             </tr>
@@ -84,7 +84,7 @@
                 <td class="td">
                     <tui-doc-copy cdkCopyToClipboard="var(--tui-font-heading-5)">--tui-font-heading-5</tui-doc-copy>
                 </td>
-                <td class="td">normal</td>
+                <td class="td">bold</td>
                 <td class="td">24px</td>
                 <td class="td">28px (1.17)</td>
             </tr>
@@ -96,7 +96,7 @@
                 <td class="td">
                     <tui-doc-copy cdkCopyToClipboard="var(--tui-font-heading-6)">--tui-font-heading-6</tui-doc-copy>
                 </td>
-                <td class="td">normal</td>
+                <td class="td">bold</td>
                 <td class="td">20px</td>
                 <td class="td">24px (1.2)</td>
             </tr>


### PR DESCRIPTION
On https://taiga-ui.dev/typography have litle discrepancy in heading list. In  font-weight column value stated as 'normal', but in variables.less it has 'bold'

<img width="841" alt="page" src="https://github.com/user-attachments/assets/90b9d141-c5eb-428f-86a3-877c9271c17c" />
<img width="442" alt="var" src="https://github.com/user-attachments/assets/72739c70-df5d-4278-81fb-56046f40283b" />
