### PR TITLE
chore(core): `DropdownOpen` ignore key events when there's no dropdown content

### DIFF
--- a/projects/core/directives/dropdown/dropdown-open.directive.ts
+++ b/projects/core/directives/dropdown/dropdown-open.directive.ts
@@ -152,7 +152,8 @@ export class TuiDropdownOpen implements OnChanges {
         if (
             !tuiIsElement(event.target) ||
             !this.host.contains(event.target) ||
-            !this.tuiDropdownEnabled
+            !this.tuiDropdownEnabled ||
+            !this.directive.content
         ) {
             return;
         }

--- a/projects/kit/components/input-number/step/input-number-step.component.ts
+++ b/projects/kit/components/input-number/step/input-number-step.component.ts
@@ -34,8 +34,8 @@ import {TUI_INPUT_NUMBER_OPTIONS} from '../input-number.options';
     changeDetection: ChangeDetectionStrategy.OnPush,
     host: {
         ngSkipHydration: 'true',
-        '(keydown.arrowDown)': 'onStep(-step())',
-        '(keydown.arrowUp)': 'onStep(step())',
+        '(keydown.arrowDown.prevent)': 'onStep(-step())',
+        '(keydown.arrowUp.prevent)': 'onStep(step())',
         '[class._with-buttons]': 'step()',
     },
 })


### PR DESCRIPTION
Fixes #10842