### PR TITLE
fix(addon-doc): `DocExample` has broken anchor link navigation for `pageTab` with index > 1

### DIFF
--- a/projects/addon-doc/components/example/example.component.ts
+++ b/projects/addon-doc/components/example/example.component.ts
@@ -2,7 +2,7 @@ import {Clipboard} from '@angular/cdk/clipboard';
 import {DOCUMENT, NgForOf, NgIf} from '@angular/common';
 import {ChangeDetectionStrategy, Component, inject, Input, signal} from '@angular/core';
 import {toSignal} from '@angular/core/rxjs-interop';
-import {RouterLink, RouterLinkActive} from '@angular/router';
+import {ActivatedRoute, RouterLink, RouterLinkActive} from '@angular/router';
 import {WA_LOCATION} from '@ng-web-apis/common';
 import {
     TUI_DOC_CODE_ACTIONS,
@@ -82,6 +82,8 @@ export class TuiDocExample {
         inject<ReadonlyArray<PolymorpheusContent<TuiContext<string>>>>(
             TUI_DOC_CODE_ACTIONS,
         );
+
+    protected readonly route = inject(ActivatedRoute);
 
     protected readonly defaultTabIndex = 0;
     protected readonly defaultTab = this.texts[this.defaultTabIndex];

--- a/projects/addon-doc/components/example/example.template.html
+++ b/projects/addon-doc/components/example/example.template.html
@@ -17,6 +17,7 @@
         class="t-link"
         [attr.title]="copy()"
         [fragment]="id"
+        [relativeTo]="route.firstChild ?? route"
         [routerLinkActiveOptions]="{matrixParams: 'exact', queryParams: 'exact', paths: 'exact', fragment: 'exact'}"
         (click)="copyExampleLink($event.currentTarget)"
     >


### PR DESCRIPTION
1. Open https://maskito.dev/core-concepts/plugins/Built-in_core_plugins
2. Click on hashtag of any example to generate anchor link


https://github.com/user-attachments/assets/b45964a9-a79d-4a45-aec6-6d4a64b0b508

