### PR TITLE
fix(kit): `inputChip` - add special character clearing

### DIFF
--- a/projects/cdk/utils/miscellaneous/index.ts
+++ b/projects/cdk/utils/miscellaneous/index.ts
@@ -26,5 +26,6 @@ export * from './provide';
 export * from './provide-options';
 export * from './pure';
 export * from './px';
+export * from './sanitize-text';
 export * from './uniq-by';
 export * from './with-styles';

--- a/projects/cdk/utils/miscellaneous/sanitize-text.ts
+++ b/projects/cdk/utils/miscellaneous/sanitize-text.ts
@@ -1,0 +1,29 @@
+/**
+ * Sanitizes pasted or dropped text by removing invisible and control characters
+ * that can appear in clipboard or drag-and-drop data.
+ *
+ * Removes:
+ * 1. ASCII control characters (0x00–0x1F) — non-printable characters like
+ *    NULL, BEL, BS, CR, LF, TAB, ESC, etc.
+ * 2. Extended control characters (0x7F–0x9F) — C1 control codes from ISO-8859-1,
+ *    often found in legacy or malformed text encodings.
+ * 3. Zero-width and special Unicode characters:
+ *    - U+200B ZERO WIDTH SPACE
+ *    - U+200C ZERO WIDTH NON-JOINER
+ *    - U+200D ZERO WIDTH JOINER
+ *    - U+FEFF BYTE ORDER MARK (BOM)
+ *
+ * @param {string} value - The input string from clipboard or drag event.
+ * @returns {string} - A cleaned string without control or invisible characters.
+ *
+ * @example
+ * tuiSanitizeText('Hello\u0000World\u200B!');
+ * // → "HelloWorld!"
+ */
+export function tuiSanitizeText(value: string): string {
+    // eslint-disable-next-line no-control-regex
+    const controlCharsRegex = /[\x00-\x1F\x7F-\x9F]/g;
+    const zeroWidthCharsRegex = /[\u200B-\u200D\uFEFF]/g;
+
+    return value.replaceAll(controlCharsRegex, '').replaceAll(zeroWidthCharsRegex, '');
+}

--- a/projects/cdk/utils/miscellaneous/test/sanitize-text.spec.ts
+++ b/projects/cdk/utils/miscellaneous/test/sanitize-text.spec.ts
@@ -1,0 +1,47 @@
+import {tuiSanitizeText} from '@taiga-ui/cdk';
+
+describe('tuiSanitizeText', () => {
+    it('removes ASCII control characters', () => {
+        const input = 'Hello\x00World\x07!';
+        const expected = 'HelloWorld!';
+
+        expect(tuiSanitizeText(input)).toBe(expected);
+    });
+
+    it('removes extended control characters', () => {
+        const input = 'Test\x7F\x80\x9FData';
+        const expected = 'TestData';
+
+        expect(tuiSanitizeText(input)).toBe(expected);
+    });
+
+    it('removes zero-width Unicode characters', () => {
+        const input = 'Hello\u200BWorld\u200C!\u200D\uFEFF';
+        const expected = 'HelloWorld!';
+
+        expect(tuiSanitizeText(input)).toBe(expected);
+    });
+
+    it('handles a mix of control and visible characters', () => {
+        const input = 'Mix\x00\x7F\u200B of\x9F\uFEFF chars!';
+        const expected = 'Mix of chars!';
+
+        expect(tuiSanitizeText(input)).toBe(expected);
+    });
+
+    it('leaves normal text unchanged', () => {
+        const input = 'Normal text without control chars';
+
+        expect(tuiSanitizeText(input)).toBe(input);
+    });
+
+    it('handles empty string', () => {
+        expect(tuiSanitizeText('')).toBe('');
+    });
+
+    it('handles string with only control characters', () => {
+        const input = '\x00\x1F\x7F\x9F\u200B\uFEFF';
+
+        expect(tuiSanitizeText(input)).toBe('');
+    });
+});

--- a/projects/kit/components/input-chip/input-chip.directive.ts
+++ b/projects/kit/components/input-chip/input-chip.directive.ts
@@ -5,7 +5,7 @@ import {TuiActiveZone} from '@taiga-ui/cdk/directives/active-zone';
 import {TuiNativeValidator} from '@taiga-ui/cdk/directives/native-validator';
 import {TUI_IS_MOBILE, tuiFallbackValueProvider} from '@taiga-ui/cdk/tokens';
 import {tuiGetClipboardDataText, tuiInjectElement} from '@taiga-ui/cdk/utils/dom';
-import {tuiDirectiveBinding} from '@taiga-ui/cdk/utils/miscellaneous';
+import {tuiDirectiveBinding, tuiSanitizeText} from '@taiga-ui/cdk/utils/miscellaneous';
 import {
     tuiAsTextfieldAccessor,
     type TuiTextfieldAccessor,
@@ -112,10 +112,7 @@ export class TuiInputChipBaseDirective<T>
                 ? event.dataTransfer?.getData('text/plain') || ''
                 : tuiGetClipboardDataText(event);
 
-        // eslint-disable-next-line no-control-regex
-        const cleanedValue = value.replaceAll(/[\x00-\x1F\x7F-\x9F]/g, '');
-
-        this.textfield.value.set(cleanedValue);
+        this.textfield.value.set(tuiSanitizeText(value));
         this.onEnter();
     }
 


### PR DESCRIPTION
Cherry pick for v4.x

Fixes #12427
