### PR TITLE
fix(core): `Dialogs` fix long words wrapping

### DIFF
--- a/projects/core/components/dialog/dialogs.style.less
+++ b/projects/core/components/dialog/dialogs.style.less
@@ -7,6 +7,7 @@
     pointer-events: none;
     overflow: hidden;
     overscroll-behavior: none;
+    overflow-wrap: break-word;
     transform: translateY(var(--t-root-top));
 
     &:has(section) {


### PR DESCRIPTION
Fixes # <!-- link to a relevant issue. -->
