### PR TITLE
fix(core): fixed parent closing when nested hint is closed

### DIFF
--- a/projects/core/directives/hint/hint-hover.directive.ts
+++ b/projects/core/directives/hint/hint-hover.directive.ts
@@ -88,4 +88,8 @@ export class TuiHintHover extends TuiDriver {
         this.toggle$.next(visible);
         this.parent?.toggle(visible);
     }
+
+    public close(): void {
+        this.toggle$.next(false);
+    }
 }

--- a/projects/core/directives/hint/hint.component.ts
+++ b/projects/core/directives/hint/hint.component.ts
@@ -94,7 +94,7 @@ export class TuiHintComponent<C = any> {
             )
             .subscribe({
                 next: ([top, left]) => this.update(top, left),
-                complete: () => this.hover.toggle(false),
+                complete: () => this.hover.close(),
             });
 
         inject(TuiHoveredService)


### PR DESCRIPTION
Previously, the complete handler of subscription was triggering `false`, which caused related hints to close prematurely.
This PR introduces a new close method to handle the case where a hint needs to be closed without notifying the parent.

Fixes #10492 <!-- https://github.com/taiga-family/taiga-ui/issues/10492  -->
