### PR TITLE
fix(kit): ensure cursor is visible on focus in single-row input-chip

### DIFF
--- a/projects/core/components/textfield/textfield-multi/textfield-multi.component.ts
+++ b/projects/core/components/textfield/textfield-multi/textfield-multi.component.ts
@@ -177,4 +177,21 @@ export class TuiTextfieldMultiComponent<T> extends TuiTextfieldBaseComponent<T> 
             // Empty catch block - silently ignore showPicker errors
         }
     }
+
+    protected onFocus(): void {
+        setTimeout(() => this.scrollTo(true), 10);
+    }
+
+    public scrollTo(end = false): void {
+        const sign = this.el.matches('[dir="rtl"] :scope') ? -1 : 1;
+        const scrollLeft = end ? sign * Number.MAX_SAFE_INTEGER : 0;
+
+        // Allow change detection to run and placeholder to be rendered
+        setTimeout(() => {
+            this.el.scrollTo({
+                left: scrollLeft,
+                top: this.rows === 1 ? 0 : Number.MAX_SAFE_INTEGER,
+            });
+        }, 10);
+    }
 }

--- a/projects/core/components/textfield/textfield-multi/textfield-multi.template.html
+++ b/projects/core/components/textfield/textfield-multi/textfield-multi.template.html
@@ -19,6 +19,7 @@
     }
     <span
         class="t-input"
+        (focus.capture)="onFocus()"
         (keydown.arrowLeft)="onLeft($event)"
     >
         <ng-content select="input" />

--- a/projects/kit/components/input-chip/input-chip.directive.ts
+++ b/projects/kit/components/input-chip/input-chip.directive.ts
@@ -93,7 +93,7 @@ export class TuiInputChipBaseDirective<T>
         }
 
         this.setValue([...this.value(), ...valid]);
-        this.scrollTo();
+        this.textfield.scrollTo(true);
     }
 
     protected onInput(): void {
@@ -102,7 +102,7 @@ export class TuiInputChipBaseDirective<T>
         if (this.separator && this.textfield.value().match(this.separator)) {
             this.onEnter();
         } else {
-            this.scrollTo();
+            this.textfield.scrollTo(true);
         }
     }
 
@@ -130,18 +130,6 @@ export class TuiInputChipBaseDirective<T>
                 );
             }
         }
-    }
-
-    protected scrollTo(): void {
-        const sign = this.textfield.el.matches('[dir="rtl"] :scope') ? -1 : 1;
-
-        // Allow change detection to run and add new tag to DOM
-        setTimeout(() => {
-            this.textfield.el.scrollTo({
-                left: sign * Number.MAX_SAFE_INTEGER,
-                top: Number.MAX_SAFE_INTEGER,
-            });
-        });
     }
 }
 

--- a/projects/kit/components/input-date-multi/input-date-multi.directive.ts
+++ b/projects/kit/components/input-date-multi/input-date-multi.directive.ts
@@ -126,7 +126,7 @@ export class TuiInputDateMultiDirective extends TuiInputChipBaseDirective<TuiDay
 
     protected override onEnter(): void {
         this.onValueChange(this.textfield.value().trim());
-        this.scrollTo();
+        this.textfield.scrollTo(true);
     }
 
     private updateValue(day: TuiDay): void {


### PR DESCRIPTION
Fixes #11889

### Solution Summary
I fixed the InputChip autoscroll issue (#11889) where the cursor wasn’t visible when I focused existing chips in single-row inputs. The problem happened because the browser thought the cursor was already visible, and the scroll method ran too early, before Angular fully rendered the placeholder.

### Here’s what I did:
- Added a 10ms delay in scrollTo inside textfield-multi.component.ts.
- Created an onFocus() handler to make sure scrolling happens at the right time.
- Fixed a TypeScript error in input-date-multi.directive.ts by replacing this.scrollTo() with this.textfield.scrollTo().

Now, the cursor is visible immediately when I click on chips. The fix works for both single- and multi-row inputs, and it keeps everything compatible with Taiga UI’s existing architecture.