### PR TITLE
chore(demo): use chevron button instead of icon in table expand demo

### DIFF
--- a/projects/demo/src/modules/components/table/examples/9/index.html
+++ b/projects/demo/src/modules/components/table/examples/9/index.html
@@ -53,10 +53,16 @@
                 *tuiCell="'action'"
                 tuiTd
             >
-                <tui-icon
-                    class="t-chevron"
+                <button
+                    appearance="flat-grayscale"
+                    size="xs"
+                    tuiIconButton
+                    type="button"
+                    [style.border-radius]="'100%'"
                     [tuiChevron]="expand.expanded()"
-                />
+                >
+                    Toggle
+                </button>
             </td>
             <td
                 *tuiCell="'firstName'"
@@ -138,10 +144,16 @@
                 *tuiCell="'action'"
                 tuiTd
             >
-                <tui-icon
-                    class="t-chevron"
+                <button
+                    appearance="flat-grayscale"
+                    size="xs"
+                    tuiIconButton
+                    type="button"
+                    [style.border-radius]="'100%'"
                     [tuiChevron]="manualOpen"
-                />
+                >
+                    Toggle
+                </button>
             </td>
             <td
                 *tuiCell="'firstName'"
@@ -204,20 +216,22 @@
     </tbody>
 
     <tbody tuiTbody>
-        <tr
-            tuiTr
-            class="expand-heading-row-custom"
-        >
+        <tr tuiTr>
             <td
                 *tuiCell="'action'"
                 tuiTd
-                class="expand-heading-row-custom__expand"
-                (click)="customToggle()"
             >
-                <tui-icon
-                    class="t-chevron"
+                <button
+                    appearance="flat-grayscale"
+                    size="xs"
+                    tuiIconButton
+                    type="button"
+                    [style.border-radius]="'100%'"
                     [tuiChevron]="customOpen"
-                />
+                    (click)="customToggle()"
+                >
+                    Toggle
+                </button>
             </td>
             <td
                 *tuiCell="'firstName'"

--- a/projects/demo/src/modules/components/table/examples/9/index.ts
+++ b/projects/demo/src/modules/components/table/examples/9/index.ts
@@ -4,7 +4,8 @@ import {changeDetection} from '@demo/emulate/change-detection';
 import {encapsulation} from '@demo/emulate/encapsulation';
 import {TuiTable, TuiTableExpand} from '@taiga-ui/addon-table';
 import {TuiMapperPipe} from '@taiga-ui/cdk';
-import {TuiExpand, TuiFormatNumberPipe, TuiHint, TuiIcon} from '@taiga-ui/core';
+import {TuiButton, TuiFormatNumberPipe, TuiHint} from '@taiga-ui/core';
+import {TuiExpand} from '@taiga-ui/experimental';
 import {TuiChevron, TuiChip} from '@taiga-ui/kit';
 
 interface Item {
@@ -19,12 +20,12 @@ interface Item {
     imports: [
         AsyncPipe,
         NgForOf,
+        TuiButton,
         TuiChevron,
         TuiChip,
         TuiExpand,
         TuiFormatNumberPipe,
         TuiHint,
-        TuiIcon,
         TuiMapperPipe,
         TuiTable,
         TuiTableExpand,


### PR DESCRIPTION
Might be more appropriate to use a button for toggling expandable table rows instead of clickable icon.
