### PR TITLE
fix: all `Input*` throws `'imports' must be an array of components, directives, pipes, or NgModules`

### DIFF
--- a/projects/addon-commerce/components/input-card/input-card.ts
+++ b/projects/addon-commerce/components/input-card/input-card.ts
@@ -1,4 +1,9 @@
-import {TuiTextfield} from '@taiga-ui/core/components/textfield';
+import {TuiLabel} from '@taiga-ui/core/components/label';
+import {
+    TuiTextfieldComponent,
+    TuiTextfieldOptionsDirective,
+} from '@taiga-ui/core/components/textfield';
+import {TuiDropdownContent} from '@taiga-ui/core/portals';
 
 import {TuiInputCardComponent} from './input-card.component';
 import {TuiInputCVCDirective} from './input-cvc.directive';
@@ -8,5 +13,8 @@ export const TuiInputCard = [
     TuiInputCardComponent,
     TuiInputCVCDirective,
     TuiInputExpireDirective,
-    ...TuiTextfield,
+    TuiLabel,
+    TuiTextfieldComponent,
+    TuiTextfieldOptionsDirective,
+    TuiDropdownContent,
 ] as const;

--- a/projects/core/components/input/input.ts
+++ b/projects/core/components/input/input.ts
@@ -1,5 +1,16 @@
-import {TuiTextfield} from '@taiga-ui/core/components/textfield';
+import {TuiLabel} from '@taiga-ui/core/components/label';
+import {
+    TuiTextfieldComponent,
+    TuiTextfieldOptionsDirective,
+} from '@taiga-ui/core/components/textfield';
+import {TuiDropdownContent} from '@taiga-ui/core/portals';
 
 import {TuiInputDirective} from './input.directive';
 
-export const TuiInput = [...TuiTextfield, TuiInputDirective] as const;
+export const TuiInput = [
+    TuiLabel,
+    TuiTextfieldComponent,
+    TuiTextfieldOptionsDirective,
+    TuiDropdownContent,
+    TuiInputDirective,
+] as const;

--- a/projects/kit/components/combo-box/combo-box.ts
+++ b/projects/kit/components/combo-box/combo-box.ts
@@ -1,5 +1,16 @@
-import {TuiTextfield} from '@taiga-ui/core/components/textfield';
+import {TuiLabel} from '@taiga-ui/core/components/label';
+import {
+    TuiTextfieldComponent,
+    TuiTextfieldOptionsDirective,
+} from '@taiga-ui/core/components/textfield';
+import {TuiDropdownContent} from '@taiga-ui/core/portals';
 
 import {TuiComboBoxDirective} from './combo-box.directive';
 
-export const TuiComboBox = [TuiComboBoxDirective, ...TuiTextfield] as const;
+export const TuiComboBox = [
+    TuiComboBoxDirective,
+    TuiLabel,
+    TuiTextfieldComponent,
+    TuiTextfieldOptionsDirective,
+    TuiDropdownContent,
+] as const;

--- a/projects/kit/components/input-chip/input-chip.ts
+++ b/projects/kit/components/input-chip/input-chip.ts
@@ -1,10 +1,22 @@
-import {TuiTextfield} from '@taiga-ui/core/components/textfield';
+import {TuiItem} from '@taiga-ui/cdk/directives/item';
+import {TuiLabel} from '@taiga-ui/core/components/label';
+import {
+    TuiTextfieldComponent,
+    TuiTextfieldMultiComponent,
+    TuiTextfieldOptionsDirective,
+} from '@taiga-ui/core/components/textfield';
+import {TuiDropdownContent} from '@taiga-ui/core/portals/dropdown';
 
 import {TuiInputChipComponent} from './input-chip.component';
 import {TuiInputChipDirective} from './input-chip.directive';
 
 export const TuiInputChip = [
-    ...TuiTextfield,
+    TuiItem,
+    TuiLabel,
+    TuiTextfieldComponent,
+    TuiTextfieldOptionsDirective,
+    TuiTextfieldMultiComponent,
+    TuiDropdownContent,
     TuiInputChipDirective,
     TuiInputChipComponent,
 ] as const;

--- a/projects/kit/components/input-color/input-color.ts
+++ b/projects/kit/components/input-color/input-color.ts
@@ -1,5 +1,16 @@
-import {TuiTextfield} from '@taiga-ui/core/components/textfield';
+import {TuiLabel} from '@taiga-ui/core/components/label';
+import {
+    TuiTextfieldComponent,
+    TuiTextfieldOptionsDirective,
+} from '@taiga-ui/core/components/textfield';
+import {TuiDropdownContent} from '@taiga-ui/core/portals';
 
 import {TuiInputColorComponent} from './input-color.component';
 
-export const TuiInputColor = [TuiInputColorComponent, ...TuiTextfield] as const;
+export const TuiInputColor = [
+    TuiInputColorComponent,
+    TuiLabel,
+    TuiTextfieldComponent,
+    TuiTextfieldOptionsDirective,
+    TuiDropdownContent,
+] as const;

--- a/projects/kit/components/input-date-multi/input-date-multi.ts
+++ b/projects/kit/components/input-date-multi/input-date-multi.ts
@@ -1,5 +1,4 @@
 import {TuiCalendar} from '@taiga-ui/core/components/calendar';
-import {TuiTextfield} from '@taiga-ui/core/components/textfield';
 import {TuiInputChip} from '@taiga-ui/kit/components/input-chip';
 
 import {TuiInputDateMultiDirective} from './input-date-multi.directive';
@@ -7,6 +6,5 @@ import {TuiInputDateMultiDirective} from './input-date-multi.directive';
 export const TuiInputDateMulti = [
     TuiInputDateMultiDirective,
     TuiCalendar,
-    ...TuiTextfield,
     ...TuiInputChip,
 ] as const;

--- a/projects/kit/components/input-date-range/input-date-range.ts
+++ b/projects/kit/components/input-date-range/input-date-range.ts
@@ -1,4 +1,9 @@
-import {TuiTextfield} from '@taiga-ui/core/components/textfield';
+import {TuiLabel} from '@taiga-ui/core/components/label';
+import {
+    TuiTextfieldComponent,
+    TuiTextfieldOptionsDirective,
+} from '@taiga-ui/core/components/textfield';
+import {TuiDropdownContent} from '@taiga-ui/core/portals';
 import {TuiCalendarRange} from '@taiga-ui/kit/components/calendar-range';
 
 import {TuiInputDateRangeDirective} from './input-date-range.directive';
@@ -6,5 +11,8 @@ import {TuiInputDateRangeDirective} from './input-date-range.directive';
 export const TuiInputDateRange = [
     TuiInputDateRangeDirective,
     TuiCalendarRange,
-    ...TuiTextfield,
+    TuiLabel,
+    TuiTextfieldComponent,
+    TuiTextfieldOptionsDirective,
+    TuiDropdownContent,
 ] as const;

--- a/projects/kit/components/input-date-time/input-date-time.ts
+++ b/projects/kit/components/input-date-time/input-date-time.ts
@@ -1,5 +1,10 @@
 import {TuiCalendar} from '@taiga-ui/core/components/calendar';
-import {TuiTextfield} from '@taiga-ui/core/components/textfield';
+import {TuiLabel} from '@taiga-ui/core/components/label';
+import {
+    TuiTextfieldComponent,
+    TuiTextfieldOptionsDirective,
+} from '@taiga-ui/core/components/textfield';
+import {TuiDropdownContent} from '@taiga-ui/core/portals';
 
 import {TuiInputDateTimeComponent} from './input-date-time.component';
 import {TuiInputDateTimeDirective} from './input-date-time.directive';
@@ -8,5 +13,8 @@ export const TuiInputDateTime = [
     TuiInputDateTimeDirective,
     TuiInputDateTimeComponent,
     TuiCalendar,
-    ...TuiTextfield,
+    TuiLabel,
+    TuiTextfieldComponent,
+    TuiTextfieldOptionsDirective,
+    TuiDropdownContent,
 ] as const;

--- a/projects/kit/components/input-date/input-date.ts
+++ b/projects/kit/components/input-date/input-date.ts
@@ -1,5 +1,10 @@
 import {TuiCalendar} from '@taiga-ui/core/components/calendar';
-import {TuiTextfield} from '@taiga-ui/core/components/textfield';
+import {TuiLabel} from '@taiga-ui/core/components/label';
+import {
+    TuiTextfieldComponent,
+    TuiTextfieldOptionsDirective,
+} from '@taiga-ui/core/components/textfield';
+import {TuiDropdownContent} from '@taiga-ui/core/portals';
 
 import {TuiInputDateComponent} from './input-date.component';
 import {TuiInputDateDirective} from './input-date.directive';
@@ -8,5 +13,8 @@ export const TuiInputDate = [
     TuiInputDateDirective,
     TuiInputDateComponent,
     TuiCalendar,
-    ...TuiTextfield,
+    TuiLabel,
+    TuiTextfieldComponent,
+    TuiTextfieldOptionsDirective,
+    TuiDropdownContent,
 ] as const;

--- a/projects/kit/components/input-month-range/input-month-range.ts
+++ b/projects/kit/components/input-month-range/input-month-range.ts
@@ -1,4 +1,9 @@
-import {TuiTextfield} from '@taiga-ui/core/components/textfield';
+import {TuiLabel} from '@taiga-ui/core/components/label';
+import {
+    TuiTextfieldComponent,
+    TuiTextfieldOptionsDirective,
+} from '@taiga-ui/core/components/textfield';
+import {TuiDropdownContent} from '@taiga-ui/core/portals';
 import {TuiCalendarMonth} from '@taiga-ui/kit/components/calendar-month';
 
 import {TuiInputMonthRangeDirective} from './input-month-range.directive';
@@ -6,5 +11,8 @@ import {TuiInputMonthRangeDirective} from './input-month-range.directive';
 export const TuiInputMonthRange = [
     TuiInputMonthRangeDirective,
     TuiCalendarMonth,
-    ...TuiTextfield,
+    TuiLabel,
+    TuiTextfieldComponent,
+    TuiTextfieldOptionsDirective,
+    TuiDropdownContent,
 ] as const;

--- a/projects/kit/components/input-month/input-month.ts
+++ b/projects/kit/components/input-month/input-month.ts
@@ -1,4 +1,9 @@
-import {TuiTextfield} from '@taiga-ui/core/components/textfield';
+import {TuiLabel} from '@taiga-ui/core/components/label';
+import {
+    TuiTextfieldComponent,
+    TuiTextfieldOptionsDirective,
+} from '@taiga-ui/core/components/textfield';
+import {TuiDropdownContent} from '@taiga-ui/core/portals';
 import {TuiCalendarMonth} from '@taiga-ui/kit/components/calendar-month';
 
 import {TuiInputMonthComponent} from './input-month.component';
@@ -8,5 +13,8 @@ export const TuiInputMonth = [
     TuiInputMonthComponent,
     TuiInputMonthDirective,
     TuiCalendarMonth,
-    ...TuiTextfield,
+    TuiLabel,
+    TuiTextfieldComponent,
+    TuiTextfieldOptionsDirective,
+    TuiDropdownContent,
 ] as const;

--- a/projects/kit/components/input-number/input-number.ts
+++ b/projects/kit/components/input-number/input-number.ts
@@ -1,4 +1,9 @@
-import {TuiTextfield} from '@taiga-ui/core/components/textfield';
+import {TuiLabel} from '@taiga-ui/core/components/label';
+import {
+    TuiTextfieldComponent,
+    TuiTextfieldOptionsDirective,
+} from '@taiga-ui/core/components/textfield';
+import {TuiDropdownContent} from '@taiga-ui/core/portals';
 
 import {TuiInputNumberDirective} from './input-number.directive';
 import {TuiQuantumValueTransformer} from './quantum.directive';
@@ -8,5 +13,8 @@ export const TuiInputNumber = [
     TuiInputNumberDirective,
     TuiInputNumberStep,
     TuiQuantumValueTransformer,
-    ...TuiTextfield,
+    TuiLabel,
+    TuiTextfieldComponent,
+    TuiTextfieldOptionsDirective,
+    TuiDropdownContent,
 ] as const;

--- a/projects/kit/components/input-phone-international/input-phone-international.ts
+++ b/projects/kit/components/input-phone-international/input-phone-international.ts
@@ -1,8 +1,16 @@
-import {TuiTextfield} from '@taiga-ui/core/components/textfield';
+import {TuiLabel} from '@taiga-ui/core/components/label';
+import {
+    TuiTextfieldComponent,
+    TuiTextfieldOptionsDirective,
+} from '@taiga-ui/core/components/textfield';
+import {TuiDropdownContent} from '@taiga-ui/core/portals';
 
 import {TuiInputPhoneInternationalComponent} from './input-phone-international.component';
 
 export const TuiInputPhoneInternational = [
     TuiInputPhoneInternationalComponent,
-    ...TuiTextfield,
+    TuiLabel,
+    TuiTextfieldComponent,
+    TuiTextfieldOptionsDirective,
+    TuiDropdownContent,
 ] as const;

--- a/projects/kit/components/input-phone/input-phone.ts
+++ b/projects/kit/components/input-phone/input-phone.ts
@@ -1,5 +1,16 @@
-import {TuiTextfield} from '@taiga-ui/core/components/textfield';
+import {TuiLabel} from '@taiga-ui/core/components/label';
+import {
+    TuiTextfieldComponent,
+    TuiTextfieldOptionsDirective,
+} from '@taiga-ui/core/components/textfield';
+import {TuiDropdownContent} from '@taiga-ui/core/portals';
 
 import {TuiInputPhoneDirective} from './input-phone.directive';
 
-export const TuiInputPhone = [TuiInputPhoneDirective, ...TuiTextfield] as const;
+export const TuiInputPhone = [
+    TuiInputPhoneDirective,
+    TuiLabel,
+    TuiTextfieldComponent,
+    TuiTextfieldOptionsDirective,
+    TuiDropdownContent,
+] as const;

--- a/projects/kit/components/input-pin/input-pin.ts
+++ b/projects/kit/components/input-pin/input-pin.ts
@@ -1,5 +1,16 @@
-import {TuiTextfield} from '@taiga-ui/core/components/textfield';
+import {TuiLabel} from '@taiga-ui/core/components/label';
+import {
+    TuiTextfieldComponent,
+    TuiTextfieldOptionsDirective,
+} from '@taiga-ui/core/components/textfield';
+import {TuiDropdownContent} from '@taiga-ui/core/portals';
 
 import {TuiInputPinComponent} from './input-pin.component';
 
-export const TuiInputPin = [TuiInputPinComponent, ...TuiTextfield] as const;
+export const TuiInputPin = [
+    TuiInputPinComponent,
+    TuiLabel,
+    TuiTextfieldComponent,
+    TuiTextfieldOptionsDirective,
+    TuiDropdownContent,
+] as const;

--- a/projects/kit/components/input-slider/input-slider.ts
+++ b/projects/kit/components/input-slider/input-slider.ts
@@ -1,4 +1,9 @@
-import {TuiTextfield} from '@taiga-ui/core/components/textfield';
+import {TuiLabel} from '@taiga-ui/core/components/label';
+import {
+    TuiTextfieldComponent,
+    TuiTextfieldOptionsDirective,
+} from '@taiga-ui/core/components/textfield';
+import {TuiDropdownContent} from '@taiga-ui/core/portals';
 import {
     TuiSliderComponent,
     TuiSliderKeySteps,
@@ -12,5 +17,8 @@ export const TuiInputSlider = [
     TuiSliderKeyStepsBase,
     TuiSliderKeySteps,
     TuiInputSliderDirective,
-    ...TuiTextfield,
+    TuiLabel,
+    TuiTextfieldComponent,
+    TuiTextfieldOptionsDirective,
+    TuiDropdownContent,
 ] as const;

--- a/projects/kit/components/input-time/input-time.ts
+++ b/projects/kit/components/input-time/input-time.ts
@@ -1,4 +1,9 @@
-import {TuiTextfield} from '@taiga-ui/core/components/textfield';
+import {TuiLabel} from '@taiga-ui/core/components/label';
+import {
+    TuiTextfieldComponent,
+    TuiTextfieldOptionsDirective,
+} from '@taiga-ui/core/components/textfield';
+import {TuiDropdownContent} from '@taiga-ui/core/portals';
 
 import {TuiInputTimeComponent} from './input-time.component';
 import {TuiInputTimeDirective} from './input-time.directive';
@@ -6,5 +11,8 @@ import {TuiInputTimeDirective} from './input-time.directive';
 export const TuiInputTime = [
     TuiInputTimeDirective,
     TuiInputTimeComponent,
-    ...TuiTextfield,
+    TuiLabel,
+    TuiTextfieldComponent,
+    TuiTextfieldOptionsDirective,
+    TuiDropdownContent,
 ] as const;

--- a/projects/kit/components/input-year/input-year.ts
+++ b/projects/kit/components/input-year/input-year.ts
@@ -1,10 +1,18 @@
 import {TuiCalendarYear} from '@taiga-ui/core/components/calendar';
-import {TuiTextfield} from '@taiga-ui/core/components/textfield';
+import {TuiLabel} from '@taiga-ui/core/components/label';
+import {
+    TuiTextfieldComponent,
+    TuiTextfieldOptionsDirective,
+} from '@taiga-ui/core/components/textfield';
+import {TuiDropdownContent} from '@taiga-ui/core/portals';
 
 import {TuiInputYearDirective} from './input-year.directive';
 
 export const TuiInputYear = [
     TuiInputYearDirective,
     TuiCalendarYear,
-    ...TuiTextfield,
+    TuiLabel,
+    TuiTextfieldComponent,
+    TuiTextfieldOptionsDirective,
+    TuiDropdownContent,
 ] as const;

--- a/projects/kit/components/select/select.ts
+++ b/projects/kit/components/select/select.ts
@@ -1,6 +1,18 @@
-import {TuiTextfield} from '@taiga-ui/core/components/textfield';
+import {TuiLabel} from '@taiga-ui/core/components/label';
+import {
+    TuiTextfieldComponent,
+    TuiTextfieldOptionsDirective,
+} from '@taiga-ui/core/components/textfield';
+import {TuiDropdownContent} from '@taiga-ui/core/portals';
 
 import {TuiNativeSelect} from './native-select/native-select.component';
 import {TuiSelectDirective} from './select.directive';
 
-export const TuiSelect = [TuiSelectDirective, TuiNativeSelect, ...TuiTextfield] as const;
+export const TuiSelect = [
+    TuiSelectDirective,
+    TuiNativeSelect,
+    TuiLabel,
+    TuiTextfieldComponent,
+    TuiTextfieldOptionsDirective,
+    TuiDropdownContent,
+] as const;

--- a/projects/kit/components/textarea/textarea.ts
+++ b/projects/kit/components/textarea/textarea.ts
@@ -1,4 +1,9 @@
-import {TuiTextfield} from '@taiga-ui/core/components/textfield';
+import {TuiLabel} from '@taiga-ui/core/components/label';
+import {
+    TuiTextfieldComponent,
+    TuiTextfieldOptionsDirective,
+} from '@taiga-ui/core/components/textfield';
+import {TuiDropdownContent} from '@taiga-ui/core/portals';
 
 import {TuiTextareaComponent} from './textarea.component';
 import {TuiTextareaDirective} from './textarea.directive';
@@ -6,5 +11,8 @@ import {TuiTextareaDirective} from './textarea.directive';
 export const TuiTextarea = [
     TuiTextareaComponent,
     TuiTextareaDirective,
-    ...TuiTextfield,
+    TuiLabel,
+    TuiTextfieldComponent,
+    TuiTextfieldOptionsDirective,
+    TuiDropdownContent,
 ] as const;


### PR DESCRIPTION
## Problem 
Open StackBlitz example of any `Input*` components.
For example:
https://taiga-ui.dev/next/components/input-time#mode

It logs
```
Error in turbo_modules/@taiga-ui/kit@4.52.0-canary.ca43bcb/components/input-time/input-time.d.ts (3:116)
'imports' must be an array of components, directives, pipes, or NgModules.
Value could not be determined statically.
```

## Why ?
It is Angular bug.
Reproduction: https://github.com/nsbarsukov/ng-import-bug-repro?tab=readme-ov-file#reproduction
(I'll create issue for Angular team soon)
