### PR TITLE
fix(kit): calendar-range fire itemChange before valueChange

### DIFF
--- a/projects/kit/components/calendar-range/calendar-range.component.ts
+++ b/projects/kit/components/calendar-range/calendar-range.component.ts
@@ -201,12 +201,12 @@ export class TuiCalendarRange implements OnInit, OnChanges {
     protected onItemSelect(item: TuiDayRangePeriod | string): void {
         if (!tuiIsString(item)) {
             this.selectedActivePeriod = item;
-            this.updateValue(item.range.dayLimit(this.min, this.max));
             this.itemChange.emit(item);
+            this.updateValue(item.range.dayLimit(this.min, this.max));
         } else if (this.activePeriod !== null) {
             this.selectedActivePeriod = null;
-            this.updateValue(null);
             this.itemChange.emit(null);
+            this.updateValue(null);
         }
 
         this.initDefaultViewedMonth();
@@ -224,8 +224,8 @@ export class TuiCalendarRange implements OnInit, OnChanges {
             const range = TuiDayRange.sort(this.value, day);
 
             this.value = range;
-            this.updateValue(range);
             this.itemChange.emit(this.findItemByDayRange(range));
+            this.updateValue(range);
         } else {
             this.value = day;
         }

--- a/projects/kit/components/calendar-range/test/calendar-range.component.spec.ts
+++ b/projects/kit/components/calendar-range/test/calendar-range.component.spec.ts
@@ -288,6 +288,23 @@ describe('rangeCalendarComponent', () => {
             );
         });
 
+        it('should fire itemChange before valueChange', () => {
+            const itemChangeSpy = jest.spyOn(testComponent.component.itemChange, 'emit');
+            const valueChangeSpy = jest.spyOn(
+                testComponent.component.valueChange,
+                'emit',
+            );
+
+            if (component.items[1]) {
+                component['onItemSelect'](component.items[1]);
+            }
+
+            const itemChangeOrder = itemChangeSpy.mock.invocationCallOrder[0] || 0;
+            const valueChangeOrder = valueChangeSpy.mock.invocationCallOrder[0] || 0;
+
+            expect(itemChangeOrder).toBeLessThan(valueChangeOrder);
+        });
+
         it('when min later than current month, defaultViewedMonth is next month after min', () => {
             const minDate = TuiDay.currentLocal().append({month: 3});
 


### PR DESCRIPTION
changes the order from valueChange -> itemChange to itemChange -> valueChange

Fixes #9878 
