### PR TITLE
fix(kit): make `InputNumber` with `[step]` safe for decimal arithmetic

### DIFF
--- a/projects/kit/components/input-number/step/input-number-step.component.ts
+++ b/projects/kit/components/input-number/step/input-number-step.component.ts
@@ -10,7 +10,7 @@ import {
 } from '@angular/core';
 import {takeUntilDestroyed} from '@angular/core/rxjs-interop';
 import {tuiInjectElement} from '@taiga-ui/cdk/utils/dom';
-import {tuiClamp} from '@taiga-ui/cdk/utils/math';
+import {tuiClamp, tuiSum} from '@taiga-ui/cdk/utils/math';
 import {TuiButton} from '@taiga-ui/core/components/button';
 import {
     TUI_TEXTFIELD_OPTIONS,
@@ -80,8 +80,9 @@ export class TuiInputNumberStep {
 
     protected onStep(step: number): void {
         const current = this.input.value() ?? 0;
+        const value = tuiSum(current, step);
 
-        this.input.setValue(tuiClamp(current + step, this.input.min(), this.input.max()));
+        this.input.setValue(tuiClamp(value, this.input.min(), this.input.max()));
         this.el.setSelectionRange(Number.MAX_SAFE_INTEGER, Number.MAX_SAFE_INTEGER);
     }
 }


### PR DESCRIPTION
Fixes #13351

Relates:
* https://github.com/taiga-family/taiga-ui/issues/12884

https://github.com/user-attachments/assets/83ad2785-be43-451c-be41-b22d79440449

