### PR TITLE
chore(demo): increase specificity in `Basic` example of `CardLarge` documentation page

### DIFF
--- a/projects/demo/src/modules/components/card-large/examples/1/index.less
+++ b/projects/demo/src/modules/components/card-large/examples/1/index.less
@@ -8,6 +8,6 @@ section {
     border: 1px dashed;
 }
 
-.label {
+[tuiLink].label {
     font: var(--tui-font-text-l);
 }


### PR DESCRIPTION
Now `[tuiHeader] [tuiLink]` has the same specificity as `.label[_ngcontent-ng-c####]` – `Specificity(0,2,0)`.
And order of style loading decides.

**Webpack:**
<img  height="400" alt="webpack" src="https://github.com/user-attachments/assets/4fb386b7-7199-488e-8b6b-d98a79d1e540" />


**ESBuild:**
<img width="1489" height="463" alt="esbuild" src="https://github.com/user-attachments/assets/b304b273-25d7-4091-9d34-70487d003fcd" />


