### PR TITLE
fix(addon-commerce): `InputCardGroup` fix stacking order of labels

### DIFF
--- a/projects/addon-commerce/components/input-card-group/input-card-group.style.less
+++ b/projects/addon-commerce/components/input-card-group/input-card-group.style.less
@@ -281,7 +281,6 @@
 
 .t-icon {
     cursor: pointer;
-    border-width: 0.25rem;
     pointer-events: auto;
 }
 

--- a/projects/addon-commerce/components/input-card-group/input-card-group.template.html
+++ b/projects/addon-commerce/components/input-card-group/input-card-group.template.html
@@ -144,6 +144,7 @@
         tuiAppearance="icon"
         class="t-icon"
         [icon]="icons.close"
+        [style.border-width.rem]="0.25"
         (click)="clear()"
     />
     <tui-icon
@@ -151,6 +152,7 @@
         automation-id="tui-input-card-group__dropdown"
         tuiAppearance="icon"
         tuiChevron
+        class="t-icon"
         (click)="toggle()"
     />
 </div>


### PR DESCRIPTION
Fixes #12201