### PR TITLE
chore(kit): invalid import inside `InputTime`

### DIFF
--- a/projects/kit/components/input-time/input-time.directive.ts
+++ b/projects/kit/components/input-time/input-time.directive.ts
@@ -23,7 +23,7 @@ import {
     tuiDropdownEnabled,
     tuiDropdownOpen,
 } from '@taiga-ui/core/directives/dropdown';
-import {tuiAsAuxiliary} from '@taiga-ui/core/tokens/auxiliary';
+import {tuiAsAuxiliary} from '@taiga-ui/core/tokens';
 import {TuiSelectOption} from '@taiga-ui/kit/components/select';
 import {TUI_TIME_TEXTS} from '@taiga-ui/kit/tokens';
 import {tuiMaskito} from '@taiga-ui/kit/utils';


### PR DESCRIPTION
```
Error in 
turbo_modules/@taiga-ui/kit@4.42.0-canary.551f28f/fesm2022/taiga-ui-kit-components-input-time.mjs

The entrypoint for '@taiga-ui/core' could not successfully be resolved. 
The file '/turbo_modules/@taiga-ui/core@4.42.0-canary.551f28f/tokens/auxiliary' does not exist. 
Please log an issue with the package author or check for an updated version of the package.
```