### PR TITLE
fix(addon-doc): infer typing from `TuiRawLoaderContent`

### DIFF
--- a/projects/addon-doc/types/page.ts
+++ b/projects/addon-doc/types/page.ts
@@ -20,7 +20,7 @@ export interface TuiDocRoutePageGroup extends TuiDocRoutePageBase {
     readonly subPages: readonly TuiDocRoutePage[];
 }
 
-export type TuiRawLoaderContent = Promise<{default: string}> | string;
+export type TuiRawLoaderContent = Promise<{readonly default: unknown}> | string;
 
 export const TUI_EXAMPLE_PRIMARY_FILE_NAME = {
     TS: 'TypeScript',

--- a/projects/addon-doc/utils/raw-load.ts
+++ b/projects/addon-doc/utils/raw-load.ts
@@ -2,6 +2,6 @@ import {type TuiRawLoaderContent} from '@taiga-ui/addon-doc/types';
 
 export async function tuiRawLoad(content: TuiRawLoaderContent): Promise<string> {
     return Promise.resolve(content).then((x) =>
-        typeof x === 'object' && 'default' in x ? x.default : x,
+        typeof x === 'object' && 'default' in x ? String(x.default) : x,
     );
 }


### PR DESCRIPTION
### Before

<img width="421" height="140" alt="image" src="https://github.com/user-attachments/assets/27864274-0577-464f-a866-ded231d43e59" />


### After

<img width="411" height="158" alt="image" src="https://github.com/user-attachments/assets/7c976bc7-cc4d-49fd-9103-07f32587f050" />
