### PR TITLE
fix(styles): change white-space property to nowrap

### DIFF
--- a/projects/core/components/textfield/textfield-multi/textfield-item.style.less
+++ b/projects/core/components/textfield/textfield-multi/textfield-item.style.less
@@ -12,7 +12,7 @@
         }
 
         &::after {
-            content: ', ';
+            content: ',\00a0';
         }
     }
 

--- a/projects/core/components/textfield/textfield-multi/textfield-item.style.less
+++ b/projects/core/components/textfield/textfield-multi/textfield-item.style.less
@@ -1,7 +1,7 @@
 :host {
     max-inline-size: 100%;
     flex-shrink: 0;
-    white-space: pre-wrap;
+    white-space: nowrap;
     text-overflow: ellipsis;
 
     &._string {


### PR DESCRIPTION
This pull request makes a small update to the styling of the `textfield-item` component to improve its text display behavior. Refer this issue TuiInputChip moves long values to a new string (https://github.com/taiga-family/taiga-ui/issues/11665)

* Changed the `white-space` property from `pre-wrap` to `nowrap` in `textfield-item.style.less`, causing text to remain on a single line and overflow with an ellipsis instead of wrapping.