### PR TITLE
fix(kit): get rid of dot before extension-less files

### DIFF
--- a/projects/demo-playwright/tests/kit/input-files/input-files.pw.spec.ts
+++ b/projects/demo-playwright/tests/kit/input-files/input-files.pw.spec.ts
@@ -10,6 +10,28 @@ import {
 import type {Locator} from '@playwright/test';
 import {expect, test} from '@playwright/test';
 
+test.describe('InputFiles with no-extension file', () => {
+    const stubPath = join(__dirname, '../../../stubs/no-extension-file');
+
+    test('Displays name without leading dot and no type', async ({page}) => {
+        await tuiGoto(page, `${DemoRoute.InputFiles}/API`);
+
+        const example = new TuiDocumentationApiPagePO(page).apiPageExample;
+
+        await example.locator('input[tuiInputFiles]').setInputFiles(stubPath);
+
+        await waitIcons({
+            page,
+            icons: await example.locator('tui-icon >> visible=true').all(),
+        });
+
+        await expect(example.locator('.t-name')).toHaveText('no-extension-file');
+        await expect(example.locator('.t-type')).toHaveText('');
+
+        await expect.soft(example).toHaveScreenshot('04-no-extension-file.png');
+    });
+});
+
 test.describe('InputFiles', () => {
     let example: Locator;
 

--- a/projects/kit/components/files/file/file.component.ts
+++ b/projects/kit/components/files/file/file.component.ts
@@ -165,11 +165,17 @@ export class TuiFile {
 
     @tuiPure
     private getName(file: TuiFileLike): string {
-        return file.name.split('.').slice(0, -1).join('.');
+        const dot = file.name.lastIndexOf('.');
+        // a dot at position 0 means a “hidden” file, not an extension
+
+        return dot > 0 ? file.name.slice(0, dot) : file.name;
     }
 
     @tuiPure
     private getType(file: TuiFileLike): string {
-        return `.${file.name.split('.').pop()}` || '';
+        const dot = file.name.lastIndexOf('.');
+        // only return an extension when there is one
+
+        return dot > 0 ? file.name.slice(dot) : '';
     }
 }


### PR DESCRIPTION
Uploading a file without an extension causes a period to be appended before the file's name. This fix gets rid of the period.

Fixes #10878 
