### PR TITLE
chore(demo): `viewport-fit=cover` set by default

### DIFF
--- a/projects/demo/src/index.html
+++ b/projects/demo/src/index.html
@@ -11,7 +11,7 @@
             http-equiv="x-ua-compatible"
         />
         <meta
-            content="width=device-width, initial-scale=1, user-scalable=1, maximum-scale=1"
+            content="width=device-width, initial-scale=1, user-scalable=1, maximum-scale=1, viewport-fit=cover"
             name="viewport"
         />
         <meta


### PR DESCRIPTION
Relates to #10963 

Set `viewport-fit=cover` as default viewport behavior

### Why
Better support for modern devices with notches, rounded corners, and edge-to-edge displays (iPhone X+, modern Android devices)

### Benefits
- Full screen utilization on notched devices
- Consistent experience across device types
- Future-proof for upcoming device designs

### Impact
Low risk - backward compatible, follows modern web standards

### Testing
Verify layout on notched devices and check safe area handling in critical UI components
