### PR TITLE
fix(kit): `ProgressCircle` prevents possible shrinkage (with shape distortion) inside flex container

### DIFF
--- a/projects/demo/src/modules/components/progress-circle/examples/4/index.less
+++ b/projects/demo/src/modules/components/progress-circle/examples/4/index.less
@@ -1,5 +1,6 @@
 :host {
     display: flex;
+    flex-wrap: wrap;
     gap: 1rem;
 }
 

--- a/projects/kit/components/progress/progress-circle/progress-circle.style.less
+++ b/projects/kit/components/progress/progress-circle/progress-circle.style.less
@@ -24,6 +24,7 @@
     // TODO: delete this line after bumping browser support of Safari to 16+
     font-size: 1rem; // to use em units inside svg (Safari doesn't support rem units inside svg)
     inline-size: var(--t-diameter);
+    min-inline-size: var(--t-diameter);
     block-size: var(--t-diameter);
     border-radius: 100%;
     mask: radial-gradient(


### PR DESCRIPTION
1. Set browser viewport size to 350*350
2. Open https://taiga-ui.dev/components/progress-circle#colors

### Previous behavior
<img width="958" alt="before" src="https://github.com/user-attachments/assets/4312f951-b5df-4ce8-9454-53ced167ffb8" />

### New behavior
<img width="958" alt="after" src="https://github.com/user-attachments/assets/e6ca1254-ab6e-4f33-a4db-41c62b116f81" />
