### PR TITLE
chore(layout): `Cell` inside `Select` has overflown last character

### DIFF
--- a/projects/demo/src/modules/components/cell/examples/7/index.html
+++ b/projects/demo/src/modules/components/cell/examples/7/index.html
@@ -24,14 +24,21 @@
     </button>
 </div>
 
-<label tuiLabel="Inside a dropdown">
-    <tui-select
-        [tuiTextfieldLabelOutside]="true"
-        [valueContent]="content"
-        [(ngModel)]="value"
+<label>
+    Inside a dropdown
+    <tui-textfield
+        tuiChevron
+        [content]="content"
+        [tuiTextfieldCleaner]="false"
     >
+        <input
+            tuiSelect
+            [(ngModel)]="value"
+        />
+
         <tui-data-list-wrapper
-            *tuiDataList
+            *tuiTextfieldDropdown
+            new
             [itemContent]="content"
             [items]="items"
         />
@@ -50,5 +57,5 @@
                 </span>
             </span>
         </ng-template>
-    </tui-select>
+    </tui-textfield>
 </label>

--- a/projects/demo/src/modules/components/cell/examples/7/index.ts
+++ b/projects/demo/src/modules/components/cell/examples/7/index.ts
@@ -3,10 +3,9 @@ import {Component} from '@angular/core';
 import {FormsModule} from '@angular/forms';
 import {changeDetection} from '@demo/emulate/change-detection';
 import {encapsulation} from '@demo/emulate/encapsulation';
-import {TuiAppearance, TuiLabel, TuiNotification, TuiTitle} from '@taiga-ui/core';
-import {TuiAvatar, TuiDataListWrapper} from '@taiga-ui/kit';
+import {TuiAppearance, TuiNotification, TuiTextfield, TuiTitle} from '@taiga-ui/core';
+import {TuiAvatar, TuiChevron, TuiDataListWrapper, TuiSelect} from '@taiga-ui/kit';
 import {TuiCardLarge, TuiCell} from '@taiga-ui/layout';
-import {TuiSelectModule, TuiTextfieldControllerModule} from '@taiga-ui/legacy';
 
 @Component({
     standalone: true,
@@ -17,11 +16,11 @@ import {TuiSelectModule, TuiTextfieldControllerModule} from '@taiga-ui/legacy';
         TuiAvatar,
         TuiCardLarge,
         TuiCell,
+        TuiChevron,
         TuiDataListWrapper,
-        TuiLabel,
         TuiNotification,
-        TuiSelectModule,
-        TuiTextfieldControllerModule,
+        TuiSelect,
+        TuiTextfield,
         TuiTitle,
     ],
     templateUrl: './index.html',

--- a/projects/layout/components/cell/cell.styles.less
+++ b/projects/layout/components/cell/cell.styles.less
@@ -225,6 +225,7 @@
         padding: 0;
         white-space: nowrap;
         overflow: hidden;
+        border-radius: 0;
     }
 }
 


### PR DESCRIPTION
## Previous behavior
<img width="836" alt="before" src="https://github.com/user-attachments/assets/c37f3687-8091-4e77-98ff-5b0a2aa60e84" />

## New behavior
<img width="836" alt="after" src="https://github.com/user-attachments/assets/edeeefbf-fd8a-48e4-955b-2c4741276505" />

Relates:
* https://github.com/taiga-family/taiga-ui/pull/10856/files#diff-8a26e7207cb79e383127969f7e7c47355702d5425cd5cd92c478407f97b2c616
