### PR TITLE
feat(addon-mobile): `DropdownMobile` safe-area top/bottom support

### DIFF
--- a/projects/addon-mobile/directives/dropdown-mobile/dropdown-mobile.component.ts
+++ b/projects/addon-mobile/directives/dropdown-mobile/dropdown-mobile.component.ts
@@ -117,11 +117,12 @@ export class TuiDropdownMobileComponent implements OnDestroy, AfterViewInit {
         this.doc.documentElement.scrollTop = 0;
 
         const rect = this.dropdown.el.getBoundingClientRect();
-        const topMargin = `var(--tui-dropdown-mobile-offset, ${tuiPx(GAP)})`;
+        const topMargin = `max(var(--tui-dropdown-mobile-offset, ${tuiPx(GAP)}), env(safe-area-inset-top))`;
         const offset = `(${topMargin} + ${tuiPx(rect.height + GAP)})`;
 
         this.el.style.setProperty('top', `calc(${tuiPx(offsetTop)} + ${offset})`);
         this.el.style.setProperty('height', `calc(${tuiPx(height)} - ${offset})`);
+
         this.doc.body.classList.add('t-dropdown-mobile');
         this.doc.body.style.setProperty(
             '--t-root-top',

--- a/projects/addon-mobile/directives/dropdown-mobile/dropdown-mobile.style.less
+++ b/projects/addon-mobile/directives/dropdown-mobile/dropdown-mobile.style.less
@@ -15,6 +15,8 @@ tui-dropdown-mobile:not(._sheet) {
         0 10rem var(--tui-background-base),
         0 20rem var(--tui-background-base),
         0 30rem var(--tui-background-base);
+    box-sizing: border-box;
+    padding-block-end: env(safe-area-inset-bottom);
 
     &.tui-enter,
     &.tui-leave {
@@ -41,7 +43,7 @@ tui-dropdown-mobile:not(._sheet) {
     [tuiDropdownButton][tuiDropdownButton] {
         position: fixed;
         right: 1rem;
-        bottom: 1rem;
+        bottom: ~'max(1rem, env(safe-area-inset-bottom))';
         display: inline-flex;
     }
 }
@@ -76,11 +78,12 @@ tui-dropdown-mobile._sheet {
 
     > .t-container {
         display: flex;
-        max-block-size: calc(100% - 1rem);
+        max-block-size: ~'calc(100% - max(env(safe-area-inset-top), 1rem))';
         flex-direction: column;
         border-top-left-radius: 1rem;
         border-top-right-radius: 1rem;
-        padding: 0 0.5rem;
+        padding: 0 0.5rem env(safe-area-inset-bottom);
+        box-sizing: border-box;
         scroll-snap-stop: always;
         scroll-snap-align: start;
         background: var(--tui-background-elevation-1);


### PR DESCRIPTION
Partially solved #10963 

- Sheet dropdown
- Non sheet dropdown with open keyboard
- Non sheet dropdown with close keyboard

### BEFORE

<img width="203" height="432" alt="image" src="https://github.com/user-attachments/assets/910342c4-4e54-4fbc-9051-bd8f2e4079a9" />

<img width="203" height="432" alt="image" src="https://github.com/user-attachments/assets/d47f9ce9-7441-47c5-8f15-bf307b5d8e6b" />

<img width="203" height="432" alt="image" src="https://github.com/user-attachments/assets/e23c899f-27d6-4886-8615-96dd83f123e4" />

### AFTER

<img width="203" height="432" alt="image" src="https://github.com/user-attachments/assets/2f835b76-7d2e-418b-8aae-f6dd8fc13f70" />

<img width="203" height="432" alt="image" src="https://github.com/user-attachments/assets/23578bae-0f69-4d05-a12f-325e38bad5be" />

<img width="203" height="432" alt="image" src="https://github.com/user-attachments/assets/c3aa43f2-4f02-4492-94d9-c20f770c73c7" />


### Need to be done:

- safe-zone for input field

<img width="203" height="432" alt="image" src="https://github.com/user-attachments/assets/33286f04-c8fd-41b2-b5c3-1429d49ccf95" />


<img width="203" height="432" alt="image" src="https://github.com/user-attachments/assets/455e7f17-678b-4157-845d-248b95e652f2" />