### PR TITLE
chore(demo): improve dialog search

### DIFF
--- a/projects/demo/src/modules/app/search/index.ts
+++ b/projects/demo/src/modules/app/search/index.ts
@@ -38,6 +38,7 @@ export class TuiAlgoliaSearch {
     private enableDocSearch(): void {
         docsearch({
             ...this.config,
+            maxResultsPerGroup: 7,
             transformItems: (items: Array<{url: string}>) =>
                 items.map((item) => ({
                     ...item,

--- a/projects/demo/src/modules/customization/dialogs/index.html
+++ b/projects/demo/src/modules/customization/dialogs/index.html
@@ -1,4 +1,4 @@
-<tui-doc-page header="Dialogs">
+<tui-doc-page header="Custom dialogs">
     <p>
         You can easily create your custom dialogs by extending our abstract class and providing your own component as a
         dialog.


### PR DESCRIPTION
Currently, it's impossible to find the Dialogs page via search.

First, this change increases the number of visible search results to seven, which makes it possible for the Dialogs page to appear.
Second, it updates the titles of custom dialogs to lower their search ranking, so the main Dialogs page is prioritized.

---
Before:
<img width="712" height="554" alt="Снимок экрана 2025-08-07 в 14 33 28" src="https://github.com/user-attachments/assets/5418e1b1-3269-4cbc-82ce-9c4d13683fa8" />

After:
<img width="667" height="668" alt="Снимок экрана 2025-08-07 в 14 33 43" src="https://github.com/user-attachments/assets/7053a02d-703a-491a-aaf9-53b223cb4e9c" />
