### PR TITLE
fix(layout): `CardLarge` is not compatible with `Header` (font has CSS specificity problem)

### DIFF
--- a/projects/layout/components/card/large.style.less
+++ b/projects/layout/components/card/large.style.less
@@ -1,3 +1,8 @@
+// Don't increase specificity. Otherwise, not compatible with [tuiHeader]
+[tuiCardLarge] {
+    font: var(--tui-font-text-m);
+}
+
 [tuiCardLarge][data-space] {
     --t-space: 0.75rem;
     --t-radius: var(--tui-radius-l);
@@ -5,7 +10,6 @@
     --t-padding: 0.75rem;
     --t-dim: calc(var(--t-padding) + var(--t-comp));
 
-    font: var(--tui-font-text-m);
     padding: var(--t-padding);
     border-radius: var(--t-radius);
     box-sizing: border-box;


### PR DESCRIPTION
(cherry picked from commit 3bc3141a648ec5d090742d787c32689db0c940da)

* https://github.com/taiga-family/taiga-ui/pull/12544
