### PR TITLE
fix(kit): `InputSlider` has broken `min`/`max` when `keySteps=null`

### DIFF
--- a/projects/demo-playwright/tests/kit/input-slider/input-slider.pw.spec.ts
+++ b/projects/demo-playwright/tests/kit/input-slider/input-slider.pw.spec.ts
@@ -4,6 +4,7 @@ import {
     TuiDocumentationPagePO,
     tuiGoto,
     TuiInputSliderPO,
+    TuiSliderPO,
 } from '@demo-playwright/utils';
 import type {Locator} from '@playwright/test';
 import {expect, test} from '@playwright/test';
@@ -268,6 +269,48 @@ describe('InputSlider', () => {
                         `input-slider-to-slider-keyboard-arrow-down-${i}.png`,
                     );
             }
+        });
+
+        describe('min/max restraints also works for slider', () => {
+            let slider!: TuiSliderPO;
+            let track!: {x: number; y: number; width: number; height: number};
+
+            beforeEach(async ({page}) => {
+                await tuiGoto(
+                    page,
+                    `${DemoRoute.InputSlider}/API?min=5&max=10&step=1&keySteps=null`,
+                );
+
+                slider = new TuiSliderPO(inputSlider.slider);
+                track = (await inputSlider.slider.boundingBox())!;
+                expect(track).toBeTruthy();
+            });
+
+            test('click on slider', async () => {
+                await inputSlider.slider.click({
+                    position: {x: 0.85 * track.width, y: track.height / 2},
+                });
+
+                await expect(inputSlider.slider).toHaveValue('9');
+                await expect(async () => {
+                    expect(await slider.fillPercentage).toBe(80);
+                }).toPass();
+            });
+
+            test('move thumb', async ({page}) => {
+                await page.mouse.move(track.x, track.y + track.height / 2);
+                await page.mouse.down();
+                await page.mouse.move(
+                    track.x + track.width * 0.85,
+                    track.y + track.height / 2,
+                );
+                await page.mouse.up();
+
+                await expect(inputSlider.slider).toHaveValue('9');
+                await expect(async () => {
+                    expect(await slider.fillPercentage).toBe(80);
+                }).toPass();
+            });
         });
     });
 });

--- a/projects/kit/components/input-slider/input-slider.directive.ts
+++ b/projects/kit/components/input-slider/input-slider.directive.ts
@@ -74,7 +74,10 @@ export class TuiInputSliderDirective {
             return;
         }
 
-        if (slider.keySteps && Number.isFinite(slider.keySteps?.totalSteps)) {
+        if (
+            slider.keySteps?.transformer() &&
+            Number.isFinite(slider.keySteps?.totalSteps)
+        ) {
             // TODO(v5): move all if-condition body inside `TuiSliderKeyStepsBase`
             slider.min = 0;
             slider.step = 1;


### PR DESCRIPTION
Fixes #11072
