### PR TITLE
fix(core): `Dialogs` fix overlay scrolling out of viewport

### DIFF
--- a/projects/core/components/dialog/dialogs.style.less
+++ b/projects/core/components/dialog/dialogs.style.less
@@ -8,7 +8,7 @@
     overflow: hidden;
     overscroll-behavior: none;
     overflow-wrap: break-word;
-    transform: translateY(var(--t-root-top));
+    margin-top: var(--t-root-top);
 
     &:has(section) {
         pointer-events: auto;


### PR DESCRIPTION
Fixes # <!-- link to a relevant issue. -->
