### PR TITLE
fix(kit): fixes file container size for prevent overflow extension of file

### DIFF
--- a/projects/kit/components/files/file/file.style.less
+++ b/projects/kit/components/files/file/file.style.less
@@ -103,6 +103,7 @@
 
 .t-text {
     display: flex;
+    inline-size: 100%;
 }
 
 .t-size {


### PR DESCRIPTION
Fixes #11582

<img width="404" height="223" alt="image" src="https://github.com/user-attachments/assets/93aaf3d0-e8c5-41f7-983b-09e9813dd4f4" />

