### PR TITLE
refactor: add typesafe for runtime in `tui-dropdown-mobile`

### DIFF
--- a/projects/addon-mobile/directives/dropdown-mobile/dropdown-mobile.component.ts
+++ b/projects/addon-mobile/directives/dropdown-mobile/dropdown-mobile.component.ts
@@ -45,8 +45,10 @@ export class TuiDropdownMobileComponent implements OnDestroy, AfterViewInit {
     private readonly keyboard = inject(TuiKeyboardService);
     private readonly doc = inject(DOCUMENT);
     private readonly scrollTop = this.doc.documentElement.scrollTop;
-    private readonly observer = new ResizeObserver(() =>
-        this.refresh(this.doc.defaultView!.visualViewport!),
+    private readonly observer = new ResizeObserver(
+        () =>
+            this.doc.defaultView?.visualViewport &&
+            this.refresh(this.doc.defaultView.visualViewport),
     );
 
     protected readonly directive = inject(TuiDropdownMobile);


### PR DESCRIPTION
<img width="799" height="230" alt="image" src="https://github.com/user-attachments/assets/089c3955-bc2d-4d4f-a210-f1520d9cdf8f" />

<img width="845" height="306" alt="image" src="https://github.com/user-attachments/assets/3bc912ee-1c9d-4da5-89f6-dd458b2efe49" />
