### PR TITLE
perf(core): add check for content before emitting `refresh$` in `TuiDropdownDirective`

### DIFF
--- a/projects/core/portals/dropdown/dropdown.directive.ts
+++ b/projects/core/portals/dropdown/dropdown.directive.ts
@@ -95,7 +95,9 @@ export class TuiDropdownDirective
     }
 
     public ngAfterViewChecked(): void {
-        this.refresh$.next();
+        if (this.ref()) {
+            this.refresh$.next();
+        }
     }
 
     public ngOnDestroy(): void {


### PR DESCRIPTION
Fixes #13386

Discussion: https://t.me/taiga_ui/7924/35731

This PR optimizes the usage of `refresh$` in `TuiDropdownDirective` by removing unnecessary calls when the content is not open. This prevents extra invocations of the timer within `throttleTime`. The `refresh$` logic is now only triggered when the content is actually displayed, reducing redundant processing and improving performance.