### PR TITLE
fix(core): ensure box-shadow works in Safari 26 for `tuiAppearance`

### DIFF
--- a/projects/core/styles/theme/appearance/textfield.less
+++ b/projects/core/styles/theme/appearance/textfield.less
@@ -62,7 +62,7 @@
     &:-webkit-autofill {
         -webkit-text-fill-color: var(--tui-text-primary) !important;
         caret-color: var(--tui-text-primary) !important;
-        box-shadow: 0 0 0 100rem var(--tui-service-autofill-background) inset !important;
+        box-shadow: 0 0 0 1000rem var(--tui-service-autofill-background) inset !important;
         transition: background-color 600000s 0s;
     }
 }


### PR DESCRIPTION
Fixes # <!-- link to a relevant issue. -->
