### PR TITLE
fix(core): `DropdownOpen` has unexpected auto focus inside Shadow DOM

### DIFF
--- a/projects/core/directives/dropdown/dropdown-open.directive.ts
+++ b/projects/core/directives/dropdown/dropdown-open.directive.ts
@@ -163,10 +163,12 @@ export class TuiDropdownOpen implements OnChanges {
         this.focusDropdown(up);
     }
 
-    protected onKeydown({key, target, defaultPrevented}: KeyboardEvent): void {
+    protected onKeydown(event: KeyboardEvent): void {
+        const target = tuiGetActualTarget(event);
+
         if (
-            !defaultPrevented &&
-            tuiIsEditingKey(key) &&
+            !event.defaultPrevented &&
+            tuiIsEditingKey(event.key) &&
             this.editable &&
             this.focused &&
             tuiIsHTMLElement(target) &&


### PR DESCRIPTION
### Reproduction  
1. Open https://stackblitz.com/edit/dropdown-open-shadow-dom-textfield-inside-dropdown?file=src%2Fapp%2Fapp.template.html
2. Make right click on textarea (it will open dropdown and move focus to input inside dropdown)
3. Try to type `1`

**Expected behavior:** input inside dropdown contains `1`, focus inside this input
**Actual behavior:** textarea contains `1`, focus inside dropdown, input inside dropdown is empty

Fixes #11089
