### PR TITLE
feat(layout): `Form` add default options

### DIFF
--- a/projects/layout/components/form/form.directive.ts
+++ b/projects/layout/components/form/form.directive.ts
@@ -8,7 +8,7 @@ import {
     signal,
     ViewEncapsulation,
 } from '@angular/core';
-import type {TuiStringHandler} from '@taiga-ui/cdk/types';
+import type {TuiHandler} from '@taiga-ui/cdk/types';
 import {tuiWithStyles} from '@taiga-ui/cdk/utils/miscellaneous';
 import {TUI_BUTTON_OPTIONS} from '@taiga-ui/core/components/button';
 import {TUI_NOTIFICATION_OPTIONS} from '@taiga-ui/core/components/notification';
@@ -23,11 +23,11 @@ import {TUI_HEADER_OPTIONS} from '@taiga-ui/layout/components/header';
 import type {TuiFormOptions} from './form.options';
 import {TUI_FORM_OPTIONS} from './form.options';
 
-const HEADER_SIZE: Record<string, string> = {
+const HEADER_SIZE = {
     s: 'xxxs',
     m: 'xs',
     l: 's',
-};
+} as const;
 
 @Component({
     standalone: true,
@@ -47,7 +47,7 @@ class TuiFormStyles {}
     providers: [
         projectSize(TUI_BUTTON_OPTIONS, (size) => size),
         projectSize(TUI_NOTIFICATION_OPTIONS, (size) => size),
-        projectSize(TUI_HEADER_OPTIONS, (size) => HEADER_SIZE[size]!),
+        projectSize(TUI_HEADER_OPTIONS, (size) => HEADER_SIZE[size]),
         projectSize(TUI_SWITCH_OPTIONS, (size) => (size === 'l' ? 'm' : 's')),
         projectSize(TUI_SEGMENTED_OPTIONS, (size) => (size === 'l' ? 'm' : 's')),
         {
@@ -84,7 +84,7 @@ export class TuiForm {
 
 function projectSize(
     provide: InjectionToken<any>,
-    project: TuiStringHandler<string>,
+    project: TuiHandler<TuiFormOptions['size'], string>,
 ): Provider {
     return {
         provide,

--- a/projects/layout/components/form/form.directive.ts
+++ b/projects/layout/components/form/form.directive.ts
@@ -76,8 +76,8 @@ export class TuiForm {
 
     public size: TuiFormOptions['size'] = this.options.size;
 
-    @Input('tuiForm')
-    public set tuiFormSize(size: TuiFormOptions['size'] | '') {
+    @Input()
+    public set tuiForm(size: TuiFormOptions['size'] | '') {
         this.size = size || this.options.size;
     }
 }

--- a/projects/layout/components/form/form.options.ts
+++ b/projects/layout/components/form/form.options.ts
@@ -1,0 +1,9 @@
+import {tuiCreateOptions} from '@taiga-ui/cdk/utils/di';
+import type {TuiSizeL, TuiSizeS} from '@taiga-ui/core/types';
+
+export interface TuiFormOptions {
+    readonly size: TuiSizeL | TuiSizeS;
+}
+
+export const [TUI_FORM_OPTIONS, tuiFormOptionsProvider] =
+    tuiCreateOptions<TuiFormOptions>({size: 'l'});

--- a/projects/layout/components/form/index.ts
+++ b/projects/layout/components/form/index.ts
@@ -1,1 +1,2 @@
 export * from './form.directive';
+export * from './form.options';


### PR DESCRIPTION
Added default values ​​and a provider to override directive `tuiForm` parameters at a global or more local level. This way we can define the required size once and not specify it every time in the templates.

Fixes #11010 
