### PR TITLE
chore: stackblitz starter throws `Could not import ../variables/media`

### DIFF
--- a/projects/styles/mixins/hitbox.less
+++ b/projects/styles/mixins/hitbox.less
@@ -1,4 +1,4 @@
-@import '../variables/media';
+@import '../variables/media.less';
 
 .tui-hitbox(@size) {
     @media @tui-mobile {


### PR DESCRIPTION
Open https://taiga-ui.dev/next/stackblitz
```
Error in turbo_modules/@taiga-ui/styles@5.0.0-canary.54dea89/mixins/hitbox.less (1:0)
Could not import ../variables/media from /~/src/app/app.less
```