### PR TITLE
chore(core): `Loader` remove extra space around icon

### DIFF
--- a/projects/core/components/loader/loader.style.less
+++ b/projects/core/components/loader/loader.style.less
@@ -133,7 +133,7 @@
     display: block;
     inline-size: var(--t-diameter);
     block-size: var(--t-diameter);
-    margin: 0.25rem calc(var(--t-diameter) / -2);
+    margin: 0 calc(var(--t-diameter) / -2);
     border-radius: 100%;
     overflow: hidden;
     animation: tuiLoaderRotate 4s linear infinite;


### PR DESCRIPTION
Fixes # <!-- link to a relevant issue. -->
