### PR TITLE
chore(schematics): remove unused schema for `migrateTuiLet` schematic

### DIFF
--- a/projects/cdk/schematics/collection.json
+++ b/projects/cdk/schematics/collection.json
@@ -32,8 +32,7 @@
         },
         "migrateTuiLet": {
             "description": "Migrate TuiLet directive to @let control flow",
-            "factory": "./migrate-tui-let/index",
-            "schema": "./ng-add/schema.json"
+            "factory": "./migrate-tui-let/index"
         }
     }
 }


### PR DESCRIPTION
## Previous behavior
<img width="1160" alt="Снимок экрана 2025-06-09 в 15 18 33" src="https://github.com/user-attachments/assets/cce5132e-d88b-4f64-befe-2cf7817a229c" />

## New behavior
<img width="392" alt="new" src="https://github.com/user-attachments/assets/683af0dc-b11e-4cb5-ab7c-23495d19aa6e" />


