### PR TITLE
chore: tui-chart-categorical update example

### DIFF
--- a/projects/demo/src/modules/components/axes/examples/2/index.html
+++ b/projects/demo/src/modules/components/axes/examples/2/index.html
@@ -24,7 +24,7 @@
         <p class="hint">
             <span
                 class="dot"
-                [style.background]="`var(--tui-chart-categorical-0${$index})`"
+                [style.background]="`var(--tui-chart-categorical-${$index.toString().padStart(2, '0')})`"
             ></span>
             <span class="name">{{ getSetName($index) }}</span>
             <span>{{ (item[setIndex] || 0) * 1000 | tuiAmount: 'RUB' | async }}</span>

--- a/projects/demo/src/modules/components/axes/examples/3/index.html
+++ b/projects/demo/src/modules/components/axes/examples/3/index.html
@@ -7,7 +7,7 @@
         @for (bar of value; track bar) {
             <tui-bar
                 size="m"
-                [style.background-color]="`var(--tui-chart-categorical-0${$index})`"
+                [style.background-color]="`var(--tui-chart-categorical-${$index.toString().padStart(2, '0')})`"
                 [style.height.%]="getHeight(bar)"
             />
         }

--- a/projects/demo/src/modules/components/legend-item/examples/1/index.html
+++ b/projects/demo/src/modules/components/legend-item/examples/1/index.html
@@ -13,7 +13,7 @@
                 size="s"
                 class="item"
                 [active]="isItemActive($index)"
-                [color]="`var(--tui-chart-categorical-0${$index})`"
+                [color]="`var(--tui-chart-categorical-${$index.toString().padStart(2, '0')})`"
                 [text]="label"
                 (tuiHoveredChange)="onHover($index, $event)"
             >

--- a/projects/demo/src/modules/components/legend-item/examples/2/index.html
+++ b/projects/demo/src/modules/components/legend-item/examples/2/index.html
@@ -15,7 +15,7 @@
             <tui-legend-item
                 #item
                 class="item"
-                [color]="`var(--tui-chart-categorical-0${$index})`"
+                [color]="`var(--tui-chart-categorical-${$index.toString().padStart(2, '0')})`"
                 [disabled]="!isEnabled($index)"
                 [text]="label"
                 (click)="onClick($index)"


### PR DESCRIPTION
updated a small example in the demo that generates colors so that more than 10 colors are displayed correctly.