### PR TITLE
fix(core): add `try/catch` around `showPicker()` to handle cross-origin iframe errors

### DIFF
--- a/projects/core/components/textfield/textfield-multi/textfield-multi.component.ts
+++ b/projects/core/components/textfield/textfield-multi/textfield-multi.component.ts
@@ -180,8 +180,9 @@ export class TuiTextfieldMultiComponent<T>
 
         try {
             this.input?.nativeElement.showPicker?.();
-        } catch {
+        } catch (error) {
             // Ignore showPicker errors (e.g., cross-origin iframe restrictions)
+            console.debug('showPicker failed:', error);
         }
     }
 }

--- a/projects/core/components/textfield/textfield-multi/textfield-multi.component.ts
+++ b/projects/core/components/textfield/textfield-multi/textfield-multi.component.ts
@@ -177,6 +177,11 @@ export class TuiTextfieldMultiComponent<T>
         }
 
         this.open.update((open) => !open);
-        this.input?.nativeElement.showPicker?.();
+
+        try {
+            this.input?.nativeElement.showPicker?.();
+        } catch {
+            // Ignore showPicker errors (e.g., cross-origin iframe restrictions)
+        }
     }
 }

--- a/projects/core/components/textfield/textfield-multi/textfield-multi.component.ts
+++ b/projects/core/components/textfield/textfield-multi/textfield-multi.component.ts
@@ -180,9 +180,8 @@ export class TuiTextfieldMultiComponent<T>
 
         try {
             this.input?.nativeElement.showPicker?.();
-        } catch (error) {
-            // Ignore showPicker errors (e.g., cross-origin iframe restrictions)
-            console.debug('showPicker failed:', error);
+        } catch {
+            // Empty catch block - silently ignore showPicker errors
         }
     }
 }

--- a/projects/core/components/textfield/textfield.component.ts
+++ b/projects/core/components/textfield/textfield.component.ts
@@ -179,9 +179,8 @@ export class TuiTextfieldBaseComponent<T>
 
         try {
             this.input?.nativeElement.showPicker?.();
-        } catch (error) {
-            // Ignore showPicker errors (e.g., cross-origin iframe restrictions)
-            console.debug('showPicker failed:', error);
+        } catch {
+            // Empty catch block - silently ignore showPicker errors
         }
     }
 

--- a/projects/core/components/textfield/textfield.component.ts
+++ b/projects/core/components/textfield/textfield.component.ts
@@ -179,8 +179,9 @@ export class TuiTextfieldBaseComponent<T>
 
         try {
             this.input?.nativeElement.showPicker?.();
-        } catch {
+        } catch (error) {
             // Ignore showPicker errors (e.g., cross-origin iframe restrictions)
+            console.debug('showPicker failed:', error);
         }
     }
 

--- a/projects/core/components/textfield/textfield.component.ts
+++ b/projects/core/components/textfield/textfield.component.ts
@@ -176,7 +176,12 @@ export class TuiTextfieldBaseComponent<T>
         }
 
         this.open.update((open) => !open);
-        this.input?.nativeElement.showPicker?.();
+
+        try {
+            this.input?.nativeElement.showPicker?.();
+        } catch {
+            // Ignore showPicker errors (e.g., cross-origin iframe restrictions)
+        }
     }
 
     protected onScroll(element: HTMLElement): void {


### PR DESCRIPTION

## fix(core): add try/catch around showPicker() to handle cross-origin iframe errors

fixes https://github.com/taiga-family/taiga-ui/issues/11662

Problem
Textfield components throw an unhandled error when [showPicker()](vscode-file://vscode-app/c:/Users/anees/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) is called from cross-origin iframes (like StackBlitz examples):

Solution
Added try/catch blocks around [showPicker()](vscode-file://vscode-app/c:/Users/anees/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) calls in files:

```
textfield.component.ts

textfield.multicomponent.ts

```
The catch blocks include debug logging to help with troubleshooting while allowing the application to continue working normally.

✅ Result
✅ Fixes error when clicking textfields in StackBlitz examples
✅ Maintains full functionality in normal contexts
✅ Graceful degradation when native picker is unavailable
✅ Debug logging for troubleshooting
🔗 Closes
Fixes #11662

