### PR TITLE
chore: remove redundant standalone flags

### DIFF
--- a/projects/addon-charts/components/axes/test/axes.component.spec.ts
+++ b/projects/addon-charts/components/axes/test/axes.component.spec.ts
@@ -5,7 +5,6 @@ import {CHAR_NO_BREAK_SPACE} from '@taiga-ui/cdk';
 
 describe('Axes', () => {
     @Component({
-        standalone: true,
         imports: [TuiAxes],
         template: `
             <tui-axes #defaultValues />

--- a/projects/addon-charts/components/bar-chart/test/bar-chart.component.spec.ts
+++ b/projects/addon-charts/components/bar-chart/test/bar-chart.component.spec.ts
@@ -4,7 +4,6 @@ import {TuiBarChart} from '@taiga-ui/addon-charts';
 
 describe('BarChart', () => {
     @Component({
-        standalone: true,
         imports: [TuiBarChart],
         template: `
             <tui-bar-chart

--- a/projects/addon-charts/components/bar-set/test/bar-set.component.spec.ts
+++ b/projects/addon-charts/components/bar-set/test/bar-set.component.spec.ts
@@ -5,7 +5,6 @@ import {TuiBarSet} from '@taiga-ui/addon-charts';
 
 describe('BarSet', () => {
     @Component({
-        standalone: true,
         imports: [TuiBarSet],
         template: `
             <tui-bar-set

--- a/projects/addon-charts/components/line-chart/line-chart-hint.directive.ts
+++ b/projects/addon-charts/components/line-chart/line-chart-hint.directive.ts
@@ -32,7 +32,6 @@ import {
 import {TuiLineChart} from './line-chart.component';
 
 @Directive({
-    standalone: true,
     selector: '[tuiLineChartHint]',
     providers: [TuiHoveredService],
 })

--- a/projects/addon-charts/components/line-days-chart/line-days-chart-hint.directive.ts
+++ b/projects/addon-charts/components/line-days-chart/line-days-chart-hint.directive.ts
@@ -29,7 +29,6 @@ function find(value: ReadonlyArray<[TuiDay, number]>, current: TuiDay): [TuiDay,
 
 // TODO: Consider extending TuiLineChartHintDirective
 @Directive({
-    standalone: true,
     selector: '[tuiLineChartHint]',
     providers: [TuiHoveredService],
 })

--- a/projects/addon-charts/components/pie-chart/pie-chart.directive.ts
+++ b/projects/addon-charts/components/pie-chart/pie-chart.directive.ts
@@ -11,7 +11,6 @@ import {tuiGetDuration} from '@taiga-ui/core/utils/miscellaneous';
 import {BehaviorSubject, map, pairwise, switchMap, takeWhile} from 'rxjs';
 
 @Directive({
-    standalone: true,
     selector: 'path[tuiPieChart]',
 })
 export class TuiPieChartDirective {

--- a/projects/addon-charts/components/pie-chart/test/pie-chart.component.spec.ts
+++ b/projects/addon-charts/components/pie-chart/test/pie-chart.component.spec.ts
@@ -6,7 +6,6 @@ import {TuiPageObject} from '@taiga-ui/testing';
 
 describe('PieChart', () => {
     @Component({
-        standalone: true,
         imports: [TuiPieChart],
         template: `
             <tui-pie-chart [value]="value" />

--- a/projects/addon-commerce/components/input-card-group/test/input-card-group.component.spec.ts
+++ b/projects/addon-commerce/components/input-card-group/test/input-card-group.component.spec.ts
@@ -9,7 +9,6 @@ import {firstValueFrom, timer} from 'rxjs';
 
 describe('InputCardGroup', () => {
     @Component({
-        standalone: true,
         imports: [ReactiveFormsModule, TuiIcon, TuiInputCardGroup],
         template: `
             <tui-input-card-group

--- a/projects/addon-commerce/components/input-cvc/input-cvc.directive.ts
+++ b/projects/addon-commerce/components/input-cvc/input-cvc.directive.ts
@@ -5,7 +5,6 @@ import {TuiWithTextfield} from '@taiga-ui/core/components/textfield';
 import {tuiMaskito} from '@taiga-ui/kit/utils';
 
 @Directive({
-    standalone: true,
     selector: 'input[tuiInputCVC]',
     hostDirectives: [MaskitoDirective, TuiWithTextfield],
     host: {

--- a/projects/addon-commerce/components/input-expire/input-expire.directive.ts
+++ b/projects/addon-commerce/components/input-expire/input-expire.directive.ts
@@ -5,7 +5,6 @@ import {TuiWithTextfield} from '@taiga-ui/core/components/textfield';
 import {tuiMaskito} from '@taiga-ui/kit/utils';
 
 @Directive({
-    standalone: true,
     selector: 'input[tuiInputExpire]',
     hostDirectives: [MaskitoDirective, TuiWithTextfield],
     host: {

--- a/projects/addon-commerce/pipes/amount/amount.pipe.ts
+++ b/projects/addon-commerce/pipes/amount/amount.pipe.ts
@@ -12,7 +12,7 @@ import {tuiFormatSignSymbol} from './amount.utils';
 
 const DEFAULT_PRECISION = 2;
 
-@Pipe({standalone: true, name: 'tuiAmount'})
+@Pipe({name: 'tuiAmount'})
 export class TuiAmountPipe implements PipeTransform {
     private readonly options = inject(TUI_AMOUNT_OPTIONS);
     private readonly format = inject(TUI_NUMBER_FORMAT);

--- a/projects/addon-commerce/pipes/currency/currency.pipe.ts
+++ b/projects/addon-commerce/pipes/currency/currency.pipe.ts
@@ -3,7 +3,6 @@ import {type TuiCurrencyVariants} from '@taiga-ui/addon-commerce/types';
 import {tuiFormatCurrency} from '@taiga-ui/addon-commerce/utils';
 
 @Pipe({
-    standalone: true,
     name: 'tuiCurrency',
 })
 export class TuiCurrencyPipe implements PipeTransform {

--- a/projects/addon-commerce/pipes/decimal/decimal.pipe.ts
+++ b/projects/addon-commerce/pipes/decimal/decimal.pipe.ts
@@ -4,7 +4,7 @@ import {type TuiCurrencyVariants} from '@taiga-ui/addon-commerce/types';
 import {TUI_NUMBER_FORMAT} from '@taiga-ui/core/tokens';
 import {map, type Observable, switchMap} from 'rxjs';
 
-@Pipe({standalone: true, name: 'tuiDecimal'})
+@Pipe({name: 'tuiDecimal'})
 export class TuiDecimalPipe implements PipeTransform {
     private readonly format = inject(TUI_NUMBER_FORMAT);
     private readonly amountPipe = Injector.create({

--- a/projects/addon-commerce/pipes/format-card/format-card.pipe.ts
+++ b/projects/addon-commerce/pipes/format-card/format-card.pipe.ts
@@ -2,7 +2,6 @@ import {Pipe, type PipeTransform} from '@angular/core';
 import {CHAR_NO_BREAK_SPACE} from '@taiga-ui/cdk/constants';
 
 @Pipe({
-    standalone: true,
     name: 'tuiFormatCard',
 })
 export class TuiFormatCardPipe implements PipeTransform {

--- a/projects/addon-doc/components/api/api-item-number.directive.ts
+++ b/projects/addon-doc/components/api/api-item-number.directive.ts
@@ -1,7 +1,6 @@
 import {Directive, Input} from '@angular/core';
 
 @Directive({
-    standalone: true,
     selector: 'tr[tuiDocAPIItem][type=number]',
 })
 export class TuiDocAPINumberItem {

--- a/projects/addon-doc/components/api/api.component.ts
+++ b/projects/addon-doc/components/api/api.component.ts
@@ -7,7 +7,6 @@ import {
 import {TUI_DOC_DOCUMENTATION_TEXTS} from '@taiga-ui/addon-doc/tokens';
 
 @Component({
-    standalone: true,
     selector: 'table[tuiDocAPI]',
     templateUrl: './api.template.html',
     styleUrl: './api.style.less',

--- a/projects/addon-doc/components/doc-tab/index.ts
+++ b/projects/addon-doc/components/doc-tab/index.ts
@@ -1,7 +1,6 @@
 import {ChangeDetectionStrategy, Component, Input} from '@angular/core';
 
 @Component({
-    standalone: true,
     selector: 'tui-doc-tab',
     templateUrl: './index.html',
     styleUrl: './index.less',

--- a/projects/addon-doc/components/documentation/documentation-property-connector.directive.ts
+++ b/projects/addon-doc/components/documentation/documentation-property-connector.directive.ts
@@ -23,7 +23,6 @@ export type TuiDocumentationPropertyType = 'input-output' | 'input' | 'output' |
 
 // @bad TODO: refactor output and value sync
 @Directive({
-    standalone: true,
     selector: 'ng-template[documentationPropertyName]',
     exportAs: 'documentationProperty',
 })

--- a/projects/addon-doc/components/documentation/pipes/cleaner.pipe.ts
+++ b/projects/addon-doc/components/documentation/pipes/cleaner.pipe.ts
@@ -1,7 +1,6 @@
 import {Pipe, type PipeTransform} from '@angular/core';
 
 @Pipe({
-    standalone: true,
     name: 'tuiShowCleanerPipe',
 })
 export class TuiShowCleanerPipe implements PipeTransform {

--- a/projects/addon-doc/components/documentation/pipes/color.pipe.ts
+++ b/projects/addon-doc/components/documentation/pipes/color.pipe.ts
@@ -2,7 +2,6 @@ import {Pipe, type PipeTransform} from '@angular/core';
 import {tuiRgbToHex} from '@taiga-ui/cdk/utils/color';
 
 @Pipe({
-    standalone: true,
     name: 'tuiGetColorPipe',
 })
 export class TuiGetColorPipe implements PipeTransform {

--- a/projects/addon-doc/components/documentation/pipes/inspect.pipe.ts
+++ b/projects/addon-doc/components/documentation/pipes/inspect.pipe.ts
@@ -3,7 +3,6 @@ import {tuiInspectAny} from '@taiga-ui/addon-doc/utils';
 import {TUI_IS_E2E} from '@taiga-ui/cdk/tokens';
 
 @Pipe({
-    standalone: true,
     name: 'tuiInspectAny',
 })
 export class TuiInspectPipe implements PipeTransform {

--- a/projects/addon-doc/components/documentation/pipes/opacity.pipe.ts
+++ b/projects/addon-doc/components/documentation/pipes/opacity.pipe.ts
@@ -1,7 +1,6 @@
 import {Pipe, type PipeTransform} from '@angular/core';
 
 @Pipe({
-    standalone: true,
     name: 'tuiGetOpacity',
 })
 export class TuiGetOpacityPipe implements PipeTransform {

--- a/projects/addon-doc/components/documentation/pipes/optional.pipe.ts
+++ b/projects/addon-doc/components/documentation/pipes/optional.pipe.ts
@@ -1,7 +1,6 @@
 import {Pipe, type PipeTransform} from '@angular/core';
 
 @Pipe({
-    standalone: true,
     name: 'tuiIsOptionalPipe',
 })
 export class TuiIsOptionalPipe implements PipeTransform {

--- a/projects/addon-doc/components/documentation/pipes/primitive-polymorpheus-content.pipe.ts
+++ b/projects/addon-doc/components/documentation/pipes/primitive-polymorpheus-content.pipe.ts
@@ -2,7 +2,6 @@ import {Pipe, type PipeTransform} from '@angular/core';
 import {tuiIsNumber, tuiIsString} from '@taiga-ui/cdk/utils/miscellaneous';
 
 @Pipe({
-    standalone: true,
     name: 'tuiIsPrimitivePolymorpheusContentPipe',
 })
 export class TuiIsPrimitivePolymorpheusContentPipe implements PipeTransform {

--- a/projects/addon-doc/components/documentation/pipes/strip-optional.pipe.ts
+++ b/projects/addon-doc/components/documentation/pipes/strip-optional.pipe.ts
@@ -1,7 +1,6 @@
 import {Pipe, type PipeTransform} from '@angular/core';
 
 @Pipe({
-    standalone: true,
     name: 'tuiStripOptionalPipe',
 })
 export class TuiStripOptionalPipe implements PipeTransform {

--- a/projects/addon-doc/components/documentation/pipes/type-reference.pipe.ts
+++ b/projects/addon-doc/components/documentation/pipes/type-reference.pipe.ts
@@ -5,7 +5,6 @@ import {
 } from '@taiga-ui/addon-doc/tokens';
 
 @Pipe({
-    standalone: true,
     name: 'tuiDocTypeReference',
 })
 export class TuiDocTypeReferencePipe implements PipeTransform {

--- a/projects/addon-doc/components/example/example-get-tabs.pipe.ts
+++ b/projects/addon-doc/components/example/example-get-tabs.pipe.ts
@@ -1,7 +1,6 @@
 import {Pipe, type PipeTransform} from '@angular/core';
 
 @Pipe({
-    standalone: true,
     name: 'tuiDocExampleGetTabs',
 })
 export class TuiDocExampleGetTabsPipe implements PipeTransform {

--- a/projects/addon-doc/components/navigation/scroll-into-view.directive.ts
+++ b/projects/addon-doc/components/navigation/scroll-into-view.directive.ts
@@ -6,7 +6,6 @@ import {tuiGetElementObscures, tuiInjectElement} from '@taiga-ui/cdk/utils/dom';
 import {debounceTime, filter, ReplaySubject, switchMap, take} from 'rxjs';
 
 @Directive({
-    standalone: true,
     selector: '[tuiDocScrollIntoViewLink]',
 })
 export class TuiDocScrollIntoViewLink {

--- a/projects/addon-doc/components/page/page-tab.directive.ts
+++ b/projects/addon-doc/components/page/page-tab.directive.ts
@@ -1,7 +1,6 @@
 import {Directive, inject, Input, TemplateRef} from '@angular/core';
 
 @Directive({
-    standalone: true,
     selector: 'ng-template[pageTab]',
 })
 export class TuiDocPageTabConnector {

--- a/projects/addon-doc/directives/text-code/text-code.directive.ts
+++ b/projects/addon-doc/directives/text-code/text-code.directive.ts
@@ -4,7 +4,6 @@ import {Directive, Input} from '@angular/core';
  * @deprecated: use [textContent]="code"
  */
 @Directive({
-    standalone: true,
     selector: 'code[tuiDocText]',
     host: {
         '[textContent]': 'code',

--- a/projects/addon-mobile/components/mobile-calendar-dropdown/mobile-calendar-dropdown.directive.ts
+++ b/projects/addon-mobile/components/mobile-calendar-dropdown/mobile-calendar-dropdown.directive.ts
@@ -14,7 +14,6 @@ import {TuiMobileCalendarDropdown} from './mobile-calendar-dropdown.component';
 
 // TODO: Rename to TuiMobileCalendarDropdown in v5
 @Directive({
-    standalone: true,
     selector: '[tuiMobileCalendar]',
     providers: [
         {

--- a/projects/addon-mobile/components/mobile-dialog/test/mobile-dialog.component.spec.ts
+++ b/projects/addon-mobile/components/mobile-dialog/test/mobile-dialog.component.spec.ts
@@ -9,7 +9,6 @@ import {TuiPageObject} from '@taiga-ui/testing';
 
 describe('Mobile Dialog with TUI_MOBILE_DIALOG_OPTIONS', () => {
     @Component({
-        standalone: true,
         imports: [TuiRoot],
         template: `
             <tui-root />

--- a/projects/addon-mobile/components/swipe-action/swipe-actions-auto-close.directive.ts
+++ b/projects/addon-mobile/components/swipe-action/swipe-actions-auto-close.directive.ts
@@ -2,7 +2,6 @@ import {Directive, Input} from '@angular/core';
 import {tuiGetActualTarget, tuiInjectElement} from '@taiga-ui/cdk/utils/dom';
 
 @Directive({
-    standalone: true,
     selector: 'tui-swipe-actions[autoClose]',
     host: {
         '(document:pointerdown.zoneless)': 'handleEvent($event)',

--- a/projects/addon-mobile/components/tab-bar/tab-bar-item.directive.ts
+++ b/projects/addon-mobile/components/tab-bar/tab-bar-item.directive.ts
@@ -8,7 +8,6 @@ import {EMPTY, filter, type Observable} from 'rxjs';
 import {TuiTabBarComponent} from './tab-bar.component';
 
 @Directive({
-    standalone: true,
     selector: '[tuiTabBarItem][routerLinkActive]',
 })
 export class TuiTabBarItemDirective {

--- a/projects/addon-mobile/directives/elastic-sticky/elastic-sticky.directive.ts
+++ b/projects/addon-mobile/directives/elastic-sticky/elastic-sticky.directive.ts
@@ -3,7 +3,6 @@ import {Directive, inject, Output} from '@angular/core';
 import {TuiElasticStickyService} from './elastic-sticky.service';
 
 @Directive({
-    standalone: true,
     selector: '[tuiElasticSticky]',
     providers: [TuiElasticStickyService],
     exportAs: 'tuiElasticSticky',

--- a/projects/addon-mobile/directives/responsive-dialog/responsive-dialog.directive.ts
+++ b/projects/addon-mobile/directives/responsive-dialog/responsive-dialog.directive.ts
@@ -8,7 +8,6 @@ import {
 } from './responsive-dialog.service';
 
 @Directive({
-    standalone: true,
     selector: 'ng-template[tuiResponsiveDialog]',
     inputs: ['options: tuiResponsiveDialogOptions', 'open: tuiResponsiveDialog'],
     outputs: ['openChange: tuiResponsiveDialogChange'],

--- a/projects/addon-mobile/directives/touchable/touchable.directive.ts
+++ b/projects/addon-mobile/directives/touchable/touchable.directive.ts
@@ -22,7 +22,6 @@ export function tuiFindTouchIndex(touches: TouchList, id: number): number {
 }
 
 @Directive({
-    standalone: true,
     selector: '[tuiTouchable]',
 })
 export class TuiTouchable {

--- a/projects/addon-table/components/table-pagination/test/table-pagination.component.spec.ts
+++ b/projects/addon-table/components/table-pagination/test/table-pagination.component.spec.ts
@@ -7,7 +7,6 @@ describe('TablePagination', () => {
     let testComponent: Test;
 
     @Component({
-        standalone: true,
         imports: [TuiTablePagination],
         template: `
             <tui-table-pagination

--- a/projects/addon-table/components/table/caption/caption.component.ts
+++ b/projects/addon-table/components/table/caption/caption.component.ts
@@ -1,7 +1,6 @@
 import {ChangeDetectionStrategy, Component, ViewEncapsulation} from '@angular/core';
 
 @Component({
-    standalone: true,
     selector: 'caption[tuiCaption]',
     template: '<ng-content/>',
     styleUrl: './caption.style.less',

--- a/projects/addon-table/components/table/directives/cell.directive.ts
+++ b/projects/addon-table/components/table/directives/cell.directive.ts
@@ -1,7 +1,6 @@
 import {Directive, inject, Input, TemplateRef} from '@angular/core';
 
 @Directive({
-    standalone: true,
     selector: 'ng-template[tuiCell]',
 })
 export class TuiTableCell {

--- a/projects/addon-table/components/table/directives/direction-order.directive.ts
+++ b/projects/addon-table/components/table/directives/direction-order.directive.ts
@@ -5,7 +5,6 @@ import {TuiSortDirection} from '../table.options';
 import {TuiTableDirective} from './table.directive';
 
 @Directive({
-    standalone: true,
     selector: 'table[tuiTable][tuiDirectionOrder]',
 })
 export class TuiTableDirectionOrder<T> {

--- a/projects/addon-table/components/table/directives/head.directive.ts
+++ b/projects/addon-table/components/table/directives/head.directive.ts
@@ -1,7 +1,6 @@
 import {Directive, inject, Input, TemplateRef} from '@angular/core';
 
 @Directive({
-    standalone: true,
     selector: '[tuiHead]',
 })
 export class TuiTableHead<T extends Partial<Record<keyof T, unknown>>> {

--- a/projects/addon-table/components/table/directives/resized.directive.ts
+++ b/projects/addon-table/components/table/directives/resized.directive.ts
@@ -6,7 +6,6 @@ import {tuiInjectElement} from '@taiga-ui/cdk/utils/dom';
 import {distinctUntilChanged, map, switchMap, takeUntil} from 'rxjs';
 
 @Directive({
-    standalone: true,
     selector: '[tuiResized]',
 })
 export class TuiTableResized {

--- a/projects/addon-table/components/table/directives/sort-by.directive.ts
+++ b/projects/addon-table/components/table/directives/sort-by.directive.ts
@@ -15,7 +15,6 @@ import {TuiTableSortable} from './sortable.directive';
 import {TuiTableDirective} from './table.directive';
 
 @Directive({
-    standalone: true,
     selector: 'table[tuiTable][tuiSortBy]',
 })
 export class TuiTableSortBy<T extends Partial<Record<keyof T, unknown>>> {

--- a/projects/addon-table/components/table/directives/sortable.directive.ts
+++ b/projects/addon-table/components/table/directives/sortable.directive.ts
@@ -7,7 +7,6 @@ import {TuiTableSortBy} from './sort-by.directive';
 import {TuiTableDirective} from './table.directive';
 
 @Directive({
-    standalone: true,
     selector: 'th[tuiTh][tuiSortable]',
 })
 export class TuiTableSortable<T extends Partial<Record<keyof T, unknown>>>

--- a/projects/addon-table/components/table/directives/stuck.directive.ts
+++ b/projects/addon-table/components/table/directives/stuck.directive.ts
@@ -9,7 +9,6 @@ import {catchError, distinctUntilChanged, EMPTY, map} from 'rxjs';
 
 // TODO: Consider making universal and moving to CDK
 @Directive({
-    standalone: true,
     selector: 'tui-stuck:never',
     providers: [
         IntersectionObserverService,

--- a/projects/addon-table/components/table/directives/test/direction-order.directive.spec.ts
+++ b/projects/addon-table/components/table/directives/test/direction-order.directive.spec.ts
@@ -4,7 +4,6 @@ import {TuiSortDirection, TuiTable, TuiTableDirective} from '@taiga-ui/addon-tab
 
 describe('TuiDirectionOrder directive', () => {
     @Component({
-        standalone: true,
         imports: [TuiTable],
         template: `
             <table

--- a/projects/addon-table/components/table/directives/thead.directive.ts
+++ b/projects/addon-table/components/table/directives/thead.directive.ts
@@ -4,7 +4,6 @@ import {WA_INTERSECTION_ROOT_MARGIN} from '@ng-web-apis/intersection-observer';
 import {TuiStuck} from './stuck.directive';
 
 @Directive({
-    standalone: true,
     selector: 'thead[tuiThead]',
     providers: [
         {

--- a/projects/addon-table/components/table/pipes/table-sort.pipe.ts
+++ b/projects/addon-table/components/table/pipes/table-sort.pipe.ts
@@ -6,7 +6,6 @@ import {TuiTableDirective} from '../directives/table.directive';
 import {type TuiSortDirection} from '../table.options';
 
 @Pipe({
-    standalone: true,
     name: 'tuiTableSort',
     pure: false,
 })

--- a/projects/addon-table/components/table/table-expand/table-expand.component.ts
+++ b/projects/addon-table/components/table/table-expand/table-expand.component.ts
@@ -20,7 +20,6 @@ import {map, of, Subject, switchMap, timer} from 'rxjs';
 import {TUI_TABLE_OPTIONS} from '../table.options';
 
 @Component({
-    standalone: true,
     selector: 'tui-table-expand',
     templateUrl: './table-expand.template.html',
     styleUrl: './table-expand.style.less',

--- a/projects/addon-table/components/table/td/td.component.ts
+++ b/projects/addon-table/components/table/td/td.component.ts
@@ -3,7 +3,6 @@ import {TuiControl} from '@taiga-ui/cdk/classes';
 import {TuiTextfieldComponent} from '@taiga-ui/core/components/textfield';
 
 @Component({
-    standalone: true,
     selector: 'th[tuiTd], td[tuiTd]',
     template: '<ng-content />',
     styleUrl: './td.style.less',

--- a/projects/addon-table/directives/table-control/checkbox-row.directive.ts
+++ b/projects/addon-table/directives/table-control/checkbox-row.directive.ts
@@ -12,7 +12,6 @@ import {tuiArrayToggle} from '@taiga-ui/cdk/utils/miscellaneous';
 import {TuiTableControlDirective} from './table-control.directive';
 
 @Directive({
-    standalone: true,
     selector: '[tuiCheckbox][tuiCheckboxRow]',
     providers: [{provide: NgControl, useClass: NgModel}],
     host: {

--- a/projects/addon-table/directives/table-control/checkbox-table.directive.ts
+++ b/projects/addon-table/directives/table-control/checkbox-table.directive.ts
@@ -5,7 +5,6 @@ import {tuiInjectElement} from '@taiga-ui/cdk/utils/dom';
 import {TuiTableControlDirective} from './table-control.directive';
 
 @Directive({
-    standalone: true,
     selector: '[tuiCheckbox][tuiCheckboxTable]',
     providers: [{provide: NgControl, useClass: NgModel}],
     host: {'(change)': 'parent.toggleAll()'},

--- a/projects/addon-table/directives/table-control/table-control.directive.ts
+++ b/projects/addon-table/directives/table-control/table-control.directive.ts
@@ -6,7 +6,6 @@ import {tuiArrayToggle} from '@taiga-ui/cdk/utils/miscellaneous';
 import {type TuiCheckboxRowDirective} from './checkbox-row.directive';
 
 @Directive({
-    standalone: true,
     selector: '[tuiTable][ngModel],[tuiTable][formControl],[tuiTable][formControlName]',
     providers: [tuiFallbackValueProvider([])],
 })

--- a/projects/addon-table/directives/table-filters/generic-filter.directive.ts
+++ b/projects/addon-table/directives/table-filters/generic-filter.directive.ts
@@ -5,7 +5,6 @@ import {tuiProvide} from '@taiga-ui/cdk/utils/miscellaneous';
 import {AbstractTuiTableFilter} from './abstract-table-filter';
 
 @Directive({
-    standalone: true,
     selector: '[tuiGenericFilter]',
     providers: [tuiProvide(AbstractTuiTableFilter, TuiGenericFilter)],
 })

--- a/projects/addon-table/directives/table-filters/table-filter.directive.ts
+++ b/projects/addon-table/directives/table-filters/table-filter.directive.ts
@@ -9,7 +9,6 @@ import {type TuiTableFilter} from './table-filter';
 import {TuiTableFiltersDirective} from './table-filters.directive';
 
 @Directive({
-    standalone: true,
     selector: '[tuiTableFilter]',
 })
 export class TuiTableFilterDirective<T> implements OnInit, OnDestroy, TuiTableFilter<T> {

--- a/projects/addon-table/directives/table-filters/table-filters.directive.ts
+++ b/projects/addon-table/directives/table-filters/table-filters.directive.ts
@@ -12,7 +12,6 @@ import {
 import {type TuiTableFilter} from './table-filter';
 
 @Directive({
-    standalone: true,
     selector: '[tuiTableFilters]',
 })
 export class TuiTableFiltersDirective<T> {

--- a/projects/addon-table/directives/table-filters/table-filters.pipe.ts
+++ b/projects/addon-table/directives/table-filters/table-filters.pipe.ts
@@ -4,7 +4,6 @@ import {type Observable} from 'rxjs';
 import {TuiTableFiltersDirective} from './table-filters.directive';
 
 @Pipe({
-    standalone: true,
     name: 'tuiTableFilters',
 })
 export class TuiTableFiltersPipe<T> implements PipeTransform {

--- a/projects/cdk/directives/active-zone/active-zone.directive.ts
+++ b/projects/cdk/directives/active-zone/active-zone.directive.ts
@@ -23,7 +23,6 @@ import {
 
 @Injectable({providedIn: 'root'})
 @Directive({
-    standalone: true,
     selector:
         '[tuiActiveZone]:not(ng-container), [tuiActiveZoneChange]:not(ng-container), [tuiActiveZoneParent]:not(ng-container)',
     inputs: ['tuiActiveZoneParentSetter: tuiActiveZoneParent'],

--- a/projects/cdk/directives/active-zone/tests/active-zone.directive.spec.ts
+++ b/projects/cdk/directives/active-zone/tests/active-zone.directive.spec.ts
@@ -6,7 +6,6 @@ import {provideTaiga} from '@taiga-ui/core';
 
 describe('TuiActiveZone', () => {
     @Component({
-        standalone: true,
         imports: [ReactiveFormsModule, TuiActiveZone],
         template: `
             <p id="parent-info">Parent zone: {{ parentActive }}</p>

--- a/projects/cdk/directives/animated/animated-parent.directive.ts
+++ b/projects/cdk/directives/animated/animated-parent.directive.ts
@@ -8,7 +8,6 @@ import {tuiInjectElement} from '@taiga-ui/cdk/utils/dom';
 import {TUI_ENTER, TUI_LEAVE, TuiAnimated} from './animated.directive';
 
 @Directive({
-    standalone: true,
     selector: '[tuiAnimatedParent]',
     providers: [provideMutationObserverInit({childList: true})],
     hostDirectives: [

--- a/projects/cdk/directives/animated/animated.directive.ts
+++ b/projects/cdk/directives/animated/animated.directive.ts
@@ -15,7 +15,6 @@ export const TUI_ENTER = 'tui-enter';
 export const TUI_LEAVE = 'tui-leave';
 
 @Directive({
-    standalone: true,
     selector: '[tuiAnimated]',
     host: {
         class: TUI_ENTER,

--- a/projects/cdk/directives/auto-focus/autofocus.directive.ts
+++ b/projects/cdk/directives/auto-focus/autofocus.directive.ts
@@ -10,7 +10,6 @@ import {
 } from './autofocus.options';
 
 @Directive({
-    standalone: true,
     selector: '[tuiAutoFocus]',
     providers: TUI_AUTOFOCUS_PROVIDERS,
 })

--- a/projects/cdk/directives/auto-focus/test/auto-focus.directive.spec.ts
+++ b/projects/cdk/directives/auto-focus/test/auto-focus.directive.spec.ts
@@ -21,7 +21,6 @@ import {provideTaiga} from '@taiga-ui/core';
 describe('TuiAutoFocus directive', () => {
     describe('works for focusable HTML element', () => {
         @Component({
-            standalone: true,
             imports: [TuiAutoFocus],
             template: `
                 <div
@@ -59,7 +58,6 @@ describe('TuiAutoFocus directive', () => {
 
     describe('works for iOS decoy method', () => {
         @Component({
-            standalone: true,
             imports: [TuiAutoFocus],
             template: `
                 <input tuiAutoFocus />
@@ -114,7 +112,6 @@ describe('TuiAutoFocus directive', () => {
 
     describe('autoFocus flag is false', () => {
         @Component({
-            standalone: true,
             imports: [TuiAutoFocus],
             template: `
                 <div

--- a/projects/cdk/directives/click-outside/click-outside.directive.ts
+++ b/projects/cdk/directives/click-outside/click-outside.directive.ts
@@ -12,7 +12,6 @@ import {filter, fromEvent, map, type Observable} from 'rxjs';
  * @deprecated use {@link TuiActiveZone} instead
  */
 @Directive({
-    standalone: true,
     selector: '[tuiClickOutside]',
 })
 export class TuiClickOutside {

--- a/projects/cdk/directives/control/control.directive.ts
+++ b/projects/cdk/directives/control/control.directive.ts
@@ -2,7 +2,6 @@ import {Directive, inject} from '@angular/core';
 import {type AbstractControl, NgControl} from '@angular/forms';
 
 @Directive({
-    standalone: true,
     selector: '[tuiControl]',
     exportAs: 'ngControl',
 })

--- a/projects/cdk/directives/control/test/control.directive.spec.ts
+++ b/projects/cdk/directives/control/test/control.directive.spec.ts
@@ -7,7 +7,6 @@ import {provideTaiga} from '@taiga-ui/core';
 
 describe('TuiNgControl', () => {
     @Component({
-        standalone: true,
         imports: [ReactiveFormsModule, TuiNgControl],
         template: `
             <form [formGroup]="form">

--- a/projects/cdk/directives/copy-processor/copy-processor.directive.ts
+++ b/projects/cdk/directives/copy-processor/copy-processor.directive.ts
@@ -5,7 +5,6 @@ import {tuiGetSelectedText} from '@taiga-ui/cdk/utils';
 import {identity} from 'rxjs';
 
 @Directive({
-    standalone: true,
     selector: '[tuiCopyProcessor]',
     host: {
         '(copy.prevent)': 'onCopy($event)',

--- a/projects/cdk/directives/droppable/droppable.directive.ts
+++ b/projects/cdk/directives/droppable/droppable.directive.ts
@@ -5,7 +5,6 @@ import {tuiIsPresent} from '@taiga-ui/cdk/utils/miscellaneous';
 import {distinctUntilChanged, filter, map, merge, startWith, switchMap} from 'rxjs';
 
 @Directive({
-    standalone: true,
     selector: '[tuiDroppableDropped], [tuiDroppableDragOverChange]',
     host: {
         '(dragover.prevent.zoneless)': '0',

--- a/projects/cdk/directives/droppable/test/droppable.directive.spec.ts
+++ b/projects/cdk/directives/droppable/test/droppable.directive.spec.ts
@@ -7,7 +7,6 @@ import {TuiMockEvent} from '@taiga-ui/testing';
 
 describe('TuiDroppable Directive', () => {
     @Component({
-        standalone: true,
         imports: [TuiDroppable],
         template: `
             <div

--- a/projects/cdk/directives/element/element.directive.ts
+++ b/projects/cdk/directives/element/element.directive.ts
@@ -2,7 +2,6 @@ import {Directive, ElementRef} from '@angular/core';
 import {tuiInjectElement} from '@taiga-ui/cdk/utils';
 
 @Directive({
-    standalone: true,
     selector: '[tuiElement]',
     exportAs: 'elementRef',
 })

--- a/projects/cdk/directives/focus-trap/focus-trap.directive.ts
+++ b/projects/cdk/directives/focus-trap/focus-trap.directive.ts
@@ -8,7 +8,6 @@ import {
 import {tuiGetClosestFocusable, tuiGetFocused} from '@taiga-ui/cdk/utils/focus';
 
 @Directive({
-    standalone: true,
     selector: '[tuiFocusTrap]',
     host: {
         tabIndex: '0',

--- a/projects/cdk/directives/font-size/font-size.directive.ts
+++ b/projects/cdk/directives/font-size/font-size.directive.ts
@@ -8,9 +8,7 @@ export const TUI_FONT_SIZE_HANDLER = new InjectionToken<(size: number) => void>(
     ngDevMode ? 'TUI_FONT_SIZE_HANDLER' : '',
 );
 
-@Directive({
-    standalone: true,
-})
+@Directive()
 export class TuiFontSize {
     private readonly handler = inject(TUI_FONT_SIZE_HANDLER, {optional: true});
     protected readonly nothing = inject(DestroyRef).onDestroy(

--- a/projects/cdk/directives/high-dpi/high-dpi.directive.ts
+++ b/projects/cdk/directives/high-dpi/high-dpi.directive.ts
@@ -5,7 +5,6 @@ import {WA_WINDOW} from '@ng-web-apis/common';
  * Only adds current content if user has High DPI display
  */
 @Directive({
-    standalone: true,
     selector: '[tuiHighDpi]',
 })
 export class TuiHighDpi {

--- a/projects/cdk/directives/hovered/hovered.directive.ts
+++ b/projects/cdk/directives/hovered/hovered.directive.ts
@@ -3,7 +3,6 @@ import {Directive, inject, Output} from '@angular/core';
 import {TuiHoveredService} from './hovered.service';
 
 @Directive({
-    standalone: true,
     selector: '[tuiHoveredChange]',
     providers: [TuiHoveredService],
 })

--- a/projects/cdk/directives/item/item.directive.ts
+++ b/projects/cdk/directives/item/item.directive.ts
@@ -4,7 +4,6 @@ import {Directive} from '@angular/core';
  * Blank directive for queries via `@ContentChildren` / `@ViewChildren` / `querySelector`
  */
 @Directive({
-    standalone: true,
     selector: '[tuiItem]',
 })
 export class TuiItem {}

--- a/projects/cdk/directives/let/let.directive.ts
+++ b/projects/cdk/directives/let/let.directive.ts
@@ -6,7 +6,6 @@ import {TuiLetContext} from './let-context';
  * @deprecated use @let instead
  */
 @Directive({
-    standalone: true,
     selector: '[tuiLet]',
 })
 export class TuiLet<T> {

--- a/projects/cdk/directives/let/test/let.directive.spec.ts
+++ b/projects/cdk/directives/let/test/let.directive.spec.ts
@@ -10,7 +10,6 @@ import {provideTaiga} from '@taiga-ui/core';
 
 describe('Let', () => {
     @Component({
-        standalone: true,
         imports: [TuiLet],
         template: `
             <div

--- a/projects/cdk/directives/media/media.directive.ts
+++ b/projects/cdk/directives/media/media.directive.ts
@@ -2,7 +2,6 @@ import {Directive, EventEmitter, Input, Output} from '@angular/core';
 import {tuiInjectElement} from '@taiga-ui/cdk/utils';
 
 @Directive({
-    standalone: true,
     selector: 'video[tuiMedia], audio[tuiMedia]',
     exportAs: 'tuiMedia',
     host: {

--- a/projects/cdk/directives/native-validator/native-validator.directive.ts
+++ b/projects/cdk/directives/native-validator/native-validator.directive.ts
@@ -5,7 +5,6 @@ import {tuiInjectElement, tuiProvide} from '@taiga-ui/cdk/utils';
 import {BehaviorSubject, delay, of, switchMap} from 'rxjs';
 
 @Directive({
-    standalone: true,
     selector: '[tuiNativeValidator]',
     providers: [tuiProvide(NG_VALIDATORS, TuiNativeValidator, true)],
     host: {

--- a/projects/cdk/directives/obscured/obscured.directive.ts
+++ b/projects/cdk/directives/obscured/obscured.directive.ts
@@ -9,7 +9,6 @@ import {TuiObscuredService} from './obscured.service';
  * Directive that monitors element visibility
  */
 @Directive({
-    standalone: true,
     selector: '[tuiObscured]',
     providers: [TuiObscuredService],
 })

--- a/projects/cdk/directives/pan/pan.directive.ts
+++ b/projects/cdk/directives/pan/pan.directive.ts
@@ -3,7 +3,6 @@ import {Directive, inject, Output} from '@angular/core';
 import {TuiPanService} from './pan.service';
 
 @Directive({
-    standalone: true,
     selector: '[tuiPan]',
     providers: [TuiPanService],
 })

--- a/projects/cdk/directives/platform/platform.directive.ts
+++ b/projects/cdk/directives/platform/platform.directive.ts
@@ -2,7 +2,6 @@ import {Directive, inject, Input} from '@angular/core';
 import {TUI_PLATFORM} from '@taiga-ui/cdk/tokens';
 
 @Directive({
-    standalone: true,
     selector: '[tuiPlatform]',
     providers: [
         {

--- a/projects/cdk/directives/repeat-times/repeat-times.directive.ts
+++ b/projects/cdk/directives/repeat-times/repeat-times.directive.ts
@@ -16,7 +16,6 @@ export class TuiRepeatTimesContext implements TuiContext<number> {
  * {@link TuiRepeatTimesContext.$implicit index} of a template instance.
  */
 @Directive({
-    standalone: true,
     selector: '[tuiRepeatTimes][tuiRepeatTimesOf]',
 })
 export class TuiRepeatTimes {

--- a/projects/cdk/directives/repeat-times/test/repeat-times.directive.spec.ts
+++ b/projects/cdk/directives/repeat-times/test/repeat-times.directive.spec.ts
@@ -8,7 +8,6 @@ const DEFAULT_TEST_COUNT = 3;
 
 describe('TuiRepeatTimes directive', () => {
     @Component({
-        standalone: true,
         imports: [TuiRepeatTimes],
         template: `
             <div

--- a/projects/cdk/directives/resizer/resizable.directive.ts
+++ b/projects/cdk/directives/resizer/resizable.directive.ts
@@ -2,7 +2,6 @@ import {Directive} from '@angular/core';
 import {TuiElement} from '@taiga-ui/cdk/directives/element';
 
 @Directive({
-    standalone: true,
     selector: '[tuiResizable]',
 })
 export class TuiResizable extends TuiElement {}

--- a/projects/cdk/directives/resizer/resizer.directive.ts
+++ b/projects/cdk/directives/resizer/resizer.directive.ts
@@ -11,7 +11,6 @@ import {tuiPx} from '@taiga-ui/cdk/utils/miscellaneous';
 import {TuiResizable} from './resizable.directive';
 
 @Directive({
-    standalone: true,
     selector: '[tuiResizer]',
     host: {
         '[style.cursor]': 'cursor',

--- a/projects/cdk/directives/swipe/swipe.directive.ts
+++ b/projects/cdk/directives/swipe/swipe.directive.ts
@@ -3,7 +3,6 @@ import {Directive, inject, Output} from '@angular/core';
 import {TuiSwipeService} from './swipe.service';
 
 @Directive({
-    standalone: true,
     selector: '[tuiSwipe]',
     providers: [TuiSwipeService],
 })

--- a/projects/cdk/directives/transitioned/transitioned.directive.ts
+++ b/projects/cdk/directives/transitioned/transitioned.directive.ts
@@ -2,7 +2,6 @@ import {Directive, inject, NgZone} from '@angular/core';
 import {tuiInjectElement} from '@taiga-ui/cdk/utils';
 
 @Directive({
-    standalone: true,
     selector: '[tuiTransitioned]',
     host: {
         '[style.transition]': '"none"',

--- a/projects/cdk/directives/validator/test/validator.directive.spec.ts
+++ b/projects/cdk/directives/validator/test/validator.directive.spec.ts
@@ -6,7 +6,6 @@ import {provideTaiga} from '@taiga-ui/core';
 
 describe('TuiValidator directive', () => {
     @Component({
-        standalone: true,
         imports: [ReactiveFormsModule, TuiValidator],
         template: `
             @if (show) {

--- a/projects/cdk/directives/validator/validator.directive.ts
+++ b/projects/cdk/directives/validator/validator.directive.ts
@@ -4,7 +4,6 @@ import {EMPTY_FUNCTION} from '@taiga-ui/cdk/constants';
 import {tuiProvide} from '@taiga-ui/cdk/utils';
 
 @Directive({
-    standalone: true,
     selector: '[tuiValidator]',
     inputs: ['validate: tuiValidator'],
     providers: [tuiProvide(NG_VALIDATORS, TuiValidator, true)],

--- a/projects/cdk/directives/value-changes/test/value-changes.directive.spec.ts
+++ b/projects/cdk/directives/value-changes/test/value-changes.directive.spec.ts
@@ -7,7 +7,6 @@ import {provideTaiga} from '@taiga-ui/core';
 
 describe('TuiValueChangesDirective', () => {
     @Component({
-        standalone: true,
         imports: [ReactiveFormsModule, TuiValueChanges],
         template: `
             <form

--- a/projects/cdk/directives/value-changes/value-changes.directive.ts
+++ b/projects/cdk/directives/value-changes/value-changes.directive.ts
@@ -3,7 +3,6 @@ import {ControlContainer, NgControl} from '@angular/forms';
 import {distinctUntilChanged, EMPTY, type Observable, Subject, switchAll} from 'rxjs';
 
 @Directive({
-    standalone: true,
     selector: '[tuiValueChanges]',
 })
 export class TuiValueChanges<T> implements DoCheck {

--- a/projects/cdk/directives/visual-viewport/visual-viewport.directive.ts
+++ b/projects/cdk/directives/visual-viewport/visual-viewport.directive.ts
@@ -5,7 +5,6 @@ import {ViewportService} from '@ng-web-apis/screen-orientation';
 import {tuiInjectElement, tuiPx} from '@taiga-ui/cdk/utils';
 
 @Directive({
-    standalone: true,
     selector: '[tuiVisualViewport]',
 })
 export class TuiVisualViewport {

--- a/projects/cdk/directives/zoom/zoom.directive.ts
+++ b/projects/cdk/directives/zoom/zoom.directive.ts
@@ -3,7 +3,6 @@ import {Directive, inject} from '@angular/core';
 import {TuiZoomService} from './zoom.service';
 
 @Directive({
-    standalone: true,
     selector: '[tuiZoom]',
     outputs: ['tuiZoom'],
     providers: [TuiZoomService],

--- a/projects/cdk/pipes/animation/animation.pipe.ts
+++ b/projects/cdk/pipes/animation/animation.pipe.ts
@@ -4,7 +4,6 @@ import {TUI_ANIMATIONS_SPEED} from '@taiga-ui/core/tokens';
 import {tuiGetDuration} from '@taiga-ui/core/utils/miscellaneous';
 
 @Pipe({
-    standalone: true,
     name: 'tuiAnimation',
 })
 export class TuiAnimationPipe implements PipeTransform {

--- a/projects/cdk/pipes/filter/filter.pipe.ts
+++ b/projects/cdk/pipes/filter/filter.pipe.ts
@@ -2,7 +2,6 @@ import {Pipe, type PipeTransform} from '@angular/core';
 import {type TuiMatcher} from '@taiga-ui/cdk/types';
 
 @Pipe({
-    standalone: true,
     name: 'tuiFilter',
 })
 export class TuiFilterPipe implements PipeTransform {

--- a/projects/cdk/pipes/is-present/is-present.pipe.ts
+++ b/projects/cdk/pipes/is-present/is-present.pipe.ts
@@ -2,7 +2,6 @@ import {Pipe, type PipeTransform} from '@angular/core';
 import {tuiIsPresent} from '@taiga-ui/cdk/utils';
 
 @Pipe({
-    standalone: true,
     name: 'tuiIsPresent',
 })
 export class TuiIsPresentPipe implements PipeTransform {

--- a/projects/cdk/pipes/keys/keys.pipe.ts
+++ b/projects/cdk/pipes/keys/keys.pipe.ts
@@ -1,7 +1,6 @@
 import {Pipe, type PipeTransform} from '@angular/core';
 
 @Pipe({
-    standalone: true,
     name: 'tuiKeys',
 })
 export class TuiKeysPipe implements PipeTransform {

--- a/projects/cdk/pipes/mapper/mapper.pipe.ts
+++ b/projects/cdk/pipes/mapper/mapper.pipe.ts
@@ -2,7 +2,6 @@ import {Pipe, type PipeTransform} from '@angular/core';
 import {type TuiMapper} from '@taiga-ui/cdk/types';
 
 @Pipe({
-    standalone: true,
     name: 'tuiMapper',
 })
 export class TuiMapperPipe implements PipeTransform {

--- a/projects/cdk/pipes/obfuscate/obfuscate.pipe.ts
+++ b/projects/cdk/pipes/obfuscate/obfuscate.pipe.ts
@@ -3,7 +3,6 @@ import {inject, Pipe, type PipeTransform} from '@angular/core';
 import {TUI_OBFUSCATE_OPTIONS} from './obfuscate.options';
 
 @Pipe({
-    standalone: true,
     name: 'tuiObfuscate',
 })
 export class TuiObfuscatePipe implements PipeTransform {

--- a/projects/cdk/pipes/repeat-times/index.ts
+++ b/projects/cdk/pipes/repeat-times/index.ts
@@ -2,7 +2,6 @@ import {Pipe, type PipeTransform} from '@angular/core';
 import {tuiClamp} from '@taiga-ui/cdk/utils';
 
 @Pipe({
-    standalone: true,
     name: 'tuiRepeatTimes',
 })
 export class TuiRepeatTimesPipe implements PipeTransform {

--- a/projects/cdk/pipes/replace/replace.pipe.ts
+++ b/projects/cdk/pipes/replace/replace.pipe.ts
@@ -1,7 +1,6 @@
 import {Pipe, type PipeTransform} from '@angular/core';
 
 @Pipe({
-    standalone: true,
     name: 'tuiReplace',
 })
 export class TuiReplacePipe implements PipeTransform {

--- a/projects/cdk/pipes/to-array/to-array.pipe.ts
+++ b/projects/cdk/pipes/to-array/to-array.pipe.ts
@@ -1,7 +1,6 @@
 import {Pipe, type PipeTransform, type QueryList} from '@angular/core';
 
 @Pipe({
-    standalone: true,
     name: 'tuiToArray',
 })
 export class TuiToArrayPipe implements PipeTransform {

--- a/projects/cdk/schematics/ng-update/v4/tests/schematic-migrate-axes.spec.ts
+++ b/projects/cdk/schematics/ng-update/v4/tests/schematic-migrate-axes.spec.ts
@@ -17,7 +17,7 @@ const collectionPath = join(__dirname, '../../../migration.json');
 
 const COMPONENT_BEFORE = `import {ChangeDetectionStrategy, Component} from '@angular/core';
 import {TuiLineHandler} from '@taiga-ui/addon-charts';
- 
+
 @Component({
     standalone: true,
     selector: 'test-axes',

--- a/projects/core/components/button/test/button.directive.spec.ts
+++ b/projects/core/components/button/test/button.directive.spec.ts
@@ -8,7 +8,6 @@ import {TuiButton} from '../button.directive';
 
 describe('ButtonDirective', () => {
     @Component({
-        standalone: true,
         imports: [TuiButton],
         template: `
             <button

--- a/projects/core/components/calendar/test/calendar-sheet.component.spec.ts
+++ b/projects/core/components/calendar/test/calendar-sheet.component.spec.ts
@@ -22,7 +22,6 @@ describe('CalendarSheet', () => {
     const today = 23;
 
     @Component({
-        standalone: true,
         imports: [TuiCalendarSheet],
         template: `
             <tui-calendar-sheet

--- a/projects/core/components/calendar/test/calendar-year.component.spec.ts
+++ b/projects/core/components/calendar/test/calendar-year.component.spec.ts
@@ -6,7 +6,6 @@ import {TuiPageObject} from '@taiga-ui/testing';
 
 describe('TuiCalendarYearComponent', () => {
     @Component({
-        standalone: true,
         imports: [TuiCalendarYear],
         template: `
             <tui-calendar-year

--- a/projects/core/components/calendar/test/calendar.component.spec.ts
+++ b/projects/core/components/calendar/test/calendar.component.spec.ts
@@ -8,7 +8,6 @@ import {TuiCalendarHarness} from '@taiga-ui/testing';
 
 describe('Calendar', () => {
     @Component({
-        standalone: true,
         imports: [TuiCalendar],
         template: `
             <tui-calendar

--- a/projects/core/components/data-list/data-list.directive.ts
+++ b/projects/core/components/data-list/data-list.directive.ts
@@ -2,7 +2,6 @@ import {Directive, type Provider, type Type} from '@angular/core';
 import {tuiProvide} from '@taiga-ui/cdk/utils/miscellaneous';
 
 @Directive({
-    standalone: true,
     selector: 'ng-template[tuiDataList]',
 })
 export class TuiDataListDirective {}

--- a/projects/core/components/data-list/opt-group.directive.ts
+++ b/projects/core/components/data-list/opt-group.directive.ts
@@ -1,7 +1,6 @@
 import {Directive, Input} from '@angular/core';
 
 @Directive({
-    standalone: true,
     selector: 'tui-opt-group',
     host: {
         role: 'group',

--- a/projects/core/components/data-list/option/option-content.ts
+++ b/projects/core/components/data-list/option/option-content.ts
@@ -29,9 +29,7 @@ export function tuiAsOptionContent(
     };
 }
 
-@Directive({
-    standalone: true,
-})
+@Directive()
 export class TuiWithOptionContent {
     @ContentChild(TUI_OPTION_CONTENT, {descendants: true})
     protected readonly localContent: Type<any> | null = null;

--- a/projects/core/components/data-list/option/option.directive.ts
+++ b/projects/core/components/data-list/option/option.directive.ts
@@ -24,7 +24,6 @@ import {TUI_OPTION_CONTENT} from './option-content';
 // TODO(v5): rename `TuiOptionNew` => `TuiOption` & remove [new] from selector
 // TODO: Consider all use cases for aria roles
 @Directive({
-    standalone: true,
     selector: 'button[tuiOption][new], a[tuiOption][new], label[tuiOption][new]',
     hostDirectives: [TuiWithIcons],
     host: {
@@ -90,7 +89,6 @@ export class TuiOptionNew<T = unknown> implements OnDestroy {
 
 // TODO(v5): remove [new] from selector
 @Directive({
-    standalone: true,
     selector:
         'button[tuiOption][value][new], a[tuiOption][value][new], label[tuiOption][value][new]',
     host: {

--- a/projects/core/components/dialog/active-zone-adapter.directive.ts
+++ b/projects/core/components/dialog/active-zone-adapter.directive.ts
@@ -4,7 +4,6 @@ import {TuiActiveZone} from '@taiga-ui/cdk/directives/active-zone';
 import {tuiGetFocused} from '@taiga-ui/cdk/utils/focus';
 
 @Directive({
-    standalone: true,
     selector: '[tuiActiveZoneAdapter]',
     hostDirectives: [TuiActiveZone],
 })

--- a/projects/core/components/error/test/error-pipe.spec.ts
+++ b/projects/core/components/error/test/error-pipe.spec.ts
@@ -20,7 +20,6 @@ describe('TuiErrorPipe', () => {
     const max = 15;
 
     @Component({
-        standalone: true,
         imports: [ReactiveFormsModule, TuiError, TuiHint, TuiRoot],
         template: `
             <tui-root>

--- a/projects/core/components/icon/icon.component.ts
+++ b/projects/core/components/icon/icon.component.ts
@@ -9,7 +9,6 @@ import {
 import {TuiIcons} from '@taiga-ui/core/directives';
 
 @Component({
-    standalone: true,
     // :not([tuiBadge]) is required to avoid double matching of TuiIcons
     selector: 'tui-icon:not([tuiBadge])',
     template: '',

--- a/projects/core/components/icon/icon.pipe.ts
+++ b/projects/core/components/icon/icon.pipe.ts
@@ -3,7 +3,6 @@ import {type TuiStringHandler} from '@taiga-ui/cdk/types';
 import {tuiInjectIconResolver} from '@taiga-ui/core/tokens';
 
 @Pipe({
-    standalone: true,
     name: 'tuiIcon',
 })
 export class TuiIconPipe implements PipeTransform {

--- a/projects/core/components/link/test/link.directive.spec.ts
+++ b/projects/core/components/link/test/link.directive.spec.ts
@@ -8,7 +8,6 @@ import {TuiLink} from '../link.directive';
 
 describe('LinkDirective', () => {
     @Component({
-        standalone: true,
         imports: [TuiLink],
         template: `
             <a

--- a/projects/core/components/loader/test/loader-options.spec.ts
+++ b/projects/core/components/loader/test/loader-options.spec.ts
@@ -7,7 +7,6 @@ describe('Loader component options', () => {
     let testComponent: Test;
 
     @Component({
-        standalone: true,
         imports: [TuiLoader],
         template: `
             <tui-loader />

--- a/projects/core/components/loader/test/loader.component.spec.ts
+++ b/projects/core/components/loader/test/loader.component.spec.ts
@@ -8,7 +8,6 @@ import {TuiLoaderHarness} from '@taiga-ui/testing';
 
 describe('Loader', () => {
     @Component({
-        standalone: true,
         imports: [TuiLoader],
         template: `
             @if (custom) {

--- a/projects/core/components/scrollbar/scroll-ref.directive.ts
+++ b/projects/core/components/scrollbar/scroll-ref.directive.ts
@@ -5,7 +5,6 @@ import {TUI_SCROLL_REF} from '@taiga-ui/core/tokens';
 export const SCROLL_REF_SELECTOR = '[tuiScrollRef]';
 
 @Directive({
-    standalone: true,
     selector: '[tuiScrollRef]',
     providers: [tuiProvide(TUI_SCROLL_REF, ElementRef)],
 })

--- a/projects/core/components/scrollbar/scrollable.directive.ts
+++ b/projects/core/components/scrollbar/scrollable.directive.ts
@@ -4,7 +4,6 @@ import {tuiInjectElement} from '@taiga-ui/cdk/utils/dom';
 import {TUI_SCROLLABLE} from './scrollbar.component';
 
 @Directive({
-    standalone: true,
     selector: '[tuiScrollable]',
 })
 export class TuiScrollable implements OnInit {

--- a/projects/core/components/scrollbar/scrollbar.directive.ts
+++ b/projects/core/components/scrollbar/scrollbar.directive.ts
@@ -24,7 +24,6 @@ interface ComputedDimension {
 }
 
 @Directive({
-    standalone: true,
     selector: '[tuiScrollbar]',
     providers: [TuiScrollbarService],
 })

--- a/projects/core/components/spin-button/test/spin-button.component.spec.ts
+++ b/projects/core/components/spin-button/test/spin-button.component.spec.ts
@@ -4,7 +4,6 @@ import {TuiSpinButton} from '@taiga-ui/core';
 
 describe('primitiveSpinButton', () => {
     @Component({
-        standalone: true,
         imports: [TuiSpinButton],
         template: `
             <tui-spin-button>My button</tui-spin-button>

--- a/projects/core/components/textfield/select-like.directive.ts
+++ b/projects/core/components/textfield/select-like.directive.ts
@@ -3,7 +3,6 @@ import {TUI_IS_ANDROID} from '@taiga-ui/cdk/tokens';
 import {tuiInjectElement} from '@taiga-ui/cdk/utils/dom';
 
 @Directive({
-    standalone: true,
     selector: '[tuiSelectLike]',
     host: {
         tuiSelectLike: '',

--- a/projects/core/components/textfield/textfield-content.directive.ts
+++ b/projects/core/components/textfield/textfield-content.directive.ts
@@ -9,7 +9,6 @@ import {
 import {TuiTextfieldComponent} from './textfield.component';
 
 @Directive({
-    standalone: true,
     selector: 'ng-template[tuiTextfieldContent]',
 })
 export class TuiTextfieldContent implements DoCheck, OnDestroy {

--- a/projects/core/components/textfield/textfield.directive.ts
+++ b/projects/core/components/textfield/textfield.directive.ts
@@ -22,7 +22,6 @@ import {tuiAsTextfieldAccessor, type TuiTextfieldAccessor} from './textfield-acc
 
 // TODO: Drop in v5 after updated Angular and hostDirectives inherit
 @Directive({
-    standalone: true,
     providers: [tuiAsTextfieldAccessor(TuiTextfieldBase)],
     host: {
         tuiTextfield: '',
@@ -104,7 +103,6 @@ export class TuiTextfieldBase<T> implements TuiTextfieldAccessor<T> {
 }
 
 @Directive({
-    standalone: true,
     selector: 'input[tuiTextfield]',
     providers: [
         tuiAsTextfieldAccessor(TuiTextfieldDirective),
@@ -115,7 +113,6 @@ export class TuiTextfieldBase<T> implements TuiTextfieldAccessor<T> {
 export class TuiTextfieldDirective<T> extends TuiTextfieldBase<T> {}
 
 @Directive({
-    standalone: true,
     hostDirectives: [
         {
             directive: TuiTextfieldDirective,

--- a/projects/core/components/textfield/textfield.options.ts
+++ b/projects/core/components/textfield/textfield.options.ts
@@ -47,7 +47,6 @@ export function tuiTextfieldOptionsProvider(
 }
 
 @Directive({
-    standalone: true,
     selector: '[tuiTextfieldAppearance],[tuiTextfieldSize],[tuiTextfieldCleaner]',
     providers: [tuiProvide(TUI_TEXTFIELD_OPTIONS, TuiTextfieldOptionsDirective)],
 })

--- a/projects/core/components/textfield/with-native-picker.directive.ts
+++ b/projects/core/components/textfield/with-native-picker.directive.ts
@@ -9,7 +9,7 @@ import {tuiInjectElement} from '@taiga-ui/cdk/utils/dom';
  * If effects inside `tuiValue` will be called before `<input />` get `type="text"`,
  * it will cause loss of initial value
  */
-@Directive({standalone: true})
+@Directive()
 export class TuiWithNativePicker {
     constructor() {
         tuiInjectElement<HTMLInputElement>().type = 'text';

--- a/projects/core/directives/appearance/with-appearance.ts
+++ b/projects/core/directives/appearance/with-appearance.ts
@@ -3,7 +3,6 @@ import {Directive} from '@angular/core';
 import {TuiAppearance} from './appearance.directive';
 
 @Directive({
-    standalone: true,
     hostDirectives: [
         {
             directive: TuiAppearance,

--- a/projects/core/directives/dropdown/dropdown-content.directive.ts
+++ b/projects/core/directives/dropdown/dropdown-content.directive.ts
@@ -4,7 +4,6 @@ import {Directive, inject, type OnDestroy, PLATFORM_ID, TemplateRef} from '@angu
 import {TuiDropdownDirective} from './dropdown.directive';
 
 @Directive({
-    standalone: true,
     selector: 'ng-template[tuiDropdown]',
 })
 export class TuiDropdownContent implements OnDestroy {

--- a/projects/core/directives/dropdown/dropdown-context.directive.ts
+++ b/projects/core/directives/dropdown/dropdown-context.directive.ts
@@ -20,7 +20,6 @@ function activeZoneFilter(this: TuiDropdownContext, event?: Event): boolean {
 }
 
 @Directive({
-    standalone: true,
     selector: '[tuiDropdownContext]',
     providers: [
         TuiActiveZone,

--- a/projects/core/directives/dropdown/dropdown-hover.directive.ts
+++ b/projects/core/directives/dropdown/dropdown-hover.directive.ts
@@ -29,7 +29,6 @@ import {TUI_DROPDOWN_HOVER_OPTIONS} from './dropdown-hover.options';
 import {TuiDropdownOpen} from './dropdown-open.directive';
 
 @Directive({
-    standalone: true,
     selector: '[tuiDropdownHover]',
     providers: [TuiActiveZone, tuiAsDriver(TuiDropdownHover)],
     host: {

--- a/projects/core/directives/dropdown/dropdown-limit-width.ts
+++ b/projects/core/directives/dropdown/dropdown-limit-width.ts
@@ -8,7 +8,6 @@ import {
 } from './dropdown-options.directive';
 
 @Directive({
-    standalone: true,
     providers: [tuiDropdownOptionsProvider({})],
 })
 export class TuiDropdownFixed {
@@ -22,7 +21,7 @@ export class TuiDropdownFixed {
     }
 }
 
-@Directive({standalone: true})
+@Directive()
 export class TuiDropdownAuto {
     constructor() {
         /**

--- a/projects/core/directives/dropdown/dropdown-manual.directive.ts
+++ b/projects/core/directives/dropdown/dropdown-manual.directive.ts
@@ -4,7 +4,6 @@ import {tuiAsDriver} from '@taiga-ui/core/classes';
 import {TuiDropdownDriver} from './dropdown.driver';
 
 @Directive({
-    standalone: true,
     selector: '[tuiDropdownManual]',
     providers: [TuiDropdownDriver, tuiAsDriver(TuiDropdownDriver)],
 })

--- a/projects/core/directives/dropdown/dropdown-open-legacy.directive.ts
+++ b/projects/core/directives/dropdown/dropdown-open-legacy.directive.ts
@@ -5,7 +5,6 @@ import {distinctUntilChanged, Subject} from 'rxjs';
  * @deprecated TODO: remove in v.5 when legacy controls are dropped
  */
 @Directive({
-    standalone: true,
     selector:
         '[tuiDropdownOpen]:not([tuiDropdown]),[tuiDropdownOpenChange]:not([tuiDropdown])',
 })

--- a/projects/core/directives/dropdown/dropdown-open.directive.ts
+++ b/projects/core/directives/dropdown/dropdown-open.directive.ts
@@ -51,7 +51,6 @@ function shouldClose(this: TuiDropdownOpen, event: KeyboardEvent): boolean {
 }
 
 @Directive({
-    standalone: true,
     selector: '[tuiDropdown][tuiDropdownOpen],[tuiDropdown][tuiDropdownOpenChange]',
     providers: [TuiDropdownDriver, tuiAsDriver(TuiDropdownDriver)],
     hostDirectives: [

--- a/projects/core/directives/dropdown/dropdown-options.directive.ts
+++ b/projects/core/directives/dropdown/dropdown-options.directive.ts
@@ -58,7 +58,6 @@ export const tuiDropdownOptionsProvider: (
 });
 
 @Directive({
-    standalone: true,
     selector:
         '[tuiDropdownAlign], [tuiDropdownAppearance], [tuiDropdownDirection], [tuiDropdownLimitWidth], [tuiDropdownMinHeight], [tuiDropdownMaxHeight], [tuiDropdownOffset]',
     providers: [tuiProvide(TUI_DROPDOWN_OPTIONS, TuiDropdownOptionsDirective)],

--- a/projects/core/directives/dropdown/dropdown-position-sided.directive.ts
+++ b/projects/core/directives/dropdown/dropdown-position-sided.directive.ts
@@ -8,7 +8,6 @@ import {TUI_DROPDOWN_OPTIONS} from './dropdown-options.directive';
 import {TuiDropdownPosition} from './dropdown-position.directive';
 
 @Directive({
-    standalone: true,
     selector: '[tuiDropdownSided]',
     providers: [TuiDropdownPosition, tuiAsPositionAccessor(TuiDropdownPositionSided)],
 })

--- a/projects/core/directives/dropdown/dropdown-position.directive.ts
+++ b/projects/core/directives/dropdown/dropdown-position.directive.ts
@@ -13,9 +13,7 @@ import {type TuiPoint, type TuiVerticalDirection} from '@taiga-ui/core/types';
 import {TuiDropdownDirective} from './dropdown.directive';
 import {TUI_DROPDOWN_OPTIONS, type TuiDropdownAlign} from './dropdown-options.directive';
 
-@Directive({
-    standalone: true,
-})
+@Directive()
 export class TuiDropdownPosition extends TuiPositionAccessor {
     private readonly el = tuiInjectElement();
     private readonly options = inject(TUI_DROPDOWN_OPTIONS);

--- a/projects/core/directives/dropdown/dropdown-selection.directive.ts
+++ b/projects/core/directives/dropdown/dropdown-selection.directive.ts
@@ -29,7 +29,6 @@ import {BehaviorSubject, combineLatest, distinctUntilChanged, filter, map} from 
 import {TuiDropdownDirective} from './dropdown.directive';
 
 @Directive({
-    standalone: true,
     selector: '[tuiDropdownSelection]',
     providers: [
         tuiAsDriver(TuiDropdownSelection),

--- a/projects/core/directives/dropdown/dropdown.directive.ts
+++ b/projects/core/directives/dropdown/dropdown.directive.ts
@@ -35,7 +35,6 @@ import {TUI_DROPDOWN_COMPONENT} from './dropdown.providers';
 import {TuiDropdownPosition} from './dropdown-position.directive';
 
 @Directive({
-    standalone: true,
     selector: '[tuiDropdown]:not(ng-container):not(ng-template)',
     providers: [
         tuiAsRectAccessor(TuiDropdownDirective),

--- a/projects/core/directives/dropdown/dropdown.driver.ts
+++ b/projects/core/directives/dropdown/dropdown.driver.ts
@@ -11,9 +11,7 @@ export class TuiDropdownDriver extends BehaviorSubject<boolean> implements TuiDr
     }
 }
 
-@Directive({
-    standalone: true,
-})
+@Directive()
 export class TuiDropdownDriverDirective extends TuiDriverDirective {
     public readonly type = 'dropdown';
 }

--- a/projects/core/directives/dropdown/test/dropdown.directive.spec.ts
+++ b/projects/core/directives/dropdown/test/dropdown.directive.spec.ts
@@ -11,7 +11,6 @@ import {TuiPageObject} from '@taiga-ui/testing';
 
 describe('TuiDropdownDirective', () => {
     @Component({
-        standalone: true,
         imports: [PolymorpheusTemplate, TuiDropdownDirective, TuiDropdownManual, TuiRoot],
         template: `
             <tui-root>

--- a/projects/core/directives/dropdown/with-dropdown-open.directive.ts
+++ b/projects/core/directives/dropdown/with-dropdown-open.directive.ts
@@ -3,7 +3,6 @@ import {Directive} from '@angular/core';
 import {TuiDropdownOpen} from './dropdown-open.directive';
 
 @Directive({
-    standalone: true,
     hostDirectives: [
         {
             directive: TuiDropdownOpen,

--- a/projects/core/directives/hint/hint-options.directive.ts
+++ b/projects/core/directives/hint/hint-options.directive.ts
@@ -83,7 +83,6 @@ export const tuiHintOptionsProvider: (
  * @deprecated: drop in 5.0
  */
 @Directive({
-    standalone: true,
     selector: '[tuiHintContent]',
     providers: [tuiProvide(TUI_HINT_OPTIONS, TuiHintOptionsDirective)],
 })

--- a/projects/core/directives/hint/test/hint.directive.spec.ts
+++ b/projects/core/directives/hint/test/hint.directive.spec.ts
@@ -12,7 +12,6 @@ type Hint = TemplateRef<Record<string, unknown>> | string | null | undefined;
 
 describe('Hint', () => {
     @Component({
-        standalone: true,
         imports: [TuiHint, TuiRoot],
         template: `
             <tui-root>

--- a/projects/core/directives/icons/with-icons.ts
+++ b/projects/core/directives/icons/with-icons.ts
@@ -3,7 +3,6 @@ import {Directive} from '@angular/core';
 import {TuiIcons} from './icons.directive';
 
 @Directive({
-    standalone: true,
     hostDirectives: [
         {
             directive: TuiIcons,

--- a/projects/core/directives/items-handlers/items-handlers.directive.ts
+++ b/projects/core/directives/items-handlers/items-handlers.directive.ts
@@ -9,7 +9,6 @@ import {tuiProvide} from '@taiga-ui/cdk/utils/miscellaneous';
 import {TUI_ITEMS_HANDLERS, type TuiItemsHandlers} from './items-handlers.tokens';
 
 @Directive({
-    standalone: true,
     providers: [tuiProvide(TUI_ITEMS_HANDLERS, TuiItemsHandlersDirective)],
 })
 export class TuiItemsHandlersDirective<T> implements TuiItemsHandlers<T> {
@@ -43,7 +42,6 @@ export class TuiItemsHandlersDirective<T> implements TuiItemsHandlers<T> {
 }
 
 @Directive({
-    standalone: true,
     hostDirectives: [
         {
             directive: TuiItemsHandlersDirective,

--- a/projects/core/directives/items-handlers/items-handlers.validator.ts
+++ b/projects/core/directives/items-handlers/items-handlers.validator.ts
@@ -7,7 +7,6 @@ import {tuiProvide} from '@taiga-ui/cdk/utils/miscellaneous';
 import {TuiItemsHandlersDirective} from './items-handlers.directive';
 
 @Directive({
-    standalone: true,
     providers: [tuiProvide(NG_VALIDATORS, TuiItemsHandlersValidator, true)],
 })
 export class TuiItemsHandlersValidator extends TuiValidator {

--- a/projects/core/directives/number-format/number-format.directive.ts
+++ b/projects/core/directives/number-format/number-format.directive.ts
@@ -4,7 +4,6 @@ import {TUI_NUMBER_FORMAT, type TuiNumberFormatSettings} from '@taiga-ui/core/to
 import {combineLatest, map, Observable, ReplaySubject} from 'rxjs';
 
 @Directive({
-    standalone: true,
     selector: '[tuiNumberFormat]',
     providers: [tuiProvide(TUI_NUMBER_FORMAT, TuiNumberFormat)],
 })

--- a/projects/core/pipes/auto-color/auto-color.pipe.ts
+++ b/projects/core/pipes/auto-color/auto-color.pipe.ts
@@ -2,7 +2,6 @@ import {Pipe, type PipeTransform} from '@angular/core';
 import {tuiStringHashToHsl} from '@taiga-ui/core/utils';
 
 @Pipe({
-    standalone: true,
     name: 'tuiAutoColor',
 })
 export class TuiAutoColorPipe implements PipeTransform {

--- a/projects/core/pipes/calendar-sheet/calendar-sheet.pipe.ts
+++ b/projects/core/pipes/calendar-sheet/calendar-sheet.pipe.ts
@@ -7,7 +7,6 @@ import {getDayFromMonthRowCol} from './utils';
 const CALENDAR_ROWS_COUNT = 6;
 
 @Pipe({
-    standalone: true,
     name: 'tuiCalendarSheet',
 })
 export class TuiCalendarSheetPipe implements PipeTransform {

--- a/projects/core/pipes/flag/flag.pipe.ts
+++ b/projects/core/pipes/flag/flag.pipe.ts
@@ -7,7 +7,6 @@ type IsoCode = TuiLooseUnion<TuiCountryIsoCode>;
 
 // TODO: Move to kit in v5
 @Pipe({
-    standalone: true,
     name: 'tuiFlag',
 })
 export class TuiFlagPipe implements PipeTransform {

--- a/projects/core/pipes/format-date/format-date.pipe.ts
+++ b/projects/core/pipes/format-date/format-date.pipe.ts
@@ -3,7 +3,6 @@ import {TuiFormatDateService} from '@taiga-ui/core/services';
 import {type Observable} from 'rxjs';
 
 @Pipe({
-    standalone: true,
     name: 'tuiFormatDate',
 })
 export class TuiFormatDatePipe implements PipeTransform {

--- a/projects/core/pipes/format-number/format-number.pipe.ts
+++ b/projects/core/pipes/format-number/format-number.pipe.ts
@@ -4,7 +4,6 @@ import {tuiFormatNumber} from '@taiga-ui/core/utils/format';
 import {map, type Observable} from 'rxjs';
 
 @Pipe({
-    standalone: true,
     name: 'tuiFormatNumber',
 })
 export class TuiFormatNumberPipe implements PipeTransform {

--- a/projects/core/pipes/initials/initials.pipe.ts
+++ b/projects/core/pipes/initials/initials.pipe.ts
@@ -1,7 +1,6 @@
 import {Pipe, type PipeTransform} from '@angular/core';
 
 @Pipe({
-    standalone: true,
     name: 'tuiInitials',
 })
 export class TuiInitialsPipe implements PipeTransform {

--- a/projects/core/pipes/month/month.pipe.ts
+++ b/projects/core/pipes/month/month.pipe.ts
@@ -5,7 +5,6 @@ import {TUI_MONTHS} from '@taiga-ui/core/tokens';
 import {map, type Observable} from 'rxjs';
 
 @Pipe({
-    standalone: true,
     name: 'tuiMonth',
 })
 export class TuiMonthPipe implements PipeTransform {

--- a/projects/core/pipes/order-week-days/order-week-days.pipe.ts
+++ b/projects/core/pipes/order-week-days/order-week-days.pipe.ts
@@ -11,7 +11,6 @@ function convertToSundayFirstWeekFormat(
 }
 
 @Pipe({
-    standalone: true,
     name: 'tuiOrderWeekDays',
 })
 export class TuiOrderWeekDaysPipe implements PipeTransform {

--- a/projects/demo-cypress/src/tests/input-chip.cy.ts
+++ b/projects/demo-cypress/src/tests/input-chip.cy.ts
@@ -18,7 +18,6 @@ interface User {
 }
 
 @Component({
-    standalone: true,
     imports: [
         FormsModule,
         ReactiveFormsModule,

--- a/projects/demo/src/modules/app/abstract.app.ts
+++ b/projects/demo/src/modules/app/abstract.app.ts
@@ -36,9 +36,7 @@ export const DEMO_PAGE_LOADED_PROVIDER = {
     },
 };
 
-@Directive({
-    standalone: true,
-})
+@Directive()
 export abstract class AbstractDemo implements OnInit {
     protected abstract readonly storage: Storage;
     protected abstract readonly router: Router;

--- a/projects/demo/src/modules/app/search/index.ts
+++ b/projects/demo/src/modules/app/search/index.ts
@@ -12,7 +12,6 @@ import {TUI_DARK_MODE} from '@taiga-ui/core';
 import {SEARCH_CONFIG} from './env';
 
 @Component({
-    standalone: true,
     selector: 'tui-algolia-search',
     template: '',
     styleUrl: './index.less',

--- a/projects/demo/src/modules/components/combo-box/examples/12/option.ts
+++ b/projects/demo/src/modules/components/combo-box/examples/12/option.ts
@@ -5,7 +5,6 @@ import {TuiOptionWithValue} from '@taiga-ui/core';
 import {tuiInjectValue} from '@taiga-ui/kit';
 
 @Component({
-    standalone: true,
     template: '<span>{{selected() ? "←" : ""}}</span>',
     styles: ':host {flex-direction: row-reverse; justify-content: start}',
     encapsulation,

--- a/projects/demo/src/modules/components/error/examples/7/index.ts
+++ b/projects/demo/src/modules/components/error/examples/7/index.ts
@@ -7,7 +7,6 @@ import {TuiError, TuiTextfield, tuiValidationErrorsProvider} from '@taiga-ui/cor
 import {injectContext, PolymorpheusComponent} from '@taiga-ui/polymorpheus';
 
 @Component({
-    standalone: true,
     template: 'Required: {{ context.$implicit }}',
     changeDetection: ChangeDetectionStrategy.OnPush,
 })

--- a/projects/demo/src/modules/components/icons-group/icons-group.directive.ts
+++ b/projects/demo/src/modules/components/icons-group/icons-group.directive.ts
@@ -1,7 +1,6 @@
 import {Directive, inject, input, TemplateRef} from '@angular/core';
 
 @Directive({
-    standalone: true,
     selector: '[iconGroup]',
 })
 export class IconsGroupTemplate {

--- a/projects/demo/src/modules/components/input-chip/examples/10/index.ts
+++ b/projects/demo/src/modules/components/input-chip/examples/10/index.ts
@@ -19,7 +19,6 @@ import {
 import {TuiChevron, TuiInputChip, TuiMultiSelect} from '@taiga-ui/kit';
 
 @Component({
-    standalone: true,
     imports: [
         CdkFixedSizeVirtualScroll,
         CdkVirtualForOf,

--- a/projects/demo/src/modules/components/select/examples/10/option.ts
+++ b/projects/demo/src/modules/components/select/examples/10/option.ts
@@ -5,7 +5,6 @@ import {TuiOptionWithValue} from '@taiga-ui/core';
 import {tuiInjectValue} from '@taiga-ui/kit';
 
 @Component({
-    standalone: true,
     template: '<span>{{selected() ? "←" : ""}}</span>',
     styles: ':host {flex-direction: row-reverse; justify-content: start}',
     encapsulation,

--- a/projects/demo/src/modules/components/table/examples/11/index.ts
+++ b/projects/demo/src/modules/components/table/examples/11/index.ts
@@ -10,7 +10,6 @@ interface Data {
 }
 
 @Component({
-    standalone: true,
     imports: [TuiTable],
     templateUrl: './index.html',
     encapsulation,

--- a/projects/demo/src/modules/components/table/examples/9/index.ts
+++ b/projects/demo/src/modules/components/table/examples/9/index.ts
@@ -73,7 +73,6 @@ function getRandom(min: number, max: number): number {
 }
 
 @Component({
-    standalone: true,
     imports: [TuiButton, TuiChevron, TuiTable],
     templateUrl: './index.html',
     styleUrl: './index.less',

--- a/projects/demo/src/modules/components/tabs/examples/8/index.ts
+++ b/projects/demo/src/modules/components/tabs/examples/8/index.ts
@@ -5,7 +5,6 @@ import {encapsulation} from '@demo/emulate/encapsulation';
 import {TuiTabs} from '@taiga-ui/kit';
 
 @Component({
-    standalone: true,
     selector: 'example-1',
     template: 'example-1',
     changeDetection: ChangeDetectionStrategy.OnPush,
@@ -13,7 +12,6 @@ import {TuiTabs} from '@taiga-ui/kit';
 class Nav1 {}
 
 @Component({
-    standalone: true,
     selector: 'example-2',
     template: 'example-2',
     changeDetection: ChangeDetectionStrategy.OnPush,
@@ -21,7 +19,6 @@ class Nav1 {}
 class Nav2 {}
 
 @Component({
-    standalone: true,
     selector: 'example-3',
     template: 'example-3',
     changeDetection: ChangeDetectionStrategy.OnPush,
@@ -29,7 +26,6 @@ class Nav2 {}
 class Nav3 {}
 
 @Component({
-    standalone: true,
     selector: 'example-4',
     template: 'example-4',
     changeDetection: ChangeDetectionStrategy.OnPush,
@@ -37,7 +33,6 @@ class Nav3 {}
 class Nav4 {}
 
 @Component({
-    standalone: true,
     selector: 'example-5',
     template: 'example-5',
     changeDetection: ChangeDetectionStrategy.OnPush,

--- a/projects/demo/src/modules/components/toast/examples/1/index.ts
+++ b/projects/demo/src/modules/components/toast/examples/1/index.ts
@@ -6,7 +6,6 @@ import {TuiButton} from '@taiga-ui/core';
 import {TuiAvatar, TuiBadge, TuiToast} from '@taiga-ui/kit';
 
 @Component({
-    standalone: true,
     imports: [TuiAvatar, TuiBadge, TuiButton, TuiPlatform, TuiToast],
     templateUrl: './index.html',
     styleUrl: './index.less',

--- a/projects/demo/src/modules/components/toast/examples/2/index.ts
+++ b/projects/demo/src/modules/components/toast/examples/2/index.ts
@@ -9,7 +9,6 @@ import {TuiProgressCircle, TuiToast} from '@taiga-ui/kit';
 import {BehaviorSubject, of, switchMap, take, timer} from 'rxjs';
 
 @Component({
-    standalone: true,
     imports: [TuiButton, TuiLoader, TuiPlatform, TuiProgressCircle, TuiToast],
     templateUrl: './index.html',
     styleUrl: './index.less',

--- a/projects/demo/src/modules/components/toast/examples/3/index.ts
+++ b/projects/demo/src/modules/components/toast/examples/3/index.ts
@@ -7,7 +7,6 @@ import {TuiToast, TuiToastService} from '@taiga-ui/kit';
 import {injectContext, PolymorpheusComponent} from '@taiga-ui/polymorpheus';
 
 @Component({
-    standalone: true,
     imports: [TuiIcon, TuiToast],
     template: `
         <div tuiToast>
@@ -28,7 +27,6 @@ export class Toast {
 }
 
 @Component({
-    standalone: true,
     imports: [TuiButton, TuiToast],
     templateUrl: './index.html',
     styleUrl: './index.less',

--- a/projects/demo/src/modules/components/toast/index.ts
+++ b/projects/demo/src/modules/components/toast/index.ts
@@ -5,7 +5,6 @@ import {TuiButton} from '@taiga-ui/core';
 import {TUI_TOAST_OPTIONS, TuiToast} from '@taiga-ui/kit';
 
 @Component({
-    standalone: true,
     imports: [TuiButton, TuiDemo, TuiToast],
     templateUrl: './index.html',
     changeDetection,

--- a/projects/demo/src/modules/components/utils/browser/examples/1/index.ts
+++ b/projects/demo/src/modules/components/utils/browser/examples/1/index.ts
@@ -5,7 +5,6 @@ import {WA_USER_AGENT} from '@ng-web-apis/common';
 import {tuiInjectElement, tuiIsEdge, tuiIsFirefox, tuiIsSafari} from '@taiga-ui/cdk';
 
 @Component({
-    standalone: true,
     templateUrl: './index.html',
     encapsulation,
     changeDetection,

--- a/projects/demo/src/modules/components/utils/miscellaneous/examples/1/index.ts
+++ b/projects/demo/src/modules/components/utils/miscellaneous/examples/1/index.ts
@@ -3,7 +3,6 @@ import {changeDetection} from '@demo/emulate/change-detection';
 import {encapsulation} from '@demo/emulate/encapsulation';
 
 @Component({
-    standalone: true,
     templateUrl: './index.html',
     encapsulation,
     changeDetection,

--- a/projects/demo/src/modules/components/utils/miscellaneous/examples/2/index.ts
+++ b/projects/demo/src/modules/components/utils/miscellaneous/examples/2/index.ts
@@ -4,7 +4,6 @@ import {encapsulation} from '@demo/emulate/encapsulation';
 import {tuiFlatLength} from '@taiga-ui/cdk';
 
 @Component({
-    standalone: true,
     templateUrl: './index.html',
     encapsulation,
     changeDetection,

--- a/projects/demo/src/modules/components/utils/tokens/examples/4/index.ts
+++ b/projects/demo/src/modules/components/utils/tokens/examples/4/index.ts
@@ -4,7 +4,6 @@ import {encapsulation} from '@demo/emulate/encapsulation';
 import {TUI_IS_MOBILE} from '@taiga-ui/cdk';
 
 @Component({
-    standalone: true,
     templateUrl: './index.html',
     encapsulation,
     changeDetection,

--- a/projects/demo/src/modules/customization/dialogs/examples/2/custom-dialog/custom-dialog.directive.ts
+++ b/projects/demo/src/modules/customization/dialogs/examples/2/custom-dialog/custom-dialog.directive.ts
@@ -4,7 +4,6 @@ import {TuiPopoverDirective, TuiPopoverService} from '@taiga-ui/cdk';
 import {CustomDialogService} from './custom-dialog.service';
 
 @Directive({
-    standalone: true,
     selector: 'ng-template[tuiCustomDialog]',
     inputs: ['open: tuiCustomDialog', 'options: tuiCustomDialogOptions'],
     outputs: ['openChange: tuiCustomDialogChange'],

--- a/projects/demo/src/modules/customization/portals/examples/1/portal.ts
+++ b/projects/demo/src/modules/customization/portals/examples/1/portal.ts
@@ -5,7 +5,6 @@ import {TuiPortals, TuiPortalService, tuiProvide} from '@taiga-ui/cdk';
 import {CustomPortalService} from './service';
 
 @Component({
-    standalone: true,
     selector: 'custom-host',
     template: '<ng-container #vcr />',
     styles: `

--- a/projects/demo/src/modules/customization/routable/eager/examples/1/dialog.component.ts
+++ b/projects/demo/src/modules/customization/routable/eager/examples/1/dialog.component.ts
@@ -1,7 +1,6 @@
 import {ChangeDetectionStrategy, Component} from '@angular/core';
 
 @Component({
-    standalone: true,
     template: 'Eager loaded dialog content',
     changeDetection: ChangeDetectionStrategy.OnPush,
 })

--- a/projects/demo/src/modules/customization/routable/eager/examples/2/dialog.component.ts
+++ b/projects/demo/src/modules/customization/routable/eager/examples/2/dialog.component.ts
@@ -1,7 +1,6 @@
 import {ChangeDetectionStrategy, Component} from '@angular/core';
 
 @Component({
-    standalone: true,
     template: 'Dialog content via named outlet',
     changeDetection: ChangeDetectionStrategy.OnPush,
 })

--- a/projects/demo/src/modules/customization/routable/lazy/examples/1/dialog.component.ts
+++ b/projects/demo/src/modules/customization/routable/lazy/examples/1/dialog.component.ts
@@ -1,7 +1,6 @@
 import {ChangeDetectionStrategy, Component} from '@angular/core';
 
 @Component({
-    standalone: true,
     template: 'Lazy loaded dialog content',
     changeDetection: ChangeDetectionStrategy.OnPush,
 })

--- a/projects/demo/src/modules/customization/viewport/examples/2/index.ts
+++ b/projects/demo/src/modules/customization/viewport/examples/2/index.ts
@@ -10,7 +10,6 @@ import {
 } from '@taiga-ui/core';
 
 @Component({
-    standalone: true,
     selector: 'portal-host',
     template: `
         <ng-content />

--- a/projects/demo/src/modules/customization/viewport/examples/3/index.ts
+++ b/projects/demo/src/modules/customization/viewport/examples/3/index.ts
@@ -14,7 +14,6 @@ import {
 import {TuiSegmented} from '@taiga-ui/kit';
 
 @Component({
-    standalone: true,
     selector: 'portal-host',
     template: '<ng-content />',
     changeDetection: ChangeDetectionStrategy.OnPush,

--- a/projects/demo/src/modules/directives/active-zone/examples/2/index.ts
+++ b/projects/demo/src/modules/directives/active-zone/examples/2/index.ts
@@ -5,7 +5,6 @@ import {TuiActiveZone} from '@taiga-ui/cdk';
 import {TuiButton, TuiDialogService, TuiTextfield} from '@taiga-ui/core';
 
 @Component({
-    standalone: true,
     imports: [TuiActiveZone, TuiButton, TuiTextfield],
     templateUrl: './index.html',
     styleUrl: './index.less',

--- a/projects/demo/src/modules/directives/dropdown-open/examples/5/index.ts
+++ b/projects/demo/src/modules/directives/dropdown-open/examples/5/index.ts
@@ -12,7 +12,6 @@ import {
 } from '@taiga-ui/core';
 
 @Directive({
-    standalone: true,
     selector: '[topRight]',
     providers: [tuiAsPositionAccessor(TopRightDirective)],
 })

--- a/projects/demo/src/modules/markup/lists/examples/1/index.ts
+++ b/projects/demo/src/modules/markup/lists/examples/1/index.ts
@@ -3,7 +3,6 @@ import {changeDetection} from '@demo/emulate/change-detection';
 import {encapsulation} from '@demo/emulate/encapsulation';
 
 @Component({
-    standalone: true,
     templateUrl: './index.html',
     encapsulation,
     changeDetection,

--- a/projects/demo/src/modules/markup/lists/examples/2/index.ts
+++ b/projects/demo/src/modules/markup/lists/examples/2/index.ts
@@ -3,7 +3,6 @@ import {changeDetection} from '@demo/emulate/change-detection';
 import {encapsulation} from '@demo/emulate/encapsulation';
 
 @Component({
-    standalone: true,
     templateUrl: './index.html',
     encapsulation,
     changeDetection,

--- a/projects/demo/src/modules/markup/lists/examples/3/index.ts
+++ b/projects/demo/src/modules/markup/lists/examples/3/index.ts
@@ -3,7 +3,6 @@ import {changeDetection} from '@demo/emulate/change-detection';
 import {encapsulation} from '@demo/emulate/encapsulation';
 
 @Component({
-    standalone: true,
     templateUrl: './index.html',
     encapsulation,
     changeDetection,

--- a/projects/demo/src/modules/markup/lists/examples/4/index.ts
+++ b/projects/demo/src/modules/markup/lists/examples/4/index.ts
@@ -3,7 +3,6 @@ import {changeDetection} from '@demo/emulate/change-detection';
 import {encapsulation} from '@demo/emulate/encapsulation';
 
 @Component({
-    standalone: true,
     templateUrl: './index.html',
     encapsulation,
     changeDetection,

--- a/projects/demo/src/modules/markup/lists/examples/5/index.ts
+++ b/projects/demo/src/modules/markup/lists/examples/5/index.ts
@@ -3,7 +3,6 @@ import {changeDetection} from '@demo/emulate/change-detection';
 import {encapsulation} from '@demo/emulate/encapsulation';
 
 @Component({
-    standalone: true,
     templateUrl: './index.html',
     encapsulation,
     changeDetection,

--- a/projects/demo/src/modules/markup/lists/examples/6/index.ts
+++ b/projects/demo/src/modules/markup/lists/examples/6/index.ts
@@ -3,7 +3,6 @@ import {changeDetection} from '@demo/emulate/change-detection';
 import {encapsulation} from '@demo/emulate/encapsulation';
 
 @Component({
-    standalone: true,
     templateUrl: './index.html',
     encapsulation,
     changeDetection,

--- a/projects/demo/src/modules/markup/lists/examples/7/index.ts
+++ b/projects/demo/src/modules/markup/lists/examples/7/index.ts
@@ -3,7 +3,6 @@ import {changeDetection} from '@demo/emulate/change-detection';
 import {encapsulation} from '@demo/emulate/encapsulation';
 
 @Component({
-    standalone: true,
     templateUrl: './index.html',
     encapsulation,
     changeDetection,

--- a/projects/demo/src/utils/component.pipe.ts
+++ b/projects/demo/src/utils/component.pipe.ts
@@ -4,7 +4,6 @@ import {TuiDocPage} from '@taiga-ui/addon-doc';
 import {toKebab} from './kebab.pipe';
 
 @Pipe({
-    standalone: true,
     name: 'tuiComponent',
 })
 export class TuiComponentPipe implements PipeTransform {

--- a/projects/demo/src/utils/disabled.directive.ts
+++ b/projects/demo/src/utils/disabled.directive.ts
@@ -2,7 +2,6 @@ import {Directive, inject, Input} from '@angular/core';
 import {NgControl} from '@angular/forms';
 
 @Directive({
-    standalone: true,
     selector: '[tuiDisabled]',
 })
 export class TuiDisabledDirective {

--- a/projects/demo/src/utils/example.pipe.ts
+++ b/projects/demo/src/utils/example.pipe.ts
@@ -4,7 +4,6 @@ import {TuiDocPage, type TuiRawLoaderContent} from '@taiga-ui/addon-doc';
 import {toKebab} from './kebab.pipe';
 
 @Pipe({
-    standalone: true,
     name: 'tuiExample',
 })
 export class TuiExamplePipe implements PipeTransform {

--- a/projects/demo/src/utils/kebab.pipe.ts
+++ b/projects/demo/src/utils/kebab.pipe.ts
@@ -10,7 +10,6 @@ export function toKebab(str: string): string {
 }
 
 @Pipe({
-    standalone: true,
     name: 'tuiKebab',
 })
 export class TuiKebabPipe implements PipeTransform {

--- a/projects/experimental/components/search-results/search-hotkey.directive.ts
+++ b/projects/experimental/components/search-results/search-hotkey.directive.ts
@@ -4,7 +4,6 @@ import {TuiInputSearch} from '@taiga-ui/layout/components/input-search';
 import {TUI_INPUT_SEARCH} from '@taiga-ui/layout/tokens';
 
 @Directive({
-    standalone: true,
     selector: 'input[tuiSearchHotkey]',
     host: {
         '[placeholder]': 'placeholder()',

--- a/projects/kit/components/accordion/accordion.component.ts
+++ b/projects/kit/components/accordion/accordion.component.ts
@@ -13,7 +13,6 @@ import {type TuiSizeL, type TuiSizeS} from '@taiga-ui/core/types';
 import {TuiAccordionDirective} from './accordion.directive';
 
 @Component({
-    standalone: true,
     selector: 'tui-accordion',
     template: '<ng-content />',
     styleUrl: './accordion.style.less',

--- a/projects/kit/components/accordion/accordion.directive.ts
+++ b/projects/kit/components/accordion/accordion.directive.ts
@@ -7,7 +7,6 @@ import {TuiChevron} from '@taiga-ui/kit/directives/chevron';
 import {TuiAccordionComponent} from './accordion.component';
 
 @Directive({
-    standalone: true,
     selector: 'button[tuiAccordion]',
     providers: [
         tuiAvatarOptionsProvider({size: 's'}),

--- a/projects/kit/components/avatar/avatar-stack.component.ts
+++ b/projects/kit/components/avatar/avatar-stack.component.ts
@@ -7,7 +7,6 @@ import {
 import {type TuiHorizontalDirection} from '@taiga-ui/core/types';
 
 @Component({
-    standalone: true,
     selector: 'tui-avatar-stack',
     template: '<ng-content />',
     styleUrl: './avatar-stack.style.less',

--- a/projects/kit/components/badge-notification/badge-notification.component.ts
+++ b/projects/kit/components/badge-notification/badge-notification.component.ts
@@ -5,7 +5,6 @@ import {type TuiSizeL, type TuiSizeXS} from '@taiga-ui/core/types';
 import {TUI_BADGE_NOTIFICATION_OPTIONS} from './badge-notification.options';
 
 @Component({
-    standalone: true,
     selector: 'tui-badge-notification',
     template: '<ng-content />',
     styleUrl: './badge-notification.style.less',

--- a/projects/kit/components/badged-content/badged-content.directive.ts
+++ b/projects/kit/components/badged-content/badged-content.directive.ts
@@ -2,7 +2,6 @@ import {Directive, Input} from '@angular/core';
 import {type TuiLooseUnion} from '@taiga-ui/cdk/types';
 
 @Directive({
-    standalone: true,
     selector: '[tuiSlot]',
 })
 export class TuiBadgedContentDirective {

--- a/projects/kit/components/breadcrumbs/test/breadcrumbs.component.spec.ts
+++ b/projects/kit/components/breadcrumbs/test/breadcrumbs.component.spec.ts
@@ -29,7 +29,6 @@ const ITEMS = [
 
 describe('Breadcrumbs Wrapper', () => {
     @Component({
-        standalone: true,
         imports: [RouterTestingModule, TuiBreadcrumbs, TuiItem, TuiLink],
         template: `
             <tui-breadcrumbs

--- a/projects/kit/components/calendar-month/test/calendar-month.component.spec.ts
+++ b/projects/kit/components/calendar-month/test/calendar-month.component.spec.ts
@@ -8,7 +8,6 @@ const TODAY = TuiDay.currentLocal();
 
 describe('CalendarMonth', () => {
     @Component({
-        standalone: true,
         imports: [TuiCalendarMonth],
         template: `
             <tui-calendar-month

--- a/projects/kit/components/calendar-range/test/calendar-range.component.spec.ts
+++ b/projects/kit/components/calendar-range/test/calendar-range.component.spec.ts
@@ -30,7 +30,6 @@ import {type Observable, of} from 'rxjs';
 
 describe('rangeCalendarComponent', () => {
     @Component({
-        standalone: true,
         imports: [TuiCalendarRange],
         template: `
             <tui-calendar-range

--- a/projects/kit/components/carousel/carousel-autoscroll.directive.ts
+++ b/projects/kit/components/carousel/carousel-autoscroll.directive.ts
@@ -3,7 +3,6 @@ import {Directive, inject, Output} from '@angular/core';
 import {TuiCarouselDirective} from './carousel.directive';
 
 @Directive({
-    standalone: true,
     selector: '[tuiCarouselAutoscroll]',
 })
 export class TuiCarouselAutoscroll {

--- a/projects/kit/components/carousel/carousel-buttons.directive.ts
+++ b/projects/kit/components/carousel/carousel-buttons.directive.ts
@@ -2,7 +2,6 @@ import {Directive} from '@angular/core';
 import {tuiButtonOptionsProvider} from '@taiga-ui/core/components/button';
 
 @Directive({
-    standalone: true,
     selector: '[tuiCarouselButtons]',
     providers: [
         tuiButtonOptionsProvider({

--- a/projects/kit/components/carousel/carousel-scroll.directive.ts
+++ b/projects/kit/components/carousel/carousel-scroll.directive.ts
@@ -4,7 +4,6 @@ import {tuiInjectElement} from '@taiga-ui/cdk/utils/dom';
 import {filter, map, tap, throttleTime} from 'rxjs';
 
 @Directive({
-    standalone: true,
     selector: '[tuiCarouselScroll]',
 })
 export class TuiCarouselScroll {

--- a/projects/kit/components/carousel/carousel.directive.ts
+++ b/projects/kit/components/carousel/carousel.directive.ts
@@ -14,9 +14,7 @@ import {
     Observable,
 } from 'rxjs';
 
-@Directive({
-    standalone: true,
-})
+@Directive()
 export class TuiCarouselDirective extends Observable<unknown> {
     private readonly el = tuiInjectElement();
     private readonly platform = inject(PLATFORM_ID);

--- a/projects/kit/components/checkbox/checkbox.component.ts
+++ b/projects/kit/components/checkbox/checkbox.component.ts
@@ -11,7 +11,6 @@ import {TUI_RADIO_OPTIONS, TuiRadioComponent} from '@taiga-ui/kit/components/rad
 import {TUI_CHECKBOX_OPTIONS, type TuiCheckboxOptions} from './checkbox.options';
 
 @Component({
-    standalone: true,
     selector: 'input[type="checkbox"][tuiCheckbox]',
     template: '',
     styles: '@import "@taiga-ui/kit/styles/components/checkbox.less";',

--- a/projects/kit/components/combo-box/combo-box.directive.ts
+++ b/projects/kit/components/combo-box/combo-box.directive.ts
@@ -35,7 +35,6 @@ import {
 import {TuiSelectOption} from '@taiga-ui/kit/components/select';
 
 @Directive({
-    standalone: true,
     selector: 'input[tuiComboBox]',
     providers: [
         tuiAsOptionContent(TuiSelectOption),

--- a/projects/kit/components/compass/compass.component.ts
+++ b/projects/kit/components/compass/compass.component.ts
@@ -6,7 +6,6 @@ import {
 } from '@angular/core';
 
 @Component({
-    standalone: true,
     selector: 'tui-compass',
     template: '',
     styles: '@import "@taiga-ui/kit/styles/components/compass.less";',

--- a/projects/kit/components/copy/copy.directive.ts
+++ b/projects/kit/components/copy/copy.directive.ts
@@ -17,7 +17,6 @@ import {map, startWith, Subject, switchMap, timer} from 'rxjs';
 import {TUI_COPY_OPTIONS} from './copy.options';
 
 @Directive({
-    standalone: true,
     selector: 'tui-icon[tuiCopy]',
     providers: [
         {

--- a/projects/kit/components/elastic-container/elastic-container.directive.ts
+++ b/projects/kit/components/elastic-container/elastic-container.directive.ts
@@ -8,7 +8,6 @@ import {tuiInjectElement} from '@taiga-ui/cdk/utils/dom';
 import {debounceTime, distinctUntilChanged, map, merge} from 'rxjs';
 
 @Directive({
-    standalone: true,
     selector: '[tuiElasticContainer]',
     providers: [
         ResizeObserverService,

--- a/projects/kit/components/files/input-files/input-files-validator.directive.ts
+++ b/projects/kit/components/files/input-files/input-files-validator.directive.ts
@@ -10,7 +10,6 @@ import {
 import {TUI_INPUT_FILES_OPTIONS} from './input-files.options';
 
 @Directive({
-    standalone: true,
     inputs: ['accept', 'maxFileSize'],
     providers: [tuiProvide(NG_VALIDATORS, TuiInputFilesValidator, true)],
     exportAs: 'tuiInputFilesValidator',

--- a/projects/kit/components/files/input-files/input-files.directive.ts
+++ b/projects/kit/components/files/input-files/input-files.directive.ts
@@ -19,7 +19,6 @@ import {TUI_INPUT_FILES_OPTIONS} from './input-files.options';
 import {TuiInputFilesValidator} from './input-files-validator.directive';
 
 @Directive({
-    standalone: true,
     selector: 'input[tuiInputFiles]',
     providers: [
         tuiAsControl(TuiInputFilesDirective),

--- a/projects/kit/components/files/pipes/file-rejected.pipe.ts
+++ b/projects/kit/components/files/pipes/file-rejected.pipe.ts
@@ -14,7 +14,6 @@ import {
 import {TUI_INPUT_FILES_OPTIONS} from '../input-files/input-files.options';
 
 @Pipe({
-    standalone: true,
     name: 'tuiFileRejected',
 })
 export class TuiFileRejectedPipe implements PipeTransform {

--- a/projects/kit/components/filter/test/filter.component.spec.ts
+++ b/projects/kit/components/filter/test/filter.component.spec.ts
@@ -30,7 +30,6 @@ const ARR_OBJECT_WITH_ZERO_BADGE = [new ItemWithBadge('Focused Zone', 0)];
 
 describe('Filter', () => {
     @Component({
-        standalone: true,
         imports: [ReactiveFormsModule, TuiFilter],
         template: `
             <tui-filter

--- a/projects/kit/components/input-chip/input-chip.directive.ts
+++ b/projects/kit/components/input-chip/input-chip.directive.ts
@@ -27,7 +27,6 @@ import {TUI_INPUT_CHIP_OPTIONS} from './input-chip.options';
 
 // TODO(v5): remove base component after angular update
 @Directive({
-    standalone: true,
     host: {
         enterkeyhint: 'enter',
         '[disabled]': 'disabled()',
@@ -146,7 +145,6 @@ export class TuiInputChipBaseDirective<T>
 }
 
 @Directive({
-    standalone: true,
     selector: 'input[tuiInputChip]',
     providers: [
         tuiAsControl(TuiInputChipDirective),

--- a/projects/kit/components/input-date-multi/input-date-multi.directive.ts
+++ b/projects/kit/components/input-date-multi/input-date-multi.directive.ts
@@ -24,7 +24,6 @@ import {
 import {tuiMaskito} from '@taiga-ui/kit/utils';
 
 @Directive({
-    standalone: true,
     selector: 'input[tuiInputDateMulti]',
     providers: [
         tuiAsControl(TuiInputDateMultiDirective),

--- a/projects/kit/components/input-date-range/input-date-range.directive.ts
+++ b/projects/kit/components/input-date-range/input-date-range.directive.ts
@@ -27,7 +27,6 @@ import {tuiMaskito} from '@taiga-ui/kit/utils';
 import {TUI_INPUT_DATE_RANGE_OPTIONS} from './input-date-range.options';
 
 @Directive({
-    standalone: true,
     selector: 'input[tuiInputDateRange]',
     providers: [
         // TODO: Add SelectOption after data-list in calendar-range is refactored

--- a/projects/kit/components/input-date-time/input-date-time.directive.ts
+++ b/projects/kit/components/input-date-time/input-date-time.directive.ts
@@ -49,7 +49,6 @@ const MIN_TIME = new TuiTime(0, 0);
 const MAX_TIME = TuiTime.fromAbsoluteMilliseconds(MILLISECONDS_IN_DAY - 1);
 
 @Directive({
-    standalone: true,
     selector: 'input[tuiInputDateTime]',
     providers: [
         tuiAsOptionContent(TuiSelectOption),

--- a/projects/kit/components/input-date/input-date.directive.ts
+++ b/projects/kit/components/input-date/input-date.directive.ts
@@ -58,7 +58,6 @@ export const TUI_DATE_ADAPTER: Record<TuiDateMode, MaskitoDateMode> = {
 };
 
 @Directive({
-    standalone: true,
     host: {
         '[attr.inputmode]': 'mobile && open() ? "none" : "numeric"',
         '[disabled]': 'disabled()',
@@ -174,7 +173,6 @@ export abstract class TuiInputDateBase<
 }
 
 @Directive({
-    standalone: true,
     selector: 'input[tuiInputDate]',
     providers: [
         tuiAsOptionContent(TuiSelectOption),

--- a/projects/kit/components/input-inline/test/input-inline.component.spec.ts
+++ b/projects/kit/components/input-inline/test/input-inline.component.spec.ts
@@ -13,7 +13,6 @@ import {TuiInputInline} from '../input-inline.component';
 
 describe('InputInline', () => {
     @Component({
-        standalone: true,
         imports: [ReactiveFormsModule, TuiInputInline],
         template: `
             <tui-input-inline>

--- a/projects/kit/components/input-month-range/input-month-range.directive.ts
+++ b/projects/kit/components/input-month-range/input-month-range.directive.ts
@@ -24,7 +24,6 @@ import {TUI_MONTH_FORMATTER} from '@taiga-ui/kit/tokens';
 import {TUI_INPUT_MONTH_RANGE_OPTIONS} from './input-month-range.options';
 
 @Directive({
-    standalone: true,
     selector: 'input[tuiInputMonthRange]',
     providers: [
         tuiAsControl(TuiInputMonthRangeDirective),

--- a/projects/kit/components/input-month/input-month.directive.ts
+++ b/projects/kit/components/input-month/input-month.directive.ts
@@ -22,7 +22,6 @@ import {TUI_MONTH_FORMATTER} from '@taiga-ui/kit/tokens';
 import {TUI_INPUT_MONTH_OPTIONS} from './input-month.options';
 
 @Directive({
-    standalone: true,
     selector: 'input[tuiInputMonth]',
     providers: [
         tuiAsControl(TuiInputMonthDirective),

--- a/projects/kit/components/input-number/input-number.directive.ts
+++ b/projects/kit/components/input-number/input-number.directive.ts
@@ -26,7 +26,6 @@ import {TUI_INPUT_NUMBER_OPTIONS} from './input-number.options';
 const DEFAULT_MAX_LENGTH = 18;
 
 @Directive({
-    standalone: true,
     selector: 'input[tuiInputNumber]',
     providers: [
         tuiAsControl(TuiInputNumberDirective),

--- a/projects/kit/components/input-number/quantum.directive.ts
+++ b/projects/kit/components/input-number/quantum.directive.ts
@@ -38,7 +38,6 @@ export class TuiQuantumValueTransformerBase extends TuiValueTransformer<
 }
 
 @Directive({
-    standalone: true,
     selector: '[tuiInputNumber][quantum]',
     inputs: ['quantum'],
     providers: [tuiProvide(TuiValueTransformer, TuiQuantumValueTransformer)],
@@ -52,7 +51,6 @@ export class TuiQuantumValueTransformer extends TuiQuantumValueTransformerBase {
 }
 
 @Directive({
-    standalone: true,
     hostDirectives: [
         {
             directive: TuiQuantumValueTransformer,

--- a/projects/kit/components/input-phone-international/test/input-phone-international.component.spec.ts
+++ b/projects/kit/components/input-phone-international/test/input-phone-international.component.spec.ts
@@ -21,7 +21,6 @@ import {of} from 'rxjs';
 
 describe('InputPhoneInternational', () => {
     @Component({
-        standalone: true,
         imports: [ReactiveFormsModule, TuiInputPhoneInternational, TuiRoot, TuiTextfield],
         template: `
             <tui-root>

--- a/projects/kit/components/input-phone/input-phone.directive.ts
+++ b/projects/kit/components/input-phone/input-phone.directive.ts
@@ -34,7 +34,6 @@ function isText(value: string): boolean {
 }
 
 @Directive({
-    standalone: true,
     selector: 'input[tuiInputPhone]',
     providers: [
         tuiAsControl(TuiInputPhone),

--- a/projects/kit/components/input-time/input-time.directive.ts
+++ b/projects/kit/components/input-time/input-time.directive.ts
@@ -37,7 +37,6 @@ import {tuiMaskito} from '@taiga-ui/kit/utils';
 import {TUI_INPUT_TIME_OPTIONS} from './input-time.options';
 
 @Directive({
-    standalone: true,
     selector: 'input[tuiInputTime]',
     providers: [
         tuiAsControl(TuiInputTimeDirective),

--- a/projects/kit/components/input-year/input-year.directive.ts
+++ b/projects/kit/components/input-year/input-year.directive.ts
@@ -19,7 +19,6 @@ import {tuiMaskito} from '@taiga-ui/kit/utils';
 import {TUI_INPUT_YEAR_OPTIONS} from './input-year.options';
 
 @Directive({
-    standalone: true,
     selector: 'input[tuiInputYear]',
     providers: [
         tuiAsControl(TuiInputYearDirective),

--- a/projects/kit/components/items-with-more/items-with-more.directive.ts
+++ b/projects/kit/components/items-with-more/items-with-more.directive.ts
@@ -3,7 +3,6 @@ import {tuiInjectElement} from '@taiga-ui/cdk/utils/dom';
 import {Subject} from 'rxjs';
 
 @Directive({
-    standalone: true,
     host: {
         '[class._multiline]': 'linesLimit > 1',
         '[style.--t-min-width.px]': 'maxWidth()',

--- a/projects/kit/components/items-with-more/more.directive.ts
+++ b/projects/kit/components/items-with-more/more.directive.ts
@@ -2,7 +2,6 @@ import {Directive} from '@angular/core';
 import {type TuiContext} from '@taiga-ui/cdk/types';
 
 @Directive({
-    standalone: true,
     selector: '[tuiMore]',
 })
 export class TuiMore {

--- a/projects/kit/components/like/like.component.ts
+++ b/projects/kit/components/like/like.component.ts
@@ -15,7 +15,6 @@ import {TUI_ICON_END, TUI_ICON_START} from '@taiga-ui/core/tokens';
 import {TUI_LIKE_OPTIONS} from './like.options';
 
 @Component({
-    standalone: true,
     selector: 'input[tuiLike][type=checkbox]',
     template: '',
     styles: '@import "@taiga-ui/kit/styles/components/like.less";',

--- a/projects/kit/components/line-clamp/line-clamp-position.directive.ts
+++ b/projects/kit/components/line-clamp/line-clamp-position.directive.ts
@@ -8,7 +8,6 @@ import {TuiHintDirective} from '@taiga-ui/core/directives/hint';
 import {type TuiPoint} from '@taiga-ui/core/types';
 
 @Directive({
-    standalone: true,
     selector: '[tuiLineClampPosition]',
     providers: [tuiAsPositionAccessor(TuiLineClampPositionDirective)],
 })

--- a/projects/kit/components/message/message.directive.ts
+++ b/projects/kit/components/message/message.directive.ts
@@ -20,7 +20,6 @@ import {
 class Styles {}
 
 @Directive({
-    standalone: true,
     selector: '[tuiMessage]',
     providers: [
         {

--- a/projects/kit/components/multi-select/multi-select-group/multi-select-group.component.ts
+++ b/projects/kit/components/multi-select/multi-select-group/multi-select-group.component.ts
@@ -21,7 +21,6 @@ import {TUI_MULTI_SELECT_TEXTS} from '@taiga-ui/kit/tokens';
 import {tuiInjectValue} from '@taiga-ui/kit/utils';
 
 @Component({
-    standalone: true,
     selector: 'tui-opt-group[tuiMultiSelectGroup]',
     imports: [TuiLink],
     templateUrl: './multi-select-group.template.html',

--- a/projects/kit/components/notification-middle/notification-middle.directive.ts
+++ b/projects/kit/components/notification-middle/notification-middle.directive.ts
@@ -6,7 +6,6 @@ import {type TuiNotificationMiddleOptions} from './notification-middle.component
 import {TuiNotificationMiddleService} from './notification-middle.service';
 
 @Directive({
-    standalone: true,
     selector: 'ng-template[tuiNotificationMiddle]',
     inputs: ['options: tuiNotificationMiddleOptions', 'open: tuiNotificationMiddle'],
     outputs: ['openChange: tuiNotificationMiddleChange'],

--- a/projects/kit/components/pagination/test/pagination.component.spec.ts
+++ b/projects/kit/components/pagination/test/pagination.component.spec.ts
@@ -17,7 +17,6 @@ interface TuiPaginationParams {
 
 describe('TuiPaginationComponent', () => {
     @Component({
-        standalone: true,
         imports: [TuiPagination],
         template: `
             <tui-pagination

--- a/projects/kit/components/preview/action/preview-action.directive.ts
+++ b/projects/kit/components/preview/action/preview-action.directive.ts
@@ -2,7 +2,6 @@ import {Directive} from '@angular/core';
 import {tuiButtonOptionsProvider} from '@taiga-ui/core/components/button';
 
 @Directive({
-    standalone: true,
     selector: '[tuiPreviewAction]',
     providers: [
         tuiButtonOptionsProvider({

--- a/projects/kit/components/preview/dialog/preview-dialog.directive.ts
+++ b/projects/kit/components/preview/dialog/preview-dialog.directive.ts
@@ -5,7 +5,6 @@ import {tuiAsPopover} from '@taiga-ui/cdk/services';
 import {TuiPreviewDialogService} from './preview-dialog.service';
 
 @Directive({
-    standalone: true,
     selector: 'ng-template[tuiPreviewDialog]',
     inputs: ['open: tuiPreviewDialog'],
     outputs: ['openChange: tuiPreviewDialogChange'],

--- a/projects/kit/components/preview/pagination/test/preview-pagination.spec.ts
+++ b/projects/kit/components/preview/pagination/test/preview-pagination.spec.ts
@@ -8,7 +8,6 @@ describe('PreviewPagination', () => {
     let testComponent: Test;
 
     @Component({
-        standalone: true,
         imports: [TuiPreview],
         template: `
             <tui-preview-pagination

--- a/projects/kit/components/preview/title/preview-title.component.ts
+++ b/projects/kit/components/preview/title/preview-title.component.ts
@@ -1,7 +1,6 @@
 import {ChangeDetectionStrategy, Component} from '@angular/core';
 
 @Component({
-    standalone: true,
     selector: 'tui-preview-title',
     template: `
         <ng-content />

--- a/projects/kit/components/progress/progress-bar/progress-bar.component.ts
+++ b/projects/kit/components/progress/progress-bar/progress-bar.component.ts
@@ -10,7 +10,6 @@ import {type TuiSizeXXL, type TuiSizeXXS} from '@taiga-ui/core/types';
 import {TUI_PROGRESS_OPTIONS} from '../progress.options';
 
 @Component({
-    standalone: true,
     selector: 'progress[tuiProgressBar]',
     template: '',
     styles: '@import "@taiga-ui/kit/styles/components/progress-bar.less";',

--- a/projects/kit/components/progress/progress-bar/progress-color-segments.directive.ts
+++ b/projects/kit/components/progress/progress-bar/progress-color-segments.directive.ts
@@ -8,7 +8,6 @@ import {tuiInjectElement} from '@taiga-ui/cdk/utils/dom';
 import {map} from 'rxjs';
 
 @Directive({
-    standalone: true,
     selector: 'progress[tuiProgressBar][tuiProgressColorSegments]',
     providers: [
         MutationObserverService,

--- a/projects/kit/components/progress/progress-circle/progress-circle.component.ts
+++ b/projects/kit/components/progress/progress-circle/progress-circle.component.ts
@@ -7,7 +7,6 @@ import {delay, of} from 'rxjs';
 import {TUI_PROGRESS_OPTIONS} from '../progress.options';
 
 @Component({
-    standalone: true,
     selector: 'tui-progress-circle',
     templateUrl: './progress-circle.template.html',
     styleUrl: './progress-circle.style.less',

--- a/projects/kit/components/progress/progress-label/progress-label.component.ts
+++ b/projects/kit/components/progress/progress-label/progress-label.component.ts
@@ -1,7 +1,6 @@
 import {ChangeDetectionStrategy, Component} from '@angular/core';
 
 @Component({
-    standalone: true,
     selector: 'label[tuiProgressLabel]',
     templateUrl: './progress-label.template.html',
     styleUrl: './progress-label.style.less',

--- a/projects/kit/components/progress/test/progress-color-segments.spec.ts
+++ b/projects/kit/components/progress/test/progress-color-segments.spec.ts
@@ -13,7 +13,6 @@ describe('TuiProgressColorSegments', () => {
     let mutationObserverServiceMock: MutationObserverServiceMock;
 
     @Component({
-        standalone: true,
         imports: [TuiProgress],
         template: `
             <progress

--- a/projects/kit/components/pulse/pulse.component.ts
+++ b/projects/kit/components/pulse/pulse.component.ts
@@ -11,7 +11,6 @@ import {tuiInjectElement} from '@taiga-ui/cdk/utils/dom';
 import {tuiAsRectAccessor, TuiRectAccessor} from '@taiga-ui/core/classes';
 
 @Component({
-    standalone: true,
     selector: 'tui-pulse',
     template: '',
     styleUrl: './pulse.style.less',

--- a/projects/kit/components/push/test/push.component.spec.ts
+++ b/projects/kit/components/push/test/push.component.spec.ts
@@ -8,7 +8,6 @@ import {TuiPushService} from '../push.service';
 
 describe('Push with TUI_PUSH_OPTIONS', () => {
     @Component({
-        standalone: true,
         imports: [TuiRoot],
         template: `
             <tui-root />

--- a/projects/kit/components/radio/radio.component.ts
+++ b/projects/kit/components/radio/radio.component.ts
@@ -19,7 +19,6 @@ import {distinctUntilChanged} from 'rxjs';
 import {TUI_RADIO_OPTIONS, type TuiRadioOptions} from './radio.options';
 
 @Component({
-    standalone: true,
     selector: 'input[type="radio"][tuiRadio]',
     template: '',
     styles: '@import "@taiga-ui/kit/styles/components/radio.less";',

--- a/projects/kit/components/radio/radio.directive.ts
+++ b/projects/kit/components/radio/radio.directive.ts
@@ -4,7 +4,6 @@ import {TUI_DEFAULT_IDENTITY_MATCHER} from '@taiga-ui/cdk/constants';
 import {type TuiIdentityMatcher} from '@taiga-ui/cdk/types';
 
 @Directive({
-    standalone: true,
     selector: 'input[type="radio"][tuiRadio][identityMatcher]',
 })
 export class TuiRadioDirective<T> {

--- a/projects/kit/components/range/range-change.directive.ts
+++ b/projects/kit/components/range/range-change.directive.ts
@@ -9,9 +9,7 @@ import {map, repeat, startWith, switchMap, takeUntil, tap} from 'rxjs';
 
 import {TuiRange} from './range.component';
 
-@Directive({
-    standalone: true,
-})
+@Directive()
 export class TuiRangeChange {
     private readonly doc = inject(DOCUMENT);
     private readonly el = tuiInjectElement();

--- a/projects/kit/components/routable-dialog/routable-dialog.component.ts
+++ b/projects/kit/components/routable-dialog/routable-dialog.component.ts
@@ -12,7 +12,6 @@ import {PolymorpheusComponent} from '@taiga-ui/polymorpheus';
 import {from, of, switchMap} from 'rxjs';
 
 @Component({
-    standalone: true,
     selector: 'tui-routable-dialog',
     template: '',
     changeDetection: ChangeDetectionStrategy.OnPush,

--- a/projects/kit/components/routable-dialog/test/routable-dialog.component.spec.ts
+++ b/projects/kit/components/routable-dialog/test/routable-dialog.component.spec.ts
@@ -23,7 +23,6 @@ function providerOf(serviceToken: any, mockedService: any): Provider {
 }
 
 @Component({
-    standalone: true,
     template: '',
     changeDetection: ChangeDetectionStrategy.OnPush,
 })

--- a/projects/kit/components/segmented/segmented.component.ts
+++ b/projects/kit/components/segmented/segmented.component.ts
@@ -24,7 +24,6 @@ export const [TUI_SEGMENTED_OPTIONS, tuiSegmentedOptionsProvider] = tuiCreateOpt
 });
 
 @Component({
-    standalone: true,
     selector: 'tui-segmented',
     template: '<ng-content />',
     styleUrl: './segmented.style.less',

--- a/projects/kit/components/segmented/segmented.directive.ts
+++ b/projects/kit/components/segmented/segmented.directive.ts
@@ -17,7 +17,6 @@ import {map, switchMap} from 'rxjs';
 import {TuiSegmented} from './segmented.component';
 
 @Directive({
-    standalone: true,
     host: {
         '(click)': 'update($event.target)',
     },

--- a/projects/kit/components/select/select.directive.ts
+++ b/projects/kit/components/select/select.directive.ts
@@ -18,7 +18,6 @@ import {
 import {TuiSelectOption} from './select-option/select-option.component';
 
 @Directive({
-    standalone: true,
     selector: 'input[tuiSelect]',
     providers: [
         tuiAsOptionContent(TuiSelectOption),

--- a/projects/kit/components/slider/helpers/slider-key-steps.directive.ts
+++ b/projects/kit/components/slider/helpers/slider-key-steps.directive.ts
@@ -15,7 +15,6 @@ import {TuiSliderComponent} from '../slider.component';
 import {tuiCreateKeyStepsTransformer, type TuiKeySteps} from './key-steps';
 
 @Directive({
-    standalone: true,
     selector: 'input[tuiSlider][keySteps]',
     host: {
         '[attr.min]': 'transformer() ? 0 : slider.min',
@@ -93,7 +92,6 @@ export class TuiSliderKeyStepsBase {
 }
 
 @Directive({
-    standalone: true,
     selector:
         'input[tuiSlider][keySteps][ngModel],input[tuiSlider][keySteps][formControl],input[tuiSlider][keySteps][formControlName]',
     providers: [tuiFallbackValueProvider(0)],

--- a/projects/kit/components/slider/helpers/slider-readonly.directive.ts
+++ b/projects/kit/components/slider/helpers/slider-readonly.directive.ts
@@ -23,7 +23,6 @@ const SLIDER_INTERACTION_KEYS = new Set([
  * This directive imitates this native behaviour.
  */
 @Directive({
-    standalone: true,
     selector: 'input[tuiSlider][readonly]',
     host: {
         '(keydown)': 'preventKeyboardInteraction($event)',

--- a/projects/kit/components/slider/slider.component.ts
+++ b/projects/kit/components/slider/slider.component.ts
@@ -19,7 +19,6 @@ import {TuiSliderKeyStepsBase} from './helpers/slider-key-steps.directive';
 import {TUI_SLIDER_OPTIONS} from './slider.options';
 
 @Component({
-    standalone: true,
     selector: 'input[type=range][tuiSlider]',
     template: '',
     styleUrl: './slider.style.less',

--- a/projects/kit/components/slider/test/slider-key-steps.spec.ts
+++ b/projects/kit/components/slider/test/slider-key-steps.spec.ts
@@ -6,7 +6,6 @@ import {type TuiKeySteps, TuiSlider, TuiSliderComponent} from '@taiga-ui/kit';
 
 describe('TuiSliderKeyStepsDirective', () => {
     @Component({
-        standalone: true,
         imports: [ReactiveFormsModule, TuiSlider],
         template: `
             <input

--- a/projects/kit/components/slider/test/slider.spec.ts
+++ b/projects/kit/components/slider/test/slider.spec.ts
@@ -6,7 +6,6 @@ import {TuiSliderComponent} from '@taiga-ui/kit';
 
 describe('Slider', () => {
     @Component({
-        standalone: true,
         imports: [FormsModule, ReactiveFormsModule, TuiSliderComponent],
         template: `
             <input

--- a/projects/kit/components/switch/switch.component.ts
+++ b/projects/kit/components/switch/switch.component.ts
@@ -12,7 +12,6 @@ import {TUI_RADIO_OPTIONS, TuiRadioComponent} from '@taiga-ui/kit/components/rad
 import {TUI_SWITCH_OPTIONS, type TuiSwitchOptions} from './switch.options';
 
 @Component({
-    standalone: true,
     selector: 'input[type="checkbox"][tuiSwitch]',
     template: '',
     styles: '@import "@taiga-ui/kit/styles/components/switch.less";',

--- a/projects/kit/components/tabs/tab.directive.ts
+++ b/projects/kit/components/tabs/tab.directive.ts
@@ -11,7 +11,6 @@ import {EMPTY, filter, merge, switchMap, take} from 'rxjs';
 export const TUI_TAB_ACTIVATE = 'tui-tab-activate';
 
 @Directive({
-    standalone: true,
     selector:
         'a[tuiTab]:not([routerLink]), a[tuiTab][routerLink][routerLinkActive], button[tuiTab]',
     hostDirectives: [TuiWithIcons],

--- a/projects/kit/components/tabs/tabs-horizontal.directive.ts
+++ b/projects/kit/components/tabs/tabs-horizontal.directive.ts
@@ -22,7 +22,6 @@ import {TuiTabsDirective} from './tabs.directive';
 import {TUI_TABS_OPTIONS} from './tabs.options';
 
 @Directive({
-    standalone: true,
     selector: 'tui-tabs:not([vertical]), nav[tuiTabs]:not([vertical])',
     providers: [
         MutationObserverService,

--- a/projects/kit/components/tabs/tabs-vertical.directive.ts
+++ b/projects/kit/components/tabs/tabs-vertical.directive.ts
@@ -4,7 +4,6 @@ import {type TuiHorizontalDirection} from '@taiga-ui/core/types';
 import {TuiTabsDirective} from './tabs.directive';
 
 @Directive({
-    standalone: true,
     selector: 'tui-tabs[vertical], nav[tuiTabs][vertical]',
     hostDirectives: [
         {

--- a/projects/kit/components/tabs/test/tabs.component.spec.ts
+++ b/projects/kit/components/tabs/test/tabs.component.spec.ts
@@ -16,7 +16,6 @@ import {
 
 describe('Tabs', () => {
     @Component({
-        standalone: true,
         imports: [TuiTabs],
         template: `
             <tui-tabs

--- a/projects/kit/components/textarea/textarea-limit.directive.ts
+++ b/projects/kit/components/textarea/textarea-limit.directive.ts
@@ -26,7 +26,6 @@ import {injectContext, PolymorpheusComponent} from '@taiga-ui/polymorpheus';
 import {tuiTextareaOptionsProvider} from './textarea.options';
 
 @Component({
-    standalone: true,
     template: `
         <span [textContent]="context.$implicit.slice(0, limit())"></span>
         <span
@@ -42,7 +41,6 @@ export class TuiTextareaLimitComponent {
 }
 
 @Component({
-    standalone: true,
     template: '{{ length() }} / {{ limit() }}',
     styleUrl: './textarea-limit.style.less',
     changeDetection: ChangeDetectionStrategy.OnPush,
@@ -55,7 +53,6 @@ export class TuiTextareaCounterComponent {
 const COMPONENT = new PolymorpheusComponent(TuiTextareaLimitComponent);
 
 @Directive({
-    standalone: true,
     selector: '[tuiTextarea][limit]',
     providers: [
         tuiProvide(NG_VALIDATORS, TuiTextareaLimit, true),

--- a/projects/kit/components/tiles/tile-handle.directive.ts
+++ b/projects/kit/components/tiles/tile-handle.directive.ts
@@ -13,7 +13,6 @@ function isDragging(this: TuiTileHandle): boolean {
 }
 
 @Directive({
-    standalone: true,
     selector: '[tuiTileHandle]',
     host: {
         '[style.touchAction]': '"none"',

--- a/projects/kit/components/tiles/tile.component.ts
+++ b/projects/kit/components/tiles/tile.component.ts
@@ -15,7 +15,6 @@ import {TuiTileService} from './tile.service';
 import {TuiTilesComponent} from './tiles.component';
 
 @Component({
-    standalone: true,
     selector: 'tui-tile',
     templateUrl: './tile.template.html',
     changeDetection: ChangeDetectionStrategy.OnPush,

--- a/projects/kit/components/tiles/tiles.component.ts
+++ b/projects/kit/components/tiles/tiles.component.ts
@@ -18,7 +18,6 @@ import {BehaviorSubject, debounce, filter, map, Subject, timer} from 'rxjs';
 import {TUI_TILES_REORDER} from './tiles.tokens';
 
 @Component({
-    standalone: true,
     selector: 'tui-tiles',
     template: '<ng-content />',
     styleUrl: './tiles.style.less',

--- a/projects/kit/components/tree/directives/tree-children.directive.ts
+++ b/projects/kit/components/tree/directives/tree-children.directive.ts
@@ -3,7 +3,6 @@ import {EMPTY_ARRAY} from '@taiga-ui/cdk/constants';
 import {type TuiHandler} from '@taiga-ui/cdk/types';
 
 @Directive({
-    standalone: true,
     selector: 'tui-tree[childrenHandler]',
 })
 export class TuiTreeChildren<T> {

--- a/projects/kit/components/tree/directives/tree-controller.directive.ts
+++ b/projects/kit/components/tree/directives/tree-controller.directive.ts
@@ -6,7 +6,6 @@ import {type TuiTreeAccessor, type TuiTreeController} from '../misc/tree.interfa
 import {TUI_TREE_ACCESSOR, TUI_TREE_CONTROLLER} from '../misc/tree.tokens';
 
 @Directive({
-    standalone: true,
     selector: '[tuiTreeController][map]',
     providers: [
         tuiProvide(TUI_TREE_ACCESSOR, TuiTreeControllerDirective),

--- a/projects/kit/components/tree/directives/tree-item-controller.directive.ts
+++ b/projects/kit/components/tree/directives/tree-item-controller.directive.ts
@@ -6,7 +6,6 @@ import {type TuiTreeController} from '../misc/tree.interfaces';
 import {TUI_TREE_CONTROLLER} from '../misc/tree.tokens';
 
 @Directive({
-    standalone: true,
     selector: '[tuiTreeController]:not([map])',
     providers: [tuiProvide(TUI_TREE_CONTROLLER, TuiTreeItemController)],
     exportAs: 'tuiTreeController',

--- a/projects/kit/components/tree/directives/tree-node.directive.ts
+++ b/projects/kit/components/tree/directives/tree-node.directive.ts
@@ -5,7 +5,6 @@ import {type TuiTreeAccessor} from '../misc/tree.interfaces';
 import {TUI_TREE_ACCESSOR} from '../misc/tree.tokens';
 
 @Directive({
-    standalone: true,
     selector: 'tui-tree-item[tuiTreeNode]',
 })
 export class TuiTreeNode<T> implements OnDestroy {

--- a/projects/kit/directives/button-close/button-close.directive.ts
+++ b/projects/kit/directives/button-close/button-close.directive.ts
@@ -3,7 +3,6 @@ import {TuiButton, tuiButtonOptionsProvider} from '@taiga-ui/core/components/but
 import {TUI_COMMON_ICONS, TUI_ICON_START} from '@taiga-ui/core/tokens';
 
 @Directive({
-    standalone: true,
     selector: '[tuiButtonClose]',
     providers: [
         tuiButtonOptionsProvider({appearance: 'neutral', size: 's'}),

--- a/projects/kit/directives/button-select/button-select.directive.ts
+++ b/projects/kit/directives/button-select/button-select.directive.ts
@@ -15,7 +15,6 @@ import {
 import {TuiSelectOption} from '@taiga-ui/kit/components/select';
 
 @Directive({
-    standalone: true,
     selector: 'button[tuiButtonSelect]',
     providers: [
         tuiAsOptionContent(TuiSelectOption),

--- a/projects/kit/directives/connected/connected.directive.ts
+++ b/projects/kit/directives/connected/connected.directive.ts
@@ -16,7 +16,6 @@ import {tuiWithStyles} from '@taiga-ui/cdk/utils/miscellaneous';
 class Styles {}
 
 @Directive({
-    standalone: true,
     selector: '[tuiConnected]',
 })
 export class TuiConnected {

--- a/projects/kit/directives/data-list-dropdown-manager/data-list-dropdown-manager.directive.ts
+++ b/projects/kit/directives/data-list-dropdown-manager/data-list-dropdown-manager.directive.ts
@@ -31,7 +31,6 @@ import {
 } from 'rxjs';
 
 @Directive({
-    standalone: true,
     selector: 'tui-data-list[tuiDataListDropdownManager]',
 })
 export class TuiDataListDropdownManager implements AfterViewInit {

--- a/projects/kit/directives/fluid-typography/fluid-typography.directive.ts
+++ b/projects/kit/directives/fluid-typography/fluid-typography.directive.ts
@@ -14,7 +14,6 @@ import {TUI_FLUID_TYPOGRAPHY_OPTIONS} from './fluid-typography.options';
 const STEP = 1 / 16;
 
 @Directive({
-    standalone: true,
     selector: '[tuiFluidTypography]',
     providers: [
         ResizeObserverService,

--- a/projects/kit/directives/highlight/highlight.directive.ts
+++ b/projects/kit/directives/highlight/highlight.directive.ts
@@ -12,7 +12,6 @@ export const [TUI_HIGHLIGHT_OPTIONS, tuiHighlightOptionsProvider] = tuiCreateOpt
 });
 
 @Directive({
-    standalone: true,
     selector: '[tuiHighlight]',
     providers: [ResizeObserverService],
     host: {

--- a/projects/kit/directives/highlight/test/highlight.directive.spec.ts
+++ b/projects/kit/directives/highlight/test/highlight.directive.spec.ts
@@ -5,7 +5,6 @@ import {TuiHighlight} from '@taiga-ui/kit';
 
 describe('TuiHighlight directive', () => {
     @Component({
-        standalone: true,
         imports: [TuiHighlight],
         template: `
             <div

--- a/projects/kit/directives/lazy-loading/lazy-loading.directive.ts
+++ b/projects/kit/directives/lazy-loading/lazy-loading.directive.ts
@@ -11,7 +11,6 @@ import {TuiLazyLoadingService} from './lazy-loading.service';
  * @deprecated: Drop in v5.0
  */
 @Directive({
-    standalone: true,
     selector: 'img[loading="lazy"],img[tuiLoading="lazy"]',
     providers: [TuiLazyLoadingService, IntersectionObserverService],
     host: {

--- a/projects/kit/directives/password/password.directive.ts
+++ b/projects/kit/directives/password/password.directive.ts
@@ -12,7 +12,6 @@ import {TUI_PASSWORD_TEXTS} from '@taiga-ui/kit/tokens';
 import {TUI_PASSWORD_OPTIONS} from './password.options';
 
 @Directive({
-    standalone: true,
     selector: 'tui-icon[tuiPassword]',
     providers: [
         {

--- a/projects/kit/directives/present/present.directive.ts
+++ b/projects/kit/directives/present/present.directive.ts
@@ -2,7 +2,6 @@ import {Directive, type OnDestroy, Output} from '@angular/core';
 import {BehaviorSubject, distinctUntilChanged, skip} from 'rxjs';
 
 @Directive({
-    standalone: true,
     selector: '[tuiPresentChange]',
     host: {
         '[style.animation]': '"tuiPresent 1s infinite"',

--- a/projects/kit/directives/unfinished-validator/unfinished-validator.directive.ts
+++ b/projects/kit/directives/unfinished-validator/unfinished-validator.directive.ts
@@ -9,7 +9,6 @@ import {isObservable} from 'rxjs';
 import {tuiCreateUnfinishedValidator} from './unfinished.validator';
 
 @Directive({
-    standalone: true,
     selector: 'input[tuiUnfinishedValidator]',
     providers: [tuiProvide(NG_VALIDATORS, TuiUnfinishedValidator, true)],
 })

--- a/projects/kit/directives/unmask-handler/unmask-handler.directive.ts
+++ b/projects/kit/directives/unmask-handler/unmask-handler.directive.ts
@@ -10,7 +10,6 @@ import {tuiProvide} from '@taiga-ui/cdk/utils/miscellaneous';
 import {identity} from 'rxjs';
 
 @Directive({
-    standalone: true,
     selector: '[maskito][tuiUnmaskHandler]',
     providers: [tuiProvide(TuiValueTransformer, TuiUnmaskHandler)],
 })

--- a/projects/kit/pipes/emails/emails.pipe.ts
+++ b/projects/kit/pipes/emails/emails.pipe.ts
@@ -3,7 +3,6 @@ import {inject, Pipe, type PipeTransform} from '@angular/core';
 import {TUI_EMAIL_PIPE_OPTIONS} from './emails.options';
 
 @Pipe({
-    standalone: true,
     name: 'tuiEmails',
 })
 export class TuiEmailsPipe implements PipeTransform {

--- a/projects/kit/pipes/filter-by-input/filter-by-input.pipe.ts
+++ b/projects/kit/pipes/filter-by-input/filter-by-input.pipe.ts
@@ -12,7 +12,6 @@ import {tuiIsFlat} from '@taiga-ui/kit/utils';
 
 // TODO: Consider replacing TuiTextfieldComponent with proper token once we refactor textfields
 @Pipe({
-    standalone: true,
     name: 'tuiFilterByInput',
     pure: false,
 })

--- a/projects/kit/pipes/hide-selected/hide-selected.pipe.ts
+++ b/projects/kit/pipes/hide-selected/hide-selected.pipe.ts
@@ -6,7 +6,6 @@ import {TUI_ITEMS_HANDLERS} from '@taiga-ui/core/directives/items-handlers';
 import {tuiIsFlat} from '@taiga-ui/kit/utils';
 
 @Pipe({
-    standalone: true,
     name: 'tuiHideSelected',
     pure: false,
 })

--- a/projects/kit/pipes/sort-countries/sort-countries.pipe.ts
+++ b/projects/kit/pipes/sort-countries/sort-countries.pipe.ts
@@ -5,7 +5,6 @@ import {TUI_COUNTRIES} from '@taiga-ui/kit/tokens';
 import {map, type Observable} from 'rxjs';
 
 @Pipe({
-    standalone: true,
     name: 'tuiSortCountries',
 })
 export class TuiSortCountriesPipe implements PipeTransform {

--- a/projects/kit/pipes/stringify-content/stringify-content.pipe.ts
+++ b/projects/kit/pipes/stringify-content/stringify-content.pipe.ts
@@ -3,7 +3,6 @@ import {type TuiStringHandler} from '@taiga-ui/cdk/types';
 import {type TuiValueContentContext} from '@taiga-ui/core/types';
 
 @Pipe({
-    standalone: true,
     name: 'tuiStringifyContent',
 })
 export class TuiStringifyContentPipe implements PipeTransform {

--- a/projects/kit/pipes/stringify/stringify.pipe.ts
+++ b/projects/kit/pipes/stringify/stringify.pipe.ts
@@ -2,7 +2,6 @@ import {Pipe, type PipeTransform} from '@angular/core';
 import {type TuiStringHandler} from '@taiga-ui/cdk/types';
 
 @Pipe({
-    standalone: true,
     name: 'tuiStringify',
 })
 export class TuiStringifyPipe implements PipeTransform {

--- a/projects/layout/components/app-bar/app-bar-size.directive.ts
+++ b/projects/layout/components/app-bar/app-bar-size.directive.ts
@@ -8,7 +8,6 @@ import {TuiAppBarComponent} from './app-bar.component';
 
 // TODO: Make size automatic based on tuiPlatform in v5
 @Directive({
-    standalone: true,
     selector: 'tui-app-bar[tuiAppBarSize]',
 })
 export class TuiAppBarSizeDirective {

--- a/projects/layout/components/app-bar/app-bar.directive.ts
+++ b/projects/layout/components/app-bar/app-bar.directive.ts
@@ -2,7 +2,6 @@ import {Directive, input} from '@angular/core';
 import {type TuiLooseUnion} from '@taiga-ui/cdk/types';
 
 @Directive({
-    standalone: true,
     selector: '[tuiSlot]',
 })
 export class TuiAppBarDirective {

--- a/projects/layout/components/block-status/block-status.component.ts
+++ b/projects/layout/components/block-status/block-status.component.ts
@@ -7,7 +7,6 @@ import {
 import {type TuiSizeL} from '@taiga-ui/core/types';
 
 @Component({
-    standalone: true,
     selector: 'tui-block-status',
     templateUrl: './block-status.template.html',
     styleUrl: './block-status.style.less',

--- a/projects/layout/components/block-status/block-status.directive.ts
+++ b/projects/layout/components/block-status/block-status.directive.ts
@@ -2,7 +2,6 @@ import {Directive, input} from '@angular/core';
 import {type TuiLooseUnion} from '@taiga-ui/cdk/types';
 
 @Directive({
-    standalone: true,
     selector: '[tuiSlot]',
 })
 export class TuiBlockStatusDirective {

--- a/projects/layout/components/dynamic-header/dynamic-header-anchor.directive.ts
+++ b/projects/layout/components/dynamic-header/dynamic-header-anchor.directive.ts
@@ -12,7 +12,6 @@ import {WaIntersectionObserverDirective} from '@ng-web-apis/intersection-observe
 import {TuiDynamicHeaderContainerDirective} from './dynamic-header-container.directive';
 
 @Directive({
-    standalone: true,
     selector: '[tuiDynamicHeaderAnchor]',
 })
 export class TuiDynamicHeaderAnchorDirective implements AfterViewInit, OnDestroy {

--- a/projects/layout/components/dynamic-header/dynamic-header-container.directive.ts
+++ b/projects/layout/components/dynamic-header/dynamic-header-container.directive.ts
@@ -11,7 +11,6 @@ import {distinctUntilChanged, fromEvent, map, pairwise} from 'rxjs';
 import {TuiDynamicHeaderAnchorDirective} from './dynamic-header-anchor.directive';
 
 @Directive({
-    standalone: true,
     selector: '[tuiDynamicHeaderContainer]',
     hostDirectives: [WaIntersectionRoot, WaIntersectionObserverDirective],
     host: {

--- a/projects/layout/components/navigation/aside-item.directive.ts
+++ b/projects/layout/components/navigation/aside-item.directive.ts
@@ -21,7 +21,6 @@ import {TUI_CHEVRON, TuiChevron} from '@taiga-ui/kit/directives/chevron';
 import {TuiHintAsideDirective} from './hint-aside.directive';
 
 @Directive({
-    standalone: true,
     selector: '[tuiAsideItem]',
     providers: [
         tuiAsDataListHost(TuiAsideItemDirective),

--- a/projects/layout/components/navigation/drawer.component.ts
+++ b/projects/layout/components/navigation/drawer.component.ts
@@ -60,7 +60,6 @@ class TuiDrawerComponent {
 }
 
 @Component({
-    standalone: true,
     // TODO: move to host directives
     selector: '[tuiIconButton][tuiNavigationDrawer]',
     template: '<ng-template><ng-content /></ng-template>',

--- a/projects/layout/components/navigation/header.component.ts
+++ b/projects/layout/components/navigation/header.component.ts
@@ -13,7 +13,6 @@ import {tuiBadgeOptionsProvider} from '@taiga-ui/kit/components/badge';
 import {tuiBadgeNotificationOptionsProvider} from '@taiga-ui/kit/components/badge-notification';
 
 @Component({
-    standalone: true,
     selector: 'header[tuiNavigationHeader]',
     template: '<ng-content />',
     styleUrl: './header.style.less',

--- a/projects/layout/components/navigation/hint-aside.directive.ts
+++ b/projects/layout/components/navigation/hint-aside.directive.ts
@@ -7,7 +7,6 @@ import {TuiHintDirective, tuiHintOptionsProvider} from '@taiga-ui/core/directive
 import {TuiAsideComponent} from './aside.component';
 
 @Directive({
-    standalone: true,
     selector: '[tuiHintAside]',
     providers: [tuiHintOptionsProvider({direction: 'right'})],
     hostDirectives: [TuiHintDirective],

--- a/projects/layout/components/navigation/logo.component.ts
+++ b/projects/layout/components/navigation/logo.component.ts
@@ -1,7 +1,6 @@
 import {ChangeDetectionStrategy, Component, ViewEncapsulation} from '@angular/core';
 
 @Component({
-    standalone: true,
     selector: '[tuiNavigationLogo]',
     template: '<ng-content />',
     styleUrl: './logo.style.less',

--- a/projects/layout/components/navigation/main.component.ts
+++ b/projects/layout/components/navigation/main.component.ts
@@ -1,7 +1,6 @@
 import {ChangeDetectionStrategy, Component, ViewEncapsulation} from '@angular/core';
 
 @Component({
-    standalone: true,
     selector: 'main[tuiNavigationMain]',
     template: '<ng-content />',
     styleUrl: './main.style.less',

--- a/projects/layout/components/navigation/nav.component.ts
+++ b/projects/layout/components/navigation/nav.component.ts
@@ -4,7 +4,6 @@ import {tuiBadgeOptionsProvider} from '@taiga-ui/kit/components/badge';
 import {tuiTabsOptionsProvider} from '@taiga-ui/kit/components/tabs';
 
 @Component({
-    standalone: true,
     selector: 'nav[tuiNavigationNav]',
     template: '<ng-content />',
     styleUrl: './nav.style.less',

--- a/projects/layout/components/navigation/subheader.component.ts
+++ b/projects/layout/components/navigation/subheader.component.ts
@@ -22,7 +22,6 @@ const PROVIDERS = [
 ];
 
 @Component({
-    standalone: true,
     selector: '[tuiSubheader]:not([compact]),[tuiNavigationSubheader]:not([compact])',
     template: `
         <ng-content select="[tuiLink]" />
@@ -42,7 +41,6 @@ const PROVIDERS = [
 export class TuiSubheaderComponent {}
 
 @Component({
-    standalone: true,
     selector: '[tuiSubheader][compact],[tuiNavigationSubheader][compact]',
     template: `
         <div class="t-nav-subheader">

--- a/projects/layout/components/search/search-filter.component.ts
+++ b/projects/layout/components/search/search-filter.component.ts
@@ -16,7 +16,6 @@ import {TUI_ICON_START} from '@taiga-ui/core/tokens';
 import {TUI_COMMON_ICONS} from '@taiga-ui/layout/tokens';
 
 @Component({
-    standalone: true,
     selector: 'button[tuiSearchFilter]',
     template: '<ng-template><ng-content /></ng-template>filters',
     changeDetection: ChangeDetectionStrategy.OnPush,

--- a/projects/layout/components/search/search.component.ts
+++ b/projects/layout/components/search/search.component.ts
@@ -10,7 +10,6 @@ import {tuiBlockOptionsProvider} from '@taiga-ui/kit/components/block';
 import {tuiSwitchOptionsProvider} from '@taiga-ui/kit/components/switch';
 
 @Component({
-    standalone: true,
     selector: 'search[tuiSearch]',
     template: '<ng-content/>',
     styleUrl: './search.styles.less',

--- a/projects/legacy/components/dialog/dialog.directive.ts
+++ b/projects/legacy/components/dialog/dialog.directive.ts
@@ -6,7 +6,6 @@ import {type TuiDialogOptions} from './dialog.interfaces';
 import {TuiDialogService} from './dialog.service';
 
 @Directive({
-    standalone: true,
     selector: 'ng-template[tuiDialog]',
     inputs: ['options: tuiDialogOptions', 'open: tuiDialog'],
     outputs: ['openChange: tuiDialogChange'],

--- a/projects/legacy/components/input-date-range/test/input-date-range.component.spec.ts
+++ b/projects/legacy/components/input-date-range/test/input-date-range.component.spec.ts
@@ -33,7 +33,6 @@ import {TuiNativeInputPO, TuiPageObject} from '@taiga-ui/testing';
 
 describe('InputDateRangeComponent', () => {
     @Component({
-        standalone: true,
         imports: [
             FormsModule,
             ReactiveFormsModule,
@@ -451,7 +450,6 @@ describe('InputDateRangeComponent', () => {
         }
 
         @Component({
-            standalone: true,
             imports: [
                 ReactiveFormsModule,
                 TuiInputDateRangeModule,

--- a/projects/legacy/components/input-date-time/test/input-date-time.component.spec.ts
+++ b/projects/legacy/components/input-date-time/test/input-date-time.component.spec.ts
@@ -22,7 +22,6 @@ import {TuiNativeInputPO, TuiPageObject} from '@taiga-ui/testing';
 
 describe('InputDateTime', () => {
     @Component({
-        standalone: true,
         imports: [ReactiveFormsModule, TuiInputDateTimeModule, TuiRoot],
         template: `
             <tui-root>
@@ -410,7 +409,6 @@ describe('InputDateTime', () => {
         }
 
         @Component({
-            standalone: true,
             imports: [ReactiveFormsModule, TuiInputDateTimeModule, TuiRoot],
             template: `
                 <tui-root>
@@ -544,7 +542,6 @@ describe('InputDateTime', () => {
         }
 
         @Component({
-            standalone: true,
             imports: [ReactiveFormsModule, TuiInputDateTimeModule, TuiRoot],
             template: `
                 <tui-root>

--- a/projects/legacy/components/input-month-range/test/input-month-range.component.spec.ts
+++ b/projects/legacy/components/input-month-range/test/input-month-range.component.spec.ts
@@ -7,7 +7,6 @@ import {TuiInputMonthRangeComponent, TuiInputMonthRangeModule} from '@taiga-ui/l
 
 describe('InputMonthRange', () => {
     @Component({
-        standalone: true,
         imports: [ReactiveFormsModule, TuiInputMonthRangeModule],
         template: `
             <tui-input-month-range [formControl]="control" />

--- a/projects/legacy/components/input-number/test/input-number-format.spec.ts
+++ b/projects/legacy/components/input-number/test/input-number-format.spec.ts
@@ -13,7 +13,6 @@ import {TuiNativeInputPO} from '@taiga-ui/testing';
 
 describe('InputNumber - backward compatibility for separators', () => {
     @Component({
-        standalone: true,
         imports: [ReactiveFormsModule, TuiInputNumberModule, TuiNumberFormat],
         template: `
             <ng-container [formGroup]="form">

--- a/projects/legacy/components/input-number/test/input-number.component.spec.ts
+++ b/projects/legacy/components/input-number/test/input-number.component.spec.ts
@@ -25,7 +25,6 @@ import {TuiNativeInputPO, TuiPageObject} from '@taiga-ui/testing';
 
 describe('InputNumber', () => {
     @Component({
-        standalone: true,
         imports: [
             ReactiveFormsModule,
             TuiHint,

--- a/projects/legacy/components/input-range/test/input-range.component.spec.ts
+++ b/projects/legacy/components/input-range/test/input-range.component.spec.ts
@@ -13,7 +13,6 @@ import {TuiNativeInputPO, TuiPageObject} from '@taiga-ui/testing';
 
 describe('InputRange', () => {
     @Component({
-        standalone: true,
         imports: [ReactiveFormsModule, TuiInputRangeModule],
         template: `
             @if (default) {

--- a/projects/legacy/components/input-slider/test/input-slider.component.spec.ts
+++ b/projects/legacy/components/input-slider/test/input-slider.component.spec.ts
@@ -16,7 +16,6 @@ import {
 import {TuiNativeInputPO, TuiPageObject} from '@taiga-ui/testing';
 
 @Component({
-    standalone: true,
     imports: [
         ReactiveFormsModule,
         TuiInputSliderModule,

--- a/projects/legacy/components/input-tag/test/input-tag.component.spec.ts
+++ b/projects/legacy/components/input-tag/test/input-tag.component.spec.ts
@@ -31,7 +31,6 @@ const TAG = 'Tag';
 
 describe('InputTag', () => {
     @Component({
-        standalone: true,
         imports: [
             ReactiveFormsModule,
             TuiHint,

--- a/projects/legacy/components/input/test/input.component.spec.ts
+++ b/projects/legacy/components/input/test/input.component.spec.ts
@@ -50,7 +50,6 @@ const ITEMS = [
 
 describe('Input', () => {
     @Component({
-        standalone: true,
         imports: [
             ReactiveFormsModule,
             TuiDataListDirective,

--- a/projects/legacy/components/multi-select/test/multi-select.component.spec.ts
+++ b/projects/legacy/components/multi-select/test/multi-select.component.spec.ts
@@ -41,7 +41,6 @@ describe('MultiSelect', () => {
         ];
 
         @Component({
-            standalone: true,
             imports: [
                 ReactiveFormsModule,
                 TuiDataListDirective,
@@ -258,7 +257,6 @@ describe('MultiSelect', () => {
         const items = [new User('Alexander', 'Inkin', '1')];
 
         @Component({
-            standalone: true,
             imports: [
                 ReactiveFormsModule,
                 TuiDataListDirective,

--- a/projects/legacy/components/pdf-viewer/pdf-viewer.directive.ts
+++ b/projects/legacy/components/pdf-viewer/pdf-viewer.directive.ts
@@ -6,7 +6,6 @@ import {type TuiPdfViewerOptions} from './pdf-viewer.options';
 import {TuiPdfViewerService} from './pdf-viewer.service';
 
 @Directive({
-    standalone: true,
     selector: 'ng-template[tuiPdfViewer]',
     inputs: ['options: tuiPdfViewerOptions', 'open: tuiPdfViewer'],
     outputs: ['openChange: tuiPdfViewerChange'],

--- a/projects/legacy/components/pdf-viewer/test/pdf-viewer.component.spec.ts
+++ b/projects/legacy/components/pdf-viewer/test/pdf-viewer.component.spec.ts
@@ -9,7 +9,6 @@ import {TuiPdfViewerService} from '../pdf-viewer.service';
 
 describe('Pdf Viewer with TUI_PDF_VIEWER_OPTIONS', () => {
     @Component({
-        standalone: true,
         imports: [TuiRoot],
         template: `
             <tui-root />

--- a/projects/legacy/components/primitive-textfield/test/primitive-textfield.component.spec.ts
+++ b/projects/legacy/components/primitive-textfield/test/primitive-textfield.component.spec.ts
@@ -10,7 +10,6 @@ import {TuiPrimitiveTextfieldHarness} from '@taiga-ui/testing';
 
 describe('PrimitiveTextfield', () => {
     @Component({
-        standalone: true,
         imports: [TuiPrimitiveTextfieldModule, TuiTextfieldControllerModule],
         template: `
             <tui-primitive-textfield id="test1" />

--- a/projects/legacy/components/primitive-textfield/test/textfield.component.spec.ts
+++ b/projects/legacy/components/primitive-textfield/test/textfield.component.spec.ts
@@ -6,7 +6,6 @@ import {TuiPrimitiveTextfieldModule} from '../primitive-textfield.module';
 
 describe('Textfield', () => {
     @Component({
-        standalone: true,
         imports: [TuiPrimitiveTextfieldModule],
         template: `
             <input

--- a/projects/legacy/components/select/test/select.component.spec.ts
+++ b/projects/legacy/components/select/test/select.component.spec.ts
@@ -34,7 +34,6 @@ const MATCHER: TuiIdentityMatcher<Beast> = (item1, item2) => item1.id === item2.
 
 describe('Select', () => {
     @Component({
-        standalone: true,
         imports: [
             ReactiveFormsModule,
             TuiDataListDirective,

--- a/projects/legacy/components/tag/test/tag-options.spec.ts
+++ b/projects/legacy/components/tag/test/tag-options.spec.ts
@@ -8,7 +8,6 @@ describe('Tag component options', () => {
     let testComponent: Test;
 
     @Component({
-        standalone: true,
         imports: [TuiTagModule],
         template: `
             <tui-tag />

--- a/projects/legacy/components/tag/test/tag.component.spec.ts
+++ b/projects/legacy/components/tag/test/tag.component.spec.ts
@@ -8,7 +8,6 @@ import {TuiTagHarness} from '@taiga-ui/testing';
 
 describe('Tag', () => {
     @Component({
-        standalone: true,
         imports: [TuiTagModule],
         template: `
             <tui-tag id="default" />

--- a/projects/legacy/components/textarea/test/textarea.component.spec.ts
+++ b/projects/legacy/components/textarea/test/textarea.component.spec.ts
@@ -24,7 +24,6 @@ const DEFAULT_HEIGHT = 108;
 
 describe('Textarea', () => {
     @Component({
-        standalone: true,
         imports: [ReactiveFormsModule, TuiHint, TuiTextareaModule],
         template: `
             <tui-textarea

--- a/projects/legacy/directives/legacy-dropdown-open-monitor/legacy-dropdown-open-monitor.ts
+++ b/projects/legacy/directives/legacy-dropdown-open-monitor/legacy-dropdown-open-monitor.ts
@@ -6,7 +6,6 @@ import {TuiDropdownOpen, TuiDropdownOpenLegacy} from '@taiga-ui/core/directives/
 import {distinctUntilChanged} from 'rxjs';
 
 @Directive({
-    standalone: true,
     selector: '[tuiDropdownOpenMonitor]',
 })
 export class TuiLegacyDropdownOpenMonitorDirective implements AfterViewInit {

--- a/projects/legacy/directives/unfinished-validator/unfinished-validator.directive.ts
+++ b/projects/legacy/directives/unfinished-validator/unfinished-validator.directive.ts
@@ -7,7 +7,6 @@ import {TUI_FOCUSABLE_ITEM_ACCESSOR} from '@taiga-ui/legacy/tokens';
 import {tuiCreateUnfinishedValidator} from './unfinished.validator';
 
 @Directive({
-    standalone: true,
     selector: '[tuiUnfinishedValidator]',
     providers: [tuiProvide(NG_VALIDATORS, TuiUnfinishedValidator, true)],
 })


### PR DESCRIPTION
## Summary
- remove redundant `standalone: true` declarations from Angular components, directives, pipes, and companion specs
- rely on the Angular 19 default standalone behavior across the codebase
