### PR TITLE
chore: stackblitz starter throws `project "demo" is missing a required property "root"`

### DIFF
--- a/projects/demo/src/pages/app/stackblitz/project-files/configs.md
+++ b/projects/demo/src/pages/app/stackblitz/project-files/configs.md
@@ -2,17 +2,16 @@
 
 ```json
 {
-  "$schema": "http://json-schema.org/draft-07/schema",
-  "root": "",
-  "sourceRoot": "src",
-  "version": 1,
+  "$schema": "./node_modules/@angular/cli/lib/config/schema.json",
+  "newProjectRoot": "projects",
   "projects": {
     "demo": {
       "architect": {
         "build": {
-          "builder": "@angular-devkit/build-angular:application",
+          "builder": "@angular/build:application",
           "configurations": {
             "development": {
+              "extractLicenses": false,
               "namedChunks": true,
               "optimization": false,
               "sourceMap": true
@@ -21,6 +20,7 @@
           "options": {
             "index": "src/index.html",
             "browser": "src/main.ts",
+            "outputPath": "dist/demo",
             "polyfills": [],
             "styles": ["src/styles.less"],
             "tsConfig": "tsconfig.json"
@@ -28,9 +28,6 @@
         },
         "serve": {
           "builder": "@angular/build:dev-server",
-          "options": {
-            "prebundle": false
-          },
           "configurations": {
             "development": {
               "buildTarget": "demo:build:development"
@@ -39,9 +36,14 @@
           "defaultConfiguration": "development"
         }
       },
-      "projectType": "application"
+      "prefix": "app",
+      "projectType": "application",
+      "root": "",
+      "schematics": {},
+      "sourceRoot": "src"
     }
-  }
+  },
+  "version": 1
 }
 ```
 


### PR DESCRIPTION
## Problem
Open https://taiga-ui.dev/next/stackblitz

Download repository using this button
<img width="1276" height="626" alt="starter" src="https://github.com/user-attachments/assets/53ad5518-0be7-46a4-899a-d1d0f7aa280c" />

Install deps and run `npm run build`.

It throws
```
> ng build

Workspace extension with invalid name (root) found.
Workspace extension with invalid name (sourceRoot) found.
Workspace config file cannot be loaded: /angular.json

Project "demo" is missing a required property "root".
```

## Solution 
Copy-pasted configs from official angular starter
https://github.com/stackblitz/starters/blob/main/angular/angular.json