### PR TITLE
fix(kit): `TabsWithMore` duplicates tabs on client hydration

### DIFF
--- a/projects/demo/src/modules/app/app.config.ts
+++ b/projects/demo/src/modules/app/app.config.ts
@@ -12,6 +12,7 @@ import {
     provideZoneChangeDetection,
 } from '@angular/core';
 import {toSignal} from '@angular/core/rxjs-interop';
+import {provideClientHydration} from '@angular/platform-browser';
 import {provideAnimations} from '@angular/platform-browser/animations';
 import {
     NavigationStart,
@@ -67,6 +68,7 @@ import {TuiViewportScroller} from './utils/viewport-scroller.service';
 export const config: ApplicationConfig = {
     providers: [
         provideAnimations(), // TODO: explore why Tabs does not properly work without it. Then remove it
+        provideClientHydration(),
         provideRouter(
             ROUTES,
             withInMemoryScrolling({

--- a/projects/kit/components/breadcrumbs/breadcrumbs.template.html
+++ b/projects/kit/components/breadcrumbs/breadcrumbs.template.html
@@ -70,3 +70,5 @@
         <span class="t-char">{{ options.icon }}</span>
     }
 </ng-template>
+
+<ng-content />

--- a/projects/kit/components/carousel/carousel.template.html
+++ b/projects/kit/components/carousel/carousel.template.html
@@ -29,3 +29,5 @@
         </div>
     </div>
 </div>
+
+<ng-content />

--- a/projects/kit/components/tabs/tabs-with-more.template.html
+++ b/projects/kit/components/tabs/tabs-with-more.template.html
@@ -73,3 +73,5 @@
         }
     </div>
 </ng-template>
+
+<ng-content />


### PR DESCRIPTION
Fixes #12188
<img height="200" alt="image" src="https://github.com/user-attachments/assets/807b0d4f-1623-4814-b451-76df86ef1a0a" />

## Reproduction
```html
<tui-root>
    <tui-tabs-with-more>
        @for (tab of ['aaaa', 'bbbb', 'cccc']; track tab) {
            <button
                *tuiItem
                tuiTab
            >
                {{ tab }}
            </button>
        }
    </tui-tabs-with-more>
</tui-root>
```

## Previous behavior
```
Angular hydrated 5 component(s) and 54 node(s), 0 component(s) were skipped.
```
<img width="764" height="245" alt="before" src="https://github.com/user-attachments/assets/f47f65a2-5f36-470b-b133-eb1707a5ca1f" />

## New behavior
```
Angular hydrated 5 component(s) and 68 node(s), 0 component(s) were skipped.
```
<img width="764" height="338" alt="after" src="https://github.com/user-attachments/assets/1053c011-c760-4ecc-be7c-019b42ec11a8" />

## Conclusion 
**If you use `*tuiItem`, you should ensure that host component has `<ng-content />`!**
