### PR TITLE
fix(cdk): migration fails with `JavaScript heap out of memory` because of `allure-results` directory

### DIFF
--- a/projects/cdk/schematics/constants/file-globs.ts
+++ b/projects/cdk/schematics/constants/file-globs.ts
@@ -10,6 +10,7 @@ const EXCLUDE_DIRECTORIES = [
     'dll',
     'tmp',
     '__build__',
+    'allure-results',
     // hidden directories
     '.rpt2_cache',
     '.husky',


### PR DESCRIPTION
Cherry-picked from:
* https://github.com/taiga-family/taiga-ui/pull/12931
