### PR TITLE
refactor: replace deprecated params of `Number`-mask by new alternatives

### DIFF
--- a/projects/demo/src/modules/components/textfield/examples/5/index.ts
+++ b/projects/demo/src/modules/components/textfield/examples/5/index.ts
@@ -17,7 +17,7 @@ const postfix = ' rad';
 const numberOptions = maskitoNumberOptionsGenerator({
     postfix,
     decimalSeparator: ',',
-    precision: 8,
+    maximumFractionDigits: 8,
     min: 0,
 });
 

--- a/projects/kit/components/input-number/input-number.directive.ts
+++ b/projects/kit/components/input-number/input-number.directive.ts
@@ -3,6 +3,7 @@ import {toSignal} from '@angular/core/rxjs-interop';
 import {MaskitoDirective} from '@maskito/angular';
 import type {MaskitoOptions} from '@maskito/core';
 import {maskitoInitialCalibrationPlugin} from '@maskito/core';
+import type {MaskitoNumberParams} from '@maskito/kit';
 import {
     maskitoCaretGuard,
     maskitoNumberOptionsGenerator,
@@ -108,16 +109,21 @@ export class TuiInputNumberDirective extends TuiControl<number | null> {
     });
 
     protected readonly mask = tuiMaskito(
-        computed(({decimalMode, ...numberFormat} = this.numberFormat()) =>
-            this.computeMask({
-                ...numberFormat,
-                precision: this.precision(),
-                min: this.min(),
-                max: this.max(),
-                prefix: this.prefix(),
-                postfix: this.postfix(),
-                decimalZeroPadding: decimalMode === 'always',
-            }),
+        computed(
+            (
+                {decimalMode, ...numberFormat} = this.numberFormat(),
+                maximumFractionDigits = this.precision(),
+            ) =>
+                this.computeMask({
+                    ...numberFormat,
+                    maximumFractionDigits,
+                    min: this.min(),
+                    max: this.max(),
+                    prefix: this.prefix(),
+                    postfix: this.postfix(),
+                    minimumFractionDigits:
+                        decimalMode === 'always' ? maximumFractionDigits : 0,
+                }),
         ),
     );
 
@@ -216,9 +222,7 @@ export class TuiInputNumberDirective extends TuiControl<number | null> {
         this.max.set(Math.max(min, max));
     }
 
-    private computeMask(
-        params: NonNullable<Parameters<typeof maskitoNumberOptionsGenerator>[0]>,
-    ): MaskitoOptions {
+    private computeMask(params: MaskitoNumberParams): MaskitoOptions {
         const {prefix = '', postfix = ''} = params;
         const {plugins, ...options} = maskitoNumberOptionsGenerator(params);
         const initialCalibrationPlugin = maskitoInitialCalibrationPlugin(

--- a/projects/legacy/components/input-number/input-number.component.ts
+++ b/projects/legacy/components/input-number/input-number.component.ts
@@ -10,6 +10,7 @@ import {
 import {takeUntilDestroyed} from '@angular/core/rxjs-interop';
 import type {MaskitoOptions} from '@maskito/core';
 import {maskitoInitialCalibrationPlugin} from '@maskito/core';
+import type {MaskitoNumberParams} from '@maskito/kit';
 import {
     maskitoCaretGuard,
     maskitoNumberOptionsGenerator,
@@ -342,20 +343,20 @@ export class TuiInputNumberComponent
         prefix: string,
         postfix: string,
     ): MaskitoOptions {
-        const generatorParams = {
+        const params: MaskitoNumberParams = {
             decimalSeparator,
             thousandSeparator,
             min,
             max,
             prefix,
             postfix,
-            precision,
-            decimalZeroPadding: decimalMode === 'always',
+            maximumFractionDigits: precision,
+            minimumFractionDigits: decimalMode === 'always' ? precision : 0,
         };
-        const {plugins, ...options} = maskitoNumberOptionsGenerator(generatorParams);
+        const {plugins, ...options} = maskitoNumberOptionsGenerator(params);
         const initialCalibrationPlugin = maskitoInitialCalibrationPlugin(
             maskitoNumberOptionsGenerator({
-                ...generatorParams,
+                ...params,
                 min: Number.MIN_SAFE_INTEGER,
                 max: Number.MAX_SAFE_INTEGER,
             }),


### PR DESCRIPTION
Relates:
* https://github.com/taiga-family/maskito/pull/2022