### PR TITLE
fix(core): only Safari dispatches `beforeinput` event when using `execCommand` on an element

### DIFF
--- a/projects/addon-commerce/components/input-card-group/input-card-group.component.ts
+++ b/projects/addon-commerce/components/input-card-group/input-card-group.component.ts
@@ -7,6 +7,7 @@ import {
     type ElementRef,
     EventEmitter,
     inject,
+    INJECTOR,
     Input,
     Output,
     PLATFORM_ID,
@@ -60,6 +61,7 @@ import {
     TuiWithDropdownOpen,
 } from '@taiga-ui/core/directives/dropdown';
 import {TUI_COMMON_ICONS} from '@taiga-ui/core/tokens';
+import {tuiSafetyDelete, tuiSafetyInsertText} from '@taiga-ui/core/utils/miscellaneous';
 import {TuiChevron} from '@taiga-ui/kit/directives/chevron';
 import {type PolymorpheusContent, PolymorpheusOutlet} from '@taiga-ui/polymorpheus';
 import {EMPTY, map, merge, Subject, switchMap, timer} from 'rxjs';
@@ -125,6 +127,7 @@ export class TuiInputCardGroup
     @ViewChild('inputCVC', {static: true})
     private readonly inputCVC?: ElementRef<HTMLInputElement>;
 
+    private readonly injector = inject(INJECTOR);
     private readonly doc = inject(DOCUMENT);
     private readonly isServer = isPlatformServer(inject(PLATFORM_ID));
     private readonly focus$ = new Subject<void>();
@@ -245,9 +248,8 @@ export class TuiInputCardGroup
             return;
         }
 
-        this.inputExpire.nativeElement.focus({preventScroll: true});
-        this.inputExpire.nativeElement.select();
-        this.doc.execCommand('insertText', false, this.expire);
+        tuiSafetyInsertText(this.injector, this.expire, this.inputExpire?.nativeElement);
+
         this.inputExpire.nativeElement.blur();
         (activeElement as HTMLElement | null)?.focus({preventScroll: true});
     }
@@ -288,11 +290,9 @@ export class TuiInputCardGroup
     public clear(): void {
         this.expirePrefilled = false;
 
-        [this.inputCVC, this.inputExpire, this.inputCard].forEach((e) => {
-            e?.nativeElement.focus();
-            e?.nativeElement.select();
-            e?.nativeElement.ownerDocument.execCommand('delete');
-        });
+        [this.inputCVC, this.inputExpire, this.inputCard].forEach((e) =>
+            tuiSafetyDelete(this.injector, e?.nativeElement),
+        );
 
         this.onChange(null);
     }

--- a/projects/core/components/textfield/textfield.directive.ts
+++ b/projects/core/components/textfield/textfield.directive.ts
@@ -1,4 +1,12 @@
-import {computed, Directive, inject, Input, type OnChanges, signal} from '@angular/core';
+import {
+    computed,
+    Directive,
+    inject,
+    INJECTOR,
+    Input,
+    type OnChanges,
+    signal,
+} from '@angular/core';
 import {NgControl} from '@angular/forms';
 import {TuiNativeValidator} from '@taiga-ui/cdk/directives/native-validator';
 import {tuiInjectElement, tuiValue} from '@taiga-ui/cdk/utils/dom';
@@ -15,6 +23,7 @@ import {
     type TuiItemsHandlers,
 } from '@taiga-ui/core/directives/items-handlers';
 import {type TuiInteractiveState} from '@taiga-ui/core/types';
+import {tuiSafetyDelete, tuiSafetyInsertText} from '@taiga-ui/core/utils';
 
 import {TuiTextfieldComponent} from './textfield.component';
 import {TUI_TEXTFIELD_OPTIONS} from './textfield.options';
@@ -38,6 +47,7 @@ export class TuiTextfieldBase<T> implements OnChanges, TuiTextfieldAccessor<T> {
     // TODO: refactor to signal inputs after Angular update
     private readonly focused = signal<boolean | null>(null);
 
+    protected readonly injector = inject(INJECTOR);
     protected readonly control = inject(NgControl, {optional: true});
     protected readonly a = tuiAppearance(inject(TUI_TEXTFIELD_OPTIONS).appearance, {});
     protected readonly s = tuiAppearanceState(null, {});
@@ -92,17 +102,12 @@ export class TuiTextfieldBase<T> implements OnChanges, TuiTextfieldAccessor<T> {
     }
 
     public setValue(value: T | null): void {
-        this.el.focus();
-        this.el.select();
-
         if (value == null) {
-            this.el.ownerDocument.execCommand('delete');
+            tuiSafetyDelete(this.injector);
         } else {
-            this.el.ownerDocument.execCommand(
-                'insertText',
-                false,
-                this.handlers.stringify()(value),
-            );
+            const text = this.handlers.stringify()(value);
+
+            tuiSafetyInsertText(this.injector, text);
         }
     }
 }

--- a/projects/core/utils/miscellaneous/index.ts
+++ b/projects/core/utils/miscellaneous/index.ts
@@ -2,5 +2,7 @@ export * from './font-scaling';
 export * from './is-editing-key';
 export * from './is-obscured';
 export * from './override-options';
+export * from './safety-delete';
+export * from './safety-insert-text';
 export * from './size-bigger';
 export * from './to-animation-options';

--- a/projects/core/utils/miscellaneous/safety-delete.ts
+++ b/projects/core/utils/miscellaneous/safety-delete.ts
@@ -1,0 +1,26 @@
+import {inject, type Injector, runInInjectionContext} from '@angular/core';
+import {WA_WINDOW} from '@ng-web-apis/common';
+import {tuiInjectElement} from '@taiga-ui/cdk/utils/dom';
+
+export function tuiSafetyDelete(injector: Injector, el?: HTMLInputElement): void {
+    return runInInjectionContext(injector, () => {
+        const element = el ?? tuiInjectElement<HTMLInputElement>();
+        const selection = inject(WA_WINDOW).getSelection();
+
+        element.focus({preventScroll: true});
+        element.select();
+
+        if (element && (element.tagName === 'INPUT' || element.tagName === 'TEXTAREA')) {
+            const start = element.selectionStart ?? 0;
+            const end = element.selectionEnd ?? 0;
+
+            if (start !== end) {
+                element.value = element.value.slice(0, start) + element.value.slice(end);
+                element.selectionStart = element.selectionEnd = start;
+                element.dispatchEvent(new Event('input', {bubbles: true}));
+            }
+        } else if ((selection?.rangeCount ?? 0) > 0 && !selection?.isCollapsed) {
+            selection?.deleteFromDocument();
+        }
+    });
+}

--- a/projects/core/utils/miscellaneous/safety-insert-text.ts
+++ b/projects/core/utils/miscellaneous/safety-insert-text.ts
@@ -1,0 +1,65 @@
+import {DOCUMENT} from '@angular/common';
+import {inject, type Injector, runInInjectionContext} from '@angular/core';
+import {WA_WINDOW} from '@ng-web-apis/common';
+import {tuiInjectElement} from '@taiga-ui/cdk/utils/dom';
+
+export function tuiSafetyInsertText(
+    injector: Injector,
+    text: string,
+    el?: HTMLInputElement,
+): void {
+    return runInInjectionContext(injector, () => {
+        const doc = inject(DOCUMENT);
+        const element = el ?? tuiInjectElement<HTMLInputElement>();
+        const selection = inject(WA_WINDOW).getSelection();
+        const focusedBefore = doc.activeElement === element;
+
+        element.focus({preventScroll: true});
+        element.select();
+
+        if (element.tagName === 'INPUT' || element.tagName === 'TEXTAREA') {
+            const input = element as HTMLInputElement | HTMLTextAreaElement;
+            const start = input.selectionStart ?? 0;
+            const end = input.selectionEnd ?? 0;
+
+            input.value = input.value.slice(0, start) + text + input.value.slice(end);
+            input.selectionStart = input.selectionEnd = start + text.length;
+            input.dispatchEvent(new Event('input', {bubbles: true}));
+            input.dispatchEvent(new Event('change', {bubbles: true}));
+        } else if (element.isContentEditable && selection?.rangeCount) {
+            const range = selection.getRangeAt(0);
+            const textNode = doc.createTextNode(text);
+
+            range.deleteContents();
+            range.insertNode(textNode);
+            range.setStartAfter(textNode);
+            range.collapse(true);
+            selection.removeAllRanges();
+            selection.addRange(range);
+        } else {
+            if (selection && selection.rangeCount > 0) {
+                const range = selection.getRangeAt(0);
+
+                if (element.contains(range.commonAncestorContainer)) {
+                    range.deleteContents();
+                    range.insertNode(doc.createTextNode(text));
+                } else {
+                    element.textContent += text;
+                }
+            } else {
+                element.textContent += text;
+            }
+        }
+
+        if (focusedBefore && doc.activeElement !== element) {
+            element.focus();
+        }
+
+        element.dispatchEvent(
+            new CustomEvent('insertText', {
+                detail: {text},
+                bubbles: true,
+            }),
+        );
+    });
+}


### PR DESCRIPTION


Fixes #11634
