### PR TITLE
feat(addon-doc): support for switching text direction in documentation

### DIFF
--- a/projects/addon-doc/components/main/main.component.ts
+++ b/projects/addon-doc/components/main/main.component.ts
@@ -1,3 +1,4 @@
+import {DOCUMENT, NgIf} from '@angular/common';
 import {
     ChangeDetectionStrategy,
     Component,
@@ -6,8 +7,12 @@ import {
     ViewEncapsulation,
 } from '@angular/core';
 import {RouterOutlet} from '@angular/router';
-import {TUI_DOC_ICONS} from '@taiga-ui/addon-doc/tokens';
+import {
+    TUI_DOC_DIRECTION_ENABLED,
+    TUI_DOC_ICONS,
+} from '@taiga-ui/addon-doc/tokens';
 import {TuiButton} from '@taiga-ui/core/components/button';
+import {TuiIcon} from '@taiga-ui/core/components/icon';
 import {TuiRoot} from '@taiga-ui/core/components/root';
 import {TUI_DARK_MODE} from '@taiga-ui/core/tokens';
 
@@ -17,7 +22,15 @@ import {TuiDocNavigation} from '../navigation/navigation.component';
 @Component({
     standalone: true,
     selector: 'tui-doc-main',
-    imports: [RouterOutlet, TuiButton, TuiDocHeader, TuiDocNavigation, TuiRoot],
+    imports: [
+        NgIf,
+        RouterOutlet,
+        TuiButton,
+        TuiDocHeader,
+        TuiDocNavigation,
+        TuiIcon,
+        TuiRoot,
+    ],
     templateUrl: './main.template.html',
     styleUrls: ['./main.style.less'],
     encapsulation: ViewEncapsulation.None,
@@ -26,10 +39,18 @@ import {TuiDocNavigation} from '../navigation/navigation.component';
     changeDetection: ChangeDetectionStrategy.Default,
 })
 export class TuiDocMain {
+    private readonly doc = inject(DOCUMENT);
     private readonly icons = inject(TUI_DOC_ICONS);
+    protected readonly dir = inject(TUI_DOC_DIRECTION_ENABLED);
     protected readonly darkMode = inject(TUI_DARK_MODE);
     protected readonly theme = computed(() => (this.darkMode() ? 'dark' : null));
     protected readonly icon = computed(() =>
         this.darkMode() ? this.icons.light : this.icons.dark,
     );
+
+    public changeTextDirection(): void {
+        const dir = this.doc.documentElement.getAttribute('dir') ?? 'ltr';
+
+        this.doc.documentElement.setAttribute('dir', dir === 'ltr' ? 'rtl' : 'ltr');
+    }
 }

--- a/projects/addon-doc/components/main/main.component.ts
+++ b/projects/addon-doc/components/main/main.component.ts
@@ -7,10 +7,7 @@ import {
     ViewEncapsulation,
 } from '@angular/core';
 import {RouterOutlet} from '@angular/router';
-import {
-    TUI_DOC_DIRECTION_ENABLED,
-    TUI_DOC_ICONS,
-} from '@taiga-ui/addon-doc/tokens';
+import {TUI_DOC_DIRECTION_ENABLED, TUI_DOC_ICONS} from '@taiga-ui/addon-doc/tokens';
 import {TuiButton} from '@taiga-ui/core/components/button';
 import {TuiIcon} from '@taiga-ui/core/components/icon';
 import {TuiRoot} from '@taiga-ui/core/components/root';

--- a/projects/addon-doc/components/main/main.style.less
+++ b/projects/addon-doc/components/main/main.style.less
@@ -100,6 +100,7 @@ tui-doc-navigation.tui-doc-navigation {
     display: block;
 }
 
+.tui-doc-switch-direction,
 .tui-doc-dark-mode-switch {
     margin-inline-start: 1rem;
 }

--- a/projects/addon-doc/components/main/main.template.html
+++ b/projects/addon-doc/components/main/main.template.html
@@ -9,6 +9,21 @@
     </div>
     <header tuiDocHeader>
         <ng-content select="tuiDocHeader" />
+
+        <button
+            *ngIf="dir"
+            appearance="outline"
+            aria-label="Switch directionality of the element's text"
+            iconEnd="@tui.a-large-small"
+            size="s"
+            tuiButton
+            type="button"
+            class="tui-doc-switch-direction"
+            (click)="changeTextDirection()"
+        >
+            <tui-icon icon="@tui.arrow-right-left" />
+        </button>
+
         <button
             appearance="secondary"
             aria-label="Switch between dark and light mode"

--- a/projects/addon-doc/tokens/doc-icons.ts
+++ b/projects/addon-doc/tokens/doc-icons.ts
@@ -1,5 +1,6 @@
 import type {Provider} from '@angular/core';
 import {InjectionToken} from '@angular/core';
+import {TUI_FALSE_HANDLER} from '@taiga-ui/cdk/constants';
 import {tuiProvideOptions} from '@taiga-ui/cdk/utils/miscellaneous';
 
 export interface TuiDocIcons {
@@ -40,3 +41,8 @@ export const TUI_DOC_ICONS = new InjectionToken(ngDevMode ? 'TUI_DOC_ICONS' : ''
 export function tuiDocIconsProvider(icons: Partial<TuiDocIcons>): Provider {
     return tuiProvideOptions(TUI_DOC_ICONS, icons, TUI_DOC_DEFAULT_ICONS);
 }
+
+export const TUI_DOC_DIRECTION_ENABLED = new InjectionToken(
+    ngDevMode ? 'TUI_DOC_DIRECTION_ENABLED' : '',
+    {factory: TUI_FALSE_HANDLER},
+);

--- a/projects/cdk/constants/used-icons.ts
+++ b/projects/cdk/constants/used-icons.ts
@@ -20,6 +20,8 @@ export const TUI_USED_ICONS = [
     '@tui.uzcard',
     '@tui.verve',
     '@tui.external-link',
+    '@tui.a-large-small',
+    '@tui.arrow-right-left',
     '@tui.search',
     '@tui.sun',
     '@tui.moon',

--- a/projects/demo/src/modules/app/app.config.ts
+++ b/projects/demo/src/modules/app/app.config.ts
@@ -14,13 +14,11 @@ import type {UrlTree} from '@angular/router';
 import {provideRouter, withInMemoryScrolling} from '@angular/router';
 import {environment} from '@demo/environments/environment';
 import {WA_SESSION_STORAGE} from '@ng-web-apis/common';
-import {
-    TUI_DOC_DIRECTION_ENABLED,
-    type TuiDocSourceCodePathOptions,
-} from '@taiga-ui/addon-doc';
+import type {TuiDocSourceCodePathOptions} from '@taiga-ui/addon-doc';
 import {
     TUI_DOC_CODE_EDITOR,
     TUI_DOC_DEFAULT_TABS,
+    TUI_DOC_DIRECTION_ENABLED,
     TUI_DOC_EXAMPLE_CONTENT_PROCESSOR,
     TUI_DOC_LOGO,
     TUI_DOC_PAGES,

--- a/projects/demo/src/modules/app/app.config.ts
+++ b/projects/demo/src/modules/app/app.config.ts
@@ -14,7 +14,10 @@ import type {UrlTree} from '@angular/router';
 import {provideRouter, withInMemoryScrolling} from '@angular/router';
 import {environment} from '@demo/environments/environment';
 import {WA_SESSION_STORAGE} from '@ng-web-apis/common';
-import type {TuiDocSourceCodePathOptions} from '@taiga-ui/addon-doc';
+import {
+    TUI_DOC_DIRECTION_ENABLED,
+    type TuiDocSourceCodePathOptions,
+} from '@taiga-ui/addon-doc';
 import {
     TUI_DOC_CODE_EDITOR,
     TUI_DOC_DEFAULT_TABS,
@@ -158,6 +161,10 @@ export const config: ApplicationConfig = {
         {
             provide: TUI_DOC_LOGO,
             useValue: LOGO_CONTENT,
+        },
+        {
+            provide: TUI_DOC_DIRECTION_ENABLED,
+            useValue: true,
         },
         {
             provide: TUI_DOC_SEARCH_ENABLED,

--- a/projects/demo/src/modules/app/app.style.less
+++ b/projects/demo/src/modules/app/app.style.less
@@ -34,7 +34,8 @@ app {
 
 @media @tui-mobile {
     // Increasing specificity
-    .app-link.app-link {
+    .app-link.app-link,
+    .tui-doc-switch-direction.tui-doc-switch-direction {
         display: none;
     }
 

--- a/projects/demo/src/modules/app/app.template.html
+++ b/projects/demo/src/modules/app/app.template.html
@@ -1,6 +1,6 @@
 <router-outlet *ngIf="isLanding(); else portal" />
 <ng-template #portal>
-    <tui-doc-main>
+    <tui-doc-main #main>
         <div
             ngProjectAs="tuiDocHeader"
             class="app-links"
@@ -29,6 +29,15 @@
                 More
                 <ng-template #more>
                     <tui-data-list size="m">
+                        <a
+                            iconStart="@tui.arrow-right-left"
+                            tuiOption
+                            class="app-link-dropdown"
+                            (click)="main.changeTextDirection()"
+                        >
+                            RTL / LTR
+                        </a>
+                        <hr />
                         <a
                             href="https://github.com/taiga-family/taiga-ui"
                             iconStart="assets/images/github.svg"

--- a/projects/demo/used-icons.ts
+++ b/projects/demo/used-icons.ts
@@ -10,6 +10,7 @@ export const TUI_USED_ICONS = [
     '@tui.settings',
     '@tui.chevron-down',
     '@tui.ellipsis',
+    '@tui.arrow-right-left',
     '@tui.star',
     '@tui.github',
     '@tui.calendar',


### PR DESCRIPTION
<img width="1370" alt="image" src="https://github.com/user-attachments/assets/040feca2-10a1-4612-b986-53e1b8af68db" />


Easily test functionality directly within the documentation