### PR TITLE
feat(cdk): detect webdriver by default in e2e token

### DIFF
--- a/projects/cdk/tokens/environment.ts
+++ b/projects/cdk/tokens/environment.ts
@@ -53,15 +53,19 @@ export const TUI_IS_TOUCH = new InjectionToken(ngDevMode ? 'TUI_IS_TOUCH' : '', 
 });
 
 /**
+ * @deprecated: use only {@link TUI_IS_E2E}
  * Detect if app is running under Cypress
  * {@link https://docs.cypress.io/faq/questions/using-cypress-faq#Is-there-any-way-to-detect-if-my-app-is-running-under-Cypress Cypress docs}
+ * TODO: remove in v5
  */
 export const TUI_IS_CYPRESS = new InjectionToken(ngDevMode ? 'TUI_IS_CYPRESS' : '', {
     factory: () => !!inject<any>(WA_WINDOW).Cypress,
 });
 
 /**
+ * @deprecated: use only {@link TUI_IS_E2E}
  * Manually provide `true` when running tests in Playwright
+ * TODO: remove in v5
  */
 export const TUI_IS_PLAYWRIGHT = new InjectionToken<boolean>(
     ngDevMode ? 'TUI_IS_PLAYWRIGHT' : '',
@@ -74,5 +78,8 @@ export const TUI_IS_PLAYWRIGHT = new InjectionToken<boolean>(
  * Detect if app is running under any of test frameworks
  */
 export const TUI_IS_E2E = new InjectionToken(ngDevMode ? 'TUI_IS_E2E' : '', {
-    factory: () => inject(TUI_IS_CYPRESS) || inject(TUI_IS_PLAYWRIGHT),
+    factory: () =>
+        inject(TUI_IS_CYPRESS) ||
+        inject(TUI_IS_PLAYWRIGHT) ||
+        inject(WA_NAVIGATOR).webdriver,
 });

--- a/projects/demo/src/modules/app/app.config.ts
+++ b/projects/demo/src/modules/app/app.config.ts
@@ -13,7 +13,6 @@ import {provideAnimations} from '@angular/platform-browser/animations';
 import type {UrlTree} from '@angular/router';
 import {provideRouter, withInMemoryScrolling} from '@angular/router';
 import {environment} from '@demo/environments/environment';
-import {WA_SESSION_STORAGE} from '@ng-web-apis/common';
 import type {TuiDocSourceCodePathOptions} from '@taiga-ui/addon-doc';
 import {
     TUI_DOC_CODE_EDITOR,
@@ -32,12 +31,7 @@ import {
     tuiDocExampleOptionsProvider,
     tuiSortPages,
 } from '@taiga-ui/addon-doc';
-import {
-    TUI_FALSE_HANDLER,
-    TUI_IS_E2E,
-    TUI_IS_PLAYWRIGHT,
-    TUI_PLATFORM,
-} from '@taiga-ui/cdk';
+import {TUI_FALSE_HANDLER, TUI_IS_E2E, TUI_PLATFORM} from '@taiga-ui/cdk';
 import {
     TUI_DROPDOWN_HOVER_DEFAULT_OPTIONS,
     TUI_DROPDOWN_HOVER_OPTIONS,
@@ -83,10 +77,6 @@ export const config: ApplicationConfig = {
         {
             provide: TUI_PLATFORM,
             useValue: 'web',
-        },
-        {
-            provide: TUI_IS_PLAYWRIGHT,
-            useFactory: () => Boolean(inject(WA_SESSION_STORAGE).getItem('playwright')),
         },
         {
             provide: HIGHLIGHT_OPTIONS,


### PR DESCRIPTION
Common standard: https://developer.mozilla.org/en-US/docs/Web/API/Navigator/webdriver

Playwright, like other browser automation tools, sets navigator.webdriver to true in the browser environment it controls. This is a standard property indicating that the browser is under automated control.

While navigator.webdriver is the most reliable, in some scenarios, Playwright might inject or modify other global variables or functions. This is less standardized and depends on Playwright's internal implementation, but you could look for:
Specific properties on window or document that are unique to Playwright's setup.
The presence of certain event listeners or functions that Playwright might add for its internal workings.

This approach is generally discouraged due to its reliance on internal Playwright details that could change in future versions.