### PR TITLE
chore: stackblitz throws `Can't find package: @taiga-ui/font-watcher` 

### DIFF
--- a/projects/demo/src/modules/app/stackblitz/stackblitz-deps.service.ts
+++ b/projects/demo/src/modules/app/stackblitz/stackblitz-deps.service.ts
@@ -69,6 +69,7 @@ export class StackblitzDepsService {
             '@taiga-ui/polymorpheus': cdkDeps['@taiga-ui/polymorpheus'],
             '@ng-web-apis/common': cdkDeps['@ng-web-apis/common'],
             '@taiga-ui/event-plugins': cdkDeps['@taiga-ui/event-plugins'],
+            '@taiga-ui/font-watcher': cdkDeps['@taiga-ui/font-watcher'],
             '@ng-web-apis/intersection-observer':
                 kitDeps['@ng-web-apis/intersection-observer'],
             '@ng-web-apis/platform': cdkDeps['@ng-web-apis/platform'],


### PR DESCRIPTION
(cherry picked from commit 48fffafabe88f8b2cf55f5694adbc8194075faa1)

* https://github.com/taiga-family/taiga-ui/pull/13369
