### PR TITLE
fix(addon-doc): `tuiRawLoad` is incompatible with esbuild loaders

### DIFF
--- a/projects/addon-doc/utils/raw-load.ts
+++ b/projects/addon-doc/utils/raw-load.ts
@@ -1,5 +1,7 @@
 import {type TuiRawLoaderContent} from '@taiga-ui/addon-doc/types';
 
 export async function tuiRawLoad(content: TuiRawLoaderContent): Promise<string> {
-    return content instanceof Promise ? (await content).default : content;
+    return Promise.resolve(content).then((x) =>
+        typeof x === 'object' && 'default' in x ? x.default : x,
+    );
 }


### PR DESCRIPTION
Cherry-picked:
* https://github.com/taiga-family/taiga-ui/pull/12269

```ts
import { Component } from '@angular/core';
import { AsyncPipe } from '@angular/common';

@Component({
  selector: 'app-root',
  imports: [AsyncPipe],
  template: `
    <code><pre>{{raw | async}}</pre></code>
  `,
})
export class App {
  md = import('./example.md');
  raw = this.md.then((m) => m.default);
  isPromise = this.md instanceof Promise; // false

  constructor() {
    console.log(this.md.then((x) => x)); // ZoneAwarePromise
  }
}
```

https://stackblitz.com/edit/zone-aware-promise-instanceof-promise?file=src%2Fmain.ts