### PR TITLE
fix(cdk): `TuiDay.toLocalNativeDate()` does not support year < 1900

### DIFF
--- a/projects/cdk/date-time/day.ts
+++ b/projects/cdk/date-time/day.ts
@@ -370,7 +370,12 @@ export class TuiDay extends TuiMonth {
      * Returns native {@link Date} based on local time zone
      */
     public override toLocalNativeDate(): Date {
-        return new Date(this.year, this.month, this.day);
+        const date = new Date(this.year, this.month, this.day);
+
+        // for years less than 1900
+        date.setFullYear(this.year);
+
+        return date;
     }
 
     /**

--- a/projects/cdk/date-time/day.ts
+++ b/projects/cdk/date-time/day.ts
@@ -370,10 +370,9 @@ export class TuiDay extends TuiMonth {
      * Returns native {@link Date} based on local time zone
      */
     public override toLocalNativeDate(): Date {
-        const date = new Date(this.year, this.month, this.day);
+        const date = super.toLocalNativeDate();
 
-        // for years less than 1900
-        date.setFullYear(this.year);
+        date.setDate(this.day);
 
         return date;
     }

--- a/projects/cdk/date-time/month.ts
+++ b/projects/cdk/date-time/month.ts
@@ -178,7 +178,12 @@ export class TuiMonth extends TuiYear implements TuiMonthLike {
      * Returns native {@link Date} based on local time zone
      */
     public toLocalNativeDate(): Date {
-        return new Date(this.year, this.month);
+        const date = new Date(this.year, this.month);
+
+        // for years less than 1900
+        date.setFullYear(this.year);
+
+        return date;
     }
 
     /**

--- a/projects/cdk/date-time/test/day.spec.ts
+++ b/projects/cdk/date-time/test/day.spec.ts
@@ -862,10 +862,28 @@ describe('TuiDay', () => {
                 });
             });
 
-            it('toLocalNativeDate returns native Date with time zone offset', () => {
-                const result = new TuiDay(2000, 0, 1);
+            describe('toLocalNativeDate', () => {
+                it('returns native Date with time zone offset', () => {
+                    const result = new TuiDay(2000, 0, 1);
 
-                expect(result.toLocalNativeDate()).toEqual(new Date(2000, 0, 1));
+                    expect(result.toLocalNativeDate()).toEqual(new Date(2000, 0, 1));
+                });
+
+                it('supports year < 1900', () => {
+                    const date = new TuiDay(1703, 4, 27).toLocalNativeDate();
+
+                    expect(date.getFullYear()).toEqual(1703);
+                    expect(date.getMonth()).toEqual(4);
+                    expect(date.getDate()).toEqual(27);
+                });
+
+                it('supports year < 100', () => {
+                    const date = new TuiDay(99, 4, 27).toLocalNativeDate();
+
+                    expect(date.getFullYear()).toEqual(99);
+                    expect(date.getMonth()).toEqual(4);
+                    expect(date.getDate()).toEqual(27);
+                });
             });
 
             it('toUtcNativeDate returns native Date without time zone offset', () => {

--- a/projects/demo-cypress/src/tests/input-date.cy.ts
+++ b/projects/demo-cypress/src/tests/input-date.cy.ts
@@ -54,4 +54,11 @@ describe('InputDate', () => {
 
         cy.get('[tuiInputDate]').should('have.value', '15.01.201');
     });
+
+    it('allows to enter year < 1900 for unset `[min]` limit', () => {
+        cy.get('[tuiInputDate]')
+            .clear()
+            .type('2751703')
+            .should('have.value', '27.05.1703');
+    });
 });


### PR DESCRIPTION
Fixes #11404
