### PR TITLE
fix(kit): `InputNumber` rejects decimal part (even if `precision > 0`) if affixes include decimal pseudo separator

### DIFF
--- a/projects/kit/components/input-number/input-number.component.ts
+++ b/projects/kit/components/input-number/input-number.component.ts
@@ -371,6 +371,10 @@ export class TuiInputNumberComponent
             postfix,
             precision: decimalMode === 'never' ? 0 : precision,
             decimalZeroPadding: decimalMode === 'always',
+            // https://github.com/taiga-family/maskito/issues/703
+            decimalPseudoSeparators: ['.', ',', 'б', 'ю'].filter(
+                x => !`${prefix}${postfix}`.includes(x),
+            ),
         });
 
         return {


### PR DESCRIPTION

https://taiga-ui.dev/v3/components/input-number/API?precision=2&tuiTextfieldPostfix=руб

Impossible to enter decimal digits
