### PR TITLE
feat(kit): `InputSlider` hides slider for non-interactive state

### DIFF
--- a/projects/demo-playwright/tests/kit/input-slider/input-slider.pw.spec.ts
+++ b/projects/demo-playwright/tests/kit/input-slider/input-slider.pw.spec.ts
@@ -227,7 +227,7 @@ describe('InputSlider', () => {
             );
 
             await expect(inputSlider.textfield).toBeDisabled();
-            await expect(inputSlider.slider).toBeDisabled();
+            await expect(inputSlider.slider).toBeHidden();
 
             await expect(
                 new TuiDocumentationPagePO(page).apiPageExample,
@@ -253,13 +253,13 @@ describe('InputSlider', () => {
             await page.keyboard.down('ArrowUp');
 
             await expect(inputSlider.textfield).toHaveValue('0');
-            await expect(inputSlider.slider).toHaveValue('0');
+            await expect(inputSlider.slider).toBeHidden();
 
             await inputSlider.textfield.press('ArrowDown');
             await page.keyboard.down('ArrowDown');
 
             await expect(inputSlider.textfield).toHaveValue('0');
-            await expect(inputSlider.slider).toHaveValue('0');
+            await expect(inputSlider.slider).toBeHidden();
         });
     });
 

--- a/projects/kit/components/input-slider/input-slider.directive.ts
+++ b/projects/kit/components/input-slider/input-slider.directive.ts
@@ -143,6 +143,8 @@ export class TuiInputSliderDirective {
     styles: [
         // TODO: tui-textfield:has([tuiInputSlider]) .t-clear
         'tui-textfield [tuiInputSlider] ~ .t-content .t-clear {display: none !important}',
+        // TODO: tui-textfield:has([tuiInputSlider]) [tuiSlider]:disabled
+        'tui-textfield [tuiInputSlider] ~ [tuiSlider]:disabled {display: none}',
     ],
     encapsulation: ViewEncapsulation.None,
     changeDetection: ChangeDetectionStrategy.OnPush,


### PR DESCRIPTION
Update according to the latest design specs

Partially solves #11826