### PR TITLE
fix(addon-table): `Th` allow aligning to the right when sortable

### DIFF
--- a/projects/addon-table/components/table/th/th.style.less
+++ b/projects/addon-table/components/table/th/th.style.less
@@ -117,6 +117,7 @@
     .button-clear();
 
     display: inline-flex;
+    vertical-align: top;
     flex-direction: inherit;
     align-items: center;
     outline: none;

--- a/projects/addon-table/components/table/th/th.style.less
+++ b/projects/addon-table/components/table/th/th.style.less
@@ -116,7 +116,7 @@
     .transition(color);
     .button-clear();
 
-    display: flex;
+    display: inline-flex;
     flex-direction: inherit;
     align-items: center;
     outline: none;


### PR DESCRIPTION
 Allow aligning to the right when sortable th.
 There is no possibility to align table header through css text-align inside component.