### PR TITLE
refactor: Safari 14 doesn't support logical properties for float

### DIFF
--- a/projects/addon-doc/components/toc/index.less
+++ b/projects/addon-doc/components/toc/index.less
@@ -4,10 +4,15 @@
     position: sticky;
     top: 6rem;
     display: block;
-    float: inline-end;
+    float: right;
     inline-size: 14rem;
     margin-inline-start: 5rem;
     font: var(--tui-font-body-s);
+
+    // Safari 15+
+    @supports (float: inline-end) {
+        float: inline-end;
+    }
 
     &:empty {
         display: none;

--- a/projects/core/portals/hint/hint.style.less
+++ b/projects/core/portals/hint/hint.style.less
@@ -75,8 +75,13 @@
         }
 
         [tuiIconButton][data-appearance='icon'][data-size='xs'] {
-            float: inline-end;
+            float: right;
             margin-inline-end: -0.25rem;
+
+            // Safari 15+
+            @supports (float: inline-end) {
+                float: inline-end;
+            }
         }
 
         img {

--- a/projects/demo/src/pages/components/surface/examples/7/index.less
+++ b/projects/demo/src/pages/components/surface/examples/7/index.less
@@ -85,8 +85,13 @@
     }
 
     .link {
-        float: inline-end;
+        float: right;
         font: var(--tui-font-body-m);
+
+        // Safari 15+
+        @supports (float: inline-end) {
+            float: inline-end;
+        }
     }
 
     .scrollbar {

--- a/projects/demo/src/pages/directives/media/examples/1/index.less
+++ b/projects/demo/src/pages/directives/media/examples/1/index.less
@@ -3,6 +3,11 @@
 }
 
 .video {
-    float: inline-start;
+    float: left;
     margin-inline-end: 1.5rem;
+
+    // Safari 15+
+    @supports (float: inline-start) {
+        float: inline-start;
+    }
 }

--- a/projects/legacy/components/mobile-dialog/mobile-dialog.style.less
+++ b/projects/legacy/components/mobile-dialog/mobile-dialog.style.less
@@ -61,7 +61,12 @@
 
     :host:not(._ios) & {
         margin: 0.5rem 0 0.5rem 0.5rem;
-        float: inline-end;
+        float: right;
+
+        // Safari 15+
+        @supports (float: inline-end) {
+            float: inline-end;
+        }
 
         &_column {
             display: block;


### PR DESCRIPTION
<img width="477" height="324" alt="image" src="https://github.com/user-attachments/assets/90fe1277-748d-443a-900f-843c641a4f41" />
