### PR TITLE
fix(kit): `Select` should ignore `Backspace`/`Delete` keyboard keys if cleaner is disabled

### DIFF
--- a/projects/core/components/textfield/select-like.directive.ts
+++ b/projects/core/components/textfield/select-like.directive.ts
@@ -2,6 +2,8 @@ import {Directive, inject} from '@angular/core';
 import {TUI_IS_ANDROID} from '@taiga-ui/cdk/tokens';
 import {tuiInjectElement} from '@taiga-ui/cdk/utils/dom';
 
+import {TUI_TEXTFIELD_OPTIONS} from './textfield.options';
+
 @Directive({
     standalone: true,
     selector: '[tuiSelectLike]',
@@ -11,7 +13,8 @@ import {tuiInjectElement} from '@taiga-ui/cdk/utils/dom';
         spellcheck: 'false',
         autocomplete: 'off',
         // Click on cleaner icon does not trigger `beforeinput` event --> handle all kind of deletion in input event
-        '(beforeinput)': '$event.inputType.includes("delete") || $event.preventDefault()',
+        '(beforeinput)':
+            'options.cleaner() && $event.inputType.includes("delete") || $event.preventDefault()',
         '(input.capture)': '$event.inputType?.includes("delete") && clear()',
         // Hide Android text select handle (bubble marker below transparent caret)
         '(mousedown)': 'prevent($event)',
@@ -20,6 +23,7 @@ import {tuiInjectElement} from '@taiga-ui/cdk/utils/dom';
 export class TuiSelectLike {
     private readonly el = tuiInjectElement<HTMLInputElement>();
     private readonly isAndroid = inject(TUI_IS_ANDROID);
+    protected readonly options = inject(TUI_TEXTFIELD_OPTIONS);
 
     protected clear(): void {
         this.el.value = '';

--- a/projects/demo-playwright/tests/kit/select/select.pw.spec.ts
+++ b/projects/demo-playwright/tests/kit/select/select.pw.spec.ts
@@ -1,0 +1,49 @@
+import {DemoRoute} from '@demo/routes';
+import {TuiDocumentationPagePO, tuiGoto, TuiSelectPO} from '@demo-playwright/utils';
+import {expect, type Locator, test} from '@playwright/test';
+
+const {describe, beforeEach} = test;
+
+describe('Select', () => {
+    describe('Keyboard clearing', () => {
+        [true, false].forEach((cleanerEnabled) => {
+            describe(`tuiTextfieldCleaner=${cleanerEnabled}`, () => {
+                let example!: Locator;
+                let select!: TuiSelectPO;
+
+                beforeEach(async ({page}) => {
+                    await tuiGoto(
+                        page,
+                        `${DemoRoute.Select}/API?tuiTextfieldCleaner=${cleanerEnabled}`,
+                    );
+                    example = new TuiDocumentationPagePO(page).apiPageExample;
+                    select = new TuiSelectPO(
+                        example.locator('tui-textfield:has([tuiSelect])'),
+                    );
+
+                    await select.textfield.click();
+                    await select.selectOptions([1]);
+                    await select.textfield.click();
+
+                    await expect(select.dropdown).toBeVisible();
+                    await expect(select.textfield).toHaveValue('United Arab Emirates');
+                });
+
+                test('Backspace', async ({page}) => {
+                    await page.keyboard.press('Backspace');
+                    await expect(select.textfield).toHaveValue(
+                        cleanerEnabled ? '' : 'United Arab Emirates',
+                    );
+                });
+
+                test('Delete', async ({page}) => {
+                    await page.keyboard.press('ControlOrMeta+A');
+                    await page.keyboard.press('Delete');
+                    await expect(select.textfield).toHaveValue(
+                        cleanerEnabled ? '' : 'United Arab Emirates',
+                    );
+                });
+            });
+        });
+    });
+});


### PR DESCRIPTION
Cherry-picked:
* https://github.com/taiga-family/taiga-ui/pull/12865
