### PR TITLE
chore: remove deprecation comment for legacy signature of `tuiPure` decorator

### DIFF
--- a/projects/cdk/utils/miscellaneous/pure.ts
+++ b/projects/cdk/utils/miscellaneous/pure.ts
@@ -47,7 +47,6 @@ function decorateGetter(
  * @throws error if used not on getter or function
  *
  * CAUTION: they must be pure.
- * @deprecated use "experimentalDecorators": false
  * TODO(v5): drop compatibility for legacy "experimentalDecorators": true
  */
 export function tuiPure<T>(


### PR DESCRIPTION
**Legacy syntax for `tuiPure` is still deprecated in will be deleted in `v5`!**

## Why comment was deleted ?

- Add `"experimentalDecorators": false` to your tsconfig
- Run the following console command
```
npx eslint projects/addon-charts/components/bar/bar.component.ts --rule "@typescript-eslint/no-deprecated: error"
```

It will throw error
```
npx eslint projects/addon-charts/components/bar/bar.component.ts --rule "@typescript-eslint/no-deprecated: error"
| Processing: projects/addon-charts/components/bar/bar.component.ts 

~/taiga-ui/projects/addon-charts/components/bar/bar.component.ts
  29:6  error  `tuiPure` is deprecated. use "experimentalDecorators": false
TODO(v5): drop compatibility for legacy "experimentalDecorators": true  @typescript-eslint/no-deprecated

✖ 1 problem (1 error, 0 warnings)
```

Overload is ignored by eslint rule for decorators :(
https://github.com/taiga-family/taiga-ui/blob/40eadd240d8d4fd5236948b42b1196a3bc796ace/projects/cdk/utils/miscellaneous/pure.ts#L59-L69