### PR TITLE
fix(kit): `InputTime`, `InputDate`, `InputMonth` with native picker ignore initial form control value

### DIFF
--- a/projects/core/components/textfield/index.ts
+++ b/projects/core/components/textfield/index.ts
@@ -8,6 +8,7 @@ export * from './textfield-auxiliary';
 export * from './textfield-content.directive';
 export * from './textfield-dropdown.directive';
 export * from './textfield-icon';
+export * from './with-native-picker.directive';
 // Moving it down for order of compilation
 export * from './select.directive';
 export * from './textfield-multi/textfield-item.component';

--- a/projects/core/components/textfield/with-native-picker.directive.ts
+++ b/projects/core/components/textfield/with-native-picker.directive.ts
@@ -7,7 +7,7 @@ import {tuiInjectElement} from '@taiga-ui/cdk/utils/dom';
  * ___
  * From Angular 19+ all effects are called before host bindings.
  * If effects inside `tuiValue` will be called before `<input />` get `type="text"`,
- * it will cause loosing initial value
+ * it will cause loss of initial value
  */
 @Directive({standalone: true})
 export class TuiWithNativePicker {

--- a/projects/core/components/textfield/with-native-picker.directive.ts
+++ b/projects/core/components/textfield/with-native-picker.directive.ts
@@ -1,0 +1,17 @@
+import {Directive} from '@angular/core';
+import {tuiInjectElement} from '@taiga-ui/cdk/utils/dom';
+
+/**
+ * Use it instead of host binding
+ * host: { '[type]': '"text"' }
+ * ___
+ * From Angular 19+ all effects are called before host bindings.
+ * If effects inside `tuiValue` will be called before `<input />` get `type="text"`,
+ * it will cause loosing initial value
+ */
+@Directive({standalone: true})
+export class TuiWithNativePicker {
+    constructor() {
+        tuiInjectElement<HTMLInputElement>().type = 'text';
+    }
+}

--- a/projects/kit/components/input-date-time/input-date-time.component.ts
+++ b/projects/kit/components/input-date-time/input-date-time.component.ts
@@ -7,7 +7,10 @@ import {
     ViewEncapsulation,
 } from '@angular/core';
 import {TuiDay, TuiTime} from '@taiga-ui/cdk/date-time';
-import {TuiTextfieldContent} from '@taiga-ui/core/components/textfield';
+import {
+    TuiTextfieldContent,
+    TuiWithNativePicker,
+} from '@taiga-ui/core/components/textfield';
 import {TuiNativeTimePicker} from '@taiga-ui/kit/components/input-time';
 
 import {TuiInputDateTimeDirective} from './input-date-time.directive';
@@ -20,6 +23,7 @@ import {TuiInputDateTimeDirective} from './input-date-time.directive';
     styleUrls: ['./input-date-time.style.less'],
     encapsulation: ViewEncapsulation.None,
     changeDetection: ChangeDetectionStrategy.OnPush,
+    hostDirectives: [TuiWithNativePicker],
     host: {ngSkipHydration: 'true'},
 })
 export class TuiInputDateTimeComponent extends TuiNativeTimePicker {

--- a/projects/kit/components/input-date/input-date.component.ts
+++ b/projects/kit/components/input-date/input-date.component.ts
@@ -7,7 +7,10 @@ import {
     ViewEncapsulation,
 } from '@angular/core';
 import {TuiDay} from '@taiga-ui/cdk/date-time';
-import {TuiTextfieldContent} from '@taiga-ui/core/components/textfield';
+import {
+    TuiTextfieldContent,
+    TuiWithNativePicker,
+} from '@taiga-ui/core/components/textfield';
 
 import {TuiInputDateDirective} from './input-date.directive';
 
@@ -19,9 +22,9 @@ import {TuiInputDateDirective} from './input-date.directive';
     styleUrls: ['./input-date.style.less'],
     encapsulation: ViewEncapsulation.None,
     changeDetection: ChangeDetectionStrategy.OnPush,
+    hostDirectives: [TuiWithNativePicker],
     host: {
         ngSkipHydration: 'true',
-        '[type]': '"text"',
         '[attr.list]': 'null',
     },
 })

--- a/projects/kit/components/input-date/input-date.directive.ts
+++ b/projects/kit/components/input-date/input-date.directive.ts
@@ -104,7 +104,7 @@ export abstract class TuiInputDateBase<
     });
 
     public readonly native =
-        Boolean(inject(TuiWithNativePicker, {optional: true})) && this.mobile;
+        !!inject(TuiWithNativePicker, {optional: true}) && this.mobile;
 
     public readonly min = signal(this.options.min);
     public readonly max = signal(this.options.max);

--- a/projects/kit/components/input-date/input-date.directive.ts
+++ b/projects/kit/components/input-date/input-date.directive.ts
@@ -16,6 +16,7 @@ import {
     tuiInjectAuxiliary,
     TuiTextfieldDirective,
     tuiTextfieldIconBinding,
+    TuiWithNativePicker,
     TuiWithTextfield,
 } from '@taiga-ui/core/components/textfield';
 import {
@@ -102,7 +103,9 @@ export abstract class TuiInputDateBase<
         onCleanup(() => subscription?.unsubscribe());
     });
 
-    public readonly native = this.el.type.includes('date') && this.mobile;
+    public readonly native =
+        Boolean(inject(TuiWithNativePicker, {optional: true})) && this.mobile;
+
     public readonly min = signal(this.options.min);
     public readonly max = signal(this.options.max);
 

--- a/projects/kit/components/input-month/input-month.component.ts
+++ b/projects/kit/components/input-month/input-month.component.ts
@@ -10,7 +10,10 @@ import {
 } from '@angular/core';
 import {TUI_ALLOW_SIGNAL_WRITES} from '@taiga-ui/cdk/constants';
 import {TUI_FIRST_DAY, TUI_LAST_DAY, TuiMonth} from '@taiga-ui/cdk/date-time';
-import {TuiTextfieldContent} from '@taiga-ui/core/components/textfield';
+import {
+    TuiTextfieldContent,
+    TuiWithNativePicker,
+} from '@taiga-ui/core/components/textfield';
 
 import {TuiInputMonthDirective} from './input-month.directive';
 
@@ -22,9 +25,9 @@ import {TuiInputMonthDirective} from './input-month.directive';
     styleUrls: ['./input-month.style.less'],
     encapsulation: ViewEncapsulation.None,
     changeDetection: ChangeDetectionStrategy.OnPush,
+    hostDirectives: [TuiWithNativePicker],
     host: {
         ngSkipHydration: 'true',
-        '[type]': '"text"',
     },
 })
 export class TuiInputMonthComponent {

--- a/projects/kit/components/input-month/input-month.directive.ts
+++ b/projects/kit/components/input-month/input-month.directive.ts
@@ -4,12 +4,12 @@ import {tuiAsControl, TuiControl, tuiValueTransformerFrom} from '@taiga-ui/cdk/c
 import {TUI_ALLOW_SIGNAL_WRITES} from '@taiga-ui/cdk/constants';
 import type {TuiMonth} from '@taiga-ui/cdk/date-time';
 import {TUI_IS_MOBILE} from '@taiga-ui/cdk/tokens';
-import {tuiInjectElement} from '@taiga-ui/cdk/utils/dom';
 import {
     tuiInjectAuxiliary,
     TuiSelectLike,
     TuiTextfieldDirective,
     tuiTextfieldIconBinding,
+    TuiWithNativePicker,
     TuiWithTextfield,
 } from '@taiga-ui/core/components/textfield';
 import {
@@ -67,7 +67,7 @@ export class TuiInputMonthDirective extends TuiControl<TuiMonth | null> {
     );
 
     public readonly native =
-        tuiInjectElement<HTMLInputElement>().type === 'month' && inject(TUI_IS_MOBILE);
+        Boolean(inject(TuiWithNativePicker, {optional: true})) && inject(TUI_IS_MOBILE);
 
     protected clear(): void {
         this.onChange(null);

--- a/projects/kit/components/input-month/input-month.directive.ts
+++ b/projects/kit/components/input-month/input-month.directive.ts
@@ -67,7 +67,7 @@ export class TuiInputMonthDirective extends TuiControl<TuiMonth | null> {
     );
 
     public readonly native =
-        Boolean(inject(TuiWithNativePicker, {optional: true})) && inject(TUI_IS_MOBILE);
+        !!inject(TuiWithNativePicker, {optional: true}) && inject(TUI_IS_MOBILE);
 
     protected clear(): void {
         this.onChange(null);

--- a/projects/kit/components/input-time/input-time.component.ts
+++ b/projects/kit/components/input-time/input-time.component.ts
@@ -21,7 +21,6 @@ import {
 import {TuiInputTimeDirective} from './input-time.directive';
 
 @Directive({
-    hostDirectives: [TuiWithNativePicker],
     host: {
         '[attr.list]': 'null',
     },
@@ -61,6 +60,7 @@ export abstract class TuiNativeTimePicker {
     styleUrls: ['./input-time.style.less'],
     encapsulation: ViewEncapsulation.None,
     changeDetection: ChangeDetectionStrategy.OnPush,
+    hostDirectives: [TuiWithNativePicker],
     host: {ngSkipHydration: 'true'},
 })
 export class TuiInputTimeComponent extends TuiNativeTimePicker {

--- a/projects/kit/components/input-time/input-time.component.ts
+++ b/projects/kit/components/input-time/input-time.component.ts
@@ -15,13 +15,14 @@ import {tuiInjectElement} from '@taiga-ui/cdk/utils/dom';
 import {
     TuiTextfieldContent,
     TuiTextfieldDirective,
+    TuiWithNativePicker,
 } from '@taiga-ui/core/components/textfield';
 
 import {TuiInputTimeDirective} from './input-time.directive';
 
 @Directive({
+    hostDirectives: [TuiWithNativePicker],
     host: {
-        '[type]': '"text"',
         '[attr.list]': 'null',
     },
 })

--- a/projects/kit/components/input-time/input-time.directive.ts
+++ b/projects/kit/components/input-time/input-time.directive.ts
@@ -13,7 +13,6 @@ import {
 import {tuiAsControl, TuiControl, tuiValueTransformerFrom} from '@taiga-ui/cdk/classes';
 import {TuiTime} from '@taiga-ui/cdk/date-time';
 import {TUI_IS_MOBILE} from '@taiga-ui/cdk/tokens';
-import {tuiInjectElement} from '@taiga-ui/cdk/utils/dom';
 import {tuiDirectiveBinding} from '@taiga-ui/cdk/utils/miscellaneous';
 import {tuiAsOptionContent} from '@taiga-ui/core/components/data-list';
 import type {TuiTextfieldAccessor} from '@taiga-ui/core/components/textfield';
@@ -22,6 +21,7 @@ import {
     TuiTextfieldComponent,
     TuiTextfieldDirective,
     tuiTextfieldIconBinding,
+    TuiWithNativePicker,
     TuiWithTextfield,
 } from '@taiga-ui/core/components/textfield';
 import {
@@ -96,7 +96,7 @@ export class TuiInputTimeDirective
     public accept: readonly TuiTime[] = [];
 
     public readonly native =
-        tuiInjectElement<HTMLInputElement>().type === 'time' && inject(TUI_IS_MOBILE);
+        Boolean(inject(TuiWithNativePicker, {optional: true})) && inject(TUI_IS_MOBILE);
 
     public readonly timeMode = signal(this.options.mode);
 

--- a/projects/kit/components/input-time/input-time.directive.ts
+++ b/projects/kit/components/input-time/input-time.directive.ts
@@ -96,7 +96,7 @@ export class TuiInputTimeDirective
     public accept: readonly TuiTime[] = [];
 
     public readonly native =
-        Boolean(inject(TuiWithNativePicker, {optional: true})) && inject(TUI_IS_MOBILE);
+        !!inject(TuiWithNativePicker, {optional: true}) && inject(TUI_IS_MOBILE);
 
     public readonly timeMode = signal(this.options.mode);
 


### PR DESCRIPTION
Fixes #11457
