### PR TITLE
fix(kit): `InputSlider` throws `not statically analyzable` error

### DIFF
--- a/projects/kit/components/input-slider/input-slider.ts
+++ b/projects/kit/components/input-slider/input-slider.ts
@@ -1,5 +1,14 @@
-import {TuiSlider} from '@taiga-ui/kit/components/slider';
+import {
+    TuiSliderComponent,
+    TuiSliderKeySteps,
+    TuiSliderKeyStepsBase,
+} from '@taiga-ui/kit/components/slider';
 
 import {TuiInputSliderDirective} from './input-slider.directive';
 
-export const TuiInputSlider = [...TuiSlider, TuiInputSliderDirective] as const;
+export const TuiInputSlider = [
+    TuiSliderComponent,
+    TuiSliderKeyStepsBase,
+    TuiSliderKeySteps,
+    TuiInputSliderDirective,
+] as const;


### PR DESCRIPTION
Open StackBlitz of this example:
https://taiga-ui.dev/components/input-slider#texfield-customization

If fails with error:
```
'imports' must be an array of components, directives, pipes, or NgModules.
Value is of type 
'[
    (not statically analyzable),
    (not statically analyzable),
    (not statically analyzable),
    (not statically analyzable),
    (not statically analyzable),
    TuiInputSliderDirective
]'.
```