### PR TITLE
fix(cdk): `TuiControl` should use `untracked` for signals inside `onChange`

### DIFF
--- a/projects/cdk/classes/control.ts
+++ b/projects/cdk/classes/control.ts
@@ -6,6 +6,7 @@ import {
     inject,
     Input,
     signal,
+    untracked,
 } from '@angular/core';
 import {takeUntilDestroyed} from '@angular/core/rxjs-interop';
 import type {ControlValueAccessor, FormControlStatus} from '@angular/forms';
@@ -98,7 +99,9 @@ export abstract class TuiControl<T> implements ControlValueAccessor {
         this.refresh$.next();
 
         this.onChange = (value: T) => {
-            if (value === this.internal()) {
+            const internal = untracked(() => this.internal());
+
+            if (value === internal) {
                 return;
             }
 


### PR DESCRIPTION
```ts
import { Component, Directive, effect, inject } from '@angular/core';
import { FormsModule } from '@angular/forms';
import { TuiControl } from '@taiga-ui/cdk';
import {
  TuiTextfield,
  TuiTextfieldDirective,
  TuiWithTextfield,
} from '@taiga-ui/core';

@Directive({
  standalone: true,
  selector: 'input[myInput]',
  hostDirectives: [TuiWithTextfield],
})
class MyControl extends TuiControl<object> {
  private readonly textfield = inject(TuiTextfieldDirective);

  onChangeEffect = effect(
    () => {
      const theOnlyEffectDepedency = this.textfield.value();

      // Never changed but effect will be infinitely triggering
      console.log({ theOnlyEffectDepedency });

      this.onChange({ ref: 'object-with-new-ref-every-time' });
    },
    { allowSignalWrites: true }
  );
}

@Component({
  standalone: true,
  selector: 'app',
  template: `
    <tui-textfield>
      <input myInput [(ngModel)]="value" />
    </tui-textfield>
  `,
  imports: [TuiTextfield, MyControl, FormsModule],
})
export class App {
  value = {};
}

```