### PR TITLE
fix: update arc chart value input handling

### DIFF
--- a/projects/addon-charts/components/arc-chart/arc-chart.component.ts
+++ b/projects/addon-charts/components/arc-chart/arc-chart.component.ts
@@ -60,7 +60,6 @@ export class TuiArcChart {
             take(1),
             // The linter rule 'no-restricted-syntax' incorrectly flags 'map(() => true)' here,
             // because the literal 'true' has type 'true' (not 'boolean'), which is intentional for this signal initialization.
-            // eslint-disable-next-line no-restricted-syntax
             map(() => true),
         ),
         {initialValue: false},

--- a/projects/addon-charts/components/arc-chart/arc-chart.template.html
+++ b/projects/addon-charts/components/arc-chart/arc-chart.template.html
@@ -2,31 +2,31 @@
 @let min = minLabel();
 @let max = maxLabel();
 @for (_ of '-'.repeat(data.length); track $index) {
-<svg
-    focusable="false"
-    viewBox="-100 -100 200 200"
-    xmlns="http://www.w3.org/2000/svg"
-    class="t-svg"
-    [style.height.rem]="getDiameter($index)"
-    [style.inset-block-start.rem]="getInset($index)"
-    [style.inset-inline-end.rem]="getInset($index)"
-    [style.inset-inline-start.rem]="getInset($index)"
->
-    <path
-        d="M -70 70 A 100 100 0 1 1 70 70"
-        vector-effect="non-scaling-stroke"
-    />
-    <path
-        #arc
-        d="M -70 70 A 100 100 0 1 1 70 70"
-        vector-effect="non-scaling-stroke"
-        class="t-value"
-        [class.t-value_inactive]="isInactive($index)"
-        [style.stroke]="`var(--tui-chart-categorical-${$index.toString().padStart(2, '0')})`"
-        [style.strokeDasharray.em]="getLength($index)"
-        [style.strokeDashoffset.em]="initialized() ? getOffset($index) : getLength($index)"
-    />
-</svg>
+    <svg
+        focusable="false"
+        viewBox="-100 -100 200 200"
+        xmlns="http://www.w3.org/2000/svg"
+        class="t-svg"
+        [style.height.rem]="getDiameter($index)"
+        [style.inset-block-start.rem]="getInset($index)"
+        [style.inset-inline-end.rem]="getInset($index)"
+        [style.inset-inline-start.rem]="getInset($index)"
+    >
+        <path
+            d="M -70 70 A 100 100 0 1 1 70 70"
+            vector-effect="non-scaling-stroke"
+        />
+        <path
+            #arc
+            d="M -70 70 A 100 100 0 1 1 70 70"
+            vector-effect="non-scaling-stroke"
+            class="t-value"
+            [class.t-value_inactive]="isInactive($index)"
+            [style.stroke]="`var(--tui-chart-categorical-${$index.toString().padStart(2, '0')})`"
+            [style.strokeDasharray.em]="getLength($index)"
+            [style.strokeDashoffset.em]="initialized() ? getOffset($index) : getLength($index)"
+        />
+    </svg>
 }
 <div class="t-content">
     <div class="t-wrapper">


### PR DESCRIPTION
Fixes #12232 

PARTIAL FIX : https://github.com/taiga-family/taiga-ui/issues/12232

This PR contains the fix for arc-chart component
Subsequent PRs will address other files. I tried changing one component at a time to prevent large batches.

##  Changes in this PR

changed inputs and outputs to use signal api
changed viewChildren to use signal api
cleaned up some redundancies 
added documentation to make explicit to consumers that internal state of the component can change some values
moved signal reads to template variables on top (easier to spot, read once use many)

## Problems

ESLint rules sometimes are forcing incorrect patterns. I skipped lint of the affected line on each case and documented the reason

## Chance for improvement

using native `@for` and template variables + computations could make the component even more reactive. Did not pursue because it was outside the scope of the ticket. 

will be paying attention to comments  and resolution before starting the next component