### PR TITLE
chore(i18n): add missing time fillers for Arabic language

### DIFF
--- a/projects/i18n/languages/arabic/kit.ts
+++ b/projects/i18n/languages/arabic/kit.ts
@@ -18,6 +18,11 @@ export const TUI_ARABIC_LANGUAGE_KIT: TuiLanguageKit = {
         'HH:MM:SS AA': 'HH:MM:SS AA',
         'HH:MM:SS.MSS': 'HH:MM:SS.MSS',
         'HH:MM:SS.MSS AA': 'HH:MM:SS.MSS AA',
+        'HH AA': 'HH AA',
+        HH: 'HH',
+        'MM:SS.MSS': 'MM:SS.MSS',
+        'MM.SS.MSS': 'MM.SS.MSS',
+        'SS.MSS': 'SS.MSS',
     },
     dateTexts: {
         DMY: 'dd/mm/yyyy',


### PR DESCRIPTION
The main branch has broken `build`-job:

```
------------------------------------------------------------------------------
Building entry point '@taiga-ui/i18n/languages/arabic'
------------------------------------------------------------------------------
- Compiling with Angular sources in Ivy partial compilation mode.
✖ Compiling with Angular sources in Ivy partial compilation mode.
projects/i18n/languages/arabic/kit.ts:13:5 - error TS2739: Type '{ 'MM:SS': string; 'HH:MM': string; 'HH:MM AA': string; 'HH:MM:SS': string; 'HH:MM:SS AA': string; 'HH:MM:SS.MSS': string; 'HH:MM:SS.MSS AA': string; }' is missing the following properties from type '{ 'MM:SS': string; 'HH:MM': string; 'HH:MM AA': string; 'HH:MM:SS': string; 'HH:MM:SS AA': string; 'HH:MM:SS.MSS': string; 'HH:MM:SS.MSS AA': string; 'HH AA': string; HH: string; 'MM:SS.MSS': string; 'MM.SS.MSS': string; 'SS.MSS': string; }': 'HH AA', HH, 'MM:SS.MSS', 'MM.SS.MSS', 'SS.MSS'

13     time: {
       ~~~~

  dist/i18n/types/language.d.ts:98:5
    98     time: {
           ~~~~
    The expected type comes from property 'time' which is declared here on type 'TuiLanguageKit'
```

Relates:
* https://github.com/taiga-family/taiga-ui/pull/11091
* https://github.com/taiga-family/taiga-ui/pull/11113