### PR TITLE
feat(kit): `PdfViewer` support safe-area top/bottom

### DIFF
--- a/projects/kit/components/pdf-viewer/pdf-viewer.style.less
+++ b/projects/kit/components/pdf-viewer/pdf-viewer.style.less
@@ -7,6 +7,8 @@
     box-sizing: border-box;
     color: #fff;
     background: #333639;
+    padding-block-start: env(safe-area-inset-top);
+    padding-block-end: env(safe-area-inset-bottom);
 
     &.tui-enter,
     &.tui-leave {


### PR DESCRIPTION
Partially solved #10963 

### BEFORE

<img width="203" height="432" alt="image" src="https://github.com/user-attachments/assets/c92cdc0f-f072-437d-b082-2dcfc0d6d470" />



### AFTER

<img width="203" height="432" alt="image" src="https://github.com/user-attachments/assets/eecf2522-eed6-4078-8a07-46531bf8d92c" />




