### PR TITLE
feat(core): introduce `--tui-appearance` to support binding appearance from CSS

### DIFF
--- a/projects/core/directives/appearance/appearance.directive.ts
+++ b/projects/core/directives/appearance/appearance.directive.ts
@@ -11,6 +11,7 @@ import {
     signal,
     ViewEncapsulation,
 } from '@angular/core';
+import {WA_WINDOW} from '@ng-web-apis/common';
 import {TUI_ALLOW_SIGNAL_WRITES} from '@taiga-ui/cdk/constants';
 import {tuiInjectElement} from '@taiga-ui/cdk/utils/dom';
 import {tuiIsString, tuiWithStyles} from '@taiga-ui/cdk/utils/miscellaneous';
@@ -36,7 +37,7 @@ class TuiAppearanceStyles {}
     host: {
         class: 'tui-appearance-initializing',
         tuiAppearance: '',
-        '[attr.data-appearance]': 'appearance()',
+        '[attr.data-appearance]': 'computedAppearance()',
         '[attr.data-state]': 'state()',
         '[attr.data-focus]': 'focus()',
         '[attr.data-mode]': 'modes()',
@@ -45,6 +46,7 @@ class TuiAppearanceStyles {}
 export class TuiAppearance {
     private readonly cdr = inject(ChangeDetectorRef, {skipSelf: true});
     private readonly el = tuiInjectElement();
+    private readonly win = inject(WA_WINDOW);
 
     protected readonly nothing = tuiWithStyles(TuiAppearanceStyles);
     protected readonly modes = computed((mode = this.mode()) =>
@@ -64,6 +66,12 @@ export class TuiAppearance {
 
     // TODO: refactor to signal inputs after Angular update
     public readonly appearance = signal(inject(TUI_APPEARANCE_OPTIONS).appearance);
+    public readonly computedAppearance = computed(
+        () =>
+            this.win.getComputedStyle(this.el).getPropertyValue('--tui-appearance') ||
+            this.appearance(),
+    );
+
     public readonly state = signal<TuiInteractiveState | null>(null);
     public readonly focus = signal<boolean | null>(null);
     public readonly mode = signal<string | readonly string[] | null>(null);

--- a/projects/core/styles/theme/appearance.less
+++ b/projects/core/styles/theme/appearance.less
@@ -11,3 +11,10 @@
 @import 'appearance/table.less';
 // Do not add it, we need it separately in proprietary theme
 // @import 'appearance/textfield.less';
+
+@supports (--tui-appearance: '') and (background: paint(transparent)) {
+    @property --tui-appearance {
+        syntax: '*';
+        inherits: false;
+    }
+}

--- a/projects/demo/src/modules/components/button/examples/8/index.html
+++ b/projects/demo/src/modules/components/button/examples/8/index.html
@@ -1,0 +1,6 @@
+<button
+    tuiButton
+    type="button"
+>
+    Flat
+</button>

--- a/projects/demo/src/modules/components/button/examples/8/index.less
+++ b/projects/demo/src/modules/components/button/examples/8/index.less
@@ -1,0 +1,3 @@
+[tuiButton] {
+    --tui-appearance: flat;
+}

--- a/projects/demo/src/modules/components/button/examples/8/index.ts
+++ b/projects/demo/src/modules/components/button/examples/8/index.ts
@@ -1,0 +1,14 @@
+import {Component} from '@angular/core';
+import {changeDetection} from '@demo/emulate/change-detection';
+import {encapsulation} from '@demo/emulate/encapsulation';
+import {TuiButton} from '@taiga-ui/core';
+
+@Component({
+    standalone: true,
+    imports: [TuiButton],
+    templateUrl: './index.html',
+    styleUrls: ['./index.less'],
+    encapsulation,
+    changeDetection,
+})
+export default class Example {}

--- a/projects/demo/src/modules/components/button/index.ts
+++ b/projects/demo/src/modules/components/button/index.ts
@@ -21,6 +21,7 @@ export default class Page {
         'Options with DI',
         'Vertical',
         'Two labels',
+        'CSS appearance',
     ];
 
     protected readonly sizes: ReadonlyArray<TuiSizeL | TuiSizeXS> = ['xs', 's', 'm', 'l'];


### PR DESCRIPTION
### Benefits

- You can assign custom appearance from any css theme to your components if you don't have access to HTML
- `@property` Next-gen CSS variables

<img width="374" height="291" alt="image" src="https://github.com/user-attachments/assets/3bd891fe-67b5-416c-a762-272576e0fcc1" />
