### PR TITLE
fix(core): tui-textfield still has `_disabled` class after enabling a control

### DIFF
--- a/projects/core/components/textfield/textfield-multi/textfield-multi.component.ts
+++ b/projects/core/components/textfield/textfield-multi/textfield-multi.component.ts
@@ -58,7 +58,7 @@ import {TUI_TEXTFIELD_ITEM} from './textfield-item.component';
         tuiProvide(TUI_SCROLL_REF, ElementRef),
     ],
     host: {
-        '[attr.data-state]': 'control()?.disabled ? "disabled" : null',
+        '[attr.data-state]': 'disabled ? "disabled" : null',
         '[class._empty]': '!control()?.value?.length',
         '[style.--t-item-height.px]': 'height()',
         '[style.--t-rows]': 'rows()',

--- a/projects/core/components/textfield/textfield.component.ts
+++ b/projects/core/components/textfield/textfield.component.ts
@@ -70,7 +70,7 @@ import {TUI_TEXTFIELD_ACCESSOR, type TuiTextfieldAccessor} from './textfield-acc
         '[attr.data-size]': 'options.size()',
         '[class._with-label]': 'hasLabel', // TODO :has([tuiLabel]
         '[class._with-template]': 'content() && control()?.value != null',
-        '[class._disabled]': 'input()?.nativeElement?.disabled', // TODO :has([tuiInput]:disabled)
+        '[class._disabled]': 'disabled', // TODO :has([tuiInput]:disabled)
         '(animationstart)': '0', // TODO :has([tuiInput]:disabled)
         '(animationcancel)': '0', // TODO :has([tuiInput]:disabled)
         '(click.self.prevent)': '0',
@@ -126,6 +126,10 @@ export class TuiTextfieldComponent<T> implements TuiDataListHost<T> {
 
     public get id(): string {
         return this.input()?.nativeElement.id || this.autoId;
+    }
+
+    public get disabled(): boolean {
+        return this.control()?.disabled ?? this.input()?.nativeElement?.disabled ?? false;
     }
 
     public get size(): TuiSizeL | TuiSizeS {

--- a/projects/demo-playwright/tests/kit/input-chip/input-chip.pw.spec.ts
+++ b/projects/demo-playwright/tests/kit/input-chip/input-chip.pw.spec.ts
@@ -100,6 +100,22 @@ test.describe('InputChip', () => {
             await expect.soft(example).toHaveScreenshot('input-chip-unique.png');
         });
 
+        test('disable control', async ({page}) => {
+            await tuiGoto(page, `${DemoRoute.InputChip}/API`);
+
+            const api = new TuiDocumentationApiPagePO(page);
+            const inputChip = new TuiInputChipPO(api.demo);
+            const toggle = await api.getToggle(api.getRow('disabled'));
+
+            await inputChip.input.fill('1,2,3');
+            await inputChip.input.blur();
+            await expect.soft(api.demo).toHaveScreenshot('input-chip-writable.png');
+            await expect(inputChip.cleaner).toHaveCount(1);
+            await toggle?.click();
+            await expect.soft(api.demo).toHaveScreenshot('input-chip-disabled.png');
+            await expect(inputChip.cleaner).toHaveCount(0);
+        });
+
         test('readonly true', async ({page}) => {
             await tuiGoto(page, `${DemoRoute.InputChip}/API`);
             const apiPage = new TuiDocumentationApiPagePO(page);


### PR DESCRIPTION


Fixes #12839
