### PR TITLE
chore(demo): disable ssr hydration for dev mode

### DIFF
--- a/projects/demo/src/modules/app/app.config.ts
+++ b/projects/demo/src/modules/app/app.config.ts
@@ -68,7 +68,7 @@ import {TuiViewportScroller} from './utils/viewport-scroller.service';
 export const config: ApplicationConfig = {
     providers: [
         provideAnimations(), // TODO: explore why Tabs does not properly work without it. Then remove it
-        provideClientHydration(),
+        ngDevMode ? [] : provideClientHydration(),
         provideRouter(
             ROUTES,
             withInMemoryScrolling({


### PR DESCRIPTION
Run `npm start` and explore console logs

```
NG0505: 
Angular hydration was requested on the client, but there was no serialized information present in the server response,
thus hydration was not enabled.
Make sure the `provideClientHydration()` is included into the list of providers in the server part of the application configuration.
Find more at https://angular.dev/errors/NG0505
```