### PR TITLE
fix(kit): `FilterByInput` should unfilter items only on unambiguous option match

### DIFF
--- a/projects/kit/pipes/filter-by-input/filter-by-input.pipe.ts
+++ b/projects/kit/pipes/filter-by-input/filter-by-input.pipe.ts
@@ -75,10 +75,9 @@ export class TuiFilterByInputPipe implements PipeTransform {
         query: string,
     ): readonly T[] {
         const match = this.getMatch(items, stringify, query);
+        const filtered = items.filter((item) => matcher(item, query, stringify));
 
-        return match != null
-            ? items
-            : items.filter((item) => matcher(item, query, stringify));
+        return match != null && filtered.length === 1 ? items : filtered;
     }
 
     private filter2d<T>(
@@ -88,10 +87,11 @@ export class TuiFilterByInputPipe implements PipeTransform {
         query: string,
     ): ReadonlyArray<readonly T[]> {
         const match = items.find((item) => this.getMatch(item, stringify, query) != null);
+        const filtered = items.map((inner) =>
+            this.filterFlat(inner, matcher, stringify, query),
+        );
 
-        return match != null
-            ? items
-            : items.map((inner) => this.filterFlat(inner, matcher, stringify, query));
+        return match != null && filtered.flat().length === 1 ? items : filtered;
     }
 
     private getMatch<T>(


### PR DESCRIPTION
Fixes #2346

https://stackblitz.com/edit/taiga-issue-2346?file=src%2Fapp%2Fapp.component.ts,src%2Fapp%2Fapp.template.html

### Previous behavior

https://github.com/user-attachments/assets/18818ae6-1028-4c2d-b793-9610f674a51f

### New behavior

https://github.com/user-attachments/assets/de6f333f-6665-496d-9b25-8be65d9b0e92


