### PR TITLE
refactor(cdk): remove TUI_ALLOW_SIGNAL_WRITES

### DIFF
--- a/projects/cdk/constants/allow-signal-writes.ts
+++ b/projects/cdk/constants/allow-signal-writes.ts
@@ -1,4 +1,0 @@
-import {type CreateEffectOptions, VERSION} from '@angular/core';
-
-export const TUI_ALLOW_SIGNAL_WRITES: CreateEffectOptions =
-    parseInt(VERSION.major, 10) >= 19 ? {} : {allowSignalWrites: true};

--- a/projects/cdk/constants/index.ts
+++ b/projects/cdk/constants/index.ts
@@ -1,4 +1,3 @@
-export * from './allow-signal-writes';
 export * from './empty';
 export * from './handlers';
 export * from './matchers';

--- a/projects/cdk/utils/dom/value.ts
+++ b/projects/cdk/utils/dom/value.ts
@@ -14,7 +14,6 @@ import {
     type WritableSignal,
 } from '@angular/core';
 import {WA_WINDOW} from '@ng-web-apis/common';
-import {TUI_ALLOW_SIGNAL_WRITES} from '@taiga-ui/cdk/constants';
 
 type WithValue = HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement;
 
@@ -39,7 +38,7 @@ export function tuiValue(
     let element = isSignal(input) ? undefined : coerceElement(input);
     let cleanup = (): void => {};
 
-    const options = {injector, ...TUI_ALLOW_SIGNAL_WRITES};
+    const options = {injector};
     const value = signal(element?.value || '');
     const process = (el: WithValue): (() => void) => {
         const update = (): void => untracked(() => value.set(el.value));

--- a/projects/cdk/utils/miscellaneous/directive-binding.ts
+++ b/projects/cdk/utils/miscellaneous/directive-binding.ts
@@ -8,7 +8,6 @@ import {
     signal,
     type WritableSignal,
 } from '@angular/core';
-import {TUI_ALLOW_SIGNAL_WRITES} from '@taiga-ui/cdk/constants';
 
 import {tuiSetSignal} from './set-signal';
 
@@ -53,7 +52,7 @@ export function tuiDirectiveBinding<
         directive.ngOnChanges?.({});
         output?.emit?.(value);
         previous = value;
-    }, TUI_ALLOW_SIGNAL_WRITES);
+    });
 
     return result;
 }

--- a/projects/core/directives/items-handlers/items-handlers.validator.ts
+++ b/projects/core/directives/items-handlers/items-handlers.validator.ts
@@ -1,6 +1,5 @@
 import {Directive, effect, inject} from '@angular/core';
 import {NG_VALIDATORS, type ValidatorFn} from '@angular/forms';
-import {TUI_ALLOW_SIGNAL_WRITES} from '@taiga-ui/cdk/constants';
 import {TuiValidator} from '@taiga-ui/cdk/directives/validator';
 import {type TuiBooleanHandler} from '@taiga-ui/cdk/types';
 import {tuiProvide} from '@taiga-ui/cdk/utils/miscellaneous';
@@ -17,7 +16,7 @@ export class TuiItemsHandlersValidator extends TuiValidator {
     protected readonly update = effect(() => {
         this.handlers.disabledItemHandler();
         this.onChange();
-    }, TUI_ALLOW_SIGNAL_WRITES);
+    });
 
     public disabledItemHandler: TuiBooleanHandler<any> = (value) =>
         Array.isArray(value)

--- a/projects/kit/components/combo-box/combo-box.directive.ts
+++ b/projects/kit/components/combo-box/combo-box.directive.ts
@@ -9,7 +9,7 @@ import {
     untracked,
 } from '@angular/core';
 import {tuiAsControl, TuiControl} from '@taiga-ui/cdk/classes';
-import {TUI_ALLOW_SIGNAL_WRITES, TUI_STRICT_MATCHER} from '@taiga-ui/cdk/constants';
+import {TUI_STRICT_MATCHER} from '@taiga-ui/cdk/constants';
 import {type TuiStringMatcher} from '@taiga-ui/cdk/types';
 import {
     tuiAsOptionContent,
@@ -82,7 +82,7 @@ export class TuiComboBox<T>
         ) {
             this.onChange(this.textfield.value() || null);
         }
-    }, TUI_ALLOW_SIGNAL_WRITES);
+    });
 
     protected readonly matchingEffect = effect(() => {
         const options = this.options();
@@ -110,13 +110,13 @@ export class TuiComboBox<T>
                  */
                 (unchanged ? value : fallback),
         );
-    }, TUI_ALLOW_SIGNAL_WRITES);
+    });
 
     protected readonly newValueEffect = effect(() => {
         const stringified = this.stringify(this.value());
 
         this.textfield.value.update((x) => stringified || x);
-    }, TUI_ALLOW_SIGNAL_WRITES);
+    });
 
     protected readonly blurEffect = effect(() => {
         const incomplete = untracked(() => this.strict() && this.value() === null);
@@ -124,7 +124,7 @@ export class TuiComboBox<T>
         if (!this.host.focused() && incomplete) {
             this.textfield.value.set('');
         }
-    }, TUI_ALLOW_SIGNAL_WRITES);
+    });
 
     // TODO(v5): use signal input
     @Input('strict')

--- a/projects/kit/components/input-date-multi/input-date-multi.directive.ts
+++ b/projects/kit/components/input-date-multi/input-date-multi.directive.ts
@@ -3,7 +3,6 @@ import {toSignal} from '@angular/core/rxjs-interop';
 import {MaskitoDirective} from '@maskito/angular';
 import {maskitoDateOptionsGenerator} from '@maskito/kit';
 import {tuiAsControl} from '@taiga-ui/cdk/classes';
-import {TUI_ALLOW_SIGNAL_WRITES} from '@taiga-ui/cdk/constants';
 import {DATE_FILLER_LENGTH, TuiDay, TuiMonth} from '@taiga-ui/cdk/date-time';
 import {TuiNativeValidator} from '@taiga-ui/cdk/directives/native-validator';
 import {tuiFallbackValueProvider} from '@taiga-ui/cdk/tokens';
@@ -74,7 +73,7 @@ export class TuiInputDateMultiDirective extends TuiInputChipBaseDirective<TuiDay
         if (this.calendar()) {
             this.processCalendar(this.calendar()!);
         }
-    }, TUI_ALLOW_SIGNAL_WRITES);
+    });
 
     protected readonly calendarOut = effect((onCleanup) => {
         const subscription = this.calendar()?.dayClick.subscribe((day) => {

--- a/projects/kit/components/input-date/input-date.directive.ts
+++ b/projects/kit/components/input-date/input-date.directive.ts
@@ -11,7 +11,6 @@ import {toSignal} from '@angular/core/rxjs-interop';
 import {MaskitoDirective} from '@maskito/angular';
 import {type MaskitoDateMode, maskitoDateOptionsGenerator} from '@maskito/kit';
 import {tuiAsControl, TuiControl, tuiValueTransformerFrom} from '@taiga-ui/cdk/classes';
-import {TUI_ALLOW_SIGNAL_WRITES} from '@taiga-ui/cdk/constants';
 import {
     DATE_FILLER_LENGTH,
     type TuiDateMode,
@@ -101,13 +100,13 @@ export abstract class TuiInputDateBase<
             (this.filler().length === this.el.value.length ? '' : this.el.value);
 
         this.textfield.value.set(value);
-    }, TUI_ALLOW_SIGNAL_WRITES);
+    });
 
     protected readonly calendarIn = effect(() => {
         if (this.calendar()) {
             this.processCalendar(this.calendar()!);
         }
-    }, TUI_ALLOW_SIGNAL_WRITES);
+    });
 
     protected readonly calendarOut = effect((onCleanup) => {
         const subscription = this.calendar()?.valueChange.subscribe((value) =>

--- a/projects/kit/components/input-month-range/input-month-range.directive.ts
+++ b/projects/kit/components/input-month-range/input-month-range.directive.ts
@@ -1,7 +1,6 @@
 import {Directive, effect, inject, signal} from '@angular/core';
 import {toSignal} from '@angular/core/rxjs-interop';
 import {tuiAsControl, TuiControl, tuiValueTransformerFrom} from '@taiga-ui/cdk/classes';
-import {TUI_ALLOW_SIGNAL_WRITES} from '@taiga-ui/cdk/constants';
 import {
     RANGE_SEPARATOR_CHAR,
     type TuiMonth,
@@ -58,7 +57,7 @@ export class TuiInputMonthRangeDirective extends TuiControl<TuiMonthRange | null
             : '';
 
         this.textfield.value.set(string);
-    }, TUI_ALLOW_SIGNAL_WRITES);
+    });
 
     protected readonly calendarInit = effect(() => {
         const calendar = this.calendar();
@@ -70,12 +69,12 @@ export class TuiInputMonthRangeDirective extends TuiControl<TuiMonthRange | null
 
     protected readonly calendarSync = effect(() => {
         this.calendar()?.value.set(this.intermediateValue() ?? this.value());
-    }, TUI_ALLOW_SIGNAL_WRITES);
+    });
 
     // TODO: use linked signal (Angular 19+)
     protected readonly resetIntermediateValue = effect(() => {
         this.intermediateValue.set(this.value() && null);
-    }, TUI_ALLOW_SIGNAL_WRITES);
+    });
 
     protected onMonthClickEffect = effect((onCleanup) => {
         const subscription = this.calendar()?.monthClick.subscribe((month) => {

--- a/projects/kit/components/input-month/input-month.component.ts
+++ b/projects/kit/components/input-month/input-month.component.ts
@@ -7,7 +7,6 @@ import {
     signal,
     ViewEncapsulation,
 } from '@angular/core';
-import {TUI_ALLOW_SIGNAL_WRITES} from '@taiga-ui/cdk/constants';
 import {TUI_FIRST_DAY, TUI_LAST_DAY, TuiMonth} from '@taiga-ui/cdk/date-time';
 import {
     TuiTextfieldContent,
@@ -39,7 +38,7 @@ export class TuiInputMonthComponent {
             calendar.min.set(this.min() ?? TUI_FIRST_DAY); // TODO(v5): remove TUI_FIRST_DAY fallback
             calendar.max.set(this.max() ?? TUI_LAST_DAY); // TODO(v5): remove TUI_LAST_DAY fallback
         }
-    }, TUI_ALLOW_SIGNAL_WRITES);
+    });
 
     // TODO(v5): use signal inputs
     @Input('min')

--- a/projects/kit/components/input-month/input-month.directive.ts
+++ b/projects/kit/components/input-month/input-month.directive.ts
@@ -1,7 +1,6 @@
 import {computed, Directive, effect, inject} from '@angular/core';
 import {toSignal} from '@angular/core/rxjs-interop';
 import {tuiAsControl, TuiControl, tuiValueTransformerFrom} from '@taiga-ui/cdk/classes';
-import {TUI_ALLOW_SIGNAL_WRITES} from '@taiga-ui/cdk/constants';
 import {type TuiMonth} from '@taiga-ui/cdk/date-time';
 import {TUI_IS_MOBILE} from '@taiga-ui/cdk/tokens';
 import {
@@ -47,11 +46,11 @@ export class TuiInputMonthDirective extends TuiControl<TuiMonth | null> {
 
     protected readonly valueEffect = effect(() => {
         this.textfield.value.set(this.formatter()?.(this.value()) || '');
-    }, TUI_ALLOW_SIGNAL_WRITES);
+    });
 
     protected readonly calendarIn = effect(() => {
         this.calendar()?.value.set(this.value());
-    }, TUI_ALLOW_SIGNAL_WRITES);
+    });
 
     protected readonly calendarOut = effect((onCleanup) => {
         const subscription = this.calendar()?.monthClick.subscribe((month) => {

--- a/projects/kit/components/input-number/input-number.directive.ts
+++ b/projects/kit/components/input-number/input-number.directive.ts
@@ -17,7 +17,7 @@ import {
     maskitoParseNumber,
 } from '@maskito/kit';
 import {tuiAsControl, TuiControl, tuiValueTransformerFrom} from '@taiga-ui/cdk/classes';
-import {CHAR_HYPHEN, CHAR_MINUS, TUI_ALLOW_SIGNAL_WRITES} from '@taiga-ui/cdk/constants';
+import {CHAR_HYPHEN, CHAR_MINUS} from '@taiga-ui/cdk/constants';
 import {TUI_IS_IOS} from '@taiga-ui/cdk/tokens';
 import {tuiInjectElement} from '@taiga-ui/cdk/utils/dom';
 import {tuiIsSafeToRound} from '@taiga-ui/cdk/utils/math';
@@ -120,7 +120,7 @@ export class TuiInputNumberDirective extends TuiControl<number | null> {
         }
 
         this.onChange(value);
-    }, TUI_ALLOW_SIGNAL_WRITES);
+    });
 
     protected maskInitialCalibrationEffect = effect(() => {
         const options = maskitoNumberOptionsGenerator({
@@ -130,7 +130,7 @@ export class TuiInputNumberDirective extends TuiControl<number | null> {
         });
 
         this.textfield.value.update((x) => maskitoTransform(x, options));
-    }, TUI_ALLOW_SIGNAL_WRITES);
+    });
 
     public readonly min = computed(() => Math.min(this.minRaw(), this.maxRaw()));
     public readonly max = computed(() => Math.max(this.minRaw(), this.maxRaw()));

--- a/projects/kit/components/input-phone-international/input-phone-international.component.ts
+++ b/projects/kit/components/input-phone-international/input-phone-international.component.ts
@@ -24,12 +24,7 @@ import {
 } from '@maskito/core';
 import {maskitoGetCountryFromNumber, maskitoPhoneOptionsGenerator} from '@maskito/phone';
 import {tuiAsControl, TuiControl} from '@taiga-ui/cdk/classes';
-import {
-    CHAR_PLUS,
-    EMPTY_QUERY,
-    TUI_ALLOW_SIGNAL_WRITES,
-    TUI_DEFAULT_MATCHER,
-} from '@taiga-ui/cdk/constants';
+import {CHAR_PLUS, EMPTY_QUERY, TUI_DEFAULT_MATCHER} from '@taiga-ui/cdk/constants';
 import {TuiActiveZone} from '@taiga-ui/cdk/directives/active-zone';
 import {
     TuiAutoFocus,
@@ -123,7 +118,7 @@ export class TuiInputPhoneInternational extends TuiControl<string> {
 
     protected valueChangeEffect = effect(() => {
         this.onChange(this.unmask(this.masked()));
-    }, TUI_ALLOW_SIGNAL_WRITES);
+    });
 
     protected readonly filtered = computed(() =>
         this.countries()

--- a/projects/kit/components/input-phone/input-phone.directive.ts
+++ b/projects/kit/components/input-phone/input-phone.directive.ts
@@ -15,7 +15,6 @@ import {
 } from '@maskito/core';
 import {maskitoCaretGuard, maskitoPrefixPostprocessorGenerator} from '@maskito/kit';
 import {tuiAsControl, TuiControl, tuiValueTransformerFrom} from '@taiga-ui/cdk/classes';
-import {TUI_ALLOW_SIGNAL_WRITES} from '@taiga-ui/cdk/constants';
 import {tuiInjectElement} from '@taiga-ui/cdk/utils/dom';
 import {
     TuiTextfieldComponent,
@@ -60,7 +59,7 @@ export class TuiInputPhone extends TuiControl<string | null> {
         if (this.value()) {
             this.textfield.value.set(maskitoTransform(this.value() ?? '', this.mask()));
         }
-    }, TUI_ALLOW_SIGNAL_WRITES);
+    });
 
     protected readonly blurEffect = effect(() => {
         const incomplete = untracked(() => !this.value());
@@ -71,7 +70,7 @@ export class TuiInputPhone extends TuiControl<string | null> {
         } else if (this.host.focused() && prefix) {
             this.textfield.value.set(this.nonRemovablePrefix());
         }
-    }, TUI_ALLOW_SIGNAL_WRITES);
+    });
 
     protected readonly options = inject(TUI_INPUT_PHONE_OPTIONS);
     protected readonly el = tuiInjectElement<HTMLInputElement>();

--- a/projects/kit/components/input-slider/input-slider.directive.ts
+++ b/projects/kit/components/input-slider/input-slider.directive.ts
@@ -8,7 +8,6 @@ import {
     ViewEncapsulation,
 } from '@angular/core';
 import {TuiNonNullableValueTransformer, TuiValueTransformer} from '@taiga-ui/cdk/classes';
-import {TUI_ALLOW_SIGNAL_WRITES} from '@taiga-ui/cdk/constants';
 import {TUI_IS_MOBILE} from '@taiga-ui/cdk/tokens';
 import {tuiInjectElement} from '@taiga-ui/cdk/utils/dom';
 import {tuiClamp} from '@taiga-ui/cdk/utils/math';
@@ -89,7 +88,7 @@ export class TuiInputSliderDirective {
         }
 
         slider.el.disabled = !this.inputNumber.interactive();
-    }, TUI_ALLOW_SIGNAL_WRITES);
+    });
 
     protected readonly sliderInitEffect = effect((onCleanup) => {
         const slider = this.slider();

--- a/projects/kit/components/input-year/input-year.directive.ts
+++ b/projects/kit/components/input-year/input-year.directive.ts
@@ -2,7 +2,6 @@ import {computed, Directive, effect, inject, Input, signal} from '@angular/core'
 import {MaskitoDirective} from '@maskito/angular';
 import {maskitoNumberOptionsGenerator} from '@maskito/kit';
 import {tuiAsControl, TuiControl, tuiValueTransformerFrom} from '@taiga-ui/cdk/classes';
-import {TUI_ALLOW_SIGNAL_WRITES} from '@taiga-ui/cdk/constants';
 import {TuiCalendarYear} from '@taiga-ui/core/components/calendar';
 import {
     tuiInjectAuxiliary,
@@ -57,9 +56,8 @@ export class TuiInputYearDirective extends TuiControl<number | null> {
      * TODO: move to [value]="value()" after update to Angular 17+
      * something wrong with change detection on host binding
      */
-    protected readonly valueEffect = effect(
-        () => this.textfield.value.set(this.value()?.toString() ?? ''),
-        TUI_ALLOW_SIGNAL_WRITES,
+    protected readonly valueEffect = effect(() =>
+        this.textfield.value.set(this.value()?.toString() ?? ''),
     );
 
     protected readonly mask = tuiMaskito(
@@ -81,7 +79,7 @@ export class TuiInputYearDirective extends TuiControl<number | null> {
             calendar.min.set(this.min());
             calendar.max.set(this.max());
         }
-    }, TUI_ALLOW_SIGNAL_WRITES);
+    });
 
     protected readonly calendarOutEffect = effect((onCleanup) => {
         const subscription = this.calendar()?.yearClick.subscribe((year) => {

--- a/projects/kit/components/select/native-select/native-select.component.ts
+++ b/projects/kit/components/select/native-select/native-select.component.ts
@@ -9,7 +9,6 @@ import {
     signal,
 } from '@angular/core';
 import {tuiAsControl, TuiControl} from '@taiga-ui/cdk/classes';
-import {TUI_ALLOW_SIGNAL_WRITES} from '@taiga-ui/cdk/constants';
 import {tuiIsPresent} from '@taiga-ui/cdk/utils/miscellaneous';
 import {
     tuiAsTextfieldAccessor,
@@ -62,7 +61,7 @@ export class TuiNativeSelect<T>
 
     protected readonly valueEffect = effect(() => {
         this.textfield.value.set(this.stringified());
-    }, TUI_ALLOW_SIGNAL_WRITES);
+    });
 
     @Input()
     public items: ReadonlyArray<readonly T[]> | readonly T[] | null = [];

--- a/projects/kit/components/select/select.directive.ts
+++ b/projects/kit/components/select/select.directive.ts
@@ -1,6 +1,5 @@
 import {Directive, effect, inject} from '@angular/core';
 import {tuiAsControl, TuiControl} from '@taiga-ui/cdk/classes';
-import {TUI_ALLOW_SIGNAL_WRITES} from '@taiga-ui/cdk/constants';
 import {tuiIsPresent} from '@taiga-ui/cdk/utils/miscellaneous';
 import {tuiAsOptionContent} from '@taiga-ui/core/components/data-list';
 import {
@@ -46,7 +45,7 @@ export class TuiSelectDirective<T>
         const string = tuiIsPresent(value) ? this.itemsHandlers.stringify()(value) : '';
 
         this.textfield.value.set(string);
-    }, TUI_ALLOW_SIGNAL_WRITES);
+    });
 
     public setValue(value: T | null): void {
         this.onChange(value);


### PR DESCRIPTION
{allowSignalWrites: true} has been deprecated since v19, and since v19 is the minimum supported version, it’s safe to remove this utility.