### PR TITLE
chore(demo-playwright): revert usage of PW Clock API in all tests

### DIFF
--- a/projects/demo-playwright/tests/core/hint/hint.pw.spec.ts
+++ b/projects/demo-playwright/tests/core/hint/hint.pw.spec.ts
@@ -76,6 +76,7 @@ test.describe('TuiHint', () => {
             await tuiGoto(
                 page,
                 `${DemoRoute.Hint}/API?tuiHintShowDelay=1000&darkMode=${mode}`,
+                {date: null},
             );
             const example = new TuiDocumentationPagePO(page);
 

--- a/projects/demo-playwright/utils/goto.ts
+++ b/projects/demo-playwright/utils/goto.ts
@@ -2,12 +2,13 @@ import type {Page} from '@playwright/test';
 import {expect} from '@playwright/test';
 
 import {tuiRemoveElement} from './hide-element';
+import {tuiMockDate} from './mock-date';
 import {tuiWaitForFonts} from './wait-for-fonts';
 import {waitIcons} from './wait-icons';
 import {waitStableState} from './wait-stable-state';
 
 interface TuiGotoOptions extends NonNullable<Parameters<Page['goto']>[1]> {
-    date?: Date;
+    date?: Date | null;
     language?: string;
     hideHeader?: boolean;
     enableNightMode?: boolean;
@@ -46,7 +47,9 @@ export async function tuiGoto(
         );
     }
 
-    await page.clock.setFixedTime(date);
+    if (date) {
+        await tuiMockDate(page, date);
+    }
 
     await page.route('https://fonts.gstatic.com/**', async (route) =>
         route.fulfill({path: `${__dirname}/../stubs/manrope-fonts.ttf`}),

--- a/projects/demo-playwright/utils/index.ts
+++ b/projects/demo-playwright/utils/index.ts
@@ -1,6 +1,7 @@
 export * from './common';
 export * from './goto';
 export * from './hide-element';
+export * from './mock-date';
 export * from './mock-images';
 export * from './page-objects';
 export * from './wait-for-fonts';

--- a/projects/demo-playwright/utils/mock-date.ts
+++ b/projects/demo-playwright/utils/mock-date.ts
@@ -1,0 +1,32 @@
+import type {Page} from '@playwright/test';
+
+type DateConstructor =
+    | [
+          year: number,
+          monthIndex: number,
+          date?: number,
+          hours?: number,
+          minutes?: number,
+          seconds?: number,
+          ms?: number,
+      ]
+    | [];
+
+export async function tuiMockDate(page: Page, date: Date): Promise<void> {
+    await page.addInitScript((fakeNow) => {
+        Object.defineProperty(globalThis, 'Date', {
+            writable: true,
+            value: class extends Date {
+                constructor(...args: DateConstructor) {
+                    if (args.length === 0) {
+                        super(fakeNow);
+                    } else {
+                        super(...args);
+                    }
+                }
+            },
+        });
+
+        Date.now = () => fakeNow;
+    }, date.valueOf());
+}


### PR DESCRIPTION
Clock API is badly compatible with Angular Change Detection.

For example, this test becomes flaky:
https://github.com/taiga-family/taiga-ui/blob/c76f760ba9d2d2cab4a69cd9396e0b0eb8fac392/projects/demo-playwright/tests/legacy/multi-select/multi-select.pw.spec.ts#L207-L226

https://github.com/taiga-family/taiga-ui/blob/14a5625d77ab64f4b68937eb38fa5aedb05c5d43/projects/legacy/components/input-tag/input-tag.component.ts#L466-L472