### PR TITLE
fix(core): `Textfield` label offset em to rem

### DIFF
--- a/projects/core/styles/components/textfield.less
+++ b/projects/core/styles/components/textfield.less
@@ -273,7 +273,7 @@ tui-textfield {
         &:not(._empty):not(:placeholder-shown) {
             & ~ label {
                 font-size: 0.83em;
-                transform: translateY(-0.7em);
+                transform: translateY(-0.7rem);
             }
 
             &:not(:disabled)[data-mode~='invalid'] ~ label,
@@ -296,7 +296,7 @@ tui-textfield {
                 & ~ label {
                     color: var(--tui-text-primary) !important;
                     font-size: 0.83em;
-                    transform: translateY(-0.7em);
+                    transform: translateY(-0.7rem);
                 }
             });
         }


### PR DESCRIPTION
Fixed: reduce the distance between top border and label by design

Before:
![image](https://github.com/user-attachments/assets/9c861165-6701-4679-bcc3-e29dff233e39)


After:
![image](https://github.com/user-attachments/assets/30a3cd97-da56-4c22-a5d3-89c9e8d0c5b6)
