### PR TITLE
fix(layout): fix app-bar-back padding inside dialog on desktop

### DIFF
--- a/projects/demo-playwright/tests/layout/app-bar.pw.spec.ts
+++ b/projects/demo-playwright/tests/layout/app-bar.pw.spec.ts
@@ -1,0 +1,20 @@
+import {DemoRoute} from '@demo/routes';
+import {tuiGoto} from '@demo-playwright/utils';
+import {expect, test} from '@playwright/test';
+
+test.describe('AppBar', () => {
+    test.use({
+        viewport: {width: 1000, height: 720},
+    });
+
+    test('desktop appbar inside dialog', async ({page}) => {
+        await tuiGoto(page, DemoRoute.AppBar);
+
+        const example = page.locator('#dialog');
+        const button = example.locator('button[tuiButton]').last();
+
+        await button.click();
+
+        await expect.soft(page).toHaveScreenshot('01-app-bar.png');
+    });
+});

--- a/projects/layout/components/app-bar/app-bar-back.style.less
+++ b/projects/layout/components/app-bar/app-bar-back.style.less
@@ -8,6 +8,10 @@
     padding: 0 1rem 0 0;
     cursor: pointer;
 
+    :host-context([data-platform='web'] tui-dialog) {
+        padding: 0 0.5rem;
+    }
+
     :host-context([data-platform='android']) {
         font-size: 0;
         padding: 0 1rem;


### PR DESCRIPTION
Fixes # <!-- link to a relevant issue. -->
