### PR TITLE
feat(kit): `InputNumber` & `InputSlider` support `quantum` property

### DIFF
--- a/projects/demo-playwright/tests/kit/input-number/input-number.pw.spec.ts
+++ b/projects/demo-playwright/tests/kit/input-number/input-number.pw.spec.ts
@@ -517,6 +517,90 @@ describe('InputNumber', () => {
             });
         });
 
+        describe('[quantum] prop', () => {
+            describe('[quantum]="10"', () => {
+                beforeEach(async ({page}) => {
+                    await tuiGoto(
+                        page,
+                        `${DemoRoute.InputNumber}/API?max=100&&quantum=10&sandboxExpanded=true`,
+                    );
+                });
+
+                describe('allows to enter number which IS NOT divisible by quantum value', () => {
+                    ['3', '5', '7', '9', '11', '14', '19'].forEach((value) => {
+                        test(`${value}`, async () => {
+                            await inputNumber.textfield.fill(value);
+                            await expect(inputNumber.textfield).toHaveValue(value);
+                        });
+                    });
+                });
+
+                describe('allows to enter number which IS divisible by quantum value', () => {
+                    ['0', '10', '20', '30', '60', '90', '100'].forEach((value) => {
+                        test(`${value}`, async () => {
+                            await inputNumber.textfield.fill(value);
+                            await expect(inputNumber.textfield).toHaveValue(value);
+                        });
+                    });
+                });
+
+                describe('rounds invalid number on blur', () => {
+                    test('4 => 0', async () => {
+                        await inputNumber.textfield.fill('3');
+                        await inputNumber.textfield.blur();
+                        await expect(inputNumber.textfield).toHaveValue('0');
+                    });
+
+                    test('5 => 10', async () => {
+                        await inputNumber.textfield.fill('5');
+                        await inputNumber.textfield.blur();
+                        await expect(inputNumber.textfield).toHaveValue('10');
+                    });
+
+                    test('6 => 10', async () => {
+                        await inputNumber.textfield.fill('6');
+                        await inputNumber.textfield.blur();
+                        await expect(inputNumber.textfield).toHaveValue('10');
+                    });
+
+                    test('19 => 20', async () => {
+                        await inputNumber.textfield.fill('19');
+                        await inputNumber.textfield.blur();
+                        await expect(inputNumber.textfield).toHaveValue('20');
+                    });
+
+                    test('77 => 80', async () => {
+                        await inputNumber.textfield.fill('77');
+                        await inputNumber.textfield.blur();
+                        await expect(inputNumber.textfield).toHaveValue('80');
+                    });
+                });
+
+                describe('form control always contains only number which IS divisible by quantum value', () => {
+                    test('4 => 0', async () => {
+                        await inputNumber.textfield.fill('3');
+                        await expect(example).toContainText('"testValue": 0');
+                        await inputNumber.textfield.blur();
+                        await expect(example).toContainText('"testValue": 0');
+                    });
+
+                    test('5 => 10', async () => {
+                        await inputNumber.textfield.fill('5');
+                        await expect(example).toContainText('"testValue": 10');
+                        await inputNumber.textfield.blur();
+                        await expect(example).toContainText('"testValue": 10');
+                    });
+
+                    test('77 => 80', async () => {
+                        await inputNumber.textfield.fill('77');
+                        await expect(example).toContainText('"testValue": 80');
+                        await inputNumber.textfield.blur();
+                        await expect(example).toContainText('"testValue": 80');
+                    });
+                });
+            });
+        });
+
         describe('[prefix] & [postfix] props', () => {
             (
                 [

--- a/projects/demo-playwright/tests/kit/input-number/input-number.pw.spec.ts
+++ b/projects/demo-playwright/tests/kit/input-number/input-number.pw.spec.ts
@@ -546,7 +546,7 @@ describe('InputNumber', () => {
 
                 describe('rounds invalid number on blur', () => {
                     test('4 => 0', async () => {
-                        await inputNumber.textfield.fill('3');
+                        await inputNumber.textfield.fill('4');
                         await inputNumber.textfield.blur();
                         await expect(inputNumber.textfield).toHaveValue('0');
                     });
@@ -578,7 +578,7 @@ describe('InputNumber', () => {
 
                 describe('form control always contains only number which IS divisible by quantum value', () => {
                     test('4 => 0', async () => {
-                        await inputNumber.textfield.fill('3');
+                        await inputNumber.textfield.fill('4');
                         await expect(example).toContainText('"testValue": 0');
                         await inputNumber.textfield.blur();
                         await expect(example).toContainText('"testValue": 0');

--- a/projects/demo-playwright/tests/kit/input-slider/input-slider.pw.spec.ts
+++ b/projects/demo-playwright/tests/kit/input-slider/input-slider.pw.spec.ts
@@ -123,6 +123,98 @@ describe('InputSlider', () => {
         });
     });
 
+    describe('[quantum] prop', () => {
+        let inputSlider!: TuiInputSliderPO;
+        let example!: Locator;
+
+        describe('[quantum]="10"', () => {
+            beforeEach(async ({page}) => {
+                await tuiGoto(
+                    page,
+                    `${DemoRoute.InputSlider}/API?max=100&&quantum=10&sandboxExpanded=true`,
+                );
+
+                example = new TuiDocumentationPagePO(page).apiPageExample;
+                inputSlider = new TuiInputSliderPO(
+                    example.locator('tui-textfield:has([tuiInputSlider])'),
+                );
+            });
+
+            describe('allows to enter number which IS NOT divisible by quantum value', () => {
+                ['3', '5', '7', '9', '11', '14', '19'].forEach((value) => {
+                    test(`${value}`, async () => {
+                        await inputSlider.textfield.fill(value);
+                        await expect(inputSlider.textfield).toHaveValue(value);
+                    });
+                });
+            });
+
+            describe('allows to enter number which IS divisible by quantum value', () => {
+                ['0', '10', '20', '30', '60', '90', '100'].forEach((value) => {
+                    test(`${value}`, async () => {
+                        await inputSlider.textfield.fill(value);
+                        await expect(inputSlider.textfield).toHaveValue(value);
+                    });
+                });
+            });
+
+            describe('rounds invalid number on blur', () => {
+                test('4 => 0', async () => {
+                    await inputSlider.textfield.fill('4');
+                    await inputSlider.textfield.blur();
+                    await expect(inputSlider.textfield).toHaveValue('0');
+                });
+
+                test('5 => 10', async () => {
+                    await inputSlider.textfield.fill('5');
+                    await inputSlider.textfield.blur();
+                    await expect(inputSlider.textfield).toHaveValue('10');
+                });
+
+                test('6 => 10', async () => {
+                    await inputSlider.textfield.fill('6');
+                    await inputSlider.textfield.blur();
+                    await expect(inputSlider.textfield).toHaveValue('10');
+                });
+
+                test('19 => 20', async () => {
+                    await inputSlider.textfield.fill('19');
+                    await inputSlider.textfield.blur();
+                    await expect(inputSlider.textfield).toHaveValue('20');
+                });
+
+                test('77 => 80', async () => {
+                    await inputSlider.textfield.fill('77');
+                    await inputSlider.textfield.blur();
+                    await expect(inputSlider.textfield).toHaveValue('80');
+                });
+            });
+
+            describe('form control always contains only number which IS divisible by quantum value', () => {
+                test('4 => 0', async () => {
+                    await inputSlider.textfield.fill('4');
+                    await expect(example).toContainText('"testValue": 0');
+                    await inputSlider.textfield.blur();
+                    await expect(example).toContainText('"testValue": 0');
+                });
+
+                test('5 => 10', async () => {
+                    await inputSlider.textfield.fill('5');
+                    await expect(example).toContainText('"testValue": 10');
+                    await inputSlider.textfield.blur();
+                    await expect(example).toContainText('"testValue": 10');
+                });
+
+                test('77 => 80', async () => {
+                    await inputSlider.textfield.fill('77');
+                    await expect(example).toContainText('"testValue": 80');
+                    await inputSlider.textfield.blur();
+                    await expect(example).toContainText('"testValue": 80');
+                });
+            });
+        });
+    });
+
     describe('[disabled] prop', () => {
         test('disables both textfield and slider when host component has disabled state', async ({
             page,

--- a/projects/demo/src/modules/components/input-number/examples/9/index.html
+++ b/projects/demo/src/modules/components/input-number/examples/9/index.html
@@ -1,0 +1,12 @@
+<tui-textfield>
+    <input
+        tuiInputNumber
+        [max]="1"
+        [min]="0"
+        [quantum]="0.05"
+        [(ngModel)]="value"
+    />
+</tui-textfield>
+
+<p><strong>Control value:</strong></p>
+<code>{{ value | json }}</code>

--- a/projects/demo/src/modules/components/input-number/examples/9/index.ts
+++ b/projects/demo/src/modules/components/input-number/examples/9/index.ts
@@ -1,0 +1,18 @@
+import {JsonPipe} from '@angular/common';
+import {Component} from '@angular/core';
+import {FormsModule} from '@angular/forms';
+import {changeDetection} from '@demo/emulate/change-detection';
+import {encapsulation} from '@demo/emulate/encapsulation';
+import {TuiTextfield} from '@taiga-ui/core';
+import {TuiInputNumber} from '@taiga-ui/kit';
+
+@Component({
+    standalone: true,
+    imports: [FormsModule, JsonPipe, TuiInputNumber, TuiTextfield],
+    templateUrl: './index.html',
+    encapsulation,
+    changeDetection,
+})
+export default class Example {
+    protected value = 0.5;
+}

--- a/projects/demo/src/modules/components/input-number/index.html
+++ b/projects/demo/src/modules/components/input-number/index.html
@@ -200,6 +200,42 @@
                 </p>
             </ng-template>
         </tui-doc-example>
+
+        <tui-doc-example
+            id="quantum"
+            heading="Quantum"
+            [component]="9 | tuiComponent"
+            [content]="9 | tuiExample"
+            [description]="quantumDescription"
+        >
+            <ng-template #quantumDescription>
+                Property
+                <code>[quantum]</code>
+                allows to set minimum indivisible value. Form control value never contains a number that is not
+                divisible by value of this property. Even if user enters any invalid number, it will be rounded to the
+                nearest valid one on
+                <code>blur</code>
+                event.
+
+                <p class="tui-space_bottom-0">
+                    In this example, form control value can only contain
+                    <code>0</code>
+                    ,
+                    <code>0.05</code>
+                    ,
+                    <code>0.1</code>
+                    ,
+                    <code>0.15</code>
+                    ...
+                    <code>0.9</code>
+                    ,
+                    <code>0.95</code>
+                    ,
+                    <code>1</code>
+                    .
+                </p>
+            </ng-template>
+        </tui-doc-example>
     </ng-template>
 
     <ng-template pageTab>
@@ -227,6 +263,7 @@
                         [placeholder]="textfieldDoc.size === 's' ? 'Enter a number' : ''"
                         [postfix]="postfix"
                         [prefix]="prefix"
+                        [quantum]="quantum"
                         [readOnly]="controlDoc.readonly"
                         [step]="step"
                         [tuiDisabled]="controlDoc.disabled"
@@ -292,6 +329,15 @@
                     Uneditable text
                     <strong>after</strong>
                     number
+                </tr>
+
+                <tr
+                    name="[quantum]"
+                    tuiDocAPIItem
+                    type="number"
+                    [(value)]="quantum"
+                >
+                    Minimum indivisible value
                 </tr>
             </tbody>
 

--- a/projects/demo/src/modules/components/input-number/index.ts
+++ b/projects/demo/src/modules/components/input-number/index.ts
@@ -40,4 +40,5 @@ export default class PageComponent {
     protected step = 0;
     protected prefix = '';
     protected postfix = '';
+    protected quantum = 0.01;
 }

--- a/projects/demo/src/modules/components/input-slider/examples/5/index.html
+++ b/projects/demo/src/modules/components/input-slider/examples/5/index.html
@@ -1,0 +1,18 @@
+<tui-textfield>
+    <input
+        tuiInputSlider
+        [max]="1"
+        [min]="0"
+        [quantum]="quantum"
+        [(ngModel)]="value"
+    />
+
+    <input
+        tuiSlider
+        type="range"
+        [step]="step"
+    />
+</tui-textfield>
+
+<p><strong>Control value:</strong></p>
+<code>{{ value | json }}</code>

--- a/projects/demo/src/modules/components/input-slider/examples/5/index.ts
+++ b/projects/demo/src/modules/components/input-slider/examples/5/index.ts
@@ -1,0 +1,23 @@
+import {JsonPipe} from '@angular/common';
+import {Component} from '@angular/core';
+import {FormsModule} from '@angular/forms';
+import {changeDetection} from '@demo/emulate/change-detection';
+import {encapsulation} from '@demo/emulate/encapsulation';
+import {TuiTextfield} from '@taiga-ui/core';
+import {TuiInputSlider} from '@taiga-ui/kit';
+
+@Component({
+    standalone: true,
+    imports: [FormsModule, JsonPipe, TuiInputSlider, TuiTextfield],
+    templateUrl: './index.html',
+    encapsulation,
+    changeDetection,
+})
+export default class Example {
+    protected value = 0.5;
+    // Form control can only contain decimal number which is multiple of this constant
+    protected quantum = 0.05;
+
+    // But granularity of each discrete slider step equals to this constant
+    protected readonly step = 0.25;
+}

--- a/projects/demo/src/modules/components/input-slider/index.html
+++ b/projects/demo/src/modules/components/input-slider/index.html
@@ -145,6 +145,42 @@
                 </p>
             </ng-template>
         </tui-doc-example>
+
+        <tui-doc-example
+            id="quantum"
+            heading="Quantum"
+            [component]="5 | tuiComponent"
+            [content]="5 | tuiExample"
+            [description]="quantumDescription"
+        >
+            <ng-template #quantumDescription>
+                Property
+                <code>[quantum]</code>
+                allows to set minimum indivisible value. Form control value never contains a number that is not
+                divisible by value of this property. Even if user enters any invalid number, it will be rounded to the
+                nearest valid one on
+                <code>blur</code>
+                event.
+
+                <p class="tui-space_bottom-0">
+                    In this example, form control value can only contain
+                    <code>0</code>
+                    ,
+                    <code>0.05</code>
+                    ,
+                    <code>0.1</code>
+                    ,
+                    <code>0.15</code>
+                    ...
+                    <code>0.9</code>
+                    ,
+                    <code>0.95</code>
+                    ,
+                    <code>1</code>
+                    .
+                </p>
+            </ng-template>
+        </tui-doc-example>
     </ng-template>
 
     <ng-template pageTab>
@@ -167,6 +203,7 @@
                         [min]="min()"
                         [postfix]="postfix"
                         [prefix]="prefix"
+                        [quantum]="quantum"
                         [readOnly]="controlDoc.readonly"
                         [tuiDisabled]="controlDoc.disabled"
                         [tuiNumberFormat]="{
@@ -248,6 +285,15 @@
                     Uneditable text
                     <strong>after</strong>
                     number
+                </tr>
+
+                <tr
+                    name="[quantum]"
+                    tuiDocAPIItem
+                    type="number"
+                    [(value)]="quantum"
+                >
+                    Minimum indivisible value
                 </tr>
             </tbody>
 

--- a/projects/demo/src/modules/components/input-slider/index.ts
+++ b/projects/demo/src/modules/components/input-slider/index.ts
@@ -37,6 +37,7 @@ export default class PageComponent {
     protected max = signal(100);
     protected prefix = '';
     protected postfix = '';
+    protected quantum = 0.01;
     protected segments: number[] | number = 1;
     protected step = 1;
     protected keySteps: TuiKeySteps | null = null;

--- a/projects/kit/components/input-number/index.ts
+++ b/projects/kit/components/input-number/index.ts
@@ -1,4 +1,5 @@
 export * from './input-number';
 export * from './input-number.directive';
 export * from './input-number.options';
+export * from './quantum.directive';
 export * from './step/input-number-step.component';

--- a/projects/kit/components/input-number/input-number.directive.ts
+++ b/projects/kit/components/input-number/input-number.directive.ts
@@ -38,7 +38,7 @@ const DEFAULT_MAX_LENGTH = 18;
         '[attr.inputMode]': 'inputMode()',
         '[attr.maxLength]':
             'element.maxLength > 0 ? element.maxLength : defaultMaxLength()',
-        '(blur)': 'onBlur()',
+        '(blur)': 'setValue(transformer.fromControlValue(control.value))',
         '(focus)': 'onFocus()',
     },
 })
@@ -162,14 +162,6 @@ export class TuiInputNumberDirective extends TuiControl<number | null> {
 
     public setValue(value: number | null): void {
         this.textfield.value.set(this.formatNumber(value));
-    }
-
-    protected onBlur(): void {
-        this.onTouched();
-
-        if (!this.unfinished()) {
-            this.setValue(this.value());
-        }
     }
 
     protected onFocus(): void {

--- a/projects/kit/components/input-number/input-number.ts
+++ b/projects/kit/components/input-number/input-number.ts
@@ -1,4 +1,9 @@
 import {TuiInputNumberDirective} from './input-number.directive';
+import {TuiQuantumValueTransformer} from './quantum.directive';
 import {TuiInputNumberStep} from './step/input-number-step.component';
 
-export const TuiInputNumber = [TuiInputNumberDirective, TuiInputNumberStep] as const;
+export const TuiInputNumber = [
+    TuiInputNumberDirective,
+    TuiInputNumberStep,
+    TuiQuantumValueTransformer,
+] as const;

--- a/projects/kit/components/input-number/quantum.directive.ts
+++ b/projects/kit/components/input-number/quantum.directive.ts
@@ -1,0 +1,49 @@
+import {Directive, inject, Input} from '@angular/core';
+import {TuiValueTransformer} from '@taiga-ui/cdk/classes';
+import {tuiRound} from '@taiga-ui/cdk/utils/math';
+import {tuiProvide} from '@taiga-ui/cdk/utils/miscellaneous';
+import {TUI_FLOATING_PRECISION} from '@taiga-ui/kit/components/slider';
+
+import {TUI_INPUT_NUMBER_OPTIONS} from './input-number.options';
+
+@Directive({
+    standalone: true,
+    selector: '[tuiInputNumber][quantum], [tuiInputSlider][quantum]',
+    providers: [tuiProvide(TuiValueTransformer, TuiQuantumValueTransformer)],
+})
+export class TuiQuantumValueTransformer extends TuiValueTransformer<
+    number | null,
+    number | null
+> {
+    private readonly parent = inject(TUI_INPUT_NUMBER_OPTIONS).valueTransformer;
+
+    @Input()
+    public quantum = 1;
+
+    public override fromControlValue(controlValue: number | null): number | null {
+        return this.parent?.fromControlValue(controlValue) ?? controlValue;
+    }
+
+    public toControlValue(internalValue: number | null): number {
+        const value = this.parent?.toControlValue(internalValue) ?? internalValue;
+
+        return (
+            value &&
+            tuiRound(
+                Math.round(value / this.quantum) * this.quantum,
+                TUI_FLOATING_PRECISION,
+            )
+        );
+    }
+}
+
+@Directive({
+    standalone: true,
+    hostDirectives: [
+        {
+            directive: TuiQuantumValueTransformer,
+            inputs: ['quantum'],
+        },
+    ],
+})
+export class TuiWithQuantumValueTransformer {}

--- a/projects/kit/components/input-number/quantum.directive.ts
+++ b/projects/kit/components/input-number/quantum.directive.ts
@@ -24,16 +24,15 @@ export class TuiQuantumValueTransformer extends TuiValueTransformer<
         return this.parent?.fromControlValue(controlValue) ?? controlValue;
     }
 
-    public toControlValue(internalValue: number | null): number {
+    public toControlValue(internalValue: number | null): number | null {
         const value = this.parent?.toControlValue(internalValue) ?? internalValue;
 
-        return (
-            value &&
-            tuiRound(
-                Math.round(value / this.quantum) * this.quantum,
-                TUI_FLOATING_PRECISION,
-            )
-        );
+        return value != null
+            ? tuiRound(
+                  Math.round(value / this.quantum) * this.quantum,
+                  TUI_FLOATING_PRECISION,
+              )
+            : value;
     }
 }
 

--- a/projects/kit/components/input-number/quantum.directive.ts
+++ b/projects/kit/components/input-number/quantum.directive.ts
@@ -1,7 +1,8 @@
 import {Directive, inject, Input} from '@angular/core';
 import {TuiValueTransformer} from '@taiga-ui/cdk/classes';
-import {tuiRound} from '@taiga-ui/cdk/utils/math';
+import {tuiIsSafeToRound, tuiRound} from '@taiga-ui/cdk/utils/math';
 import {tuiProvide} from '@taiga-ui/cdk/utils/miscellaneous';
+import {tuiGetFractionPartPadded} from '@taiga-ui/core/utils/format';
 import {TUI_FLOATING_PRECISION} from '@taiga-ui/kit/components/slider';
 
 import {TUI_INPUT_NUMBER_OPTIONS} from './input-number.options';
@@ -27,7 +28,8 @@ export class TuiQuantumValueTransformer extends TuiValueTransformer<
     public toControlValue(internalValue: number | null): number | null {
         const value = this.parent?.toControlValue(internalValue) ?? internalValue;
 
-        return value != null
+        return value != null &&
+            tuiIsSafeToRound(value, tuiGetFractionPartPadded(this.quantum).length)
             ? tuiRound(
                   Math.round(value / this.quantum) * this.quantum,
                   TUI_FLOATING_PRECISION,

--- a/projects/kit/components/input-slider/input-slider.directive.ts
+++ b/projects/kit/components/input-slider/input-slider.directive.ts
@@ -21,6 +21,7 @@ import {tuiInjectAuxiliary} from '@taiga-ui/core/components/textfield';
 import {
     TuiInputNumberDirective,
     tuiInputNumberOptionsProvider,
+    TuiWithQuantumValueTransformer,
 } from '@taiga-ui/kit/components/input-number';
 import {TuiSliderComponent} from '@taiga-ui/kit/components/slider';
 import {filter, fromEvent} from 'rxjs';
@@ -38,9 +39,10 @@ import {filter, fromEvent} from 'rxjs';
             directive: TuiInputNumberDirective,
             inputs: ['min', 'max', 'prefix', 'postfix', 'invalid', 'readOnly'],
         },
+        TuiWithQuantumValueTransformer,
     ],
     host: {
-        '(blur)': 'onBlur()',
+        '(blur)': 'inputNumber.setValue(value() ?? null)',
         '(keydown.arrowUp)': 'onStep(1)',
         '(keydown.arrowDown)': 'onStep(-1)',
     },
@@ -48,7 +50,6 @@ import {filter, fromEvent} from 'rxjs';
 export class TuiInputSliderDirective {
     private readonly isMobile = inject(TUI_IS_MOBILE);
     private readonly element = tuiInjectElement<HTMLInputElement>();
-    private readonly inputNumber = inject(TuiInputNumberDirective, {self: true});
     private readonly slider = tuiInjectAuxiliary<TuiSliderComponent>(
         (x) => x instanceof TuiSliderComponent,
     );
@@ -57,12 +58,13 @@ export class TuiInputSliderDirective {
         TuiValueTransformer<number | null, number>
     >(TuiValueTransformer, {self: true});
 
-    private readonly value = computed(() =>
-        this.controlTransformer.toControlValue(this.inputNumber.value()),
-    );
-
     private readonly keyStepsTransformer = computed(
         () => this.slider()?.keySteps?.transformer() ?? TUI_IDENTITY_VALUE_TRANSFORMER,
+    );
+
+    protected readonly inputNumber = inject(TuiInputNumberDirective, {self: true});
+    protected readonly value = computed(() =>
+        this.controlTransformer.toControlValue(this.inputNumber.value()),
     );
 
     protected readonly nothing = tuiWithStyles(TuiInputSliderStyles);
@@ -123,12 +125,6 @@ export class TuiInputSliderDirective {
             );
 
             this.inputNumber.setValue(newValue);
-        }
-    }
-
-    protected onBlur(): void {
-        if (!this.element.value) {
-            this.inputNumber.setValue(this.value() ?? null);
         }
     }
 


### PR DESCRIPTION
This PR implements missing feature for refactored new controls.

Explore legacy controls:
* https://taiga-ui.dev/legacy/input-slider/API?max=100&quantum=10
* https://taiga-ui.dev/legacy/input-range/API?max=100&quantum=10