### PR TITLE
fix(kit): add correct size behaviour for TuiBlock

### DIFF
--- a/projects/kit/components/block/block.directive.ts
+++ b/projects/kit/components/block/block.directive.ts
@@ -42,7 +42,7 @@ class TuiBlockStyles {}
     hostDirectives: [TuiNativeValidator, TuiWithAppearance, TuiWithIcons],
     host: {
         tuiBlock: '',
-        '[attr.data-size]': 'size || "l"',
+        '[attr.data-size]': 'size || options.size || "l"',
         '[class._disabled]': '!!this.control?.disabled',
     },
 })
@@ -51,7 +51,8 @@ export class TuiBlock {
     protected readonly control?: NgControl;
 
     protected readonly nothing = tuiWithStyles(TuiBlockStyles);
+    protected readonly options = inject(TUI_BLOCK_OPTIONS);
 
     @Input('tuiBlock')
-    public size: TuiSizeL | TuiSizeS | '' = inject(TUI_BLOCK_OPTIONS).size;
+    public size: TuiSizeL | TuiSizeS | '' = this.options.size;
 }


### PR DESCRIPTION
Add correct behaviour for size host attribute for TuiBlock
```
 tuiBlock: '',
        '[attr.data-size]': 'size || options.size || "l"',
        '[class._disabled]': '!!this.control?.disabled',

```