### PR TITLE
fix(kit): use only icon type in url mask

### DIFF
--- a/projects/kit/components/avatar/avatar.template.html
+++ b/projects/kit/components/avatar/avatar.template.html
@@ -1,8 +1,8 @@
 <img
-    *ngIf="type === 'img'"
+    *ngIf="type() === 'img'"
     alt=""
     loading="lazy"
-    [src]="value"
+    [src]="value()"
 />
-<ng-container *ngIf="type === 'text'">{{ value }}</ng-container>
+<ng-container *ngIf="type() === 'text'">{{ value() }}</ng-container>
 <ng-content />


### PR DESCRIPTION
Fixes #11332

## Before

Open https://taiga-ui.dev/components/avatar/API

<img width="1696" height="965" alt="image" src="https://github.com/user-attachments/assets/fca6b1ae-5621-4cb5-9dc7-9771db7972c4" />
