### PR TITLE
fix(kit): `InputNumber` with long `[prefix]`/`[postfix]` has invalid input length restriction

### DIFF
--- a/projects/demo-playwright/tests/kit/input-number/input-number.pw.spec.ts
+++ b/projects/demo-playwright/tests/kit/input-number/input-number.pw.spec.ts
@@ -607,6 +607,8 @@ describe('InputNumber', () => {
                     {prefix: '$', postfix: ''},
                     {prefix: '', postfix: 'kg'},
                     {prefix: '$', postfix: 'kg'},
+                    {prefix: '', postfix: 'Even too long postfix changes nothing'},
+                    {prefix: 'Enormous prefix is allowed too', postfix: ''},
                 ] as const
             ).forEach(({prefix, postfix}) => {
                 describe(`[prefix]="${prefix}" & [postfix]="${postfix}"`, () => {
@@ -742,6 +744,15 @@ describe('InputNumber', () => {
                         await inputNumber.textfield.blur();
 
                         await expect(inputNumber.textfield).toHaveValue('');
+                    });
+
+                    test('allows to enter huge number', async () => {
+                        await inputNumber.textfield.focus();
+                        await inputNumber.textfield.pressSequentially('1234567890123456');
+
+                        await expect(inputNumber.textfield).toHaveValue(
+                            `${prefix}1 234 567 890 123 456${postfix}`,
+                        );
                     });
                 });
             });

--- a/projects/kit/components/input-number/input-number.directive.ts
+++ b/projects/kit/components/input-number/input-number.directive.ts
@@ -97,8 +97,9 @@ export class TuiInputNumberDirective extends TuiControl<number | null> {
             !!this.precision() && this.textfield.value().includes(decimalSeparator);
         const precision = decimalPart ? Math.min(this.precision() + 1, 20) : 0;
         const takeThousand = thousandSeparator.repeat(5).length;
+        const affixes = this.prefix().length + this.postfix().length;
 
-        return DEFAULT_MAX_LENGTH + precision + takeThousand;
+        return DEFAULT_MAX_LENGTH + precision + takeThousand + affixes;
     });
 
     protected readonly onChangeEffect = effect(() => {


### PR DESCRIPTION
Cherry-pick:
* https://github.com/taiga-family/taiga-ui/pull/12514