### PR TITLE
chore(demo): temporary disable hydration

### DIFF
--- a/projects/demo/src/modules/app/app.config.ts
+++ b/projects/demo/src/modules/app/app.config.ts
@@ -12,7 +12,6 @@ import {
     provideZoneChangeDetection,
 } from '@angular/core';
 import {toSignal} from '@angular/core/rxjs-interop';
-import {provideClientHydration} from '@angular/platform-browser';
 import {provideAnimations} from '@angular/platform-browser/animations';
 import {
     NavigationStart,
@@ -68,7 +67,6 @@ import {TuiViewportScroller} from './utils/viewport-scroller.service';
 export const config: ApplicationConfig = {
     providers: [
         provideAnimations(), // TODO: explore why Tabs does not properly work without it. Then remove it
-        provideClientHydration(),
         provideRouter(
             ROUTES,
             withInMemoryScrolling({


### PR DESCRIPTION
1. Open https://taiga-ui.dev/next/components/button/API
2. Click on any select to open dropdown

Explore console logs
```
Error: ASSERTION ERROR: 
Unexpected state: no hydration info available for a given TNode, which represents a view container. 
[Expected=> null != undefined <=Actual]
    at throwError (core.mjs:530:9)
    at assertDefined (core.mjs:526:5)
    at populateDehydratedViewsInLContainerImpl (core.mjs:18029:16)
    at locateOrCreateAnchorNode (core.mjs:18045:8)
    at createContainerRef (core.mjs:17947:3)
    at createSpecialToken (core.mjs:18328:12)
    at createResultForNode (core.mjs:18315:12)
    at materializeViewResults (core.mjs:18354:21)
    at getQueryResults (core.mjs:18466:89)
    at refreshSignalQuery (core.mjs:18537:19)
```