### PR TITLE
fix(kit): support dark mode in `tuiButtonCopy`

### DIFF
--- a/projects/demo/src/modules/components/copy/examples/5/index.html
+++ b/projects/demo/src/modules/components/copy/examples/5/index.html
@@ -8,14 +8,12 @@
     <ng-template #inkin>
         <button
             tuiButtonCopy="Alexander Inkin"
-            tuiTheme="dark"
             type="button"
         >
             Name
         </button>
         <button
             tuiButtonCopy="@a.inkin"
-            tuiTheme="dark"
             type="button"
         >
             Login

--- a/projects/kit/directives/copy/button-copy.component.ts
+++ b/projects/kit/directives/copy/button-copy.component.ts
@@ -12,6 +12,8 @@ import {tuiInjectElement} from '@taiga-ui/cdk/utils/dom';
 import {tuiDirectiveBinding, tuiIsString} from '@taiga-ui/cdk/utils/miscellaneous';
 import {TuiButton, tuiButtonOptionsProvider} from '@taiga-ui/core/components/button';
 import {TUI_NOTIFICATION_OPTIONS} from '@taiga-ui/core/components/notification';
+import {TuiHintDirective} from '@taiga-ui/core/directives/hint';
+import {TUI_DARK_MODE} from '@taiga-ui/core/tokens';
 import {TuiIcons} from '@taiga-ui/core/directives/icons';
 import {TUI_COPY_TEXTS} from '@taiga-ui/kit/tokens';
 import {toSignal} from '@angular/core/rxjs-interop';
@@ -39,6 +41,8 @@ import {TUI_COPY_OPTIONS} from './copy.options';
     host: {
         tuiButton: '',
         type: 'button',
+        '[attr.tuiTheme]':
+            'appearance === "dark" ? "light" : darkMode() ? "light" : "dark"',
         '(document:click.capture)': 'copy($event.target)',
     },
 })
@@ -48,9 +52,17 @@ export class TuiButtonCopyComponent {
     private readonly options = inject(TUI_COPY_OPTIONS);
     private readonly copyTexts = toSignal(inject(TUI_COPY_TEXTS));
     private readonly notification = inject(TUI_NOTIFICATION_OPTIONS);
+    private readonly hint = inject(TuiHintDirective);
+
     private readonly check = tuiIsString(this.notification.icon)
         ? this.notification.icon
         : this.notification.icon('positive');
+
+    protected readonly appearance =
+        this.hint.appearance ||
+        this.hint.el.closest('[tuiTheme]')?.getAttribute('tuiTheme');
+
+    protected readonly darkMode = inject(TUI_DARK_MODE);
 
     protected readonly copied = signal(false);
     protected readonly copiedText = computed(() => this.copyTexts()?.[1] ?? '');


### PR DESCRIPTION
Fixes #13144
