### PR TITLE
chore(demo): increase specificity in `Imitate material` example of `Appearances` documentation pages

### DIFF
--- a/projects/demo/src/modules/customization/appearances/examples/1/index.less
+++ b/projects/demo/src/modules/customization/appearances/examples/1/index.less
@@ -41,7 +41,7 @@ tui-wrapper-example-1 {
     }
 }
 
-[tuiAppearance][data-appearance='material-button'] {
+[tuiButton][tuiAppearance][data-appearance='material-button'] {
     .transition(all);
 
     border-radius: 0.25rem;


### PR DESCRIPTION
Now `[tuiAppearance][data-appearance='material-button']` has the same specificity as `[tuiButton][data-size=s]`.
And order of style loading decides.

**Webpack:**
<img height="400" alt="next" src="https://github.com/user-attachments/assets/2585a43e-796d-4eb6-aa6b-f7ba7105569c" />

**ESBuild:**
<img height="400" alt="esbuild" src="https://github.com/user-attachments/assets/1482db71-c99c-4645-b452-9a0cd61545a1" />
