### PR TITLE
chore(core): `Textfield` remove unnecessary explicit font size

### DIFF
--- a/projects/core/styles/components/textfield.less
+++ b/projects/core/styles/components/textfield.less
@@ -72,7 +72,7 @@ tui-textfield {
     input,
     select,
     textarea {
-        font: var(--tui-font-text-ui-m);
+        font: inherit;
         resize: none;
         outline: none;
         padding-block-start: 1.125rem;
@@ -114,7 +114,6 @@ tui-textfield {
         input,
         select,
         textarea {
-            font: var(--tui-font-text-ui-s);
             padding-block-start: 0.5rem;
             padding-block-end: 0.5rem;
         }
@@ -152,7 +151,6 @@ tui-textfield {
         input,
         select,
         textarea {
-            font: var(--tui-font-text-ui-s);
             padding-block-start: 0.875rem;
             padding-block-end: 0.875rem;
         }


### PR DESCRIPTION
Fixes # <!-- link to a relevant issue. -->
