### PR TITLE
fix(core): `DropdownSided` change position depending on height instead of min-height

### DIFF
--- a/projects/core/directives/dropdown/dropdown-position-sided.directive.ts
+++ b/projects/core/directives/dropdown/dropdown-position-sided.directive.ts
@@ -34,7 +34,7 @@ export class TuiDropdownPositionSided extends TuiPositionAccessor {
         const {height, width} = rect;
         const hostRect = this.vertical.accessor?.getClientRect() ?? EMPTY_CLIENT_RECT;
         const viewport = this.viewport.getClientRect();
-        const {direction, minHeight, offset} = this.options;
+        const {direction, offset} = this.options;
         const adjusted = this.vertical.getAlign(this.options.align);
         const align = adjusted === 'center' ? 'left' : adjusted;
         const available = {
@@ -54,7 +54,7 @@ export class TuiDropdownPositionSided extends TuiPositionAccessor {
         const left = available[align] > width ? position[align] : maxLeft;
 
         if (
-            (available[this.previous] > minHeight && direction) ||
+            (available[this.previous] > height && direction) ||
             this.previous === better
         ) {
             this.vertical.emitDirection(this.previous);

--- a/projects/demo-playwright/tests/core/dropdown/dropdown.pw.spec.ts
+++ b/projects/demo-playwright/tests/core/dropdown/dropdown.pw.spec.ts
@@ -195,4 +195,15 @@ test.describe('Dropdown', () => {
 
         await expect.soft(page).toHaveScreenshot('18-dropdown-open-again.png');
     });
+
+    test('Nested sided dropdown', async ({page}) => {
+        await page.setViewportSize({width: 750, height: 400});
+        await tuiGoto(page, DemoRoute.DataList);
+        const example = new TuiDocumentationPagePO(page).getExample('#complex');
+
+        await example.scrollIntoViewIfNeeded();
+        await example.locator('button').click();
+
+        await expect.soft(page).toHaveScreenshot('19-dropdown-sided-nested.png');
+    });
 });


### PR DESCRIPTION
tuiDropdownSided doesn't adjust its height when it hits the edge of the screen. Because of that, it should change its position when the actual dropdown height exceeds the available height — not when the minimum possible height exceeds it.

before: 

https://github.com/user-attachments/assets/0f40ef6e-22e5-494e-b571-55803428d21c


---
after: 

https://github.com/user-attachments/assets/39d577cb-4577-4f9f-a1ae-94931ef727c7


Fixes #11507


