### PR TITLE
chore(kit): `InputRange` hides `--t-icon-lock` if end content is visible

### DIFF
--- a/projects/demo-playwright/tests/kit/input-range/input-range.pw.spec.ts
+++ b/projects/demo-playwright/tests/kit/input-range/input-range.pw.spec.ts
@@ -477,6 +477,18 @@ describe('InputRange', () => {
                         `32-input-range-${nonInteractiveProp}-start-has-content--end-no-content.png`,
                     );
                 });
+
+                test('START textfield without content + END textfield has non-primitive content', async ({
+                    page,
+                }) => {
+                    await tuiGoto(
+                        page,
+                        `${DemoRoute.InputRange}/API?content$=5&${nonInteractiveProp}=true`,
+                    );
+                    await expect(example).toHaveScreenshot(
+                        `33-input-range-${nonInteractiveProp}-start-no-content--end-non-primitive-content.png`,
+                    );
+                });
             });
         });
     });

--- a/projects/demo/src/modules/components/input-range/index.ts
+++ b/projects/demo/src/modules/components/input-range/index.ts
@@ -7,9 +7,9 @@ import {changeDetection} from '@demo/emulate/change-detection';
 import {DemoRoute} from '@demo/routes';
 import {TuiDemo} from '@demo/utils';
 import {type TuiContext} from '@taiga-ui/cdk';
-import {TuiNumberFormat, TuiTextfield, TuiTitle} from '@taiga-ui/core';
+import {TuiLoader, TuiNumberFormat, TuiTextfield, TuiTitle} from '@taiga-ui/core';
 import {TuiInputRange, type TuiKeySteps} from '@taiga-ui/kit';
-import {type PolymorpheusContent} from '@taiga-ui/polymorpheus';
+import {PolymorpheusComponent, type PolymorpheusContent} from '@taiga-ui/polymorpheus';
 
 @Component({
     imports: [
@@ -70,6 +70,7 @@ export default class PageComponent {
             ({$implicit: val}: TuiContext<number>) => (val === 5 ? 'FIVE' : `${val}`),
             ({$implicit: val}: TuiContext<number>) => (val === 5 ? 'FIVE' : `${val}`),
         ],
+        ['', new PolymorpheusComponent(TuiLoader)],
     ];
 
     protected min = 0;

--- a/projects/kit/components/input-range/input-range.component.ts
+++ b/projects/kit/components/input-range/input-range.component.ts
@@ -51,6 +51,8 @@ import {
         new: '', // TODO(v5): remove after deletion of legacy control
         // TODO: use css :host:has(tui-textfield[data-size]) after browser bump
         '[attr.data-size]': 'size()',
+        // TODO: Delete this line and put `tui-input-range:has(.t-content-end) {--t-icon-lock: none}` to proprietary styles
+        '[style.--t-icon-lock]': 'contentEnd() ? "none" : null',
     },
 })
 export class TuiInputRangeComponent
@@ -137,11 +139,11 @@ export class TuiInputRangeComponent
         }
     }
 
-    protected get hideStartContent(): boolean {
+    protected get contentStartHidden(): boolean {
         return this.interactive() && tuiIsFocused(this.textfieldStart);
     }
 
-    protected get hideEndContent(): boolean {
+    protected get contentEndHidden(): boolean {
         return (
             !this.content()[1] || (this.interactive() && tuiIsFocused(this.textfieldEnd))
         );

--- a/projects/kit/components/input-range/input-range.template.html
+++ b/projects/kit/components/input-range/input-range.template.html
@@ -1,4 +1,4 @@
-<tui-textfield [content]="hideStartContent ? '' : contentStart()">
+<tui-textfield [content]="contentStartHidden ? '' : contentStart()">
     <ng-container ngProjectAs="label">
         <ng-content select="label" />
     </ng-container>
@@ -23,7 +23,7 @@
         tuiInputNumber
         tuiTextfieldAppearance="none"
         class="t-end"
-        [class._hidden]="!hideEndContent || !this.interactive()"
+        [class._hidden]="!contentEndHidden || !this.interactive()"
         [disabled]="disabled()"
         [invalid]="invalid()"
         [max]="max"
@@ -38,14 +38,13 @@
         (ngModelChange)="onInput([null, $event])"
     />
 
-    <div
-        class="t-content-end"
-        [class._hidden]="hideEndContent"
-    >
-        <ng-container *polymorpheusOutlet="contentEnd() as text; context: {$implicit: value()[1]}">
-            {{ text }}
-        </ng-container>
-    </div>
+    @if (!contentEndHidden && contentEnd()) {
+        <div class="t-content-end">
+            <ng-container *polymorpheusOutlet="contentEnd() as text; context: {$implicit: value()[1]}">
+                {{ text }}
+            </ng-container>
+        </div>
+    }
 </tui-textfield>
 
 @if (interactive()) {


### PR DESCRIPTION
Relates:
* https://github.com/taiga-family/taiga-ui/pull/12122