### PR TITLE
fix(layout): `CardLarge` is not compatible with `Header` (font has CSS specificity problem)

### DIFF
--- a/projects/layout/components/card/large.style.less
+++ b/projects/layout/components/card/large.style.less
@@ -1,3 +1,8 @@
+// Don't increase specificity. Otherwise, not compatible with [tuiHeader]
+[tuiCardLarge] {
+    font: var(--tui-font-text-m);
+}
+
 [tuiCardLarge][data-space] {
     --t-space: 0.75rem;
     --t-radius: var(--tui-radius-l);
@@ -5,7 +10,6 @@
     --t-padding: 0.75rem;
     --t-dim: calc(var(--t-padding) + var(--t-comp));
 
-    font: var(--tui-font-text-m);
     padding: var(--t-padding);
     border-radius: var(--t-radius);
     box-sizing: border-box;


### PR DESCRIPTION
Now `[tuiCardLarge][data-space]` has the same specificity as `[tuiHeader][data-size=h5]`.
And order of style loading decides.

**Webpack:**
<img height="400" alt="next" src="https://github.com/user-attachments/assets/d05e5a81-95c4-4c9f-9801-e1506cd249e8" />


**ESBuild:**
<img height="400" alt="esbuild" src="https://github.com/user-attachments/assets/83b52376-af54-4edf-93d2-69eec8234559" />


