### PR TITLE
chore(demo): improve prerender

### DIFF
--- a/projects/demo/src/main.server.ts
+++ b/projects/demo/src/main.server.ts
@@ -39,7 +39,7 @@ const serverConfig = mergeApplicationConfig(config, {
                     case DemoRoute.Surface:
                         return withTabs(path, ['Layers']);
                     default:
-                        return /^\/(components|directives|pipes|services|utils|layout|navigation|charts|experimental|legacy)/.exec(
+                        return /^(components|directives|pipes|services|utils|layout|navigation|charts|experimental|legacy)/.exec(
                             path,
                         )
                             ? withTabs(path, ['API', 'Setup'])


### PR DESCRIPTION
## Previous behavior
Disable JavaScript in DevTools and try to open
https://taiga-ui.dev/next/components/button/API
It returns 404

Also, run `nx build demo` and then:
```
➜ tree dist/demo/browser/components/button                                                                                                                                         
dist/demo/browser/components/button
└── index.html
```

## New behavior
```
➜ tree dist/demo/browser/components/button                                                                                                                                         
dist/demo/browser/components/button
├── API
│   └── index.html
├── Setup
│   └── index.html
└── index.html
```