### PR TITLE
chore: remove redundant entry point

### DIFF
--- a/projects/kit/components/progress/progress-segmented/index.ts
+++ b/projects/kit/components/progress/progress-segmented/index.ts
@@ -1,1 +1,0 @@
-export * from './progress-segmented.directive';

--- a/projects/kit/components/progress/progress-segmented/ng-package.json
+++ b/projects/kit/components/progress/progress-segmented/ng-package.json
@@ -1,5 +1,0 @@
-{
-    "lib": {
-        "entryFile": "index.ts"
-    }
-}


### PR DESCRIPTION
```bash
projects/kit/components/progress
├── progress-bar # no index.ts & no ng-package.json
├── progress-circle # no index.ts & no ng-package.json
├── progress-label # no index.ts & no ng-package.json
├── progress-segmented
│   ├── index.ts # why???
│   ├── ng-package.json # why???
│   └──  progress-segmented.directive.ts
├── index.ts
├── progress.ts
└── ng-package.json
```



https://github.com/taiga-family/taiga-ui/blob/ca81b5cb599a509ea106cf50993f253cfad508c7/projects/kit/components/progress/index.ts#L8