### PR TITLE
fix(addon-table): remove generic type constraint from `TuiTableSortPipe`

### DIFF
--- a/projects/addon-table/components/table/pipes/table-sort.pipe.ts
+++ b/projects/addon-table/components/table/pipes/table-sort.pipe.ts
@@ -9,15 +9,15 @@ import {type TuiSortDirection} from '../table.options';
     name: 'tuiTableSort',
     pure: false,
 })
-export class TuiTableSortPipe<K> implements PipeTransform {
-    private readonly table = inject(TuiTableDirective<K>);
+export class TuiTableSortPipe implements PipeTransform {
+    private readonly table = inject(TuiTableDirective<any>);
 
-    public transform<T extends K>(data?: readonly T[] | null): readonly T[] {
+    public transform<T>(data?: readonly T[] | null): readonly T[] {
         return this.sort<T>(data ?? [], this.table.sorter, this.table.direction);
     }
 
     @tuiPure
-    private sort<T extends K>(
+    private sort<T>(
         data: readonly T[],
         sorter: TuiComparator<T>,
         direction: TuiSortDirection,


### PR DESCRIPTION
This PR updates the `TuiTableSortPipe` by removing the generic type parameter from the pipe class and applying it instead to the transform method.

### Why
Angular Language Service cannot infer a generic type placed on a pipe class.
Because the class-level generic cannot be resolved by the template type-checker, ALS falls back to `any` for both input and output types of the pipe.
This leads to incorrect or missing type checking inside Angular templates.

This issue is described in detail here: https://github.com/angular/angular/pull/40870#issuecomment-780882880

### What Changed

Removed the generic parameter from the pipe class declaration. As a result, ALS correctly infers the pipe's input/output types, and template type checking works as expected.