### PR TITLE
chore: showcase `tuiCell` usage in dropdown example

### DIFF
--- a/projects/demo/src/modules/directives/dropdown/examples/1/index.html
+++ b/projects/demo/src/modules/directives/dropdown/examples/1/index.html
@@ -2,15 +2,30 @@
     tuiButton
     tuiChevron
     type="button"
+    [attr.aria-expanded]="open()"
     [tuiDropdown]="dropdownContent"
-    [tuiDropdownManual]="open"
-    [tuiObscuredEnabled]="open"
+    [tuiDropdownManual]="open()"
+    [tuiObscuredEnabled]="open()"
     (click)="onClick()"
     (tuiActiveZoneChange)="onActiveZone($event)"
     (tuiObscured)="onObscured($event)"
 >
-    Choose
+    {{ buttonLabel() }}
     <ng-template #dropdownContent>
-        <div class="dropdown">But there is nothing to choose...</div>
+        <tui-data-list>
+            @for (action of actions; track action.title) {
+                <button
+                    tuiCell
+                    tuiOption
+                    type="button"
+                    (click)="onSelect(action)"
+                >
+                    <span tuiTitle>
+                        {{ action.title }}
+                        <span tuiSubtitle>{{ action.description }}</span>
+                    </span>
+                </button>
+            }
+        </tui-data-list>
     </ng-template>
 </button>

--- a/projects/demo/src/modules/directives/dropdown/examples/1/index.less
+++ b/projects/demo/src/modules/directives/dropdown/examples/1/index.less
@@ -1,9 +1,6 @@
 @import '@taiga-ui/core/styles/taiga-ui-local';
 
-.dropdown {
-    font-size: 0.8125rem;
-    line-height: 1.25rem;
-    text-transform: uppercase;
-    letter-spacing: 0.075em;
-    padding: 0.25rem 0.75rem;
+tui-data-list {
+    gap: 0.25rem;
+    padding: 0.5rem;
 }

--- a/projects/demo/src/modules/directives/dropdown/examples/1/index.ts
+++ b/projects/demo/src/modules/directives/dropdown/examples/1/index.ts
@@ -1,31 +1,69 @@
-import {Component} from '@angular/core';
+import {Component, computed, signal} from '@angular/core';
 import {changeDetection} from '@demo/emulate/change-detection';
 import {encapsulation} from '@demo/emulate/encapsulation';
 import {TuiActiveZone, TuiObscured} from '@taiga-ui/cdk';
-import {TuiButton, TuiDropdown} from '@taiga-ui/core';
+import {TuiButton, TuiCell, TuiDataList, TuiDropdown, TuiTitle} from '@taiga-ui/core';
 import {TuiChevron} from '@taiga-ui/kit';
 
+interface ExampleAction {
+    readonly description: string;
+    readonly title: string;
+}
+
 @Component({
-    imports: [TuiActiveZone, TuiButton, TuiChevron, TuiDropdown, TuiObscured],
+    imports: [
+        TuiActiveZone,
+        TuiButton,
+        TuiCell,
+        TuiChevron,
+        TuiDataList,
+        TuiDropdown,
+        TuiObscured,
+        TuiTitle,
+    ],
     templateUrl: './index.html',
     styleUrl: './index.less',
     encapsulation,
     changeDetection,
 })
 export default class Example {
-    protected open = false;
+    protected readonly actions: readonly ExampleAction[] = [
+        {
+            title: 'Create task',
+            description: 'Draft a follow-up item for the team',
+        },
+        {
+            title: 'Schedule sync',
+            description: 'Find a 30-minute window for everyone',
+        },
+        {
+            title: 'Share update',
+            description: 'Post the latest progress to the channel',
+        },
+    ];
+
+    protected readonly open = signal(false);
+    protected readonly selected = signal<ExampleAction | null>(null);
+    protected readonly buttonLabel = computed(() => this.selected()?.title ?? 'Choose');
 
     protected onClick(): void {
-        this.open = !this.open;
+        this.open.update((open) => !open);
     }
 
     protected onObscured(obscured: boolean): void {
         if (obscured) {
-            this.open = false;
+            this.open.set(false);
         }
     }
 
     protected onActiveZone(active: boolean): void {
-        this.open = active && this.open;
+        if (!active) {
+            this.open.set(false);
+        }
+    }
+
+    protected onSelect(action: ExampleAction): void {
+        this.selected.set(action);
+        this.open.set(false);
     }
 }


### PR DESCRIPTION
## Summary
- replace the basic dropdown placeholder with a list of cell-styled actions using signals for state
- add unit and Playwright coverage ensuring the new tuiCell content renders
