### PR TITLE
fix: add `ngSkipHydration` for `<input/>`-s with template inside (to prevent SSR hydration error)

### DIFF
--- a/projects/addon-commerce/components/input-card/input-card.component.ts
+++ b/projects/addon-commerce/components/input-card/input-card.component.ts
@@ -42,6 +42,7 @@ import {TUI_INPUT_CARD_OPTIONS} from './input-card.options';
     host: {
         inputmode: 'numeric',
         placeholder: '0000 0000 0000 0000',
+        ngSkipHydration: 'true',
         '[autocomplete]': 'autocomplete ? "cc-number" : "off"',
     },
 })

--- a/projects/experimental/components/input-phone-international/input-phone-international.component.ts
+++ b/projects/experimental/components/input-phone-international/input-phone-international.component.ts
@@ -103,6 +103,7 @@ const NOT_FORM_CONTROL_SYMBOLS = /[^+\d]/g;
     hostDirectives: [MaskitoDirective, TuiWithTextfield],
     host: {
         type: 'tel',
+        ngSkipHydration: 'true',
         '[attr.readonly]': 'readOnly() || null',
         '[attr.inputmode]': '!ios && open() ? "none" : null',
         '[disabled]': 'disabled()',

--- a/projects/kit/components/input-month/native-month-picker/native-month-picker.component.ts
+++ b/projects/kit/components/input-month/native-month-picker/native-month-picker.component.ts
@@ -24,6 +24,7 @@ import {TuiInputMonthDirective} from '../input-month.directive';
     encapsulation: ViewEncapsulation.None,
     changeDetection: ChangeDetectionStrategy.OnPush,
     host: {
+        ngSkipHydration: 'true',
         '[type]': '"text"',
     },
 })

--- a/projects/kit/components/input-number/step/input-number-step.component.ts
+++ b/projects/kit/components/input-number/step/input-number-step.component.ts
@@ -33,6 +33,7 @@ import {TUI_INPUT_NUMBER_OPTIONS} from '../input-number.options';
     encapsulation: ViewEncapsulation.None,
     changeDetection: ChangeDetectionStrategy.OnPush,
     host: {
+        ngSkipHydration: 'true',
         '(keydown.arrowDown)': 'onStep(-step())',
         '(keydown.arrowUp)': 'onStep(step())',
         '[class._with-buttons]': 'step()',

--- a/projects/kit/components/input-password/input-password.component.ts
+++ b/projects/kit/components/input-password/input-password.component.ts
@@ -41,6 +41,7 @@ import {TUI_INPUT_PASSWORD_OPTIONS} from './input-password.options';
     providers: [tuiFallbackValueProvider('')],
     hostDirectives: [TuiWithTextfield],
     host: {
+        ngSkipHydration: 'true',
         '[type]': 'hidden() ? "password" : "text"',
     },
 })

--- a/projects/kit/components/input-pin/input-pin.component.ts
+++ b/projects/kit/components/input-pin/input-pin.component.ts
@@ -29,6 +29,7 @@ import {tuiMaskito} from '@taiga-ui/kit/utils';
     changeDetection: ChangeDetectionStrategy.OnPush,
     hostDirectives: [MaskitoDirective],
     host: {
+        ngSkipHydration: 'true',
         inputmode: 'numeric',
         spellcheck: 'false',
         '(selectionchange)': 'onSelection()',

--- a/projects/layout/components/input-search/input-search.component.ts
+++ b/projects/layout/components/input-search/input-search.component.ts
@@ -37,6 +37,7 @@ import {PolymorpheusOutlet} from '@taiga-ui/polymorpheus';
     providers: [tuiCellOptionsProvider({size: 'm'})],
     hostDirectives: [TuiWithTextfield],
     host: {
+        ngSkipHydration: 'true',
         '(focus)': 'open()',
         '(keydown.tab.prevent)': '0',
         '(keydown.arrowDown.prevent)': 'onArrow()',


### PR DESCRIPTION
https://angular.dev/guide/hydration#valid-html-structure

```
ERROR RuntimeError:
NG0502: During hydration, Angular expected an element to be present at this location.

<input
    id="tui_41744089732122"
    _ngcontent-ng-c2887981911=""
    data-appearance="textfield"
    data-focus="false"
    formcontrolname="country"
    ng-reflect-countries-value="AF,AX,AL,DZ,AS,AD,AO,AI,AG,AR,"
    ng-reflect-country-search="true"
    ng-reflect-iso-code="RU"
    ng-reflect-name="country"
    tuiappearance=""
    tuiinputphoneinternational=""
    type="tel"
    value="******"
    class="tui-appearance-initializing"
/>

…
<!-- container --> <-- AT THIS LOCATION
…
</input>

To fix this problem:
* check corresponding component for hydration-related issues
* check to see if your template has valid HTML structure
* or skip hydration by adding the `ngSkipHydration` attribute to its host node in a template
```
