### PR TITLE
chore: fix `playwright/expect-expect` warnings

### DIFF
--- a/projects/demo-playwright/tests/legacy/input-date-time/input-date-time.pw.spec.ts
+++ b/projects/demo-playwright/tests/legacy/input-date-time/input-date-time.pw.spec.ts
@@ -32,7 +32,7 @@ test.skip('InputDateTime', () => {
 
             await documentationPage.prepareBeforeScreenshot();
 
-            await expect.soft(page).toHaveScreenshot('01-maximum-month.png');
+            await expect(page).toHaveScreenshot('01-maximum-month.png');
         });
 
         test('Minimum month more than current month', async ({page}) => {

--- a/projects/demo-playwright/tests/legacy/input-month-range/input-month-range.pw.spec.ts
+++ b/projects/demo-playwright/tests/legacy/input-month-range/input-month-range.pw.spec.ts
@@ -31,9 +31,7 @@ test.skip('InputMonthRange', () => {
 
             await documentationPage.prepareBeforeScreenshot();
 
-            await expect
-                .soft(page)
-                .toHaveScreenshot('input-month-range-maximum-month.png');
+            await expect(page).toHaveScreenshot('input-month-range-maximum-month.png');
         });
 
         test('Minimum month more than current month', async ({page}) => {

--- a/projects/demo-playwright/tests/legacy/input-month/input-month.pw.spec.ts
+++ b/projects/demo-playwright/tests/legacy/input-month/input-month.pw.spec.ts
@@ -27,7 +27,7 @@ test.skip('InputMonth', () => {
 
             await documentationPage.prepareBeforeScreenshot();
 
-            await expect.soft(page).toHaveScreenshot('input-month-maximum-month.png');
+            await expect(page).toHaveScreenshot('input-month-maximum-month.png');
         });
 
         test('Minimum month more than current month', async ({page}) => {

--- a/projects/demo-playwright/tests/legacy/input-number/input-number.pw.spec.ts
+++ b/projects/demo-playwright/tests/legacy/input-number/input-number.pw.spec.ts
@@ -26,7 +26,7 @@ test.skip('InputNumber', () => {
             await input.focus();
             await input.fill('1,2345');
 
-            await expect.soft(example).toHaveScreenshot('01-input-number.png');
+            await expect(example).toHaveScreenshot('01-input-number.png');
         });
 
         test('does not mutate already valid too large number on blur', async ({page}) => {

--- a/projects/demo-playwright/tests/legacy/input-year/input-year.pw.spec.ts
+++ b/projects/demo-playwright/tests/legacy/input-year/input-year.pw.spec.ts
@@ -20,7 +20,7 @@ test.skip('InputYear', () => {
         test('12345 => 1234', async ({page}) => {
             await input.pressSequentially('123456789');
 
-            await expect.soft(page).toHaveScreenshot('01-input-year.png');
+            await expect(page).toHaveScreenshot('01-input-year.png');
         });
 
         test('2040 => 2020', async ({page}) => {

--- a/projects/demo-playwright/tests/legacy/input/input.pw.spec.ts
+++ b/projects/demo-playwright/tests/legacy/input/input.pw.spec.ts
@@ -20,9 +20,9 @@ test.skip('Input', () => {
 
         await document.waitTuiIcons();
 
-        await expect
-            .soft(document.apiPageExample)
-            .toHaveScreenshot('01-custom-text-content-cleaner-hint.png');
+        await expect(document.apiPageExample).toHaveScreenshot(
+            '01-custom-text-content-cleaner-hint.png',
+        );
     });
 
     test('correctly aligns single custom content (as large icon)', async ({page}) => {

--- a/projects/demo-playwright/tests/legacy/textarea/textarea.pw.spec.ts
+++ b/projects/demo-playwright/tests/legacy/textarea/textarea.pw.spec.ts
@@ -18,9 +18,9 @@ test.skip('Textarea', () => {
 
         await textarea.click();
 
-        await expect
-            .soft(apiPageExample)
-            .toHaveScreenshot('01-character-with-descenders-inside-placeholder.png');
+        await expect(apiPageExample).toHaveScreenshot(
+            '01-character-with-descenders-inside-placeholder.png',
+        );
     });
 
     ['m', 'l'].forEach((size) => {


### PR DESCRIPTION
```
➜ eslint . --fix                                                                                                                                                      
| Processing: scripts/shared/update-package-json-structure.ts
/projects/demo-playwright/tests/legacy/input-date-time/input-date-time.pw.spec.ts
29:9  warning  Test has no assertions  playwright/expect-expect

/projects/demo-playwright/tests/legacy/input-month-range/input-month-range.pw.spec.ts
28:9  warning  Test has no assertions  playwright/expect-expect

/projects/demo-playwright/tests/legacy/input-month/input-month.pw.spec.ts
24:9  warning  Test has no assertions  playwright/expect-expect

/projects/demo-playwright/tests/legacy/input-number/input-number.pw.spec.ts
24:9  warning  Test has no assertions  playwright/expect-expect

/projects/demo-playwright/tests/legacy/input-year/input-year.pw.spec.ts
20:9  warning  Test has no assertions  playwright/expect-expect

/projects/demo-playwright/tests/legacy/input/input.pw.spec.ts
11:5  warning  Test has no assertions  playwright/expect-expect

/projects/demo-playwright/tests/legacy/textarea/textarea.pw.spec.ts
9:5  warning  Test has no assertions  playwright/expect-expect
```

> No need to add `.soft()` for the **last** `expect` of test!