### PR TITLE
chore(demo): `llms-full.txt` remove control flow when parse description

### DIFF
--- a/projects/demo/scripts/llms/utils/file-system.ts
+++ b/projects/demo/scripts/llms/utils/file-system.ts
@@ -67,11 +67,21 @@ export function getComponentDescription(content: string): string | undefined {
 
     const templateContent = templateMatch[1];
 
-    const cleanContent = templateContent
-        ?.replaceAll(/<script[^>]*>[\s\S]*?<\/script>/gi, '')
+    // Remove control flow tags
+    const withoutControlFlow = (templateContent || '')
+        .split(/\n+/)
+        .filter(
+            (line) =>
+                !/^\s*@(?:for|if|switch|else|case|default|defer|empty)\b/.test(line),
+        )
+        .join('\n');
+
+    const cleanContent = withoutControlFlow
+        .replaceAll(/<script[^>]*>[\s\S]*?<\/script>/gi, '')
         .replaceAll(/<ng-template[^>]*>[\s\S]*?<\/ng-template>/gi, '')
         .replaceAll(/<((\/?)(p|div|ul|ol|li|code|a|button|tui-[^>]+))/gi, '<$1')
         .replaceAll(/<[^>]+>/g, '')
+        .replaceAll(/\s+/g, ' ')
         .trim();
 
     return cleanContent;


### PR DESCRIPTION
Removed `@for (example of examples; track example) {` from llms-full.txt

```
# components/AppBar
- **Package**: `LAYOUT`
- **Type**: components
Component for the main app header

        @for (example of examples; track example) {

### How to Use (Import)
```