### PR TITLE
feat: improve safe-area support for WebView

### DIFF
--- a/projects/addon-mobile/components/sheet-dialog/sheet-dialog.style.less
+++ b/projects/addon-mobile/components/sheet-dialog/sheet-dialog.style.less
@@ -127,7 +127,7 @@
 .t-content {
     position: relative;
     isolation: isolate;
-    padding-block-end: calc(1.5rem + env(safe-area-inset-bottom));
+    padding-block-end: ~'max(1.5rem, env(safe-area-inset-bottom))';
     border-radius: inherit;
 
     &::after {

--- a/projects/core/components/dialog/dialog.style.less
+++ b/projects/core/components/dialog/dialog.style.less
@@ -98,7 +98,7 @@
             padding: env(safe-area-inset-top) 0 env(safe-area-inset-bottom);
 
             .t-close {
-                top: calc(1rem + env(safe-area-inset-top));
+                top: ~'max(1rem, env(safe-area-inset-top))';
             }
         }
     }

--- a/projects/demo/src/modules/components/dialog/examples/4/index.less
+++ b/projects/demo/src/modules/components/dialog/examples/4/index.less
@@ -10,7 +10,7 @@
     .center-left();
 
     position: fixed;
-    bottom: 1.25rem;
+    bottom: ~'max(1.25rem, env(safe-area-inset-bottom))';
     animation: tuiFadeIn var(--tui-duration) var(--tui-duration);
     animation-fill-mode: backwards;
 }

--- a/projects/kit/components/floating-container/floating-container.less
+++ b/projects/kit/components/floating-container/floating-container.less
@@ -27,7 +27,7 @@
     bottom: calc(100 * var(--tui-viewport-vh) - var(--tui-viewport-height) - var(--tui-viewport-y));
     z-index: 1;
     margin-block-start: 1rem;
-    padding-block-end: calc(1rem + env(safe-area-inset-bottom));
+    padding-block-end: ~'max(1rem, env(safe-area-inset-bottom))';
     text-align: center;
     font: var(--tui-font-text-ui-s);
     color: var(--tui-text-secondary);
@@ -48,7 +48,7 @@
     // when only button in container margin differs - (24px vs 16px), therefore need some workaround to correctly works when it's animating
     &:has(> *:only-child:not(tui-elastic-container)),
     &:has(*.ng-animating:first-child ~ .ng-animating:last-child) {
-        padding-block-end: calc(1.5rem + env(safe-area-inset-bottom));
+        padding-block-end: ~'max(1.5rem, env(safe-area-inset-bottom))';
     }
 
     &::before {
@@ -66,5 +66,5 @@
 }
 
 tui-sheet-dialog [tuiFloatingContainer] {
-    margin-block-end: calc(-1.5rem - env(safe-area-inset-bottom));
+    margin-block-end: ~'calc(-1* max(1.5rem, env(safe-area-inset-bottom)))';
 }


### PR DESCRIPTION
Partially solved #10963 

1. **SheetDialog** bottom padding
2. **Dialog** close button padding (only in fullscreen & page)
3. **Dialog** example button bottom padding
4. **FloatingContainer** buttons bottom padding

### BEFORE

<img width="203" height="432" alt="image" src="https://github.com/user-attachments/assets/baba4e40-7447-4b49-bcca-e136d6b9b417" />

<img width="203" height="432" alt="image" src="https://github.com/user-attachments/assets/0fbf3e8c-3c54-45d9-8a8f-081ec56e10b0" />

<img width="203" height="432" alt="image" src="https://github.com/user-attachments/assets/3e150e05-9a56-45f5-b666-f6284b9f0d57" />

<img width="203" height="432" alt="image" src="https://github.com/user-attachments/assets/2f17d4db-e052-41ce-a8bd-7a0de67ba3cf" />


### AFTER

<img width="203" height="432" alt="image" src="https://github.com/user-attachments/assets/e633c210-4210-4b5c-9a98-568b72150738" />

<img width="203" height="432" alt="image" src="https://github.com/user-attachments/assets/4e99570e-f26e-4d0b-aacb-94cb9b327d3a" />

<img width="203" height="432" alt="image" src="https://github.com/user-attachments/assets/9911564d-4bd3-46fd-acf4-8599071475f1" />

<img width="203" height="432" alt="image" src="https://github.com/user-attachments/assets/6b28c905-bed2-4581-b411-14e85226c2d4" />

