### PR TITLE
fix(kit): `InputRange` with `size` = `m`/`s` has unexpected shift for `[content]`

### DIFF
--- a/projects/demo-playwright/tests/kit/input-range/input-range.pw.spec.ts
+++ b/projects/demo-playwright/tests/kit/input-range/input-range.pw.spec.ts
@@ -503,6 +503,27 @@ describe('InputRange', () => {
                 });
             });
         });
+
+        describe('different textfield sizes', () => {
+            ['s', 'm', 'l'].forEach((size) => {
+                test(`${size}`, async ({page}) => {
+                    await tuiGoto(
+                        page,
+                        `${DemoRoute.InputRange}/API?content$=2&tuiTextfieldSize=${size}`,
+                    );
+                    await expect(inputRange.textfieldStart).toHaveValue('0');
+                    await expect(inputRange.textfieldEnd).toHaveValue('10');
+                    await expect(example).toHaveScreenshot(
+                        `34-input-range--size-${size}--start-has-content--end-has-content.png`,
+                    );
+
+                    await inputRange.textfieldEnd.focus();
+                    await expect(example).toHaveScreenshot(
+                        `34-input-range--size-${size}--start-has-content--end-no-content.png`,
+                    );
+                });
+            });
+        });
     });
 
     describe('Using negative values with hidden minus sign', () => {

--- a/projects/kit/components/input-range/input-range.style.less
+++ b/projects/kit/components/input-range/input-range.style.less
@@ -37,3 +37,7 @@ tui-range {
 tui-textfield::ng-deep .t-clear {
     display: none !important;
 }
+
+tui-textfield::ng-deep .t-content {
+    margin-inline-end: 0;
+}


### PR DESCRIPTION
Fixes #12751

Open https://taiga-ui.dev/next/components/input-range/API?content$=2

## Previous behavior

https://github.com/user-attachments/assets/ff8b14bf-b84e-4976-b7c4-cacdd67997c8

## New behavior

https://github.com/user-attachments/assets/a7b5df73-d6f3-4ca5-bf89-441c461b8d71

<img width="2172" height="236" alt="image" src="https://github.com/user-attachments/assets/dddcd446-41b4-4307-b71d-891b8bd68c97" />




