### PR TITLE
feat!: new browser support

### DIFF
--- a/projects/demo/src/modules/info/browsers/index.ts
+++ b/projects/demo/src/modules/info/browsers/index.ts
@@ -12,7 +12,7 @@ export default class Page {
     protected readonly desktopBrowsers = [
         {name: 'Google Chrome', version: '88+'},
         {name: 'Mozilla Firefox', version: '120+'},
-        {name: 'Safari', version: '13.1+'},
+        {name: 'Safari', version: '14.1+'},
         {name: 'Opera', version: '74+'},
         {name: 'Edge', version: '88+'},
         {name: 'Yandex Browser', version: '21.2+'},
@@ -22,7 +22,7 @@ export default class Page {
     protected readonly mobileBrowsers = [
         {name: 'Google Chrome', version: '88+'},
         {name: 'Mozilla Firefox', version: '120+'},
-        {name: 'Safari', version: '13.4+'},
+        {name: 'Safari', version: '14.5+'},
         {name: 'Opera', version: '63+'},
         {name: 'Samsung Mobile', version: '15+'},
         {name: 'Yandex Browser', version: '21.2+'},


### PR DESCRIPTION
| Browser name    | Previous | New   | Description                                                       |
|-----------------|----------|-------|-------------------------------------------------------------------|
| Chrome Mobile   |          | 88+   |                                                                   |
| Chrome Desktop  |          | 88+   |                                                                   |
| Edge Desktop    |          | 88+   |                                                                   |
| Yandex Desktop  |          | 21.2+ | 21.2 uses Chromium 88                                             |
| Yandex Mobile   |          | 21.2+ | 21.2 uses Chromium 88                                             |
| Opera Desktop   |          | 74+   | 74 uses Chromium 88                                               |
| Opera Mobile    |          | 63+   | Opera Android 62 uses Chromium 87; Opera Android 63 – Chromium 89 |
| **Safari Mobile**   | 13.4+    | **14.5+** |                                                                   |
| **Safari Desktop**  | 13.1+    | **14.1+** |                                                                   |
| Samsung Mobile  |          | 15+   | Samsung 14 uses Chromium 87; Samsung 15 – Chromium 90             |
| Firefox Mobile  |          | 120+  |                                                                   |
| Firefox Desktop |          | 120+  |                                                                   |

### New available browser features
- [flex gap](https://caniuse.com/flexbox-gap)
- [inset](https://developer.mozilla.org/en-US/docs/Web/CSS/inset#browser_compatibility)
- [BigInt](https://caniuse.com/bigint),
- [:is()](https://caniuse.com/css-matches-pseudo)
- [padding-inline](https://developer.mozilla.org/en-US/docs/Web/CSS/padding-inline#browser_compatibility)
- [margin-inline](https://developer.mozilla.org/en-US/docs/Web/CSS/margin-inline#browser_compatibility)
- [border-inline](https://developer.mozilla.org/en-US/docs/Web/CSS/border-inline#browser_compatibility)
- [inset-inline-start](https://developer.mozilla.org/en-US/docs/Web/CSS/inset-inline-start#browser_compatibility)
- [inset-inline-end](https://developer.mozilla.org/en-US/docs/Web/CSS/inset-inline-end#browser_compatibility)
- [inset-block-start](https://developer.mozilla.org/en-US/docs/Web/CSS/inset-block-start#browser_compatibility)
- [inset-block-end](https://developer.mozilla.org/en-US/docs/Web/CSS/inset-block-end)
- [\<input type="datetime-local">](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/datetime-local#browser_compatibility)