### PR TITLE
fix(kit): add filter to block pointer events when disabled

### DIFF
--- a/projects/kit/components/range/range-change.directive.ts
+++ b/projects/kit/components/range/range-change.directive.ts
@@ -5,7 +5,7 @@ import {tuiTypedFromEvent} from '@taiga-ui/cdk/observables';
 import {tuiInjectElement} from '@taiga-ui/cdk/utils/dom';
 import {tuiClamp, tuiRound} from '@taiga-ui/cdk/utils/math';
 import {TUI_FLOATING_PRECISION} from '@taiga-ui/kit/components/slider';
-import {map, repeat, startWith, switchMap, takeUntil, tap} from 'rxjs';
+import {filter, map, repeat, startWith, switchMap, takeUntil, tap} from 'rxjs';
 
 import {TuiRange} from './range.component';
 
@@ -28,6 +28,7 @@ export class TuiRangeChange {
             capture: true,
         })
             .pipe(
+                filter(() => !this.range.disabled()),
                 tap(({clientX, target, pointerId}) => {
                     activeThumb = this.detectActiveThumb(clientX, target);
                     this.range.slidersRefs


### PR DESCRIPTION
## Что сделано

- В директиву TuiRangeChange добавлен фильтр, который блокирует обработку событий pointerdown,
  если компонент range находится в состоянии disabled.
- Это предотвращает нежелательное перемещение ползунков, когда слайдер заблокирован.

## Почему это важно

Ранее, несмотря на выставленный disabled, ползунки оставались интерактивными,
что нарушает UX и может приводить к некорректному поведению компонента.

## Как проверить

1. Добавить директиву в проект.
2. Установить `disabled` в true для range-компонента.
3. Проверить, что ползунки не двигаются и pointer-события не срабатывают.
