### PR TITLE
chore(core): fix `ReferenceError: Cannot access 'TuiDropdownA11y' before initialization`

### DIFF
--- a/projects/core/portals/dropdown/dropdown-a11y.directive.ts
+++ b/projects/core/portals/dropdown/dropdown-a11y.directive.ts
@@ -1,4 +1,4 @@
-import {Directive, effect, forwardRef, inject, input} from '@angular/core';
+import {Directive, effect, inject, input} from '@angular/core';
 import {tuiInjectElement} from '@taiga-ui/cdk/utils/dom';
 
 import {TuiDropdownDirective} from './dropdown.directive';
@@ -8,10 +8,7 @@ import {TuiDropdownOpen} from './dropdown-open.directive';
 export class TuiDropdownA11y {
     private readonly el = tuiInjectElement();
     private readonly dropdown = inject(TuiDropdownDirective);
-    private readonly open = inject(
-        forwardRef(() => TuiDropdownOpen),
-        {self: true, optional: true},
-    );
+    private readonly open = inject(TuiDropdownOpen, {self: true, optional: true});
 
     public readonly tuiDropdownRole = input('listbox');
 

--- a/projects/core/portals/dropdown/dropdown-open.directive.ts
+++ b/projects/core/portals/dropdown/dropdown-open.directive.ts
@@ -43,7 +43,7 @@ import {TuiDropdownClose} from './dropdown-close.directive';
     hostDirectives: [
         TuiObscured,
         {directive: forwardRef(() => TuiDropdownA11y), inputs: ['tuiDropdownRole']},
-        {directive: forwardRef(() => TuiDropdownClose), outputs: ['tuiDropdownClose']},
+        {directive: TuiDropdownClose, outputs: ['tuiDropdownClose']},
         {
             directive: TuiActiveZone,
             inputs: ['tuiActiveZoneParent'],

--- a/projects/core/portals/dropdown/index.ts
+++ b/projects/core/portals/dropdown/index.ts
@@ -1,4 +1,3 @@
-export * from './dropdown';
 export * from './dropdown.bindings';
 export * from './dropdown.component';
 export * from './dropdown.directive';
@@ -18,3 +17,6 @@ export * from './dropdown-position.directive';
 export * from './dropdown-position-sided.directive';
 export * from './dropdown-selection.directive';
 export * from './with-dropdown-open.directive';
+
+// Must be exported last to ensure correct entrypoint initialization
+export * from './dropdown';


### PR DESCRIPTION
Open https://taiga-ui.dev/next/stackblitz

```
ReferenceError: Cannot access 'TuiDropdownA11y' before initialization
    at eval (dropdown-open.directive.ts:46:69)
    at resolveForwardRef (assert.ts:30:28)
    at createHostDirectiveDef (utils.ts:32:29)
    at Array.map (<anonymous>)
    at feature (interfaces.ts:54:42)
    at eval (template.ts:226:42)
    at Array.forEach (<anonymous>)
    at initFeatures (template.ts:226:20)
    at Object.eval [as toString] (template.ts:84:7)
    at noSideEffects (decorators.ts:61:7)
```

## Previous behavior

<img width="1264" height="562" alt="previous" src="https://github.com/user-attachments/assets/cd0c53c6-0268-46f3-ba9d-34a01f6e13f6" />

## New behavior
<img width="1264" height="562" alt="new" src="https://github.com/user-attachments/assets/1741c4cd-f069-4cc1-9925-a4e67b574632" />

## Previous unsuccessful attempts to fix
* https://github.com/taiga-family/taiga-ui/pull/13419
* https://github.com/taiga-family/taiga-ui/pull/13377
(revert these changes)