### PR TITLE
fix(core): `Dialogs` fix fixed position on iOS 26

### DIFF
--- a/projects/addon-doc/components/internal/header/index.less
+++ b/projects/addon-doc/components/internal/header/index.less
@@ -2,7 +2,7 @@
 
 :host {
     position: fixed;
-    top: 0;
+    top: var(--tui-viewport-y);
     left: 0;
     right: 0;
     // fix for Safari to prevent tabs underline above sidebar

--- a/projects/core/components/dialog/dialogs.style.less
+++ b/projects/core/components/dialog/dialogs.style.less
@@ -4,6 +4,7 @@
     .fullsize(fixed);
     .scrollbar-hidden();
 
+    top: var(--tui-viewport-y);
     pointer-events: none;
     overflow: hidden;
     overscroll-behavior: none;


### PR DESCRIPTION
Fixes # <!-- link to a relevant issue. -->
