### PR TITLE
feat(core): add variables to :host

### DIFF
--- a/projects/core/styles/theme/variables.less
+++ b/projects/core/styles/theme/variables.less
@@ -1,6 +1,7 @@
 @font-fallback: -apple-system, 'BlinkMacSystemFont', system-ui, 'Roboto', 'Segoe UI', 'Helvetica Neue', sans-serif;
 
-:root {
+:root,
+:host {
     // Deprecated TODO 4.0 delete variables --tui-heading-font and --tui-text-font
     --tui-heading-font: 'Manrope', @font-fallback;
     --tui-text-font: 'Manrope', @font-fallback;


### PR DESCRIPTION
Currently all variables injects to the `:root`. In our Shadow DOM element, we need replace it to `:host`.