### PR TITLE
fix(addon-mobile): center `ProgressBar` inside `AppBar` on android

### DIFF
--- a/projects/addon-mobile/styles/android/app-bar.less
+++ b/projects/addon-mobile/styles/android/app-bar.less
@@ -12,6 +12,10 @@ tui-app-bar {
         > * {
             max-inline-size: calc(100% - var(--t-sides, 0px));
         }
+
+        > [tuiProgressBar] {
+            .center-left();
+        }
     }
 
     > :last-child [tuiIconButton] {

--- a/projects/demo/src/modules/components/app-bar/examples/1/index.html
+++ b/projects/demo/src/modules/components/app-bar/examples/1/index.html
@@ -71,6 +71,25 @@
             type="button"
         ></button>
     </tui-app-bar>
+
+    <tui-app-bar>
+        <button
+            tuiAppBarBack
+            tuiSlot="left"
+            type="button"
+        >
+            Back
+        </button>
+
+        <div>
+            <progress
+                size="s"
+                tuiProgressBar
+                [max]="100"
+                [value]="35"
+            ></progress>
+        </div>
+    </tui-app-bar>
 </section>
 
 <h3 class="tui-space_top-8">Android</h3>
@@ -145,5 +164,21 @@
             tuiSlot="right"
             type="button"
         ></button>
+    </tui-app-bar>
+    <tui-app-bar>
+        <button
+            tuiAppBarBack
+            tuiSlot="left"
+            type="button"
+        >
+            Back
+        </button>
+
+        <progress
+            size="s"
+            tuiProgressBar
+            [max]="100"
+            [value]="35"
+        ></progress>
     </tui-app-bar>
 </section>

--- a/projects/demo/src/modules/components/app-bar/examples/1/index.ts
+++ b/projects/demo/src/modules/components/app-bar/examples/1/index.ts
@@ -3,10 +3,11 @@ import {changeDetection} from '@demo/emulate/change-detection';
 import {encapsulation} from '@demo/emulate/encapsulation';
 import {TuiPlatform} from '@taiga-ui/cdk';
 import {TuiButton, TuiTitle} from '@taiga-ui/core';
+import {TuiProgressBar} from '@taiga-ui/kit';
 import {TuiAppBar} from '@taiga-ui/layout';
 
 @Component({
-    imports: [TuiAppBar, TuiButton, TuiPlatform, TuiTitle],
+    imports: [TuiAppBar, TuiButton, TuiPlatform, TuiProgressBar, TuiTitle],
     templateUrl: './index.html',
     styleUrl: './index.less',
     encapsulation,


### PR DESCRIPTION
cherry pick #12727

Fixes https://github.com/taiga-family/taiga-ui/issues/12718
