### PR TITLE
chore(core): use `forwardRef` to avoid circular deps inside `DropdownOpen`

### DIFF
--- a/projects/core/portals/dropdown/dropdown-open.directive.ts
+++ b/projects/core/portals/dropdown/dropdown-open.directive.ts
@@ -43,7 +43,7 @@ import {TuiDropdownClose} from './dropdown-close.directive';
     hostDirectives: [
         TuiObscured,
         {directive: forwardRef(() => TuiDropdownA11y), inputs: ['tuiDropdownRole']},
-        {directive: TuiDropdownClose, outputs: ['tuiDropdownClose']},
+        {directive: forwardRef(() => TuiDropdownClose), outputs: ['tuiDropdownClose']},
         {
             directive: TuiActiveZone,
             inputs: ['tuiActiveZoneParent'],


### PR DESCRIPTION
Open https://taiga-ui.dev/next/stackblitz

```
ReferenceError: Cannot access 'TuiDropdownA11y' before initialization
    at eval (dropdown-open.directive.ts:46:69)
    at resolveForwardRef (assert.ts:30:28)
    at createHostDirectiveDef (utils.ts:32:29)
    at Array.map (<anonymous>)
    at feature (interfaces.ts:54:42)
    at eval (template.ts:226:42)
    at Array.forEach (<anonymous>)
    at initFeatures (template.ts:226:20)
    at Object.eval [as toString] (template.ts:84:7)
    at noSideEffects (decorators.ts:61:7)
```

**Possible** reason:
https://github.com/taiga-family/taiga-ui/blob/6e98cd7b739c9dcb991797d87f387d06f08fcb76/projects/core/portals/dropdown/dropdown-close.directive.ts#L23

https://github.com/taiga-family/taiga-ui/blob/6e98cd7b739c9dcb991797d87f387d06f08fcb76/projects/core/portals/dropdown/dropdown-open.directive.ts#L46