### PR TITLE
fix(addon-charts): line-chart shouldn't re-render when it goes out of viewport

### DIFF
--- a/projects/addon-charts/components/line-chart/line-chart.component.ts
+++ b/projects/addon-charts/components/line-chart/line-chart.component.ts
@@ -29,7 +29,7 @@ import {
 } from '@taiga-ui/core/directives/hint';
 import {type TuiPoint} from '@taiga-ui/core/types';
 import {type PolymorpheusContent} from '@taiga-ui/polymorpheus';
-import {distinctUntilChanged, map, type Observable, Subject} from 'rxjs';
+import {distinctUntilChanged, filter, map, type Observable, Subject} from 'rxjs';
 
 import {TUI_LINE_CHART_OPTIONS} from './line-chart.options';
 import {TuiLineChartHint} from './line-chart-hint.directive';
@@ -54,9 +54,10 @@ export class TuiLineChart implements OnChanges {
     private readonly autoId = tuiInjectId();
     private readonly resize = toSignal(
         inject(ResizeObserverService, {self: true}).pipe(
-            map(([e]) => e?.contentRect.height || 0),
+            map(([e]) => e?.contentRect.height || NaN),
+            filter((height) => !Number.isNaN(height)),
         ),
-        {initialValue: 0},
+        {initialValue: NaN},
     );
 
     private readonly box = signal('');
@@ -64,6 +65,10 @@ export class TuiLineChart implements OnChanges {
     protected readonly hintDirective = inject(TuiLineChartHint, {optional: true});
     protected readonly hintOptions = inject(TuiHintOptionsDirective, {optional: true});
     protected readonly viewBox = computed(() => {
+        if (Number.isNaN(this.resize())) {
+            return '0 0 0 0';
+        }
+
         const offset = this.height / Math.max(this.resize(), 1);
         const [x = 0, y = 0, width = 0, height = 0] = this.box().split(' ').map(Number);
 

--- a/projects/demo-playwright/tests/addon-charts/line-chart/line-chart.pw.spec.ts
+++ b/projects/demo-playwright/tests/addon-charts/line-chart/line-chart.pw.spec.ts
@@ -12,4 +12,19 @@ test.describe('LineChart', () => {
 
         await expect.soft(example).toHaveScreenshot('01-line-chart.png');
     });
+
+    test("shouldn't re-render when it goes out of the viewport", async ({page}) => {
+        await tuiGoto(page, `${DemoRoute.LineChart}#line`);
+        const documentationPage = new TuiDocumentationPagePO(page);
+        const example = documentationPage.getExample('#line');
+        const tabs = page.locator('#line button[tuiTab]');
+
+        await expect.soft(example).toHaveScreenshot('02-line-chart.png');
+
+        await tabs.filter({hasText: 'HTML'}).click();
+        await page.waitForTimeout(1000);
+        await tabs.filter({hasText: 'Preview'}).click();
+
+        await expect.soft(example).toHaveScreenshot('03-line-chart.png');
+    });
 });


### PR DESCRIPTION
### Before


https://github.com/user-attachments/assets/fe48d772-1816-4cf5-af71-cb4f6fe2ff93

### Before

