### PR TITLE
chore: stackblitz should open tabs with examples source files

### DIFF
--- a/projects/demo/src/pages/app/stackblitz/stackblitz.service.ts
+++ b/projects/demo/src/pages/app/stackblitz/stackblitz.service.ts
@@ -42,18 +42,21 @@ export class TuiStackblitzService implements TuiCodeEditor {
         appCompTs.className = APP_COMP_META.CLASS_NAME;
         appCompTs.defaultExport = false;
 
-        stackblitz.openProject({
-            ...(await this.getStackblitzProjectConfig()),
-            title: `${component}-${sampleId}`,
-            description: `Taiga UI example of the component ${component}`,
-            files: {
-                ...(await this.getBaseAngularProjectFiles()),
-                ...modifiedSupportFiles,
-                [appPrefix`app.ts`]: appCompTs.toString(),
-                [appPrefix`app.html`]: content.HTML,
-                [appPrefix`app.less`]: prepareLess(content.LESS || ''),
+        stackblitz.openProject(
+            {
+                ...(await this.getStackblitzProjectConfig()),
+                title: `${component}-${sampleId}`,
+                description: `Taiga UI example of the component ${component}`,
+                files: {
+                    ...(await this.getBaseAngularProjectFiles()),
+                    ...modifiedSupportFiles,
+                    [appPrefix`app.ts`]: appCompTs.toString(),
+                    [appPrefix`app.html`]: content.HTML,
+                    [appPrefix`app.less`]: prepareLess(content.LESS || ''),
+                },
             },
-        });
+            {openFile: ['html', 'less', 'ts'].map((x) => appPrefix`app.${x}`).join(',')},
+        );
     }
 
     public async openStarter(


### PR DESCRIPTION
Press `Edit on Stackblitz` button on any example
https://taiga-ui.dev/next/components/button#sizes

## Previous behavior
It opens `main.ts` as initial tab
<img width="1022" height="249" alt="previous" src="https://github.com/user-attachments/assets/465f12cd-59da-4f1b-98e5-83255b8b5984" />

## New behavior
<img width="1022" height="364" alt="new" src="https://github.com/user-attachments/assets/07d12b30-32ef-4138-9367-14d630545ce5" />

