### PR TITLE
feat(kit): `Preview` support safe-area top/bottom

### DIFF
--- a/projects/kit/components/preview/preview.style.less
+++ b/projects/kit/components/preview/preview.style.less
@@ -12,7 +12,7 @@
 
 .t-header {
     position: fixed;
-    top: 1rem;
+    top: ~'max(1rem, env(safe-area-inset-top))';
     display: flex;
     inline-size: 100%;
     padding: 0 1rem;
@@ -21,7 +21,7 @@
 
 .t-footer {
     position: absolute;
-    bottom: 1rem;
+    bottom: ~'max(1rem, env(safe-area-inset-bottom))';
     display: flex;
     inline-size: 100%;
     padding: 0 1rem;


### PR DESCRIPTION
Partially solved #10963 

### BEFORE

<img width="203" height="432" alt="image" src="https://github.com/user-attachments/assets/9916b547-a75b-40c6-aa90-134c21e4a398" />



### AFTER

<img width="203" height="432" alt="image" src="https://github.com/user-attachments/assets/c2fd9897-6917-4dc2-b7a0-6403da00338c" />

