### PR TITLE
feat(core): `Textfield` dispatches `(input)` event on cleaner click

### DIFF
--- a/projects/core/components/textfield/textfield-multi/textfield-multi.template.html
+++ b/projects/core/components/textfield/textfield-multi/textfield-multi.template.html
@@ -49,7 +49,7 @@
         type="button"
         class="t-clear"
         [iconStart]="icons.close"
-        (click)="accessor?.setValue([])"
+        (click)="accessor?.setValue([]); dispatchEvent('input')"
     >
         {{ clear() }}
     </button>

--- a/projects/core/components/textfield/textfield.component.ts
+++ b/projects/core/components/textfield/textfield.component.ts
@@ -188,6 +188,10 @@ export class TuiTextfieldBaseComponent<T>
             });
         }
     }
+
+    protected dispatchEvent(name: string): void {
+        this.input?.nativeElement.dispatchEvent(new Event(name, {bubbles: true}));
+    }
 }
 
 @Component({

--- a/projects/core/components/textfield/textfield.template.html
+++ b/projects/core/components/textfield/textfield.template.html
@@ -17,7 +17,7 @@
         type="button"
         class="t-clear"
         [iconStart]="icons.close"
-        (click)="accessor?.setValue(null)"
+        (click)="accessor?.setValue(null); dispatchEvent('input')"
         (pointerdown.zoneless.prevent)="input?.nativeElement?.focus()"
     >
         {{ clear() }}


### PR DESCRIPTION
```html
<tui-textfield tuiChevron>
  <input
    tuiComboBox
    [(ngModel)]="value"
    (input)="search$.next($event.target.value)"
  />

  <tui-data-list-wrapper
    *tuiTextfieldDropdown
    [items]="items$ | async"
  />
</tui-textfield>
```

https://taiga-ui.dev/components/combo-box#server-side-filtering