### PR TITLE
chore(demo): update information about tuiHighlight directive (#10765)

### DIFF
--- a/projects/demo/src/modules/directives/highlight/index.html
+++ b/projects/demo/src/modules/directives/highlight/index.html
@@ -20,11 +20,13 @@
             <dd>The default color for the highlight.</dd>
         </dl>
 
-        <p class="tui-space_bottom-0">
+        <p>
             Use function
             <code>tuiHighlightOptionsProvider</code>
             to provide new value of this token.
         </p>
+
+        <tui-notification appearance="warning">Does not work with inline elements</tui-notification>
 
         <tui-doc-example
             id="usage"


### PR DESCRIPTION
Fixes #10765

Due to the specifics of ResizeObserver, it does not track changes to inline elements.  
For a simple solution, you can use inline-block. This applies to both v3 and v4.

I added a notification about this to the documentation.