### PR TITLE
chore: stackblitz starter throws `TS2307: Cannot find module or its corresponding type declarations`

### DIFF
--- a/projects/demo/src/pages/app/stackblitz/project-files/configs.md
+++ b/projects/demo/src/pages/app/stackblitz/project-files/configs.md
@@ -62,7 +62,7 @@
     "sourceMap": true,
     "declaration": false,
     "downlevelIteration": true,
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "importHelpers": true,
     "target": "ES2022",
     "module": "ES2022",


### PR DESCRIPTION
## Problem
Open https://taiga-ui.dev/next/stackblitz

Download repository using this button
<img width="1276" height="626" alt="starter" src="https://github.com/user-attachments/assets/53ad5518-0be7-46a4-899a-d1d0f7aa280c" />

Install deps and run `npm run build`.

It throws
```
✘ [ERROR] TS2307: Cannot find module '@angular/core/primitives/di' or its corresponding type declarations. [plugin angular-compiler]

    node_modules/@angular/core/types/_discovery-chunk.d.ts:12:85:
      12 │ ...s InjectionToken$1, NotFound } from '@angular/core/primitives/di';
         ╵                                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


✘ [ERROR] TS2307: Cannot find module '@angular/common/http' or its corresponding type declarations. [plugin angular-compiler]

    node_modules/@angular/platform-browser/types/platform-browser.d.ts:10:41:
      10 │ import { HttpTransferCacheOptions } from '@angular/common/http';
         ╵                                          ~~~~~~~~~~~~~~~~~~~~~~
```

## Solution 
Copy-pasted configs from official angular starter
https://github.com/stackblitz/starters/blob/b0421a18912ea0ee833571ec37124a53c65ac40e/angular/tsconfig.json#L16