### PR TITLE
refactor(kit): `InputNumber` uses signal inputs 

### DIFF
--- a/projects/kit/components/input-number/step/input-number-step.component.ts
+++ b/projects/kit/components/input-number/step/input-number-step.component.ts
@@ -4,7 +4,8 @@ import {
     Component,
     computed,
     inject,
-    input,
+    Input,
+    signal,
     ViewEncapsulation,
 } from '@angular/core';
 import {takeUntilDestroyed} from '@angular/core/rxjs-interop';
@@ -46,6 +47,7 @@ export class TuiInputNumberStep {
     protected readonly appearance = inject(TUI_TEXTFIELD_OPTIONS).appearance;
     protected readonly options = inject<TuiInputNumberOptions>(TUI_INPUT_NUMBER_OPTIONS);
     protected readonly input = inject(TuiInputNumberDirective, {self: true});
+    protected readonly step = signal(this.options.step);
     protected readonly value = computed(() => this.input.value() ?? NaN);
     protected readonly step$ = new Subject<number>();
     protected readonly doc = inject(DOCUMENT);
@@ -69,7 +71,11 @@ export class TuiInputNumberStep {
         )
         .subscribe((value) => this.onStep(value));
 
-    public readonly step = input(this.options.step);
+    // TODO(v5): replace with signal input
+    @Input('step')
+    public set stepSetter(x: number) {
+        this.step.set(x);
+    }
 
     protected onStep(step: number): void {
         const current = this.input.value() ?? 0;


### PR DESCRIPTION


Fixes # <!-- link to a relevant issue. -->
