### PR TITLE
chore(demo): disable server bundles for development configuration of `npm start`

### DIFF
--- a/projects/demo/project.json
+++ b/projects/demo/project.json
@@ -104,7 +104,10 @@
                 "development": {
                     "optimization": false,
                     "extractLicenses": false,
-                    "sourceMap": true
+                    "sourceMap": true,
+                    "server": false,
+                    "ssr": false,
+                    "outputMode": "static"
                 },
                 "def": {
                     "fileReplacements": [


### PR DESCRIPTION
### nx serve demo -c production

```bash
→ nx serve demo -c production

# [...]

✔ Building...
Browser bundles      
Initial chunk files   | Names            |  Raw size | Estimated transfer size
chunk-BMPGMLGX.js     | -                | 431.69 kB |                37.53 kB

# [...]

Server bundles
Initial chunk files   | Names            |  Raw size
server.mjs            | server           |   1.35 MB |                        
main.server.mjs       | main.server      | 458.70 kB |                        
# [...]                      

Application bundle generation complete. [31.359 seconds]
```

Make small change inside HTML file

```bash
❯ Changes detected. Rebuilding...
✔ Changes detected. Rebuilding...

[...]

Application bundle generation complete. [12.405 seconds]
```

### nx serve demo -c development
(same as `npm start`)

```bash
→ nx serve demo -c development

# [...]

❯ Building...
✔ Building...

Initial chunk files | Names         |  Raw size
chunk-B6MORJXJ.js   | -             | 714.78 kB | 
chunk-5NVIM6HI.js   | -             | 468.58 kB | 

# [...]
# NOTHING about "Server bundles"

Application bundle generation complete. [16.792 seconds]
```

Make small change inside HTML file

```bash
❯ Changes detected. Rebuilding...
✔ Changes detected. Rebuilding...

# [...]

Application bundle generation complete. [5.070 seconds]
```