### PR TITLE
fix(kit): close `TabsWithMore` dropdown when `activeItemIndex` is updated externally

### DIFF
--- a/projects/demo-playwright/tests/kit/tabs/tabs.pw.spec.ts
+++ b/projects/demo-playwright/tests/kit/tabs/tabs.pw.spec.ts
@@ -62,6 +62,9 @@ describe('Tabs', () => {
                 await page.locator('button:has-text("Collaborators")').nth(1).focus();
                 await page.keyboard.down('Enter');
 
+                // Flaky without this in CI (mostly under load)
+                await page.waitForTimeout(100);
+
                 // Still previous one
                 await expect(example).toContainText('Currently active: John Cleese');
                 await expect(page.locator('tui-dropdown')).toHaveCount(2);
@@ -71,10 +74,7 @@ describe('Tabs', () => {
                 await page.keyboard.down('Enter');
 
                 await expect(example).toContainText('Currently active: Neil Innes');
-                // TODO: https://github.com/taiga-family/taiga-ui/issues/13005
-                // await expect(page.locator('tui-dropdown')).not.toBeAttached();
-                await expect(page.locator('tui-dropdown')).toHaveCount(1);
-                await page.waitForTimeout(100);
+                await expect(page.locator('tui-dropdown')).not.toBeAttached();
                 await expect.soft(example).toHaveScreenshot('01-tabs-8.png');
             });
 

--- a/projects/kit/components/tabs/tabs-with-more.component.ts
+++ b/projects/kit/components/tabs/tabs-with-more.component.ts
@@ -62,6 +62,7 @@ export class TuiTabsWithMore implements AfterViewChecked, AfterViewInit {
     protected readonly sync = effect(() => {
         this.activeItemIndex();
         this.maxIndex = this.getMaxIndex();
+        this.open = false;
     });
 
     public open = false;


### PR DESCRIPTION
Fixes #13005 

Fix: close `TabsWithMore` dropdown when `activeItemIndex` is updated externally (no provideAnimations())

TuiTab intentionally delays (tui-tab-activate) dispatch until the bubbled click reaches the parent (so all other click handlers run first). In a “controlled” setup (e.g. projected tab has (click)="activeItemIndex.set(i)"), the consumer updates activeItemIndex immediately. tui-tabs-with-more then re-renders synchronously and can remove/move the clicked tab from the dropdown before the parent receives the bubbled click — so tui-tab-activate is never dispatched and the internal handler that closes the dropdown is never executed. This is much harder to reproduce when animations are enabled because DOM updates may be deferred.

This PR closes the “More” dropdown whenever activeItemIndex changes.
