### PR TITLE
chore(demo): remove empty `div` in spaces page

### DIFF
--- a/projects/demo/src/modules/markup/spaces/examples/1/index.html
+++ b/projects/demo/src/modules/markup/spaces/examples/1/index.html
@@ -60,14 +60,12 @@
     <div class="example tui-space_right-5">
         <tui-doc-copy cdkCopyToClipboard="tui-space_right-5">tui-space_right-5</tui-doc-copy>
     </div>
-    <div class="example"></div>
 </div>
 <h2 class="title">
     Margin left
     <code [textContent]="'tui-space_left-<value>'"></code>
 </h2>
 <div class="row">
-    <div class="example"></div>
     <div class="example tui-space_left-1">
         <tui-doc-copy cdkCopyToClipboard="tui-space_left-1">tui-space_left-1</tui-doc-copy>
     </div>


### PR DESCRIPTION
Fixes # <!-- link to a relevant issue. -->
