### PR TITLE
fix(kit): switch check icon moved 2 pixels to the left

### DIFF
--- a/projects/kit/styles/components/switch.less
+++ b/projects/kit/styles/components/switch.less
@@ -36,7 +36,7 @@
         inline-size: 2rem;
 
         &::before {
-            inline-size: 1rem;
+            inline-size: 1.125rem;
             transform: translateX(-1rem);
             mask-size: 0.75rem;
         }


### PR DESCRIPTION
Fixes #11369