### PR TITLE
fix(core): `tuiLink` with `iconStart` has double transition

### DIFF
--- a/projects/core/styles/components/link.less
+++ b/projects/core/styles/components/link.less
@@ -51,6 +51,7 @@
         line-height: 0;
         box-sizing: border-box;
         mask-size: calc(100% + 10 * var(--tui-stroke-width, 0.125rem)) 100%;
+        transition: none;
     }
 
     &[tuiChevron]::after {


### PR DESCRIPTION
Fixes #12490 

[Screencast from 2025-11-08 12-41-57.webm](https://github.com/user-attachments/assets/4c9fa6c9-ba2f-416e-a59d-f228e6104ec9)
