### PR TITLE
fix(schematics): remove no more required explicit install of `@taiga-ui/event-plugins` for `ng add`

### DIFF
--- a/projects/cdk/schematics/ng-add/index.ts
+++ b/projects/cdk/schematics/ng-add/index.ts
@@ -22,11 +22,6 @@ function addDependencies(tree: Tree, options: TuiSchema): void {
         });
     });
 
-    addPackageJsonDependency(tree, {
-        name: '@taiga-ui/event-plugins',
-        version: '^4.0.2',
-    });
-
     removeTaigaSchematicsPackage(tree);
 
     if (packages.includes('addon-table') || packages.includes('addon-mobile')) {

--- a/projects/cdk/schematics/ng-add/tests/schematic-ng-add-standalone.spec.ts
+++ b/projects/cdk/schematics/ng-add/tests/schematic-ng-add-standalone.spec.ts
@@ -50,7 +50,6 @@ describe('ng-add [Standalone]', () => {
     "@angular/core": "~13.0.0",
     "@taiga-ui/cdk": "${TAIGA_VERSION}",
     "@taiga-ui/core": "${TAIGA_VERSION}",
-    "@taiga-ui/event-plugins": "^4.0.2",
     "@taiga-ui/icons": "${TAIGA_VERSION}",
     "@taiga-ui/kit": "${TAIGA_VERSION}"
   }
@@ -76,7 +75,6 @@ describe('ng-add [Standalone]', () => {
     "@taiga-ui/addon-mobile": "${TAIGA_VERSION}",
     "@taiga-ui/cdk": "${TAIGA_VERSION}",
     "@taiga-ui/core": "${TAIGA_VERSION}",
-    "@taiga-ui/event-plugins": "^4.0.2",
     "@taiga-ui/icons": "${TAIGA_VERSION}",
     "@taiga-ui/kit": "${TAIGA_VERSION}"
   }

--- a/projects/cdk/schematics/ng-add/tests/schematic-ng-add.spec.ts
+++ b/projects/cdk/schematics/ng-add/tests/schematic-ng-add.spec.ts
@@ -50,7 +50,6 @@ describe('ng-add', () => {
     "@angular/core": "~13.0.0",
     "@taiga-ui/cdk": "${TAIGA_VERSION}",
     "@taiga-ui/core": "${TAIGA_VERSION}",
-    "@taiga-ui/event-plugins": "^4.0.2",
     "@taiga-ui/icons": "${TAIGA_VERSION}",
     "@taiga-ui/kit": "${TAIGA_VERSION}"
   }
@@ -76,7 +75,6 @@ describe('ng-add', () => {
     "@taiga-ui/addon-mobile": "${TAIGA_VERSION}",
     "@taiga-ui/cdk": "${TAIGA_VERSION}",
     "@taiga-ui/core": "${TAIGA_VERSION}",
-    "@taiga-ui/event-plugins": "^4.0.2",
     "@taiga-ui/icons": "${TAIGA_VERSION}",
     "@taiga-ui/kit": "${TAIGA_VERSION}"
   }
@@ -102,7 +100,6 @@ describe('ng-add', () => {
     "@taiga-ui/addon-mobile": "${TAIGA_VERSION}",
     "@taiga-ui/cdk": "${TAIGA_VERSION}",
     "@taiga-ui/core": "${TAIGA_VERSION}",
-    "@taiga-ui/event-plugins": "^4.0.2",
     "@taiga-ui/icons": "${TAIGA_VERSION}",
     "@taiga-ui/kit": "${TAIGA_VERSION}"
   }


### PR DESCRIPTION
## Problem
```bash
> ng new app --directory=./
# [...]

> ng add taiga-ui@next
```

```
npm error code ERESOLVE
npm error ERESOLVE unable to resolve dependency tree
npm error
npm error While resolving: app@0.0.0
npm error Found: @taiga-ui/event-plugins@4.7.0
npm error node_modules/@taiga-ui/event-plugins
npm error   @taiga-ui/event-plugins@"^4.0.2" from the root project
npm error
npm error Could not resolve dependency:
npm error peer @taiga-ui/event-plugins@"^5.0.0" from @taiga-ui/cdk@5.0.0-rc.4
npm error node_modules/@taiga-ui/cdk
npm error   @taiga-ui/cdk@"^5.0.0-rc.4" from the root project
npm error   peer @taiga-ui/cdk@"^5.0.0-rc.4" from @taiga-ui/core@5.0.0-rc.4
npm error   node_modules/@taiga-ui/core
npm error     @taiga-ui/core@"^5.0.0-rc.4" from the root project
npm error
npm error Fix the upstream dependency conflict, or retry
npm error this command with --force or --legacy-peer-deps
npm error to accept an incorrect (and potentially broken) dependency resolution.

✖ Package install failed, see above.
The Schematic workflow failed. See above.
```

## Why no more required ?
Introduced in this PR
* https://github.com/taiga-family/taiga-ui/pull/8803

No more required after
* https://github.com/taiga-family/taiga-ui/pull/13307


It is will be installed automatically because it's peer dep
https://github.com/taiga-family/taiga-ui/blob/f306d6a7ef0e32fa4a54b21cab2a2184da0de79c/projects/cdk/package.json#L42