### PR TITLE
chore: stackblitz starter throws `Could not import @taiga-ui/styles/utils.less`

### DIFF
--- a/projects/demo/src/pages/app/stackblitz/stackblitz-deps.service.ts
+++ b/projects/demo/src/pages/app/stackblitz/stackblitz-deps.service.ts
@@ -52,6 +52,7 @@ export class StackblitzDepsService {
             '@taiga-ui/kit': version,
             '@taiga-ui/layout': version,
             '@taiga-ui/legacy': version,
+            '@taiga-ui/styles': version,
         };
     }
 


### PR DESCRIPTION
Open https://taiga-ui.dev/next/stackblitz
```
Error in src/app/app.less (1:0)
Could not import @taiga-ui/styles/utils.less from /~/src/app/app.less
```
