### PR TITLE
ci: use built-in GitHub syntax `branches-ignore` instead of screenshot bot specific

### DIFF
--- a/.github/screenshot-bot.config.yml
+++ b/.github/screenshot-bot.config.yml
@@ -5,9 +5,6 @@ screenshotsDiffsPaths: [
     '.*.diff.png', # Playwright
   ]
 
-# array of RegExp strings to match branch names which should be skipped by bot
-branchesIgnore: ['^release/.*', '^v[0-9].x$']
-
 # array of attributes (key="value") for html-tag <img /> (screenshots)
 screenshotImageAttrs: []
 

--- a/.github/workflows/screenshot-bot.yml
+++ b/.github/workflows/screenshot-bot.yml
@@ -3,6 +3,9 @@ on:
   workflow_run:
     workflows: [⚙️ E2E testing]
     types: [requested, completed]
+    branches-ignore:
+      - 'v[0-9].x'
+      - 'release/**'
   pull_request:
     types: [closed]
 


### PR DESCRIPTION
https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#onworkflow_runbranchesbranches-ignore
