### PR TITLE
fix(kit): `InputDate` & `InputDateRange` fail to clear value on `formControl.reset()`

### DIFF
--- a/projects/demo-cypress/src/tests/textfield/textfield-form-reset.cy.ts
+++ b/projects/demo-cypress/src/tests/textfield/textfield-form-reset.cy.ts
@@ -33,7 +33,7 @@ import {
             <button
                 id="reset"
                 type="button"
-                (click)="formGroup.reset()"
+                (mouseenter)="formGroup.reset()"
             >
                 Reset
             </button>
@@ -135,7 +135,7 @@ describe('Textfield + form.reset()', () => {
                 expect(form.get('comboBox')!.value).to.be.equal(null);
             });
 
-        cy.get('#reset').click();
+        cy.get('#reset').trigger('mouseenter');
         cy.get('[tuiComboBox]').should('have.value', '');
     });
 
@@ -147,7 +147,7 @@ describe('Textfield + form.reset()', () => {
                 expect(form.get('time')!.value).to.be.equal(null);
             });
 
-        cy.get('#reset').click();
+        cy.get('#reset').trigger('mouseenter');
         cy.get('[tuiInputTime]').should('have.value', '');
     });
 
@@ -159,25 +159,50 @@ describe('Textfield + form.reset()', () => {
                 expect(form.get('number')!.value).to.be.equal(null);
             });
 
-        cy.get('#reset').click();
+        cy.get('#reset').trigger('mouseenter');
         cy.get('[tuiInputNumber]').should('have.value', '');
     });
 
-    // TODO https://github.com/taiga-family/taiga-ui/issues/11365
-    it.skip('InputDate', () => {
+    it('InputDate (pristine form control)', () => {
         cy.get('[tuiInputDate]')
+            .type('99')
+            .should('have.value', '09.09')
+            .then(() => {
+                const control = form.get('date')!;
+
+                expect(control.value).to.be.equal(null);
+                expect(control.pristine).to.be.equal(true);
+            });
+
+        cy.get('#reset').trigger('mouseenter');
+        cy.get('[tuiInputDate]').should('have.value', '');
+    });
+
+    it('InputDate (already dirty form control)', () => {
+        cy.get('[tuiInputDate]')
+            .type('992000')
+            .should('have.value', '09.09.2000')
+            .then(() => {
+                const control = form.get('date')!;
+                const {year, month, day} = control.value;
+
+                expect(year).be.equal(2000);
+                expect(month).be.equal(8);
+                expect(day).be.equal(9);
+                expect(control.pristine).be.equal(false);
+            })
+            .clear()
             .type('99')
             .should('have.value', '09.09')
             .then(() => {
                 expect(form.get('date')!.value).to.be.equal(null);
             });
 
-        cy.get('#reset').click();
+        cy.get('#reset').trigger('mouseenter');
         cy.get('[tuiInputDate]').should('have.value', '');
     });
 
-    // TODO https://github.com/taiga-family/taiga-ui/issues/11365
-    it.skip('InputDateRange', () => {
+    it('InputDateRange', () => {
         cy.get('[tuiInputDateRange]')
             .type('992025')
             .should('have.value', '09.09.2025')
@@ -185,7 +210,7 @@ describe('Textfield + form.reset()', () => {
                 expect(form.get('dateRange')!.value).to.be.equal(null);
             });
 
-        cy.get('#reset').click();
+        cy.get('#reset').trigger('mouseenter');
         cy.get('[tuiInputDateRange]').should('have.value', '');
     });
 
@@ -202,7 +227,7 @@ describe('Textfield + form.reset()', () => {
                 expect(month).to.be.equal(0);
             });
 
-        cy.get('#reset').click();
+        cy.get('#reset').trigger('mouseenter');
         cy.get('[tuiInputMonth]')
             .should('have.value', '')
             .then(() => {

--- a/projects/kit/components/input-date/input-date.directive.ts
+++ b/projects/kit/components/input-date/input-date.directive.ts
@@ -122,7 +122,7 @@ export abstract class TuiInputDateBase<
     }
 
     public override writeValue(value: T | null): void {
-        const reset = this.control.pristine && !value;
+        const reset = this.control.pristine && this.control.untouched && !value;
 
         if (value !== this.value() || reset) {
             super.writeValue(value);

--- a/projects/kit/components/input-date/input-date.directive.ts
+++ b/projects/kit/components/input-date/input-date.directive.ts
@@ -121,6 +121,15 @@ export abstract class TuiInputDateBase<
         this.max.set(max instanceof TuiDay ? max : this.options.max);
     }
 
+    public override writeValue(value: T | null): void {
+        const reset = this.control.pristine && !value;
+
+        if (value !== this.value() || reset) {
+            super.writeValue(value);
+            this.textfield.value.set(this.stringify(this.value()));
+        }
+    }
+
     public setDate(value: TuiDay | TuiDayRange): void {
         this.onChange(value as T);
         this.open.set(false);


### PR DESCRIPTION
Fixes #11365
