### PR TITLE
chore(demo): remove no more relevant `ServerModule`

### DIFF
--- a/projects/demo/src/main.server.ts
+++ b/projects/demo/src/main.server.ts
@@ -1,12 +1,7 @@
-import {
-    type ApplicationRef,
-    ErrorHandler,
-    importProvidersFrom,
-    mergeApplicationConfig,
-} from '@angular/core';
+import {type ApplicationRef, ErrorHandler, mergeApplicationConfig} from '@angular/core';
 import {bootstrapApplication, type BootstrapContext} from '@angular/platform-browser';
 import {provideAnimations} from '@angular/platform-browser/animations';
-import {provideServerRendering, ServerModule} from '@angular/platform-server';
+import {provideServerRendering} from '@angular/platform-server';
 import {UNIVERSAL_PROVIDERS} from '@ng-web-apis/universal';
 
 import {App} from './modules/app/app.component';
@@ -15,7 +10,6 @@ import {ServerErrorHandler} from './modules/app/server-error-handler';
 
 const serverConfig = mergeApplicationConfig(config, {
     providers: [
-        importProvidersFrom(ServerModule),
         provideServerRendering(),
         provideAnimations(),
         UNIVERSAL_PROVIDERS,


### PR DESCRIPTION
Run `nx serve-ssr`

Explore logs

```
Angular detected an incompatible configuration,
which causes duplicate serialization of the server-side application state.

This can happen if the server providers have been provided more than once using different mechanisms.
For example:

  imports: [ServerModule], // Registers server providers
  providers: [provideServerRendering()] // Also registers server providers

To fix this,
ensure that the `provideServerRendering()` function is the only provider used and remove the other(s).
```