### PR TITLE
chore: use relative asset paths

### DIFF
--- a/projects/demo/src/assets/site.webmanifest
+++ b/projects/demo/src/assets/site.webmanifest
@@ -3,12 +3,12 @@
     "short_name": "",
     "icons": [
         {
-            "src": "/assets/android-chrome-192x192.png",
+            "src": "./assets/android-chrome-192x192.png",
             "sizes": "192x192",
             "type": "image/png"
         },
         {
-            "src": "/assets/android-chrome-512x512.png",
+            "src": "./assets/android-chrome-512x512.png",
             "sizes": "512x512",
             "type": "image/png"
         }

--- a/projects/demo/src/modules/app/app.template.html
+++ b/projects/demo/src/modules/app/app.template.html
@@ -9,7 +9,7 @@
             @if (isChristmas) {
                 <img
                     alt="Santa hat"
-                    src="/assets/images/hat.svg"
+                    src="./assets/images/hat.svg"
                     class="app-christmas"
                 />
             }

--- a/projects/demo/src/modules/components/avatar/examples/1/index.html
+++ b/projects/demo/src/modules/components/avatar/examples/1/index.html
@@ -2,7 +2,7 @@
 <div tuiCell>
     <div tuiAvatar="@tui.user"></div>
     <div tuiAvatar="@img.mastercard"></div>
-    <div tuiAvatar="/assets/icons/nx.svg"></div>
+    <div tuiAvatar="./assets/icons/nx.svg"></div>
     <div tuiAvatar="UI"></div>
 </div>
 
@@ -12,11 +12,11 @@
         <picture>
             <source
                 media="(min-width: 600px)"
-                srcset="/assets/images/wisely.png"
+                srcset="./assets/images/wisely.png"
             />
             <img
                 alt="Alex Inkin"
-                src="/assets/images/avatar.jpg"
+                src="./assets/images/avatar.jpg"
             />
         </picture>
     </div>
@@ -28,7 +28,7 @@
             [muted]="true"
         >
             <source
-                src="/assets/media/bbb.mp4"
+                src="./assets/media/bbb.mp4"
                 type="video/mp4"
             />
         </video>

--- a/projects/demo/src/modules/components/avatar/examples/2/index.html
+++ b/projects/demo/src/modules/components/avatar/examples/2/index.html
@@ -20,6 +20,6 @@
 >
     <img
         alt=""
-        src="/assets/images/avatar.jpg"
+        src="./assets/images/avatar.jpg"
     />
 </div>

--- a/projects/demo/src/modules/components/avatar/examples/7/index.html
+++ b/projects/demo/src/modules/components/avatar/examples/7/index.html
@@ -11,7 +11,7 @@
 >
     <img
         alt="Alex Inkin"
-        src="/assets/images/avatar.jpg"
+        src="./assets/images/avatar.jpg"
     />
 </div>
 

--- a/projects/demo/src/modules/components/badged-content/examples/4/index.html
+++ b/projects/demo/src/modules/components/badged-content/examples/4/index.html
@@ -1,7 +1,7 @@
 <tui-badged-content>
     <img
         alt="icon"
-        src="/assets/images/angular.svg"
+        src="./assets/images/angular.svg"
         tuiSlot="top"
         width="24"
     />
@@ -14,7 +14,7 @@
 <tui-badged-content>
     <img
         alt="icon"
-        src="/assets/images/angular.svg"
+        src="./assets/images/angular.svg"
         tuiSlot="bottom"
         width="24"
     />

--- a/projects/demo/src/modules/components/block-status/examples/4/index.html
+++ b/projects/demo/src/modules/components/block-status/examples/4/index.html
@@ -34,7 +34,7 @@
     >
         <img
             alt="Alex Inkin"
-            src="/assets/images/avatar.jpg"
+            src="./assets/images/avatar.jpg"
             tuiSlot="top"
             class="avatar"
         />

--- a/projects/demo/src/modules/components/cell/examples/3/index.html
+++ b/projects/demo/src/modules/components/cell/examples/3/index.html
@@ -29,13 +29,13 @@
         <div tuiAvatar="@tui.user">
             <img
                 alt=""
-                src="/assets/images/avatar.jpg"
+                src="./assets/images/avatar.jpg"
             />
         </div>
         <div tuiAvatar="@tui.user">
             <img
                 alt=""
-                src="/assets/images/poorly.png"
+                src="./assets/images/poorly.png"
             />
         </div>
         <div tuiAvatar>+2</div>

--- a/projects/demo/src/modules/components/cell/examples/4/index.html
+++ b/projects/demo/src/modules/components/cell/examples/4/index.html
@@ -51,7 +51,7 @@
     <div tuiAvatar="@tui.user">
         <img
             alt=""
-            src="/assets/images/avatar.jpg"
+            src="./assets/images/avatar.jpg"
         />
     </div>
     <div tuiTitle>Salary</div>

--- a/projects/demo/src/modules/components/cell/examples/5/index.html
+++ b/projects/demo/src/modules/components/cell/examples/5/index.html
@@ -68,7 +68,7 @@
     >
         <img
             alt=""
-            src="/assets/images/avatar.jpg"
+            src="./assets/images/avatar.jpg"
         />
     </div>
     <div

--- a/projects/demo/src/modules/components/chip/examples/2/index.html
+++ b/projects/demo/src/modules/components/chip/examples/2/index.html
@@ -39,7 +39,7 @@
             @if (size === 'm' || size === 's') {
                 <img
                     alt="Avatar"
-                    src="/assets/images/avatar.jpg"
+                    src="./assets/images/avatar.jpg"
                     [style.border-radius.rem]="size === 'm' ? 0.25 : 0.5"
                 />
             }
@@ -61,7 +61,7 @@
                 >
                     <img
                         alt=""
-                        src="/assets/images/avatar.jpg"
+                        src="./assets/images/avatar.jpg"
                     />
                 </div>
             }

--- a/projects/demo/src/modules/components/chip/examples/6/index.html
+++ b/projects/demo/src/modules/components/chip/examples/6/index.html
@@ -10,7 +10,7 @@
     <span tuiAvatar="@tui.user">
         <img
             alt=""
-            src="/assets/images/avatar.jpg"
+            src="./assets/images/avatar.jpg"
         />
     </span>
     <div tuiFade>AI</div>

--- a/projects/demo/src/modules/components/icon/examples/5/index.ts
+++ b/projects/demo/src/modules/components/icon/examples/5/index.ts
@@ -18,7 +18,7 @@ import {TUI_ICON_RESOLVER, TuiIcon} from '@taiga-ui/core';
                 return (name: string) =>
                     name.startsWith('@tui.')
                         ? defaultResolver(name)
-                        : `/assets/icons/${name}.svg`;
+                        : `./assets/icons/${name}.svg`;
             },
         },
     ],

--- a/projects/demo/src/modules/components/input-search/examples/1/index.ts
+++ b/projects/demo/src/modules/components/input-search/examples/1/index.ts
@@ -46,7 +46,7 @@ const DATA: Record<string, readonly Result[]> = {
             title: 'Taiga UI',
             subtitle: 'Super awesome library',
             href: 'https://taiga-ui.dev',
-            icon: '/assets/images/taiga.svg',
+            icon: './assets/images/taiga.svg',
         },
         {
             title: 'Maskito',

--- a/projects/demo/src/modules/components/like/examples/3/index.ts
+++ b/projects/demo/src/modules/components/like/examples/3/index.ts
@@ -14,7 +14,7 @@ import {TuiLike, tuiLikeOptionsProvider} from '@taiga-ui/kit';
             icons: {
                 unchecked:
                     'https://raw.githubusercontent.com/MarsiBarsi/readme-icons/main/github.svg',
-                checked: '/assets/icons/github.svg',
+                checked: './assets/icons/github.svg',
             },
         }),
     ],

--- a/projects/demo/src/modules/components/message/examples/5/index.html
+++ b/projects/demo/src/modules/components/message/examples/5/index.html
@@ -5,7 +5,7 @@
     >
         <img
             alt=""
-            src="/assets/images/avatar.jpg"
+            src="./assets/images/avatar.jpg"
         />
     </div>
     <div tuiTitle>

--- a/projects/demo/src/modules/components/slides/examples/3/home.ts
+++ b/projects/demo/src/modules/components/slides/examples/3/home.ts
@@ -15,7 +15,7 @@ import {TuiCard} from '@taiga-ui/layout';
             <div tuiAvatar="@tui.user">
                 <img
                     alt=""
-                    src="/assets/images/avatar.jpg"
+                    src="./assets/images/avatar.jpg"
                 />
             </div>
             <div tuiTitle>

--- a/projects/demo/src/modules/components/surface/examples/4/index.html
+++ b/projects/demo/src/modules/components/surface/examples/4/index.html
@@ -10,7 +10,7 @@
         [muted]="true"
     >
         <source
-            src="/assets/media/bbb.mp4"
+            src="./assets/media/bbb.mp4"
             type="video/mp4"
         />
     </video>

--- a/projects/demo/src/modules/components/surface/examples/7/index.html
+++ b/projects/demo/src/modules/components/surface/examples/7/index.html
@@ -2,7 +2,7 @@
     tuiSurface
     type="button"
     class="card"
-    [style.background-image]="'url(/assets/images/tickets.svg)'"
+    [style.background-image]="'url(./assets/images/tickets.svg)'"
     [style.color]="'#d45d8c'"
 >
     <h3 class="heading">Tickets</h3>
@@ -19,7 +19,7 @@
     tuiSurface
     type="button"
     class="card"
-    [style.background-image]="'url(/assets/images/gas.svg)'"
+    [style.background-image]="'url(./assets/images/gas.svg)'"
     [style.color]="'#7caeff'"
 >
     <h3 class="heading">Gas</h3>
@@ -85,7 +85,7 @@
     <div tuiAvatar="@tui.user">
         <img
             alt=""
-            src="/assets/images/avatar.jpg"
+            src="./assets/images/avatar.jpg"
         />
     </div>
     <label tuiLabel="Taiga UI">Alex Inkin</label>
@@ -136,7 +136,7 @@
                         >
                             <img
                                 alt=""
-                                src="/assets/images/avatar.jpg"
+                                src="./assets/images/avatar.jpg"
                             />
                         </div>
                         <label tuiTitle>

--- a/projects/demo/src/modules/components/swipe-action/examples/2/index.html
+++ b/projects/demo/src/modules/components/swipe-action/examples/2/index.html
@@ -6,7 +6,7 @@
         <div tuiAvatar="@tui.user">
             <img
                 alt=""
-                src="/assets/images/avatar.jpg"
+                src="./assets/images/avatar.jpg"
             />
         </div>
         <h3 tuiTitle="m">Alex Inkin</h3>

--- a/projects/demo/src/modules/directives/dropdown/examples/2/index.html
+++ b/projects/demo/src/modules/directives/dropdown/examples/2/index.html
@@ -35,7 +35,7 @@ will gladly answer!
         >
             <img
                 alt=""
-                src="/assets/images/avatar.jpg"
+                src="./assets/images/avatar.jpg"
             />
         </div>
         <div class="text">

--- a/projects/demo/src/modules/directives/media/examples/1/index.html
+++ b/projects/demo/src/modules/directives/media/examples/1/index.html
@@ -9,11 +9,11 @@
 >
     <source
         *tuiHighDpi
-        src="/assets/media/bbb_dpi.ogv"
+        src="./assets/media/bbb_dpi.ogv"
         type="video/ogg"
     />
     <source
-        src="/assets/media/bbb.mp4"
+        src="./assets/media/bbb.mp4"
         type="video/mp4"
     />
 </video>

--- a/projects/demo/src/modules/directives/media/examples/2/index.html
+++ b/projects/demo/src/modules/directives/media/examples/2/index.html
@@ -9,7 +9,7 @@
         (click)="toggleState()"
     >
         <source
-            src="/assets/media/bbb.mp4"
+            src="./assets/media/bbb.mp4"
             type="video/mp4"
         />
     </video>

--- a/projects/demo/src/modules/directives/title/examples/3/index.html
+++ b/projects/demo/src/modules/directives/title/examples/3/index.html
@@ -31,7 +31,7 @@
     >
         <img
             alt=""
-            src="/assets/images/avatar.jpg"
+            src="./assets/images/avatar.jpg"
         />
     </div>
     <div tuiTitle="s">


### PR DESCRIPTION
## Summary
- replace root-relative asset links with relative ./assets references across demo HTML templates, styles, and scripts
- update the PWA manifest to load icons from ./assets instead of /assets
