### PR TITLE
chore: possibility to run Cypress CT inside WebStorm

### DIFF
--- a/.idea/runConfigurations/_template__of_Cypress.xml
+++ b/.idea/runConfigurations/_template__of_Cypress.xml
@@ -1,0 +1,9 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="true" type="JavaScriptTestRunnerCypress">
+    <node-interpreter value="project" />
+    <cypress-options value="-q --component" />
+    <envs />
+    <scope-kind value="TEST_FILE" />
+    <method v="2" />
+  </configuration>
+</component>


### PR DESCRIPTION
## Previous behavior
Try to run any Cypress CT using Webstorm UI (green triangle in IDE gutter).
It fails with error

```
The testing type selected (e2e) is not configured in your config file.

Please run ‘cypress open’ and choose your testing type to automatically update your configuration file.

https://on.cypress.io/configuration


Process finished with exit code 1
```