### PR TITLE
fix(kit): `InputNumber` has missing minus sign for `min < 0` on Samsung with system keyboard

### DIFF
--- a/projects/kit/components/input-number/input-number.directive.ts
+++ b/projects/kit/components/input-number/input-number.directive.ts
@@ -86,13 +86,20 @@ export class TuiInputNumberDirective extends TuiControl<number | null> {
     protected readonly options = inject(TUI_INPUT_NUMBER_OPTIONS);
     protected readonly element = tuiInjectElement<HTMLInputElement>();
 
-    protected readonly inputMode = computed(() => {
-        if (this.isIOS && this.min() < 0) {
+    protected readonly inputMode = computed((needMinus = this.min() < 0) => {
+        if (this.isIOS && needMinus) {
             // iPhone does not have minus sign if inputMode is equal to 'numeric' / 'decimal'
             return 'text';
         }
 
-        return this.precision() ? 'decimal' : 'numeric';
+        return this.precision() &&
+            /**
+             * Samsung Keyboard does not minus sign for `decimal` input mode
+             * @see https://github.com/taiga-family/taiga-ui/issues/11061#issuecomment-2939103792
+             */
+            !needMinus
+            ? 'decimal'
+            : 'numeric';
     });
 
     protected readonly defaultMaxLength = computed(() => {

--- a/projects/legacy/components/input-number/input-number.component.ts
+++ b/projects/legacy/components/input-number/input-number.component.ts
@@ -122,7 +122,14 @@ export class TuiInputNumberComponent
             return 'text';
         }
 
-        return !this.precision ? 'numeric' : 'decimal';
+        return this.precision ||
+            /**
+             * Samsung Keyboard does not minus sign for `decimal` input mode
+             * @see https://github.com/taiga-family/taiga-ui/issues/11061#issuecomment-2939103792
+             */
+            !this.isNegativeAllowed
+            ? 'decimal'
+            : 'numeric';
     }
 
     public get calculatedMaxLength(): number {


### PR DESCRIPTION
Fixes #11061

## Previous behavior


https://github.com/user-attachments/assets/6280bda8-5bf6-4efd-8860-87b91e8ec689

## New behavior

https://github.com/user-attachments/assets/9f8ceca4-42c9-4c63-a573-1ac10ef4d6c4

