### PR TITLE
chore(addon-doc): make examples wider to fit `InputDateRange`

### DIFF
--- a/projects/addon-doc/components/example/example.style.less
+++ b/projects/addon-doc/components/example/example.style.less
@@ -115,7 +115,7 @@
 
     :host:not(._fullsize) & {
         inline-size: min-content;
-        min-inline-size: 20rem;
+        min-inline-size: 21rem;
     }
 }
 


### PR DESCRIPTION
Fixes # <!-- link to a relevant issue. -->
