### PR TITLE
fix(kit): `InputRange` with `[content]=[..., end]` has always invisible end textfield

### DIFF
--- a/projects/core/styles/components/textfield.less
+++ b/projects/core/styles/components/textfield.less
@@ -232,7 +232,7 @@ tui-textfield {
         align-items: center;
     }
 
-    &._with-template [tuiInput] {
+    &._with-template [tuiInput]:first-of-type {
         color: transparent !important;
     }
 

--- a/projects/demo-playwright/tests/kit/input-range/input-range.pw.spec.ts
+++ b/projects/demo-playwright/tests/kit/input-range/input-range.pw.spec.ts
@@ -385,13 +385,19 @@ describe('InputRange', () => {
             await tuiGoto(page, `${DemoRoute.InputRange}/API?content$=2&max=100`);
             await inputRange.textfieldEnd.fill('100');
 
+            await expect
+                .soft(example)
+                .toHaveScreenshot(
+                    '26-input-range-start-no-content--end-has-content-focused.png',
+                );
+
             await inputRange.textfieldEnd.blur();
 
             await expect(inputRange.textfieldStart).toHaveValue('0');
             await expect(inputRange.textfieldEnd).toHaveValue('100');
-            await expect
-                .soft(example)
-                .toHaveScreenshot('26-input-range-start-no-content--end-has-content.png');
+            await expect(example).toHaveScreenshot(
+                '26-input-range-start-no-content--end-has-content.png',
+            );
         });
 
         test('START textfield has content + END textfield has content', async ({
@@ -401,15 +407,19 @@ describe('InputRange', () => {
             await inputRange.textfieldEnd.fill('100');
             await inputRange.textfieldStart.fill('100');
 
+            await expect
+                .soft(example)
+                .toHaveScreenshot(
+                    '27-input-range-start-has-content--end-has-content-focused.png',
+                );
+
             await inputRange.textfieldStart.blur();
 
             await expect(inputRange.textfieldStart).toHaveValue('100');
             await expect(inputRange.textfieldEnd).toHaveValue('100');
-            await expect
-                .soft(example)
-                .toHaveScreenshot(
-                    '27-input-range-start-has-content--end-has-content.png',
-                );
+            await expect(example).toHaveScreenshot(
+                '27-input-range-start-has-content--end-has-content.png',
+            );
         });
 
         test('START textfield has content + END textfield without content', async ({

--- a/projects/demo/src/modules/components/input-range/index.html
+++ b/projects/demo/src/modules/components/input-range/index.html
@@ -316,7 +316,7 @@
             <tbody
                 #textfieldDoc
                 tuiDocTextfield
-                [hiddenOptions]="['cleaner', 'rows']"
+                [hiddenOptions]="['cleaner', 'rows', 'content']"
             ></tbody>
 
             <tbody


### PR DESCRIPTION
## Problem 1
Open 
https://taiga-ui.dev/next/components/input-range/API?content$=2
It redirected to 
https://taiga-ui.dev/next/components/input-range/API?content$=2&content=undefined

## Problem 2
Open https://taiga-ui.dev/next/components/input-range/API?content$=2

And focus END textfield.
It is always invisible.

https://github.com/user-attachments/assets/e3c55183-5e27-4304-b703-c74c8e97f276

