### PR TITLE
fix(addon-charts): `ArcChart` fix zoom in Safari

### DIFF
--- a/projects/addon-charts/components/arc-chart/arc-chart.template.html
+++ b/projects/addon-charts/components/arc-chart/arc-chart.template.html
@@ -4,10 +4,10 @@
     viewBox="-100 -100 200 200"
     xmlns="http://www.w3.org/2000/svg"
     class="t-svg"
-    [style.height.em]="getDiameter(index)"
-    [style.left.em]="getInset(index)"
-    [style.top.em]="getInset(index)"
-    [style.width.em]="getDiameter(index)"
+    [style.height.rem]="getDiameter(index)"
+    [style.left.rem]="getInset(index)"
+    [style.top.rem]="getInset(index)"
+    [style.width.rem]="getDiameter(index)"
 >
     <path
         d="M -70 70 A 100 100 0 1 1 70 70"


### PR DESCRIPTION
Fixes # <!-- link to a relevant issue. -->
