### PR TITLE
feat(core): migrate from Angular events to observables in `DropdownContext`

### DIFF
--- a/projects/core/directives/dropdown/dropdown-context.directive.ts
+++ b/projects/core/directives/dropdown/dropdown-context.directive.ts
@@ -1,5 +1,5 @@
 import {DOCUMENT} from '@angular/common';
-import {computed, DestroyRef, Directive, inject, NgZone} from '@angular/core';
+import {computed, Directive, inject} from '@angular/core';
 import {takeUntilDestroyed} from '@angular/core/rxjs-interop';
 import {EMPTY_CLIENT_RECT} from '@taiga-ui/cdk/constants';
 import {TuiActiveZone} from '@taiga-ui/cdk/directives/active-zone';
@@ -44,14 +44,12 @@ export class TuiDropdownContext extends TuiRectAccessor {
     protected readonly activeZone = inject(TuiActiveZone);
     protected readonly driver = inject(TuiDropdownDriver);
     protected readonly doc = inject(DOCUMENT);
-    protected readonly zone = inject(NgZone);
-    protected readonly destroyRef = inject(DestroyRef);
 
     protected readonly sub = merge(
         tuiTypedFromEvent(this.doc, 'pointerdown'),
         tuiTypedFromEvent(this.doc, 'contextmenu', {capture: true}),
     )
-        .pipe(tuiZonefree(this.zone), takeUntilDestroyed(this.destroyRef))
+        .pipe(tuiZonefree(), takeUntilDestroyed())
         .subscribe((event: Event) => this.closeDropdown(event));
 
     public readonly type = 'dropdown';

--- a/projects/core/directives/dropdown/dropdown-context.directive.ts
+++ b/projects/core/directives/dropdown/dropdown-context.directive.ts
@@ -1,10 +1,14 @@
-import {computed, Directive, inject} from '@angular/core';
+import {DOCUMENT} from '@angular/common';
+import {computed, DestroyRef, Directive, inject, NgZone} from '@angular/core';
+import {takeUntilDestroyed} from '@angular/core/rxjs-interop';
 import {EMPTY_CLIENT_RECT} from '@taiga-ui/cdk/constants';
 import {TuiActiveZone} from '@taiga-ui/cdk/directives/active-zone';
+import {tuiTypedFromEvent, tuiZonefree} from '@taiga-ui/cdk/observables';
 import {TUI_IS_TOUCH} from '@taiga-ui/cdk/tokens';
 import {tuiGetActualTarget, tuiPointToClientRect} from '@taiga-ui/cdk/utils/dom';
 import {tuiAsDriver, tuiAsRectAccessor, TuiRectAccessor} from '@taiga-ui/core/classes';
 import {shouldCall} from '@taiga-ui/event-plugins';
+import {merge} from 'rxjs';
 
 import {TuiDropdownDriver} from './dropdown.driver';
 
@@ -28,8 +32,6 @@ function activeZoneFilter(this: TuiDropdownContext, event?: Event): boolean {
         '[style.user-select]': 'userSelect()',
         '[style.-webkit-user-select]': 'userSelect()',
         '[style.-webkit-touch-callout]': 'userSelect()',
-        '(document:pointerdown.zoneless)': 'closeDropdown($event)',
-        '(document:contextmenu.capture.zoneless)': 'closeDropdown($event)',
         '(document:keydown.esc)': 'closeDropdown()',
         '(longtap)': 'onContextMenu($event.detail.clientX, $event.detail.clientY)',
     },
@@ -41,6 +43,16 @@ export class TuiDropdownContext extends TuiRectAccessor {
     protected readonly userSelect = computed(() => (this.isTouch() ? 'none' : null));
     protected readonly activeZone = inject(TuiActiveZone);
     protected readonly driver = inject(TuiDropdownDriver);
+    protected readonly doc = inject(DOCUMENT);
+    protected readonly zone = inject(NgZone);
+    protected readonly destroyRef = inject(DestroyRef);
+
+    protected readonly sub = merge(
+        tuiTypedFromEvent(this.doc, 'pointerdown'),
+        tuiTypedFromEvent(this.doc, 'contextmenu', {capture: true}),
+    )
+        .pipe(tuiZonefree(this.zone), takeUntilDestroyed(this.destroyRef))
+        .subscribe((event: Event) => this.closeDropdown(event));
 
     public readonly type = 'dropdown';
 


### PR DESCRIPTION
Remove host-listeners from `TuiDropdownContext` that work outside the zone.

Zoneless host-listeners still force marking `lView` as dirty, and do this on every click on absolutely any place. On the next tick, all this will be processed, and in most cases there will be no need for this.

Replace host-listeners with subscription via RxJS using `tuiZonefree`, which will not lead to marking `lView` as dirty.