### PR TITLE
feat!: new browser support

### DIFF
--- a/projects/demo/src/modules/info/browsers/index.ts
+++ b/projects/demo/src/modules/info/browsers/index.ts
@@ -10,21 +10,21 @@ import {TuiTable} from '@taiga-ui/addon-table';
 })
 export default class Page {
     protected readonly desktopBrowsers = [
-        {name: 'Google Chrome', version: '88+'},
-        {name: 'Mozilla Firefox', version: '126+'},
+        {name: 'Google Chrome', version: '107+'},
+        {name: 'Mozilla Firefox', version: '128+'},
         {name: 'Safari', version: '14.1+'},
-        {name: 'Opera', version: '74+'},
-        {name: 'Edge', version: '88+'},
-        {name: 'Yandex Browser', version: '21.2+'},
+        {name: 'Opera', version: '93+'},
+        {name: 'Edge', version: '107+'},
+        {name: 'Yandex Browser', version: '23.3+'},
         {name: 'Microsoft Internet Explorer', version: null},
     ] as const;
 
     protected readonly mobileBrowsers = [
-        {name: 'Google Chrome', version: '88+'},
-        {name: 'Mozilla Firefox', version: '126+'},
+        {name: 'Google Chrome', version: '107+'},
+        {name: 'Mozilla Firefox', version: '128+'},
         {name: 'Safari', version: '14.5+'},
-        {name: 'Opera', version: '63+'},
-        {name: 'Samsung Mobile', version: '15+'},
-        {name: 'Yandex Browser', version: '21.2+'},
+        {name: 'Opera', version: '73+'},
+        {name: 'Samsung Mobile', version: '21+'},
+        {name: 'Yandex Browser', version: '23.3+'},
     ];
 }


### PR DESCRIPTION
| Browser                                           | Previous | New  | Description                                  |
|---------------------------------------------------|----------|------|----------------------------------------------|
| Chrome Desktop<br/>Chrome Mobile<br/>Edge Desktop | 88+      | 107+ | [Angular 20 Baseline](https://angular.dev/reference/versions#browser-support)                         |
| Opera Desktop                                     | 74+      | 93+  | Chromium >= 107                              |
| Opera Mobile                                      | 63+      | 73+  | Opera Mobile 72/73 === Chromium 106/108      |
| Samsung Mobile                                    | 15+      | 21+  | Samsung Mobile 20/21 === Chromium 106/110    |
| Firefox (Desktop + Mobile)                        | 120+     | 128+ | Second-to-last ESR (at the time of revision) |

Relates:
* https://github.com/taiga-family/toolkit/pull/1514