### PR TITLE
chore(demo): fix broken example `Virtual scroll` for `ComboBox`

### DIFF
--- a/projects/demo/src/modules/components/combo-box/examples/10/index.html
+++ b/projects/demo/src/modules/components/combo-box/examples/10/index.html
@@ -6,14 +6,17 @@
     />
 
     <ng-container *tuiTextfieldDropdown>
-        <!-- 48 = 44 height + 4 margin -->
+        <!-- 44 = option height -->
+        <!-- 4 = margin between options -->
         <!-- 8 = data list padding -->
         <cdk-virtual-scroll-viewport
-            *ngIf="countries$ | async | tuiFilterByInput as items"
+            *tuiLet="countries$ | async | tuiFilterByInput as items"
             tuiScrollable
             class="scroll"
-            [itemSize]="48"
-            [style.height.px]="(items.length ? items.length : 1) * 48 + 8"
+            [itemSize]="44"
+            [maxBufferPx]="44 * 10"
+            [minBufferPx]="44 * 5"
+            [style.height.px]="(items?.length || 1) * (44 + 4) + 8"
         >
             <tui-data-list>
                 <button

--- a/projects/demo/src/modules/components/combo-box/examples/10/index.less
+++ b/projects/demo/src/modules/components/combo-box/examples/10/index.less
@@ -3,5 +3,5 @@
 .scroll {
     .scrollbar-hidden();
 
-    block-size: 12.5rem;
+    max-block-size: 100%;
 }

--- a/projects/demo/src/modules/components/combo-box/examples/10/index.ts
+++ b/projects/demo/src/modules/components/combo-box/examples/10/index.ts
@@ -1,13 +1,10 @@
-import {
-    CdkFixedSizeVirtualScroll,
-    CdkVirtualForOf,
-    CdkVirtualScrollViewport,
-} from '@angular/cdk/scrolling';
+import {ScrollingModule} from '@angular/cdk/scrolling';
 import {AsyncPipe, NgIf} from '@angular/common';
 import {Component, inject} from '@angular/core';
 import {FormsModule} from '@angular/forms';
 import {changeDetection} from '@demo/emulate/change-detection';
 import {encapsulation} from '@demo/emulate/encapsulation';
+import {TuiLet} from '@taiga-ui/cdk';
 import {TuiDataList, TuiScrollable, TuiTextfield} from '@taiga-ui/core';
 import {
     TUI_COUNTRIES,
@@ -22,15 +19,14 @@ import {map} from 'rxjs';
     standalone: true,
     imports: [
         AsyncPipe,
-        CdkFixedSizeVirtualScroll,
-        CdkVirtualForOf,
-        CdkVirtualScrollViewport,
         FormsModule,
         NgIf,
+        ScrollingModule,
         TuiChevron,
         TuiComboBox,
         TuiDataList,
         TuiFilterByInputPipe,
+        TuiLet,
         TuiScrollable,
         TuiTextfield,
     ],

--- a/projects/demo/src/modules/components/select/examples/6/index.ts
+++ b/projects/demo/src/modules/components/select/examples/6/index.ts
@@ -1,8 +1,4 @@
-import {
-    CdkFixedSizeVirtualScroll,
-    CdkVirtualForOf,
-    CdkVirtualScrollViewport,
-} from '@angular/cdk/scrolling';
+import {ScrollingModule} from '@angular/cdk/scrolling';
 import {AsyncPipe} from '@angular/common';
 import {Component, inject} from '@angular/core';
 import {FormsModule} from '@angular/forms';
@@ -16,10 +12,8 @@ import {map} from 'rxjs';
     standalone: true,
     imports: [
         AsyncPipe,
-        CdkFixedSizeVirtualScroll,
-        CdkVirtualForOf,
-        CdkVirtualScrollViewport,
         FormsModule,
+        ScrollingModule,
         TuiChevron,
         TuiDataList,
         TuiScrollable,


### PR DESCRIPTION
## Previous behavior
https://taiga-ui.dev/components/combo-box#virtual-scroll


https://github.com/user-attachments/assets/40108970-5e79-42d1-ab77-abb5d0418403

## New behavior

https://github.com/user-attachments/assets/08a3ed1f-7c08-4542-9e75-da5de2bf60b3



___

Also, review #5725 – it is not an issue for new `ComboBox` 

Fixes #5725
