### PR TITLE
fix(addon-mobile): support block status without image

### DIFF
--- a/projects/demo/src/modules/components/block-status/examples/5/index.html
+++ b/projects/demo/src/modules/components/block-status/examples/5/index.html
@@ -47,4 +47,12 @@
             Try again
         </button>
     </tui-block-status>
+
+    <tui-block-status
+        tuiPlatform="ios"
+        class="card"
+        [card]="true"
+    >
+        Something happened in this block
+    </tui-block-status>
 </div>

--- a/projects/layout/components/block-status/block-status.style.less
+++ b/projects/layout/components/block-status/block-status.style.less
@@ -16,6 +16,12 @@ tui-block-status {
         padding: 2rem;
     }
 
+    .t-block-image:empty,
+    .t-block-text:empty,
+    .t-block-actions:empty {
+        display: none;
+    }
+
     .t-block-image:not(:empty) {
         display: flex;
         margin-bottom: 2rem;


### PR DESCRIPTION
Fixes #10853

## Before

<img width="347" alt="image" src="https://github.com/user-attachments/assets/7f06978a-9fe5-41d4-8cec-92d21ee8a22c" />


## After

<img width="337" alt="image" src="https://github.com/user-attachments/assets/b511eeb7-2e12-42d4-8101-015e82db550d" />
