### PR TITLE
fix: prevent default click behavior on scroll controls in textarea

### DIFF
--- a/projects/kit/components/textarea/textarea.template.html
+++ b/projects/kit/components/textarea/textarea.template.html
@@ -2,6 +2,7 @@
     <tui-scroll-controls
         *ngIf="!isMobile"
         class="t-scroll"
+        (click.prevent)="(0)"
     />
     <span
         #text


### PR DESCRIPTION
This pull request introduces a minor update to the `projects/kit/components/textarea/textarea.template.html` file. The change adds a click event handler to prevent the default behavior when the scroll controls are clicked.

refer this #11475 issue