### PR TITLE
[WIP] chore(demo): documentation examples with `TabsWithMore` has broken More button

### DIFF
--- a/projects/demo/src/modules/app/app.component.ts
+++ b/projects/demo/src/modules/app/app.component.ts
@@ -21,7 +21,7 @@ import {TUI_DOC_SEARCH_ENABLED} from '@taiga-ui/addon-doc';
 import {TUI_IS_E2E} from '@taiga-ui/cdk';
 import {TuiButton, TuiDataList, TuiDropdown, TuiIcon} from '@taiga-ui/core';
 import {TuiBadgedContent} from '@taiga-ui/kit';
-import {distinctUntilChanged, filter, map, startWith} from 'rxjs';
+import {distinctUntilChanged, filter, map} from 'rxjs';
 
 import {CustomHost} from '../customization/portals/examples/1/portal';
 import {AbstractDemo, DEMO_PAGE_LOADED_PROVIDER} from './abstract.app';
@@ -81,9 +81,8 @@ export class App extends AbstractDemo implements OnInit {
             filter((event) => event instanceof NavigationEnd),
             map(() => this.url === '' || this.url === '/'),
             distinctUntilChanged(),
-            startWith(true),
         ),
-        {initialValue: true},
+        {initialValue: false},
     );
 
     public override ngOnInit(): void {


### PR DESCRIPTION
1. Open https://taiga-ui.dev/next/navigation/tabs#tabs-with-more
2. Click `More` button
___

1. Open https://taiga-ui.dev/next/components/button/API
2. Click on any select to open dropdown

Explore console logs
```
Error: ASSERTION ERROR: 
Unexpected state: no hydration info available for a given TNode, which represents a view container. 
[Expected=> null != undefined <=Actual]
    at throwError (core.mjs:530:9)
    at assertDefined (core.mjs:526:5)
    at populateDehydratedViewsInLContainerImpl (core.mjs:18029:16)
    at locateOrCreateAnchorNode (core.mjs:18045:8)
    at createContainerRef (core.mjs:17947:3)
    at createSpecialToken (core.mjs:18328:12)
    at createResultForNode (core.mjs:18315:12)
    at materializeViewResults (core.mjs:18354:21)
    at getQueryResults (core.mjs:18466:89)
    at refreshSignalQuery (core.mjs:18537:19)
```