### PR TITLE
chore: fixate `parse5` dependency as temporary workaround

### DIFF
--- a/projects/cdk/package.json
+++ b/projects/cdk/package.json
@@ -46,7 +46,7 @@
         "@angular-devkit/schematics": ">=16.0.0",
         "@schematics/angular": ">=16.0.0",
         "ng-morph": "^4.8.4",
-        "parse5": ">=7.3.0"
+        "parse5": "^7.3.0"
     },
     "ng-update": {
         "migrations": "./schematics/migration.json",


### PR DESCRIPTION
Relates:
* https://github.com/taiga-family/taiga-ui/issues/11408