### PR TITLE
fix: `Present` workaround for ios26

### DIFF
--- a/projects/core/components/root/animations.less
+++ b/projects/core/components/root/animations.less
@@ -7,7 +7,7 @@
 
 @keyframes tuiPresent {
     to {
-        content: '';
+        opacity: 0.99999; // https://bugs.webkit.org/show_bug.cgi?id=302153
     }
 }
 


### PR DESCRIPTION
Fixes #12463

