### PR TITLE
fix(core): `Link` has invalid `mask-size` for icons

### DIFF
--- a/projects/core/styles/components/link.less
+++ b/projects/core/styles/components/link.less
@@ -53,7 +53,6 @@
         font-size: 0;
         line-height: 0;
         box-sizing: border-box;
-        mask-size: calc(100% + 10 * var(--tui-stroke-width, 0.125rem)) 100%;
         transition: none;
     }
 


### PR DESCRIPTION
Fixes #13034
