### PR TITLE
chore: stackblitz starter throws error because of `provideExperimentalZonelessChangeDetection`

### DIFF
--- a/projects/demo/src/pages/app/stackblitz/project-files/src/main.ts.md
+++ b/projects/demo/src/pages/app/stackblitz/project-files/src/main.ts.md
@@ -1,7 +1,7 @@
 ```ts
 import {provideRouter} from '@angular/router';
 import {bootstrapApplication} from '@angular/platform-browser';
-import {Component, provideExperimentalZonelessChangeDetection} from '@angular/core';
+import {Component, provideZonelessChangeDetection} from '@angular/core';
 import {provideTaiga, tuiAssetsPathProvider, TuiRoot} from '@taiga-ui/core';
 
 import {App} from './app/app';
@@ -16,7 +16,7 @@ class Root {}
 bootstrapApplication(Root, {
   providers: [
     provideRouter([]),
-    provideExperimentalZonelessChangeDetection(),
+    provideZonelessChangeDetection(),
     /**
      * A workaround for StackBlitz only (it does not support assets).
      * Don't use this approach in real-world applications!


### PR DESCRIPTION
Open https://taiga-ui.dev/next/stackblitz

```
Error in src/main.ts (3:20)
'"@angular/core"' has no exported member named 'provideExperimentalZonelessChangeDetection'. 
Did you mean 'provideZonelessChangeDetection'?
```