### PR TITLE
chore(demo): improve example of `Copy` documentation page (letters get cut at the bottom)

### DIFF
--- a/projects/demo/src/modules/components/copy/examples/1/index.less
+++ b/projects/demo/src/modules/components/copy/examples/1/index.less
@@ -13,5 +13,5 @@ span {
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
-    vertical-align: middle;
+    vertical-align: text-bottom;
 }


### PR DESCRIPTION
Fixes #12502
