### PR TITLE
chore(schematics): migrate `closeable` to `closable`

### DIFF
--- a/projects/cdk/schematics/ng-update/interfaces/replacement-function-parameter.ts
+++ b/projects/cdk/schematics/ng-update/interfaces/replacement-function-parameter.ts
@@ -1,8 +1,9 @@
 export interface ReplacementFunctionParameter {
     readonly names: string[];
     readonly moduleSpecifier?: string[] | string;
-    readonly parameters: string[];
-    readonly valueReplacer: Array<{
+    readonly parameterName: string;
+    readonly newParameterName?: string;
+    readonly valueReplacer?: Array<{
         readonly from: string;
         readonly to: string;
     }>;

--- a/projects/cdk/schematics/ng-update/utils/replace-function-parameters.ts
+++ b/projects/cdk/schematics/ng-update/utils/replace-function-parameters.ts
@@ -31,13 +31,13 @@ function replaceFunctionParameter(item: ReplacementFunctionParameter): void {
             return;
         }
 
-        item.parameters.forEach((parameter) => {
-            const property = value.getProperty(parameter);
+        const property = value.getProperty(item.parameterName);
 
-            if (!property) {
-                return;
-            }
+        if (!property) {
+            return;
+        }
 
+        if (item.valueReplacer) {
             const replacement = property.getLastChildIfKind(SyntaxKind.StringLiteral);
 
             if (!replacement) {
@@ -49,6 +49,18 @@ function replaceFunctionParameter(item: ReplacementFunctionParameter): void {
                     replacement.setLiteralValue(to);
                 }
             });
-        });
+        }
+
+        if (item.newParameterName) {
+            if (Node.isPropertyAssignment(property)) {
+                property.rename(item.newParameterName);
+            }
+
+            if (Node.isShorthandPropertyAssignment(property)) {
+                property.replaceWithText(
+                    `${item.newParameterName}: ${item.parameterName}`,
+                );
+            }
+        }
     });
 }

--- a/projects/cdk/schematics/ng-update/v5/index.ts
+++ b/projects/cdk/schematics/ng-update/v5/index.ts
@@ -30,6 +30,7 @@ import {IDENTIFIERS_TO_REPLACE} from './steps/constants/identifiers-to-replace';
 import {MIGRATION_WARNINGS} from './steps/constants/migration-warnings';
 import {MODULES_TO_REMOVE} from './steps/constants/modules-to-remove';
 import {migrateBreakpointService} from './steps/migrate-breakpoint-service';
+import {migrateCloseable} from './steps/migrate-closeable';
 import {migrateCssVariables} from './steps/migrate-css-variables';
 import {migratePackages} from './steps/migrate-packages';
 import {migrateTemplates} from './steps/migrate-templates';
@@ -66,6 +67,10 @@ function main(options: TuiSchema, timings: MigrationStepTiming[]): Rule {
                 {
                     name: 'migrateBreakpointService',
                     step: () => migrateBreakpointService(tree, options),
+                },
+                {
+                    name: 'migrateCloseable',
+                    step: () => migrateCloseable(tree, options),
                 },
                 {
                     name: 'migratePackages',

--- a/projects/cdk/schematics/ng-update/v5/steps/constants/attrs-to-replace.ts
+++ b/projects/cdk/schematics/ng-update/v5/steps/constants/attrs-to-replace.ts
@@ -18,6 +18,22 @@ export const ATTRS_TO_REPLACE: readonly ReplacementAttribute[] = [
         to: {attrName: '[iconStart]'},
     },
     {
+        from: {attrName: '[tuiAlert]', withTagNames: ['*']},
+        to: {attrName: '[tuiNotification]'},
+    },
+    {
+        from: {attrName: '[(tuiAlert)]', withTagNames: ['*']},
+        to: {attrName: '[(tuiNotification)]'},
+    },
+    {
+        from: {attrName: '(tuiAlertChange)', withTagNames: ['*']},
+        to: {attrName: '(tuiNotificationChange)'},
+    },
+    {
+        from: {attrName: '[tuiAlertOptions]', withTagNames: ['*']},
+        to: {attrName: '[tuiNotificationOptions]'},
+    },
+    {
         from: {attrName: 'tuiButtonClose', withTagNames: ['*']},
         to: {attrName: 'tuiButtonX'},
     },

--- a/projects/cdk/schematics/ng-update/v5/steps/constants/function-parameters-to-replace.ts
+++ b/projects/cdk/schematics/ng-update/v5/steps/constants/function-parameters-to-replace.ts
@@ -3,7 +3,7 @@ import {type ReplacementFunctionParameter} from '../../../interfaces/replacement
 export const FUNCTION_PARAMETERS_TO_REPLACE: ReplacementFunctionParameter[] = [
     {
         names: ['tuiAmountOptionsProvider'],
-        parameters: ['currencyAlign'],
+        parameterName: 'currencyAlign',
         valueReplacer: [
             {from: 'left', to: 'start'},
             {from: 'right', to: 'end'},
@@ -11,7 +11,7 @@ export const FUNCTION_PARAMETERS_TO_REPLACE: ReplacementFunctionParameter[] = [
     },
     {
         names: ['tuiDropdownOptionsProvider'],
-        parameters: ['align'],
+        parameterName: 'align',
         valueReplacer: [
             {from: 'left', to: 'start'},
             {from: 'right', to: 'end'},
@@ -19,7 +19,7 @@ export const FUNCTION_PARAMETERS_TO_REPLACE: ReplacementFunctionParameter[] = [
     },
     {
         names: ['tuiHintOptionsProvider'],
-        parameters: ['direction'],
+        parameterName: 'direction',
         valueReplacer: [
             {from: 'bottom-left', to: 'bottom-start'},
             {from: 'bottom-right', to: 'bottom-end'},
@@ -32,5 +32,15 @@ export const FUNCTION_PARAMETERS_TO_REPLACE: ReplacementFunctionParameter[] = [
             {from: 'right-top', to: 'end-top'},
             {from: 'right', to: 'end'},
         ],
+    },
+    {
+        names: [
+            'tuiDialogOptionsProvider',
+            'tuiSheetDialogOptionsProvider',
+            'tuiAlertOptionsProvider',
+            'tuiNotificationOptionsProvider',
+        ],
+        parameterName: 'closeable',
+        newParameterName: 'closable',
     },
 ];

--- a/projects/cdk/schematics/ng-update/v5/steps/constants/identifiers-to-replace.ts
+++ b/projects/cdk/schematics/ng-update/v5/steps/constants/identifiers-to-replace.ts
@@ -39,6 +39,16 @@ export const IDENTIFIERS_TO_REPLACE: ReplacementIdentifierMulti[] = [
     },
     {
         from: {
+            name: 'tuiAlertOptionsProvider',
+            moduleSpecifier: '@taiga-ui/core',
+        },
+        to: {
+            name: 'tuiNotificationOptionsProvider',
+            moduleSpecifier: '@taiga-ui/core',
+        },
+    },
+    {
+        from: {
             name: 'TuiSurface',
             moduleSpecifier: '@taiga-ui/core',
         },

--- a/projects/cdk/schematics/ng-update/v5/steps/migrate-closeable.ts
+++ b/projects/cdk/schematics/ng-update/v5/steps/migrate-closeable.ts
@@ -1,0 +1,83 @@
+import {type Tree} from '@angular-devkit/schematics';
+import {
+    getSourceFiles,
+    Node,
+    type ObjectLiteralExpression,
+    type SourceFile,
+    SyntaxKind,
+} from 'ng-morph';
+
+import {ALL_TS_FILES} from '../../../constants';
+import {type TuiSchema} from '../../../ng-add/schema';
+import {isServiceMethodCall} from '../../../utils/is-service-method-call';
+
+const FACTORY_NAME = 'tuiDialog';
+const SERVICE_NAMES = [
+    'TuiDialogService',
+    'TuiAlertService',
+    'TuiNotificationService',
+    'TuiSheetDialogService',
+];
+const METHOD_NAME = 'open';
+
+export function migrateCloseable(_tree: Tree, _options: TuiSchema): void {
+    getSourceFiles(ALL_TS_FILES).forEach((sourceFile) => {
+        migrateSourceFile(sourceFile);
+    });
+}
+
+function migrateSourceFile(sourceFile: SourceFile): void {
+    const calls = sourceFile.getDescendantsOfKind(SyntaxKind.CallExpression);
+
+    calls.forEach((call) => {
+        SERVICE_NAMES.forEach((serviceName) => {
+            if (
+                call.getExpression().getText() !== FACTORY_NAME &&
+                !isServiceMethodCall(call, serviceName, METHOD_NAME)
+            ) {
+                return;
+            }
+
+            const [, options] = call.getArguments();
+
+            if (!options || !Node.isObjectLiteralExpression(options)) {
+                return;
+            }
+
+            renameCloseableKey(options);
+        });
+    });
+}
+
+function renameCloseableKey(obj: ObjectLiteralExpression): void {
+    obj.getProperties().forEach((prop) => {
+        if (Node.isPropertyAssignment(prop)) {
+            const nameNode = prop.getNameNode();
+
+            if (Node.isIdentifier(nameNode) && nameNode.getText() === 'closeable') {
+                prop.rename('closable');
+
+                return;
+            }
+
+            if (
+                Node.isStringLiteral(nameNode) &&
+                nameNode.getLiteralText() === 'closeable'
+            ) {
+                const quote = nameNode.getQuoteKind();
+
+                nameNode.replaceWithText(`${quote}closable${quote}`);
+            }
+
+            return;
+        }
+
+        if (Node.isShorthandPropertyAssignment(prop)) {
+            const name = prop.getName();
+
+            if (name === 'closeable') {
+                prop.replaceWithText('closable: closeable');
+            }
+        }
+    });
+}

--- a/projects/cdk/schematics/ng-update/v5/steps/migrate-templates.ts
+++ b/projects/cdk/schematics/ng-update/v5/steps/migrate-templates.ts
@@ -32,6 +32,7 @@ import {migrateAmountCurrencyAlign} from './templates/migrate-amount-currency-al
 import {migrateAsyncPipes} from './templates/migrate-async-pipes';
 import {migrateAvatarToDirective} from './templates/migrate-avatar';
 import {migrateAxes} from './templates/migrate-axes';
+import {migrateCloseable} from './templates/migrate-closeable';
 import {migrateFieldError} from './templates/migrate-field-error';
 import {migrateInputRange} from './templates/migrate-input-range';
 import {migrateInputYear} from './templates/migrate-input-year';
@@ -90,6 +91,7 @@ export function migrateTemplates(fileSystem: DevkitFileSystem, options: TuiSchem
         migrateAsyncPipes,
         migrateTagToChip,
         migrateAxes,
+        migrateCloseable,
     ] as const;
 
     const progressLog = setupProgressLogger({total: componentWithTemplatesPaths.length});

--- a/projects/cdk/schematics/ng-update/v5/steps/templates/migrate-closeable.ts
+++ b/projects/cdk/schematics/ng-update/v5/steps/templates/migrate-closeable.ts
@@ -1,0 +1,58 @@
+import {type UpdateRecorder} from '@angular-devkit/schematics';
+import {type DevkitFileSystem} from 'ng-morph';
+
+import {findElementsWithAttributeOnTag} from '../../../../utils/templates/elements';
+import {
+    getTemplateFromTemplateResource,
+    getTemplateOffset,
+} from '../../../../utils/templates/template-resource';
+import {type TemplateResource} from '../../../interfaces';
+
+interface Input {
+    fileSystem: DevkitFileSystem;
+    recorder: UpdateRecorder;
+    resource: TemplateResource;
+}
+
+const ATTRIBUTE_NAMES = [
+    '[tuiDialogOptions]',
+    '[tuiAlertOptions]',
+    '[tuiNotificationOptions]',
+].map((attr) => attr.toLowerCase());
+
+export function migrateCloseable({resource, recorder, fileSystem}: Input): void {
+    const template = getTemplateFromTemplateResource(resource, fileSystem);
+    const templateOffset = getTemplateOffset(resource);
+
+    const re = /(^|[,{]\s*)('?)closeable\2(\s*:)/g;
+
+    findElementsWithAttributeOnTag(template, ATTRIBUTE_NAMES).forEach((element) => {
+        element.attrs.forEach((attr) => {
+            if (!ATTRIBUTE_NAMES.includes(attr.name)) {
+                return;
+            }
+
+            const newValue = attr.value.replaceAll(re, '$1$2closable$2$3');
+
+            if (newValue === attr.value) {
+                return;
+            }
+
+            const {startOffset, endOffset} = element.sourceCodeLocation?.attrs?.[
+                attr.name
+            ] || {
+                startOffset: 0,
+                endOffset: 0,
+            };
+
+            recorder.remove(
+                templateOffset + startOffset + attr.name.length,
+                endOffset - (startOffset + attr.name.length),
+            );
+            recorder.insertRight(
+                templateOffset + startOffset + attr.name.length,
+                `="${newValue}"`,
+            );
+        });
+    });
+}

--- a/projects/cdk/schematics/ng-update/v5/steps/templates/migrate-field-error.ts
+++ b/projects/cdk/schematics/ng-update/v5/steps/templates/migrate-field-error.ts
@@ -1,6 +1,7 @@
 import {type UpdateRecorder} from '@angular-devkit/schematics';
 import {type DevkitFileSystem} from 'ng-morph';
 
+import {TODO_MARK} from '../../../../utils/insert-todo';
 import {findElementsInTemplateByFn} from '../../../../utils/templates/elements';
 import {
     getTemplateFromTemplateResource,
@@ -74,7 +75,7 @@ function migrateFieldErrorPipe({resource, recorder, fileSystem}: Input): void {
         if (tagName !== 'tui-error') {
             recorder.insertLeft(
                 templateOffset + sourceCodeLocation.startOffset,
-                '<!-- TODO: Could not migrate `tuiFieldError` automatically. The directive must be used on a <tui-error> element. Likely, you want to use `tuiError` pipe. -->',
+                `<!-- ${TODO_MARK} could not migrate \`tuiFieldError\` automatically. The directive must be used on a <tui-error> element. Likely, you want to use \`tuiError\` pipe. -->`,
             );
 
             return;

--- a/projects/cdk/schematics/ng-update/v5/tests/schematic-migrate-closeable.spec.ts
+++ b/projects/cdk/schematics/ng-update/v5/tests/schematic-migrate-closeable.spec.ts
@@ -1,0 +1,614 @@
+import {join} from 'node:path';
+
+import {resetActiveProject} from 'ng-morph';
+
+import {runMigration} from '../../../utils/run-migration';
+
+const collection = join(__dirname, '../../../migration.json');
+
+describe('ng-update closeable', () => {
+    const migrateTemplate = async (template: string): Promise<string> => {
+        const {template: result} = await runMigration({
+            template,
+            collection,
+        });
+
+        return result;
+    };
+
+    const migrateComponent = async (component: string): Promise<string> => {
+        const {component: result} = await runMigration({
+            component,
+            collection,
+        });
+
+        return result;
+    };
+
+    it('replaces closeable with closable for options in templates', async () => {
+        const result = await migrateTemplate(`
+            <ng-template
+                [tuiDialogOptions]="{
+                    size: 's',
+                    closeable: true,
+                    header: header
+                }"
+                [(tuiDialog)]="open"
+            />
+            <ng-template
+                [tuiAlertOptions]="{closeable: false, label: 'Directive', autoClose: 0}"
+                [(tuiAlert)]="show"
+            />
+            <ng-template
+                [tuiNotificationOptions]="{'closeable': false}"
+                [(tuiNotification)]="show"
+            />
+        `);
+
+        const expected = `
+            <ng-template
+                [tuiDialogOptions]="{
+                    size: 's',
+                    closable: true,
+                    header: header
+                }"
+                [(tuiDialog)]="open"
+            />
+            <ng-template
+                [tuiNotificationOptions]="{closable: false, label: 'Directive', autoClose: 0}"
+                [(tuiNotification)]="show"
+            />
+            <ng-template
+                [tuiNotificationOptions]="{'closable': false}"
+                [(tuiNotification)]="show"
+            />
+        `;
+
+        expect(result).toBe(expected);
+    });
+
+    it('replaces closeable with closable for TuiDialogService open options (class field inject)', async () => {
+        const result = await migrateComponent(`
+            import {Component, inject} from '@angular/core';
+            import type {TuiDialogContext} from '@taiga-ui/core';
+            import {TuiDialogService} from '@taiga-ui/core';
+            import type {PolymorpheusContent} from '@taiga-ui/polymorpheus';
+            import {BehaviorSubject} from 'rxjs';
+
+            @Component({standalone: true})
+            export class TestComponent {
+                private readonly dialogService = inject(TuiDialogService);
+                private readonly loading$ = new BehaviorSubject<boolean>(false);
+
+                showDialog(content: PolymorpheusContent<TuiDialogContext>): void {
+                    this.dialogService
+                        .open(content, {
+                            label: 'Test',
+                            dismissible: this.loading$.pipe(map((loading) => !loading)),
+                            closeable: this.loading$.pipe(map((loading) => !loading)),
+                        })
+                        .subscribe();
+                }
+            }
+        `);
+
+        const expected = `
+            import {Component, inject} from '@angular/core';
+            import type {TuiDialogContext} from '@taiga-ui/core';
+            import {TuiDialogService} from '@taiga-ui/core';
+            import type {PolymorpheusContent} from '@taiga-ui/polymorpheus';
+            import {BehaviorSubject} from 'rxjs';
+
+            @Component({standalone: true})
+            export class TestComponent {
+                private readonly dialogService = inject(TuiDialogService);
+                private readonly loading$ = new BehaviorSubject<boolean>(false);
+
+                showDialog(content: PolymorpheusContent<TuiDialogContext>): void {
+                    this.dialogService
+                        .open(content, {
+                            label: 'Test',
+                            dismissible: this.loading$.pipe(map((loading) => !loading)),
+                            closable: this.loading$.pipe(map((loading) => !loading)),
+                        })
+                        .subscribe();
+                }
+            }
+        `;
+
+        expect(result).toEqual(expected);
+    });
+
+    it('replaces closeable with closable for direct inject(TuiDialogService).open(...) call', async () => {
+        const result = await migrateComponent(`
+            import {Component, inject} from '@angular/core';
+            import {TuiDialogService} from '@taiga-ui/core';
+
+            @Component({standalone: true})
+            export class TestComponent {
+                constructor() {
+                    const closeable = true;
+
+                    inject(TuiDialogService).open('content', {
+                        closeable,
+                    });
+                }
+            }
+        `);
+
+        const expected = `
+            import {Component, inject} from '@angular/core';
+            import {TuiDialogService} from '@taiga-ui/core';
+
+            @Component({standalone: true})
+            export class TestComponent {
+                constructor() {
+                    const closeable = true;
+
+                    inject(TuiDialogService).open('content', {
+                        closable: closeable,
+                    });
+                }
+            }
+        `;
+
+        expect(result).toEqual(expected);
+    });
+
+    it('replaces closeable with closable when service stored in local variable', async () => {
+        const result = await migrateComponent(`
+            import {Component, inject, afterViewInit} from '@angular/core';
+            import {TuiDialogService} from '@taiga-ui/core';
+
+            @Component({standalone: true})
+            export class TestComponent {
+                constructor() {
+                    const dialog = inject(TuiDialogService);
+
+                    afterViewInit(() => {
+                        dialog.open('content', {
+                            closeable: false,
+                            other: 1,
+                        });
+                    });
+                }
+            }
+        `);
+
+        const expected = `
+            import {Component, inject, afterViewInit} from '@angular/core';
+            import {TuiDialogService} from '@taiga-ui/core';
+
+            @Component({standalone: true})
+            export class TestComponent {
+                constructor() {
+                    const dialog = inject(TuiDialogService);
+
+                    afterViewInit(() => {
+                        dialog.open('content', {
+                            closeable: false,
+                            other: 1,
+                        });
+                    });
+                }
+            }
+        `;
+
+        expect(result).toEqual(expected);
+    });
+
+    it('replaces string literal key "closeable" with "closable"', async () => {
+        const result = await migrateComponent(`
+            import {Component, inject} from '@angular/core';
+            import {TuiDialogService} from '@taiga-ui/core';
+
+            @Component({standalone: true})
+            export class TestComponent {
+                private readonly dialog = inject(TuiDialogService);
+
+                open(): void {
+                    this.dialog.open('content', {
+                        "closeable": true,
+                    });
+                }
+            }
+        `);
+
+        const expected = `
+            import {Component, inject} from '@angular/core';
+            import {TuiDialogService} from '@taiga-ui/core';
+
+            @Component({standalone: true})
+            export class TestComponent {
+                private readonly dialog = inject(TuiDialogService);
+
+                open(): void {
+                    this.dialog.open('content', {
+                        "closable": true,
+                    });
+                }
+            }
+        `;
+
+        expect(result).toEqual(expected);
+    });
+
+    it('does not change if there is no second argument', async () => {
+        const result = await migrateComponent(`
+            import {Component, inject} from '@angular/core';
+            import {TuiDialogService} from '@taiga-ui/core';
+
+            @Component({standalone: true})
+            export class TestComponent {
+                private readonly dialog = inject(TuiDialogService);
+
+                open(): void {
+                    this.dialog.open('content');
+                }
+            }
+        `);
+
+        const expected = `
+            import {Component, inject} from '@angular/core';
+            import {TuiDialogService} from '@taiga-ui/core';
+
+            @Component({standalone: true})
+            export class TestComponent {
+                private readonly dialog = inject(TuiDialogService);
+
+                open(): void {
+                    this.dialog.open('content');
+                }
+            }
+        `;
+
+        expect(result).toEqual(expected);
+    });
+
+    it('does not change if second argument is not an object literal', async () => {
+        const result = await migrateComponent(`
+            import {Component, inject} from '@angular/core';
+            import {TuiDialogService} from '@taiga-ui/core';
+
+            const options = {
+                closeable: true,
+            };
+
+            @Component({standalone: true})
+            export class TestComponent {
+                private readonly dialog = inject(TuiDialogService);
+
+                open(): void {
+                    this.dialog.open('content', options);
+                }
+            }
+        `);
+
+        const expected = `
+            import {Component, inject} from '@angular/core';
+            import {TuiDialogService} from '@taiga-ui/core';
+
+            const options = {
+                closeable: true,
+            };
+
+            @Component({standalone: true})
+            export class TestComponent {
+                private readonly dialog = inject(TuiDialogService);
+
+                open(): void {
+                    this.dialog.open('content', options);
+                }
+            }
+        `;
+
+        expect(result).toEqual(expected);
+    });
+
+    it('does not change closeable for non TuiDialogService receiver with open()', async () => {
+        const result = await migrateComponent(`
+            import {Component} from '@angular/core';
+
+            class NotDialogService {
+                open(_c: unknown, _o: unknown): void {}
+            }
+
+            @Component({standalone: true})
+            export class TestComponent {
+                private readonly dialogService = new NotDialogService();
+
+                open(): void {
+                    this.dialogService.open('content', {
+                        closeable: true,
+                    });
+                }
+            }
+        `);
+
+        const expected = `
+            import {Component} from '@angular/core';
+
+            class NotDialogService {
+                open(_c: unknown, _o: unknown): void {}
+            }
+
+            @Component({standalone: true})
+            export class TestComponent {
+                private readonly dialogService = new NotDialogService();
+
+                open(): void {
+                    this.dialogService.open('content', {
+                        closeable: true,
+                    });
+                }
+            }
+        `;
+
+        expect(result).toEqual(expected);
+    });
+
+    it('does not change object properties named closeable outside dialog.open options', async () => {
+        const result = await migrateComponent(`
+            import {Component, inject} from '@angular/core';
+            import {TuiDialogService} from '@taiga-ui/core';
+
+            @Component({standalone: true})
+            export class TestComponent {
+                private readonly dialog = inject(TuiDialogService);
+
+                open(): void {
+                    const x = {closeable: true};
+
+                    this.dialog.open('content', {
+                        closeable: false,
+                    });
+                }
+            }
+        `);
+
+        const expected = `
+            import {Component, inject} from '@angular/core';
+            import {TuiDialogService} from '@taiga-ui/core';
+
+            @Component({standalone: true})
+            export class TestComponent {
+                private readonly dialog = inject(TuiDialogService);
+
+                open(): void {
+                    const x = {closeable: true};
+
+                    this.dialog.open('content', {
+                        closable: false,
+                    });
+                }
+            }
+        `;
+
+        expect(result).toEqual(expected);
+    });
+
+    it('replaces closeable with closable for TuiAlertService.open call', async () => {
+        const result = await migrateComponent(`
+            import {Component, inject} from '@angular/core';
+            import {TuiAlertService} from '@taiga-ui/core';
+
+            @Component({standalone: true})
+            export class TestComponent {
+                constructor() {
+                    inject(TuiAlertService).open('content', {
+                        closeable: true,
+                    });
+                }
+            }
+        `);
+
+        const expected = `import { TuiNotificationService } from "@taiga-ui/core";
+
+            import {Component, inject} from '@angular/core';
+
+            @Component({standalone: true})
+            export class TestComponent {
+                constructor() {
+                    inject(TuiNotificationService).open('content', {
+                        closable: true,
+                    });
+                }
+            }
+        `;
+
+        expect(result).toEqual(expected);
+    });
+
+    it('replaces closeable with closable for TuiNotificationService.open call', async () => {
+        const result = await migrateComponent(`
+            import {Component, inject} from '@angular/core';
+            import {TuiNotificationService} from '@taiga-ui/core';
+
+            @Component({standalone: true})
+            export class TestComponent {
+                constructor() {
+                    inject(TuiNotificationService).open('content', {
+                        closeable: true,
+                    });
+                }
+            }
+        `);
+
+        const expected = `
+            import {Component, inject} from '@angular/core';
+            import {TuiNotificationService} from '@taiga-ui/core';
+
+            @Component({standalone: true})
+            export class TestComponent {
+                constructor() {
+                    inject(TuiNotificationService).open('content', {
+                        closable: true,
+                    });
+                }
+            }
+        `;
+
+        expect(result).toEqual(expected);
+    });
+
+    it('replaces closeable with closable for TuiSheetDialogService.open call', async () => {
+        const result = await migrateComponent(`
+            import {Component, inject} from '@angular/core';
+            import {TuiSheetDialogService} from '@taiga-ui/addon-mobile';
+
+            @Component({standalone: true})
+            export class TestComponent {
+                constructor() {
+                    inject(TuiSheetDialogService).open('content', {
+                        closeable: true,
+                    });
+                }
+            }
+        `);
+
+        const expected = `
+            import {Component, inject} from '@angular/core';
+            import {TuiSheetDialogService} from '@taiga-ui/addon-mobile';
+
+            @Component({standalone: true})
+            export class TestComponent {
+                constructor() {
+                    inject(TuiSheetDialogService).open('content', {
+                        closable: true,
+                    });
+                }
+            }
+        `;
+
+        expect(result).toEqual(expected);
+    });
+
+    it('replaces closeable with closable for tuiDialog call', async () => {
+        const result = await migrateComponent(`
+            import {Component, inject} from '@angular/core';
+            import {tuiDialog} from '@taiga-ui/core';
+
+            @Component({standalone: true})
+            export class TestComponent {
+                private readonly dialog = tuiDialog('content', {
+                    size: 'm',
+                    closeable: true,
+                    dismissible: true,
+                });
+
+                protected showDialog(): void {
+                    this.dialog().subscribe();
+                }
+            }
+        `);
+
+        const expected = `
+            import {Component, inject} from '@angular/core';
+            import {tuiDialog} from '@taiga-ui/core';
+
+            @Component({standalone: true})
+            export class TestComponent {
+                private readonly dialog = tuiDialog('content', {
+                    size: 'm',
+                    closable: true,
+                    dismissible: true,
+                });
+
+                protected showDialog(): void {
+                    this.dialog().subscribe();
+                }
+            }
+        `;
+
+        expect(result).toEqual(expected);
+    });
+
+    it('replaces closeable with closable for tuiDialogOptionsProvider call', async () => {
+        const result = await migrateComponent(`
+            import {tuiDialogOptionsProvider} from '@taiga-ui/core';
+
+            const closeable = false;
+
+            tuiDialogOptionsProvider({closeable});
+            tuiDialogOptionsProvider({size: 'm', closeable: true});
+        `);
+
+        const expected = `
+            import {tuiDialogOptionsProvider} from '@taiga-ui/core';
+
+            const closeable = false;
+
+            tuiDialogOptionsProvider({closable: closeable});
+            tuiDialogOptionsProvider({size: 'm', closable: true});
+        `;
+
+        expect(result).toEqual(expected);
+    });
+
+    it('replaces closeable with closable for tuiSheetDialogOptionsProvider call', async () => {
+        const result = await migrateComponent(`
+            import {tuiSheetDialogOptionsProvider} from '@taiga-ui/addon-mobile';
+
+            const closeable = false;
+
+            tuiSheetDialogOptionsProvider({closeable});
+            tuiSheetDialogOptionsProvider({size: 'm', closeable: true});
+        `);
+
+        const expected = `
+            import {tuiSheetDialogOptionsProvider} from '@taiga-ui/addon-mobile';
+
+            const closeable = false;
+
+            tuiSheetDialogOptionsProvider({closable: closeable});
+            tuiSheetDialogOptionsProvider({size: 'm', closable: true});
+        `;
+
+        expect(result).toEqual(expected);
+    });
+
+    it('replaces closeable with closable for tuiAlertOptionsProvider call', async () => {
+        const result = await migrateComponent(`
+            import {tuiAlertOptionsProvider} from '@taiga-ui/core';
+
+            const closeable = false;
+
+            tuiAlertOptionsProvider({closeable});
+            tuiAlertOptionsProvider({closeable: true, appearance: 'negative'});
+        `);
+
+        const expected = `import { tuiNotificationOptionsProvider } from "@taiga-ui/core";
+
+                        const closeable = false;
+
+            tuiNotificationOptionsProvider({closable: closeable});
+            tuiNotificationOptionsProvider({closable: true, appearance: 'negative'});
+        `;
+
+        expect(result).toEqual(expected);
+    });
+
+    it('replaces closeable with closable for tuiNotificationOptionsProvider call', async () => {
+        const result = await migrateComponent(`
+            import {tuiNotificationOptionsProvider} from '@taiga-ui/core';
+
+            const closeable = false;
+
+            tuiNotificationOptionsProvider({closeable});
+            tuiNotificationOptionsProvider({closeable: true, appearance: 'negative'});
+        `);
+
+        const expected = `
+            import {tuiNotificationOptionsProvider} from '@taiga-ui/core';
+
+            const closeable = false;
+
+            tuiNotificationOptionsProvider({closable: closeable});
+            tuiNotificationOptionsProvider({closable: true, appearance: 'negative'});
+        `;
+
+        expect(result).toEqual(expected);
+    });
+
+    afterEach(() => resetActiveProject());
+});

--- a/projects/cdk/schematics/ng-update/v5/tests/schematic-migrate-field-error.spec.ts
+++ b/projects/cdk/schematics/ng-update/v5/tests/schematic-migrate-field-error.spec.ts
@@ -171,7 +171,7 @@ ${'                    '}
             `);
 
         const expected = `
-                <!-- TODO: Could not migrate \`tuiFieldError\` automatically. The directive must be used on a <tui-error> element. Likely, you want to use \`tuiError\` pipe. --><div [error]="['required'] | tuiFieldError | async"></div>
+                <!-- TODO: (Taiga UI migration) could not migrate \`tuiFieldError\` automatically. The directive must be used on a <tui-error> element. Likely, you want to use \`tuiError\` pipe. --><div [error]="['required'] | tuiFieldError | async"></div>
             `;
 
         expect(result).toEqual(expected);

--- a/projects/cdk/schematics/utils/is-service-method-call.ts
+++ b/projects/cdk/schematics/utils/is-service-method-call.ts
@@ -1,0 +1,128 @@
+import {type CallExpression, Node, type SourceFile, SyntaxKind} from 'ng-morph';
+
+/**
+ * Checks if the given call expression is a method call on the given service.
+ */
+export function isServiceMethodCall(
+    call: CallExpression,
+    serviceName: string,
+    methodName: string,
+): boolean {
+    const propAccess = call.getExpressionIfKind(SyntaxKind.PropertyAccessExpression);
+
+    if (propAccess?.getName() !== methodName) {
+        return false;
+    }
+
+    const expr = propAccess.getExpression();
+
+    // 1) inject(Service).method(...)
+    if (Node.isCallExpression(expr) && isInjectCallWithService(expr, serviceName)) {
+        return true;
+    }
+
+    // 2) this.service.method(...)
+    if (Node.isPropertyAccessExpression(expr)) {
+        const left = expr.getExpression();
+
+        if (left.getKind() === SyntaxKind.ThisKeyword) {
+            const name = expr.getName();
+
+            return isIdentifierDeclaredAsInjectService(
+                expr.getSourceFile(),
+                name,
+                serviceName,
+            );
+        }
+
+        return false;
+    }
+
+    // 3) service.method(...)
+    if (Node.isIdentifier(expr)) {
+        return isIdentifierDeclaredAsInjectService(
+            expr.getSourceFile(),
+            expr.getText(),
+            serviceName,
+        );
+    }
+
+    return false;
+}
+
+function isInjectCallWithService(call: CallExpression, serviceName: string): boolean {
+    const callee = call.getExpression();
+
+    // inject(...)
+    if (!Node.isIdentifier(callee) || callee.getText() !== 'inject') {
+        return false;
+    }
+
+    const args = call.getArguments();
+
+    if (args.length < 1) {
+        return false;
+    }
+
+    // inject(Service)
+    const first = args[0];
+
+    if (Node.isIdentifier(first) && first.getText() === serviceName) {
+        return true;
+    }
+
+    return false;
+}
+
+function isIdentifierDeclaredAsInjectService(
+    sourceFile: SourceFile,
+    name: string,
+    serviceName: string,
+): boolean {
+    // 1) const name = inject(Service)
+    const vars = sourceFile.getVariableDeclarations().filter((v) => v.getName() === name);
+
+    for (const v of vars) {
+        const init = v.getInitializer();
+
+        if (
+            init &&
+            Node.isCallExpression(init) &&
+            isInjectCallWithService(init, serviceName)
+        ) {
+            return true;
+        }
+    }
+
+    // 2) private name = inject(Service)
+    const props = sourceFile
+        .getDescendantsOfKind(SyntaxKind.PropertyDeclaration)
+        .filter((p) => p.getName() === name);
+
+    for (const p of props) {
+        const init = p.getInitializer();
+
+        if (
+            init &&
+            Node.isCallExpression(init) &&
+            isInjectCallWithService(init, serviceName)
+        ) {
+            return true;
+        }
+    }
+
+    // 3) constructor(private service: Service) {}
+    const ctorParams = sourceFile
+        .getDescendantsOfKind(SyntaxKind.Parameter)
+        .filter((param) => param.getName() === name);
+
+    for (const p of ctorParams) {
+        const typeNode = p.getTypeNode();
+
+        if (typeNode?.getText() === serviceName) {
+            return true;
+        }
+    }
+
+    return false;
+}


### PR DESCRIPTION
Part of: #11917

Also I added the migrations for: 
 - `[(tuiAlert)]` -> `[(tuiNotification)]` 
 - `[tuiAlertOptions]` -> `[tuiNotificationOptions]`
 - `tuiAlertOptionsProvider` => `tuiNotificationOptionsProvider`