### PR TITLE
chore(demo): stackblitz fails with `Could not find stylesheet file` for examples with `Less` tab

### DIFF
--- a/projects/demo/src/modules/app/classes/ts-file-component.parser.ts
+++ b/projects/demo/src/modules/app/classes/ts-file-component.parser.ts
@@ -20,10 +20,10 @@ export class TsFileComponentParser extends TsFileParser {
         );
     }
 
-    public set styleUrls(newUrls: string[] | readonly string[]) {
+    public set styleUrl(newUrl: string) {
         this.rawFileContent = this.rawFileContent.replaceAll(
-            /(styleUrls:\s)(\[.*\])/gi,
-            `$1${JSON.stringify(newUrls)}`,
+            /(styleUrl:\s['"`])(.*)(['"`])/gi,
+            `$1${newUrl}$3`,
         );
     }
 

--- a/projects/demo/src/modules/app/stackblitz/stackblitz.service.ts
+++ b/projects/demo/src/modules/app/stackblitz/stackblitz.service.ts
@@ -12,7 +12,7 @@ import {appPrefix, getSupportFiles, prepareLess, prepareSupportFiles} from './ut
 const APP_COMP_META = {
     SELECTOR: 'app',
     TEMPLATE_URL: './app.template.html',
-    STYLE_URLS: ['./app.style.less'],
+    STYLE_URL: './app.style.less',
     CLASS_NAME: 'App',
 } as const;
 
@@ -38,7 +38,7 @@ export class TuiStackblitzService implements TuiCodeEditor {
 
         appCompTs.selector = APP_COMP_META.SELECTOR;
         appCompTs.templateUrl = APP_COMP_META.TEMPLATE_URL;
-        appCompTs.styleUrls = APP_COMP_META.STYLE_URLS;
+        appCompTs.styleUrl = APP_COMP_META.STYLE_URL;
         appCompTs.className = APP_COMP_META.CLASS_NAME;
         appCompTs.defaultExport = false;
 


### PR DESCRIPTION
Open StackBlitz of any example with existing `Less` tab (e.g. https://taiga-ui.dev/next/components/button#sizes)

StackBlitz fails with error:
```
Error in src/app/app.component.ts (8:15)
Could not find stylesheet file './index.less'.
```

Relates:
* https://github.com/taiga-family/taiga-ui/pull/12192