### PR TITLE
fix(kit): `Range` has unexpected shift on `pointerdown` without subsequent `pointermove` events

### DIFF
--- a/projects/kit/components/range/range-change.directive.ts
+++ b/projects/kit/components/range/range-change.directive.ts
@@ -2,10 +2,10 @@ import {DOCUMENT} from '@angular/common';
 import {Directive, inject, output} from '@angular/core';
 import {takeUntilDestroyed} from '@angular/core/rxjs-interop';
 import {tuiTypedFromEvent} from '@taiga-ui/cdk/observables';
-import {tuiInjectElement} from '@taiga-ui/cdk/utils/dom';
+import {tuiInjectElement, tuiIsElement, tuiIsInput} from '@taiga-ui/cdk/utils/dom';
 import {tuiClamp, tuiRound} from '@taiga-ui/cdk/utils/math';
 import {TUI_FLOATING_PRECISION} from '@taiga-ui/core/components/slider';
-import {map, repeat, startWith, switchMap, takeUntil, tap} from 'rxjs';
+import {identity, map, repeat, startWith, switchMap, takeUntil, tap} from 'rxjs';
 
 import {TuiRange} from './range.component';
 
@@ -28,9 +28,9 @@ export class TuiRangeChange {
                 tap(({clientX, target, pointerId}) => {
                     activeThumb = this.detectActiveThumb(clientX, target);
                     const slideElement =
-                        this.range.sliders()[activeThumb === 'start' ? 0 : 1];
+                        this.range.thumbs()[activeThumb === 'start' ? 0 : 1];
 
-                    slideElement?.nativeElement.setPointerCapture(pointerId);
+                    slideElement.setPointerCapture(pointerId);
                     this.activeThumbChange.emit(activeThumb);
 
                     if (this.range.focusable()) {
@@ -38,7 +38,11 @@ export class TuiRangeChange {
                     }
                 }),
                 switchMap((event) =>
-                    tuiTypedFromEvent(this.doc, 'pointermove').pipe(startWith(event)),
+                    tuiTypedFromEvent(this.doc, 'pointermove').pipe(
+                        tuiIsElement(event.target) && tuiIsInput(event.target)
+                            ? identity
+                            : startWith(event),
+                    ),
                 ),
                 map(({clientX}) => this.getFractionFromEvents(clientX ?? 0)),
                 takeUntil(tuiTypedFromEvent(this.doc, 'pointerup', {passive: true})),
@@ -64,12 +68,12 @@ export class TuiRangeChange {
         clientX: number,
         target: EventTarget | null,
     ): 'end' | 'start' {
-        const [startSliderRef, endSliderRef] = this.range.sliders();
+        const [startThumb, endThumb] = this.range.thumbs();
 
         switch (target) {
-            case endSliderRef?.nativeElement:
+            case endThumb:
                 return 'end';
-            case startSliderRef?.nativeElement:
+            case startThumb:
                 return 'start';
             default:
                 return this.findNearestActiveThumb(clientX);

--- a/projects/kit/components/range/range.component.ts
+++ b/projects/kit/components/range/range.component.ts
@@ -2,7 +2,6 @@ import {
     ChangeDetectionStrategy,
     Component,
     computed,
-    ElementRef,
     input,
     viewChildren,
 } from '@angular/core';
@@ -49,6 +48,7 @@ import {TuiRangeChange} from './range-change.directive';
 })
 export class TuiRange extends TuiControl<[number, number]> {
     private readonly el = tuiInjectElement();
+    private readonly sliders = viewChildren(TuiSliderComponent);
 
     protected lastActiveThumb: 'end' | 'start' = 'end';
 
@@ -63,10 +63,9 @@ export class TuiRange extends TuiControl<[number, number]> {
 
     public readonly start = computed(() => this.toPercent(this.value()[0]));
     public readonly end = computed(() => 100 - this.toPercent(this.value()[1]));
-    public readonly sliders = viewChildren<
-        TuiSliderComponent,
-        ElementRef<HTMLInputElement>
-    >(TuiSliderComponent, {read: ElementRef});
+    public readonly thumbs = computed(
+        ([start, end] = this.sliders()) => [start!.el, end!.el] as const,
+    );
 
     protected readonly segmentWidthRatio = computed<number>(() => 1 / this.segments());
     protected readonly fractionStep = computed<number>((step = this.step()) => {
@@ -112,7 +111,7 @@ export class TuiRange extends TuiControl<[number, number]> {
     }
 
     protected changeByStep(coefficient: number, target: HTMLElement): void {
-        const [startThumb, endThumb] = this.sliders().map((x) => x?.nativeElement);
+        const [startThumb, endThumb] = this.thumbs();
         const isEndThumb =
             target === this.el ? this.lastActiveThumb === 'end' : target === endThumb;
         const activeThumbElement = isEndThumb ? endThumb : startThumb;


### PR DESCRIPTION
Fixes #11748
