### PR TITLE
fix(core): `DropdownSelection` fix position inside new textarea

### DIFF
--- a/projects/core/directives/dropdown/dropdown-selection.directive.ts
+++ b/projects/core/directives/dropdown/dropdown-selection.directive.ts
@@ -111,8 +111,12 @@ export class TuiDropdownSelection
 
     public ngOnDestroy(): void {
         if (this.ghost) {
-            this.vcr.element.nativeElement.removeChild(this.ghost);
+            this.ghostHost.removeChild(this.ghost);
         }
+    }
+
+    private get ghostHost(): HTMLElement {
+        return this.el.querySelector('tui-textfield .t-ghost') || this.el;
     }
 
     private getRange(): Range {
@@ -159,11 +163,11 @@ export class TuiDropdownSelection
     }
 
     private veryVerySadInputFix(element: HTMLInputElement | HTMLTextAreaElement): Range {
-        const {ghost = this.initGhost(element)} = this;
-        const {top, left, width, height} = element.getBoundingClientRect();
+        const {ghost = this.initGhost(this.ghostHost)} = this;
+        const {top, left, width, height} = this.ghostHost.getBoundingClientRect();
         const {selectionStart, selectionEnd, value} = element;
         const range = this.doc.createRange();
-        const hostRect = this.el.getBoundingClientRect();
+        const hostRect = this.ghostHost.getBoundingClientRect();
 
         ghost.style.top = tuiPx(top - hostRect.top);
         ghost.style.left = tuiPx(left - hostRect.left);
@@ -180,7 +184,9 @@ export class TuiDropdownSelection
     /**
      * Create an invisible DIV styled exactly like input/textarea element inside directive
      */
-    private initGhost(element: HTMLInputElement | HTMLTextAreaElement): HTMLElement {
+    private initGhost(
+        element: HTMLElement | HTMLInputElement | HTMLTextAreaElement,
+    ): HTMLElement {
         const ghost = this.doc.createElement('div');
         const {font, letterSpacing, textTransform, padding, borderTop} =
             getComputedStyle(element);
@@ -196,7 +202,7 @@ export class TuiDropdownSelection
         ghost.style.textTransform = textTransform;
         ghost.style.padding = padding;
 
-        this.vcr.element.nativeElement.appendChild(ghost);
+        this.ghostHost.appendChild(ghost);
         this.ghost = ghost;
 
         return ghost;

--- a/projects/core/utils/dom/get-word-range.ts
+++ b/projects/core/utils/dom/get-word-range.ts
@@ -37,6 +37,7 @@ export function tuiGetWordRange(currentRange: Range): Range {
         const offset =
             Math.max(
                 content.lastIndexOf(' '),
+                content.lastIndexOf('\n'),
                 content.lastIndexOf(CHAR_NO_BREAK_SPACE),
                 content.lastIndexOf(CHAR_ZERO_WIDTH_SPACE),
             ) + 1;
@@ -58,6 +59,7 @@ export function tuiGetWordRange(currentRange: Range): Range {
             container === endContainer ? textContent.slice(endOffset + 1) : textContent;
         const offset = [
             content.indexOf(' '),
+            content.lastIndexOf('\n'),
             content.indexOf(CHAR_NO_BREAK_SPACE),
             content.indexOf(CHAR_ZERO_WIDTH_SPACE),
         ].reduce(

--- a/projects/demo-playwright/tests/kit/dropdown-selection/dropdown-selection.pw.spec.ts
+++ b/projects/demo-playwright/tests/kit/dropdown-selection/dropdown-selection.pw.spec.ts
@@ -78,4 +78,26 @@ test.describe('DropdownSelection', () => {
         await expect(page.locator('tui-dropdown')).toBeVisible();
         await expect.soft(page).toHaveScreenshot('05-dropdown-selection-scrolled.png');
     });
+
+    test('keyArrowDown / keyArrowUp must be handled correctly', async ({page}) => {
+        const api = new TuiDocumentationPagePO(page);
+        const example = api.getExample('#textarea');
+
+        await example.scrollIntoViewIfNeeded();
+        await api.waitStableState();
+
+        await page.waitForTimeout(500); // flaky in Safari
+
+        await example.locator('textarea').focus();
+
+        await example.locator('textarea').fill('\n\n\n ');
+
+        await page.keyboard.press('ArrowUp');
+        await page.keyboard.press('ArrowUp');
+        await page.keyboard.press('ArrowUp');
+        await page.keyboard.press('@');
+
+        await expect(page.locator('tui-dropdown')).toBeVisible();
+        await expect.soft(page).toHaveScreenshot('06-dropdown-selection-keydown.png');
+    });
 });

--- a/projects/demo-playwright/tests/kit/dropdown-selection/dropdown-selection.pw.spec.ts
+++ b/projects/demo-playwright/tests/kit/dropdown-selection/dropdown-selection.pw.spec.ts
@@ -41,4 +41,41 @@ test.describe('DropdownSelection', () => {
 
         await expect.soft(page).toHaveScreenshot('04-dropdown-selection.png');
     });
+
+    test('dropdown after new line char must be opened', async ({page}) => {
+        const api = new TuiDocumentationPagePO(page);
+        const example = api.getExample('#textarea');
+
+        await example.scrollIntoViewIfNeeded();
+        await api.waitStableState();
+
+        await page.waitForTimeout(500); // flaky in Safari
+
+        await example.locator('textarea').focus();
+
+        await example.locator('textarea').fill('\n@');
+
+        await expect(page.locator('tui-dropdown')).toBeVisible();
+    });
+
+    test('dropdown in scrollable textarea must be properly positioned', async ({
+        page,
+    }) => {
+        const api = new TuiDocumentationPagePO(page);
+        const example = api.getExample('#textarea');
+
+        await example.scrollIntoViewIfNeeded();
+        await api.waitStableState();
+
+        await page.waitForTimeout(500); // flaky in Safari
+
+        await example.locator('textarea').focus();
+
+        await example
+            .locator('textarea')
+            .fill('hi\nhi\nhi\nhi\nhi\nhi\nhi\nhi\nhi\nhi\nhi\nhi\nhi\nhi\n @');
+
+        await expect(page.locator('tui-dropdown')).toBeVisible();
+        await expect.soft(page).toHaveScreenshot('05-dropdown-selection-scrolled.png');
+    });
 });

--- a/projects/demo/src/modules/directives/dropdown-selection/examples/2/index.html
+++ b/projects/demo/src/modules/directives/dropdown-selection/examples/2/index.html
@@ -10,8 +10,8 @@
         [max]="4"
         [min]="4"
         [(ngModel)]="value"
-        (keydown.arrowDown)="onArrow($event, 'first')"
-        (keydown.arrowUp)="onArrow($event, 'last')"
+        (keydown.stop.arrowDown)="onArrow($event, 'first')"
+        (keydown.stop.arrowUp)="onArrow($event, 'last')"
     ></textarea>
 
     <tui-data-list *tuiTextfieldDropdown>

--- a/projects/kit/components/textarea/textarea.style.less
+++ b/projects/kit/components/textarea/textarea.style.less
@@ -60,6 +60,7 @@
 }
 
 .t-ghost {
+    position: relative;
     z-index: 1;
     order: 1;
     inline-size: stretch;


### PR DESCRIPTION
To fix the issue while maintaining compatibility with both the new and old textarea implementations, we now render the `ghost` inside the textarea's `ghost` element — if it exists.

Additionally, this PR fixes a bug where the dropdown wouldn’t appear after a newline character.

Fixes #11071 
Fixes #11286

