### PR TITLE
fix(addon-mobile): ensure default sorter always has a unique reference

### DIFF
--- a/projects/addon-table/components/table/directives/table.directive.ts
+++ b/projects/addon-table/components/table/directives/table.directive.ts
@@ -146,7 +146,7 @@ export class TuiTableDirective<T extends Partial<Record<keyof T, unknown>>>
         sorter: TuiComparator<T> | null,
         direction: TuiSortDirection = TuiSortDirection.Asc,
     ): void {
-        this.sorter = sorter || EMPTY_COMPARATOR;
+        this.sorter = sorter || EMPTY_COMPARATOR.bind({});
         this.direction = direction;
         this.sorterChange.emit(sorter);
         this.directionChange.emit(this.direction);

--- a/projects/demo-playwright/tests/addon-table/table/table.pw.spec.ts
+++ b/projects/demo-playwright/tests/addon-table/table/table.pw.spec.ts
@@ -127,4 +127,33 @@ test.describe('Table', () => {
         await page.waitForTimeout(100);
         await expect.soft(example).toHaveScreenshot('02-checkboxes-6.png');
     });
+
+    test('manual sorting', async ({page}) => {
+        await tuiGoto(page, DemoRoute.Table);
+
+        const example = new TuiDocumentationPagePO(page).getExample('#manual-sorting');
+        const name = example.locator('th').filter({hasText: 'Name'}).locator('button');
+        const color = example.locator('th').filter({hasText: 'Color'}).locator('button');
+
+        await example.scrollIntoViewIfNeeded();
+        await expect.soft(example).toHaveScreenshot('table-manual-sorting-01.png');
+
+        await color.click();
+        await expect.soft(example).toHaveScreenshot('table-manual-sorting-02.png');
+
+        await color.click();
+        await expect.soft(example).toHaveScreenshot('table-manual-sorting-03.png');
+
+        await color.click();
+        await expect.soft(example).toHaveScreenshot('table-manual-sorting-04.png');
+
+        await name.click();
+        await expect.soft(example).toHaveScreenshot('table-manual-sorting-05.png');
+
+        await name.click();
+        await expect.soft(example).toHaveScreenshot('table-manual-sorting-06.png');
+
+        await name.click();
+        await expect.soft(example).toHaveScreenshot('table-manual-sorting-07.png');
+    });
 });

--- a/projects/demo/src/modules/components/table/examples/10/index.html
+++ b/projects/demo/src/modules/components/table/examples/10/index.html
@@ -1,0 +1,52 @@
+<table
+    tuiTable
+    [columns]="columns"
+    [direction]="direction()"
+    [tuiSortBy]="sortBy()"
+    (tuiSortChange)="sortChange($event)"
+>
+    <thead>
+        <tr tuiThGroup>
+            <th
+                *tuiHead="'name'"
+                tuiSortable
+                tuiTh
+                [maxWidth]="500"
+                [minWidth]="200"
+                [resizable]="true"
+            >
+                Name
+            </th>
+            <th
+                *tuiHead="'id'"
+                tuiSortable
+                tuiTh
+            >
+                ID
+            </th>
+            <th
+                *tuiHead="'color'"
+                tuiSortable
+                tuiTh
+            >
+                Color
+            </th>
+        </tr>
+    </thead>
+    <tbody
+        tuiTbody
+        [data]="data()"
+    >
+        <tr
+            *ngFor="let item of data()"
+            tuiTr
+        >
+            <td
+                *tuiCell="'id'"
+                tuiTd
+            >
+                {{ item.id }}
+            </td>
+        </tr>
+    </tbody>
+</table>

--- a/projects/demo/src/modules/components/table/examples/10/index.ts
+++ b/projects/demo/src/modules/components/table/examples/10/index.ts
@@ -1,0 +1,153 @@
+import {NgForOf} from '@angular/common';
+import {Component, computed, signal} from '@angular/core';
+import {changeDetection} from '@demo/emulate/change-detection';
+import {encapsulation} from '@demo/emulate/encapsulation';
+import {type TuiSortChange, TuiTable} from '@taiga-ui/addon-table';
+
+interface Data {
+    id: number;
+    name: string;
+    color: string;
+}
+
+@Component({
+    standalone: true,
+    imports: [NgForOf, TuiTable],
+    templateUrl: './index.html',
+    encapsulation,
+    changeDetection,
+})
+export default class Example {
+    protected readonly initial = [
+        {
+            name: 'Apple',
+            id: 1,
+            color: 'red',
+        },
+        {
+            name: 'Banana',
+            id: 2,
+            color: 'yellow',
+        },
+        {
+            name: 'Kiwi',
+            id: 3,
+            color: 'green',
+        },
+        {
+            name: 'Orange',
+            id: 4,
+            color: 'orange',
+        },
+        {
+            name: 'Grapes',
+            id: 5,
+            color: 'purple',
+        },
+        {
+            name: 'Strawberry',
+            id: 6,
+            color: 'red',
+        },
+        {
+            name: 'Blueberry',
+            id: 7,
+            color: 'blue',
+        },
+        {
+            name: 'Pineapple',
+            id: 8,
+            color: 'yellow',
+        },
+        {
+            name: 'Mango',
+            id: 9,
+            color: 'orange',
+        },
+        {
+            name: 'Watermelon',
+            id: 10,
+            color: 'green',
+        },
+        {
+            name: 'Peach',
+            id: 11,
+            color: 'orange',
+        },
+        {
+            name: 'Pear',
+            id: 12,
+            color: 'green',
+        },
+        {
+            name: 'Cherry',
+            id: 13,
+            color: 'red',
+        },
+        {
+            name: 'Lemon',
+            id: 14,
+            color: 'yellow',
+        },
+        {
+            name: 'Lime',
+            id: 15,
+            color: 'green',
+        },
+        {
+            name: 'Pomegranate',
+            id: 16,
+            color: 'red',
+        },
+        {
+            name: 'Raspberry',
+            id: 17,
+            color: 'red',
+        },
+        {
+            name: 'Blackberry',
+            id: 18,
+            color: 'purple',
+        },
+        {
+            name: 'Cantaloupe',
+            id: 19,
+            color: 'orange',
+        },
+        {
+            name: 'Plum',
+            id: 20,
+            color: 'purple',
+        },
+    ] as const;
+
+    protected readonly columns = Object.keys(this.initial[0]);
+    protected readonly direction = signal<-1 | 1>(-1);
+    protected readonly sortBy = signal<keyof Data | null>('color');
+    protected readonly data = computed<readonly Data[]>(() => {
+        const direction = this.direction();
+        const key = this.sortBy();
+
+        return key
+            ? [...this.initial].sort((a, b) => {
+                  const valA = a[key];
+                  const valB = b[key];
+
+                  if (typeof valA === 'string' && typeof valB === 'string') {
+                      return valA.localeCompare(valB) * direction;
+                  }
+
+                  if (typeof valA === 'number' && typeof valB === 'number') {
+                      return (valA - valB) * direction;
+                  }
+
+                  return 0;
+              })
+            : this.initial;
+    });
+
+    protected sortChange({sortKey, sortDirection}: TuiSortChange<Data>): void {
+        this.sortBy.set(sortKey);
+        this.direction.set(sortDirection);
+    }
+}

--- a/projects/demo/src/modules/components/table/index.ts
+++ b/projects/demo/src/modules/components/table/index.ts
@@ -21,5 +21,6 @@ export default class Page {
         'Footer',
         'Resize a large table',
         'Expandable',
+        'Manual sorting',
     ];
 }


### PR DESCRIPTION
Fixes https://github.com/taiga-family/taiga-ui/issues/11990

### Before


https://github.com/user-attachments/assets/2abaa04a-bdee-450c-843f-6f2b9a0b0048



### After



https://github.com/user-attachments/assets/0a8b4c32-c5d0-4d3c-9871-37c2917fb773

