### PR TITLE
chore(layout): `Form` remove direct nesting for fieldset/elastic-container

### DIFF
--- a/projects/layout/components/form/form.styles.less
+++ b/projects/layout/components/form/form.styles.less
@@ -66,7 +66,8 @@
     }
 
     > fieldset:first-child > legend {
-        padding-block-start: 0;
+        inset-block-start: -0.25rem;
+        padding: 0 0 0.5rem;
     }
 
     > header {


### PR DESCRIPTION


Fixes # <!-- link to a relevant issue. -->
