### PR TITLE
chore(schematics): migrate start/end instead of left/right in hints, dropdowns, etc

### DIFF
--- a/projects/cdk/schematics/ng-update/interfaces/replacement-function-parameter.ts
+++ b/projects/cdk/schematics/ng-update/interfaces/replacement-function-parameter.ts
@@ -1,0 +1,9 @@
+export interface ReplacementFunctionParameter {
+    readonly names: string[];
+    readonly moduleSpecifier?: string[] | string;
+    readonly parameters: string[];
+    readonly valueReplacer: Array<{
+        readonly from: string;
+        readonly to: string;
+    }>;
+}

--- a/projects/cdk/schematics/ng-update/utils/replace-function-parameters.ts
+++ b/projects/cdk/schematics/ng-update/utils/replace-function-parameters.ts
@@ -1,0 +1,54 @@
+import {Node, SyntaxKind} from 'ng-morph';
+
+import {getNamedImportReferences} from '../../utils/get-named-import-references';
+import {type ReplacementFunctionParameter} from '../interfaces/replacement-function-parameter';
+
+export function replaceFunctionParameters(
+    items: readonly ReplacementFunctionParameter[],
+): void {
+    items.forEach((item) => replaceFunctionParameter(item));
+}
+
+function replaceFunctionParameter(item: ReplacementFunctionParameter): void {
+    const references = item.names.flatMap((name) =>
+        getNamedImportReferences(name, item.moduleSpecifier),
+    );
+
+    references.forEach((ref) => {
+        if (ref.wasForgotten()) {
+            return;
+        }
+
+        const parent = ref.getParent();
+
+        if (!Node.isCallExpression(parent)) {
+            return;
+        }
+
+        const [value] = parent.getArguments();
+
+        if (!Node.isObjectLiteralExpression(value)) {
+            return;
+        }
+
+        item.parameters.forEach((parameter) => {
+            const property = value.getProperty(parameter);
+
+            if (!property) {
+                return;
+            }
+
+            const replacement = property.getLastChildIfKind(SyntaxKind.StringLiteral);
+
+            if (!replacement) {
+                return;
+            }
+
+            item.valueReplacer.forEach(({from, to}) => {
+                if (replacement.getLiteralValue() === from) {
+                    replacement.setLiteralValue(to);
+                }
+            });
+        });
+    });
+}

--- a/projects/cdk/schematics/ng-update/v5/index.ts
+++ b/projects/cdk/schematics/ng-update/v5/index.ts
@@ -24,7 +24,9 @@ import {
     showWarnings,
 } from '../steps';
 import {getFileSystem} from '../utils/get-file-system';
+import {replaceFunctionParameters} from '../utils/replace-function-parameters';
 import {replaceFunctions} from '../utils/replace-functions';
+import {FUNCTION_PARAMETERS_TO_REPLACE} from './steps/constants/function-parameters-to-replace';
 import {REPLACE_FUNCTIONS} from './steps/constants/functions';
 import {IDENTIFIERS_TO_REPLACE} from './steps/constants/identifiers-to-replace';
 import {MIGRATION_WARNINGS} from './steps/constants/migration-warnings';
@@ -53,6 +55,10 @@ function main(options: TuiSchema, timings: MigrationStepTiming[]): Rule {
                 {
                     name: 'replaceFunctions',
                     step: () => replaceFunctions(REPLACE_FUNCTIONS),
+                },
+                {
+                    name: 'replaceFunctionParameters',
+                    step: () => replaceFunctionParameters(FUNCTION_PARAMETERS_TO_REPLACE),
                 },
                 {
                     name: 'removeModules',

--- a/projects/cdk/schematics/ng-update/v5/steps/constants/attr-with-values-to-replace.ts
+++ b/projects/cdk/schematics/ng-update/v5/steps/constants/attr-with-values-to-replace.ts
@@ -10,4 +10,116 @@ export const ATTR_WITH_VALUES_TO_REPLACE: ReplacementAttributeValue[] = [
         withTagNames: ['tui-range', 'input'],
         filterFn: (el) => el.tagName !== 'input' || hasElementAttribute(el, 'tuiSlider'),
     },
+    {
+        attrNames: ['tuiHintDirection'],
+        valueReplacer: [
+            {from: 'bottom-left', to: 'bottom-start'},
+            {from: 'bottom-right', to: 'bottom-end'},
+            {from: 'top-left', to: 'top-start'},
+            {from: 'top-right', to: 'top-end'},
+            {from: 'left-bottom', to: 'start-bottom'},
+            {from: 'left-top', to: 'start-top'},
+            {from: 'left', to: 'start'},
+            {from: 'right-bottom', to: 'end-bottom'},
+            {from: 'right-top', to: 'end-top'},
+            {from: 'right', to: 'end'},
+        ],
+    },
+    {
+        attrNames: ['[tuiHintDirection]'],
+        valueReplacer: [
+            {from: "'bottom-left'", to: "'bottom-start'"},
+            {from: "'bottom-right'", to: "'bottom-end'"},
+            {from: "'top-left'", to: "'top-start'"},
+            {from: "'top-right'", to: "'top-end'"},
+            {from: "'left-bottom'", to: "'start-bottom'"},
+            {from: "'left-top'", to: "'start-top'"},
+            {from: "'left'", to: "'start'"},
+            {from: "'right-bottom'", to: "'end-bottom'"},
+            {from: "'right-top'", to: "'end-top'"},
+            {from: "'right'", to: "'end'"},
+        ],
+    },
+    {
+        attrNames: ['tuiDropdownAlign', 'tuiSlot', 'tuiComment'],
+        valueReplacer: [
+            {from: 'left', to: 'start'},
+            {from: 'right', to: 'end'},
+        ],
+    },
+    {
+        attrNames: ['[tuiDropdownAlign]', '[tuiSlot]', '[tuiComment]'],
+        valueReplacer: [
+            {from: "'left'", to: "'start'"},
+            {from: "'right'", to: "'end'"},
+        ],
+    },
+    {
+        attrNames: ['direction'],
+        withTagNames: ['tui-avatar-stack', 'tui-drawer'],
+        valueReplacer: [
+            {from: 'left', to: 'start'},
+            {from: 'right', to: 'end'},
+        ],
+    },
+    {
+        attrNames: ['[direction]'],
+        withTagNames: ['tui-avatar-stack', 'tui-drawer'],
+        valueReplacer: [
+            {from: "'left'", to: "'start'"},
+            {from: "'right'", to: "'end'"},
+        ],
+    },
+    {
+        attrNames: ['vertical'],
+        withTagNames: ['tui-tabs'],
+        valueReplacer: [
+            {from: 'left', to: 'start'},
+            {from: 'right', to: 'end'},
+        ],
+    },
+    {
+        attrNames: ['[vertical]'],
+        withTagNames: ['tui-tabs'],
+        valueReplacer: [
+            {from: "'left'", to: "'start'"},
+            {from: "'right'", to: "'end'"},
+        ],
+    },
+    {
+        attrNames: ['vertical'],
+        withTagNames: ['nav'],
+        valueReplacer: [
+            {from: 'left', to: 'start'},
+            {from: 'right', to: 'end'},
+        ],
+        filterFn: (el) => hasElementAttribute(el, 'tuiTabs'),
+    },
+    {
+        attrNames: ['[vertical]'],
+        withTagNames: ['nav'],
+        valueReplacer: [
+            {from: "'left'", to: "'start'"},
+            {from: "'right'", to: "'end'"},
+        ],
+        filterFn: (el) => hasElementAttribute(el, 'tuiTabs'),
+    },
+    {
+        attrNames: ['align'],
+        withTagNames: ['input'],
+        valueReplacer: [
+            {from: 'left', to: 'start'},
+            {from: 'right', to: 'end'},
+        ],
+        filterFn: (el) => hasElementAttribute(el, 'tuiInputColor'),
+    },
+    {
+        attrNames: ['[align]'],
+        withTagNames: ['input'],
+        valueReplacer: [
+            {from: "'left'", to: "'start'"},
+            {from: "'right'", to: "'end'"},
+        ],
+        filterFn: (el) => hasElementAttribute(el, 'tuiInputColor'),
+    },
 ];

--- a/projects/cdk/schematics/ng-update/v5/steps/constants/function-parameters-to-replace.ts
+++ b/projects/cdk/schematics/ng-update/v5/steps/constants/function-parameters-to-replace.ts
@@ -1,0 +1,36 @@
+import {type ReplacementFunctionParameter} from '../../../interfaces/replacement-function-parameter';
+
+export const FUNCTION_PARAMETERS_TO_REPLACE: ReplacementFunctionParameter[] = [
+    {
+        names: ['tuiAmountOptionsProvider'],
+        parameters: ['currencyAlign'],
+        valueReplacer: [
+            {from: 'left', to: 'start'},
+            {from: 'right', to: 'end'},
+        ],
+    },
+    {
+        names: ['tuiDropdownOptionsProvider'],
+        parameters: ['align'],
+        valueReplacer: [
+            {from: 'left', to: 'start'},
+            {from: 'right', to: 'end'},
+        ],
+    },
+    {
+        names: ['tuiHintOptionsProvider'],
+        parameters: ['direction'],
+        valueReplacer: [
+            {from: 'bottom-left', to: 'bottom-start'},
+            {from: 'bottom-right', to: 'bottom-end'},
+            {from: 'top-left', to: 'top-start'},
+            {from: 'top-right', to: 'top-end'},
+            {from: 'left-bottom', to: 'start-bottom'},
+            {from: 'left-top', to: 'start-top'},
+            {from: 'left', to: 'start'},
+            {from: 'right-bottom', to: 'end-bottom'},
+            {from: 'right-top', to: 'end-top'},
+            {from: 'right', to: 'end'},
+        ],
+    },
+];

--- a/projects/cdk/schematics/ng-update/v5/steps/migrate-templates.ts
+++ b/projects/cdk/schematics/ng-update/v5/steps/migrate-templates.ts
@@ -28,6 +28,7 @@ import {HTML_COMMENTS} from './constants/html-comments';
 import {INPUTS_TO_REMOVE} from './constants/inputs-to-remove';
 import {TAGS_TO_REPLACE} from './constants/tags-to-replace';
 import {migrateAccordionItem} from './templates/migrate-accordion';
+import {migrateAmountCurrencyAlign} from './templates/migrate-amount-currency-align';
 import {migrateAsyncPipes} from './templates/migrate-async-pipes';
 import {migrateAvatarToDirective} from './templates/migrate-avatar';
 import {migrateFieldError} from './templates/migrate-field-error';
@@ -83,6 +84,7 @@ export function migrateTemplates(fileSystem: DevkitFileSystem, options: TuiSchem
         migrateTuiNotification,
         migrateRepeatTimes,
         migrateFieldError,
+        migrateAmountCurrencyAlign,
         migrateAsyncPipes,
     ] as const;
 

--- a/projects/cdk/schematics/ng-update/v5/steps/templates/migrate-amount-currency-align.ts
+++ b/projects/cdk/schematics/ng-update/v5/steps/templates/migrate-amount-currency-align.ts
@@ -1,0 +1,33 @@
+import {type UpdateRecorder} from '@angular-devkit/schematics';
+import {type DevkitFileSystem} from 'ng-morph';
+
+import {
+    getTemplateFromTemplateResource,
+    getTemplateOffset,
+} from '../../../../utils/templates/template-resource';
+import {type TemplateResource} from '../../../interfaces';
+
+interface Input {
+    fileSystem: DevkitFileSystem;
+    recorder: UpdateRecorder;
+    resource: TemplateResource;
+}
+
+export function migrateAmountCurrencyAlign({
+    resource,
+    recorder,
+    fileSystem,
+}: Input): void {
+    const template = getTemplateFromTemplateResource(resource, fileSystem);
+    const templateOffset = getTemplateOffset(resource);
+
+    const re = /(\|\s*tuiAmount\s*:\s*'[^']*'\s*:\s*)'(right|left)'/g;
+
+    [...template.matchAll(re)].forEach((match) => {
+        const start = templateOffset + match.index + match[1]!.length;
+        const oldLen = match[0].length - match[1]!.length;
+
+        recorder.remove(start, oldLen);
+        recorder.insertLeft(start, `'${match[2] === 'right' ? 'end' : 'start'}'`);
+    });
+}

--- a/projects/cdk/schematics/ng-update/v5/tests/schematic-migrate-start-end.spec.ts
+++ b/projects/cdk/schematics/ng-update/v5/tests/schematic-migrate-start-end.spec.ts
@@ -1,0 +1,456 @@
+import {join} from 'node:path';
+
+import {resetActiveProject} from 'ng-morph';
+
+import {runMigration} from '../../../utils/run-migration';
+
+const collection = join(__dirname, '../../../migration.json');
+
+describe('ng-update start/end instead of left/right', () => {
+    const migrateTemplate = async (template: string): Promise<string> => {
+        const {template: result} = await runMigration({
+            template,
+            collection,
+        });
+
+        return result;
+    };
+
+    const migrateComponent = async (component: string): Promise<string> => {
+        const {component: result} = await runMigration({
+            component,
+            collection,
+        });
+
+        return result;
+    };
+
+    it('replaces for tuiHintDirection', async () => {
+        const result = await migrateTemplate(`
+            <tui-icon tuiHintDirection="bottom-left" />
+            <tui-icon tuiHintDirection="bottom" />
+            <tui-icon tuiHintDirection="bottom-right" />
+            <tui-icon tuiHintDirection="top-left" />
+            <tui-icon tuiHintDirection="top" />
+            <tui-icon tuiHintDirection="top-right" />
+            <tui-icon tuiHintDirection="left-top" />
+            <tui-icon tuiHintDirection="left" />
+            <tui-icon tuiHintDirection="left-bottom" />
+            <tui-icon tuiHintDirection="right-top" />
+            <tui-icon tuiHintDirection="right" />
+            <tui-icon tuiHintDirection="right-bottom" />
+        `);
+        const expected = `
+            <tui-icon tuiHintDirection="bottom-start" />
+            <tui-icon tuiHintDirection="bottom" />
+            <tui-icon tuiHintDirection="bottom-end" />
+            <tui-icon tuiHintDirection="top-start" />
+            <tui-icon tuiHintDirection="top" />
+            <tui-icon tuiHintDirection="top-end" />
+            <tui-icon tuiHintDirection="start-top" />
+            <tui-icon tuiHintDirection="start" />
+            <tui-icon tuiHintDirection="start-bottom" />
+            <tui-icon tuiHintDirection="end-top" />
+            <tui-icon tuiHintDirection="end" />
+            <tui-icon tuiHintDirection="end-bottom" />
+        `;
+
+        expect(result).toEqual(expected);
+    });
+
+    it('replaces for [tuiHintDirection]', async () => {
+        const result = await migrateTemplate(`
+            <div tuiHint [tuiHintDirection]="'bottom-left'"></div>
+            <div tuiHint [tuiHintDirection]="'bottom'"></div>
+            <div tuiHint [tuiHintDirection]="'bottom-right'"></div>
+            <div tuiHint [tuiHintDirection]="'top-left'"></div>
+            <div tuiHint [tuiHintDirection]="'top'"></div>
+            <div tuiHint [tuiHintDirection]="'top-right'"></div>
+            <div tuiHint [tuiHintDirection]="'left-top'"></div>
+            <div tuiHint [tuiHintDirection]="'left'"></div>
+            <div tuiHint [tuiHintDirection]="'left-bottom'"></div>
+            <div tuiHint [tuiHintDirection]="'right-top'"></div>
+            <div tuiHint [tuiHintDirection]="'right'"></div>
+            <div tuiHint [tuiHintDirection]="'right-bottom'"></div>
+        `);
+
+        const expected = `
+            <div tuiHint [tuiHintDirection]="'bottom-start'"></div>
+            <div tuiHint [tuiHintDirection]="'bottom'"></div>
+            <div tuiHint [tuiHintDirection]="'bottom-end'"></div>
+            <div tuiHint [tuiHintDirection]="'top-start'"></div>
+            <div tuiHint [tuiHintDirection]="'top'"></div>
+            <div tuiHint [tuiHintDirection]="'top-end'"></div>
+            <div tuiHint [tuiHintDirection]="'start-top'"></div>
+            <div tuiHint [tuiHintDirection]="'start'"></div>
+            <div tuiHint [tuiHintDirection]="'start-bottom'"></div>
+            <div tuiHint [tuiHintDirection]="'end-top'"></div>
+            <div tuiHint [tuiHintDirection]="'end'"></div>
+            <div tuiHint [tuiHintDirection]="'end-bottom'"></div>
+        `;
+
+        expect(result).toEqual(expected);
+    });
+
+    it('replaces for tuiDropdownAlign', async () => {
+        const result = await migrateTemplate(`
+            <div tuiDropdownAlign="right" [tuiDropdown]="dropdown"></div>
+            <div tuiDropdownAlign="center" [tuiDropdown]="dropdown"></div>
+            <div tuiDropdownAlign="left" [tuiDropdown]="dropdown"></div>
+        `);
+
+        const expected = `
+            <div tuiDropdownAlign="end" [tuiDropdown]="dropdown"></div>
+            <div tuiDropdownAlign="center" [tuiDropdown]="dropdown"></div>
+            <div tuiDropdownAlign="start" [tuiDropdown]="dropdown"></div>
+        `;
+
+        expect(result).toEqual(expected);
+    });
+
+    it('replaces for [tuiDropdownAlign]', async () => {
+        const result = await migrateTemplate(`
+            <div [tuiDropdown]="dropdown" [tuiDropdownAlign]="'right'"></div>
+            <div [tuiDropdown]="dropdown" [tuiDropdownAlign]="'center'"></div>
+            <div [tuiDropdown]="dropdown" [tuiDropdownAlign]="'left'"></div>
+        `);
+
+        const expected = `
+            <div [tuiDropdown]="dropdown" [tuiDropdownAlign]="'end'"></div>
+            <div [tuiDropdown]="dropdown" [tuiDropdownAlign]="'center'"></div>
+            <div [tuiDropdown]="dropdown" [tuiDropdownAlign]="'start'"></div>
+        `;
+
+        expect(result).toEqual(expected);
+    });
+
+    it('replaces for tuiSlot', async () => {
+        const result = await migrateTemplate(`
+            <tui-item tuiSlot="right" />
+            <tui-item tuiSlot="left" />
+        `);
+
+        const expected = `
+            <tui-item tuiSlot="end" />
+            <tui-item tuiSlot="start" />
+        `;
+
+        expect(result).toEqual(expected);
+    });
+
+    it('replaces for [tuiSlot]', async () => {
+        const result = await migrateTemplate(`
+            <tui-item [tuiSlot]="'right'" />
+            <tui-item [tuiSlot]="'left'" />
+        `);
+
+        const expected = `
+            <tui-item [tuiSlot]="'end'" />
+            <tui-item [tuiSlot]="'start'" />
+        `;
+
+        expect(result).toEqual(expected);
+    });
+
+    it('replaces for tuiComment', async () => {
+        const result = await migrateTemplate(`
+            <div tuiComment="right">Right comment</div>
+            <div tuiComment="left">Left comment</div>
+        `);
+
+        const expected = `
+            <div tuiComment="end">Right comment</div>
+            <div tuiComment="start">Left comment</div>
+        `;
+
+        expect(result).toEqual(expected);
+    });
+
+    it('replaces for [tuiComment]', async () => {
+        const result = await migrateTemplate(`
+            <div [tuiComment]="'right'">Right comment</div>
+            <div [tuiComment]="'left'">Left comment</div>
+        `);
+
+        const expected = `
+            <div [tuiComment]="'end'">Right comment</div>
+            <div [tuiComment]="'start'">Left comment</div>
+        `;
+
+        expect(result).toEqual(expected);
+    });
+
+    it('replaces for direction on tui-avatar-stack', async () => {
+        const result = await migrateTemplate(`
+            <tui-avatar-stack direction="right" />
+            <tui-avatar-stack direction="left" />
+
+            <tui-item direction="right" />
+            <tui-item direction="left" />
+        `);
+
+        const expected = `
+            <tui-avatar-stack direction="end" />
+            <tui-avatar-stack direction="start" />
+
+            <tui-item direction="right" />
+            <tui-item direction="left" />
+        `;
+
+        expect(result).toEqual(expected);
+    });
+
+    it('replaces for [direction] on tui-avatar-stack', async () => {
+        const result = await migrateTemplate(`
+            <tui-avatar-stack [direction]="'right'" />
+            <tui-avatar-stack [direction]="'left'" />
+
+            <tui-item [direction]="'right'" />
+            <tui-item [direction]="'left'" />
+        `);
+
+        const expected = `
+            <tui-avatar-stack [direction]="'end'" />
+            <tui-avatar-stack [direction]="'start'" />
+
+            <tui-item [direction]="'right'" />
+            <tui-item [direction]="'left'" />
+        `;
+
+        expect(result).toEqual(expected);
+    });
+
+    it('replaces for direction on tui-drawer', async () => {
+        const result = await migrateTemplate(`
+            <tui-drawer direction="right">Right drawer</tui-drawer>
+            <tui-drawer direction="left">Left drawer</tui-drawer>
+
+            <tui-item direction="right" />
+            <tui-item direction="left" />
+        `);
+
+        const expected = `
+            <tui-drawer direction="end">Right drawer</tui-drawer>
+            <tui-drawer direction="start">Left drawer</tui-drawer>
+
+            <tui-item direction="right" />
+            <tui-item direction="left" />
+        `;
+
+        expect(result).toEqual(expected);
+    });
+
+    it('replaces for [direction] on tui-drawer', async () => {
+        const result = await migrateTemplate(`
+            <tui-drawer [direction]="'right'">Right drawer</tui-drawer>
+            <tui-drawer [direction]="'left'">Left drawer</tui-drawer>
+
+            <tui-item [direction]="'right'" />
+            <tui-item [direction]="'left'" />
+        `);
+
+        const expected = `
+            <tui-drawer [direction]="'end'">Right drawer</tui-drawer>
+            <tui-drawer [direction]="'start'">Left drawer</tui-drawer>
+
+            <tui-item [direction]="'right'" />
+            <tui-item [direction]="'left'" />
+        `;
+
+        expect(result).toEqual(expected);
+    });
+
+    it('replaces for vertical on tui-tabs', async () => {
+        const result = await migrateTemplate(`
+            <tui-tabs vertical="right" />
+            <tui-tabs vertical="left" />
+
+            <nav tuiTabs vertical="right" />
+            <nav tuiTabs vertical="left" />
+
+            <tui-item vertical="right" />
+            <tui-item vertical="left" />
+        `);
+
+        const expected = `
+            <tui-tabs vertical="end" />
+            <tui-tabs vertical="start" />
+
+            <tui-tabs  vertical="end" />
+            <tui-tabs  vertical="start" />
+
+            <tui-item vertical="right" />
+            <tui-item vertical="left" />
+        `;
+
+        expect(result).toEqual(expected);
+    });
+
+    it('replaces for [vertical] on tui-tabs', async () => {
+        const result = await migrateTemplate(`
+            <tui-tabs [vertical]="'right'" />
+            <tui-tabs [vertical]="'left'" />
+
+            <nav tuiTabs [vertical]="'right'" />
+            <nav tuiTabs [vertical]="'left'" />
+
+            <tui-item [vertical]="'right'" />
+            <tui-item [vertical]="'left'" />
+        `);
+
+        const expected = `
+            <tui-tabs [vertical]="'end'" />
+            <tui-tabs [vertical]="'start'" />
+
+            <tui-tabs  [vertical]="'end'" />
+            <tui-tabs  [vertical]="'start'" />
+
+            <tui-item [vertical]="'right'" />
+            <tui-item [vertical]="'left'" />
+        `;
+
+        expect(result).toEqual(expected);
+    });
+
+    it('replaces for align on input with tuiInputColor', async () => {
+        const result = await migrateTemplate(`
+            <input tuiInputColor align="right" />
+            <input tuiInputColor align="left" />
+            <input align="right" />
+            <input align="left" />
+        `);
+
+        const expected = `
+            <input tuiInputColor align="end" />
+            <input tuiInputColor align="start" />
+            <input align="right" />
+            <input align="left" />
+        `;
+
+        expect(result).toEqual(expected);
+    });
+
+    it('replaces for [align] on input with tuiInputColor', async () => {
+        const result = await migrateTemplate(`
+            <input tuiInputColor [align]="'right'" />
+            <input tuiInputColor [align]="'left'" />
+
+            <input [align]="'right'" />
+            <input [align]="'left'" />
+        `);
+
+        const expected = `
+            <input tuiInputColor [align]="'end'" />
+            <input tuiInputColor [align]="'start'" />
+
+            <input [align]="'right'" />
+            <input [align]="'left'" />
+        `;
+
+        expect(result).toEqual(expected);
+    });
+
+    it('replaces for currencyAlign on tuiAmount pipe', async () => {
+        const result = await migrateTemplate(`
+            <li>{{ -12345.1 | tuiAmount: 'USD' : 'left' }}</li>
+            <li>{{ 100 | tuiAmount: '£' : 'right' | somePipe: 'left' }}</li>
+        `);
+
+        const expected = `
+            <li>{{ -12345.1 | tuiAmount: 'USD' : 'start' }}</li>
+            <li>{{ 100 | tuiAmount: '£' : 'end' | somePipe: 'left' }}</li>
+        `;
+
+        expect(result).toEqual(expected);
+    });
+
+    it('replaces for currencyAlign on tuiAmountOptionsProvider', async () => {
+        const result = await migrateComponent(`
+            import {tuiAmountOptionsProvider} from '@taiga-ui/addon-commerce';
+
+            tuiAmountOptionsProvider({currencyAlign: 'left'});
+            tuiAmountOptionsProvider({
+                sign: 'always',
+                currency: 'USD',
+                currencyAlign: 'right',
+            });
+        `);
+
+        const expected = `
+            import {tuiAmountOptionsProvider} from '@taiga-ui/addon-commerce';
+
+            tuiAmountOptionsProvider({currencyAlign: 'start'});
+            tuiAmountOptionsProvider({
+                sign: 'always',
+                currency: 'USD',
+                currencyAlign: 'end',
+            });
+        `;
+
+        expect(result).toEqual(expected);
+    });
+
+    it('replaces for align on tuiDropdownOptionsProvider', async () => {
+        const result = await migrateComponent(`
+            import {tuiDropdownOptionsProvider} from '@taiga-ui/core';
+
+            tuiDropdownOptionsProvider({align: 'left'});
+            tuiDropdownOptionsProvider({
+                limitWidth: 'fixed',
+                align: 'right',
+            });
+        `);
+
+        const expected = `
+            import {tuiDropdownOptionsProvider} from '@taiga-ui/core';
+
+            tuiDropdownOptionsProvider({align: 'start'});
+            tuiDropdownOptionsProvider({
+                limitWidth: 'fixed',
+                align: 'end',
+            });
+        `;
+
+        expect(result).toEqual(expected);
+    });
+
+    it('replaces for direction on tuiHintOptionsProvider', async () => {
+        const result = await migrateComponent(`
+            import {tuiHintOptionsProvider} from '@taiga-ui/core';
+
+            tuiHintOptionsProvider({direction: 'bottom-left'});
+            tuiHintOptionsProvider({direction: 'bottom'});
+            tuiHintOptionsProvider({direction: 'bottom-right'});
+            tuiHintOptionsProvider({direction: 'top-left'});
+            tuiHintOptionsProvider({direction: 'top'});
+            tuiHintOptionsProvider({direction: 'top-right'});
+            tuiHintOptionsProvider({direction: 'left-top'});
+            tuiHintOptionsProvider({direction: 'left'});
+            tuiHintOptionsProvider({direction: 'left-bottom'});
+            tuiHintOptionsProvider({direction: 'right-top'});
+            tuiHintOptionsProvider({direction: 'right'});
+            tuiHintOptionsProvider({direction: 'right-bottom'});
+        `);
+
+        const expected = `
+            import {tuiHintOptionsProvider} from '@taiga-ui/core';
+
+            tuiHintOptionsProvider({direction: 'bottom-start'});
+            tuiHintOptionsProvider({direction: 'bottom'});
+            tuiHintOptionsProvider({direction: 'bottom-end'});
+            tuiHintOptionsProvider({direction: 'top-start'});
+            tuiHintOptionsProvider({direction: 'top'});
+            tuiHintOptionsProvider({direction: 'top-end'});
+            tuiHintOptionsProvider({direction: 'start-top'});
+            tuiHintOptionsProvider({direction: 'start'});
+            tuiHintOptionsProvider({direction: 'start-bottom'});
+            tuiHintOptionsProvider({direction: 'end-top'});
+            tuiHintOptionsProvider({direction: 'end'});
+            tuiHintOptionsProvider({direction: 'end-bottom'});
+        `;
+
+        expect(result).toEqual(expected);
+    });
+
+    afterEach(() => resetActiveProject());
+});


### PR DESCRIPTION
Part of #11917 


