### PR TITLE
fix(kit): `FilterByInputPipe` should not reset filter results on exact match for `InputChip`

### DIFF
--- a/projects/demo-cypress/src/tests/combo-box/combo-box-groups.cy.ts
+++ b/projects/demo-cypress/src/tests/combo-box/combo-box-groups.cy.ts
@@ -1,0 +1,107 @@
+import {ChangeDetectionStrategy, Component, EventEmitter, Output} from '@angular/core';
+import {FormControl, ReactiveFormsModule} from '@angular/forms';
+import {TuiRoot, TuiTextfield} from '@taiga-ui/core';
+import {
+    TuiChevron,
+    TuiComboBox,
+    TuiDataListWrapper,
+    TuiFilterByInputPipe,
+} from '@taiga-ui/kit';
+import {createOutputSpy} from 'cypress/angular';
+
+const ITEMS = [
+    ['Caesar', 'Greek', 'Apple and Chicken', 'Chicken'],
+    ['Broccoli Cheddar', 'Chicken and Rice', 'Chicken Noodle'],
+] as const;
+
+@Component({
+    standalone: true,
+    imports: [
+        ReactiveFormsModule,
+        TuiChevron,
+        TuiComboBox,
+        TuiDataListWrapper,
+        TuiFilterByInputPipe,
+        TuiRoot,
+        TuiTextfield,
+    ],
+    template: `
+        <tui-root>
+            <tui-textfield tuiChevron>
+                <input
+                    placeholder="Enter"
+                    tuiComboBox
+                    [formControl]="control"
+                />
+
+                <tui-data-list-wrapper
+                    *tuiTextfieldDropdown
+                    new
+                    [items]="items | tuiFilterByInput"
+                    [labels]="labels"
+                />
+            </tui-textfield>
+        </tui-root>
+    `,
+    changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class Sandbox {
+    protected readonly control = new FormControl<string | null>(null);
+    protected labels = ['Salad', 'Soup'] as const;
+    protected readonly items = ITEMS;
+
+    @Output()
+    public readonly valueChanges = new EventEmitter<string | null>();
+
+    constructor() {
+        this.control.valueChanges.subscribe((x) => this.valueChanges.emit(x));
+    }
+}
+
+describe('ComboBox + DataListWrapper with groups (2d array items)', () => {
+    beforeEach(() => {
+        cy.mount(Sandbox, {
+            componentProperties: {valueChanges: createOutputSpy('valueChanges')},
+        });
+    });
+
+    it('all items are visible if dropdown open for empty textfield', () => {
+        cy.get('[tuiComboBox]').click().should('have.value', '');
+        cy.get('tui-dropdown').should('be.visible');
+        cy.get('[tuiOption]').should('have.length', ITEMS.flat().length);
+
+        ITEMS.flat().forEach((item) => {
+            cy.get('tui-data-list').contains(item);
+        });
+    });
+
+    it('filter works for both groups', () => {
+        cy.get('[tuiComboBox]').type('cHiCkE');
+        cy.get('tui-dropdown').should('be.visible');
+        cy.get('[tuiOption]').should('have.length', 4);
+
+        cy.get('tui-data-list').should('contain', 'Apple and Chicken');
+        cy.get('tui-data-list').should('contain', 'Chicken');
+        cy.get('tui-data-list').should('contain', 'Chicken and Rice');
+        cy.get('tui-data-list').should('contain', 'Chicken Noodle');
+
+        // Filtered
+        cy.get('tui-data-list').should('not.contain', 'Caesar');
+        cy.get('tui-data-list').should('not.contain', 'Greek');
+        cy.get('tui-data-list').should('not.contain', 'Broccoli Cheddar');
+    });
+
+    it('reset filter for both groups on exact match', () => {
+        cy.get('[tuiComboBox]').type('cHiCkE');
+        cy.get('[tuiOption]').should('have.length', 4);
+
+        cy.get('[tuiComboBox]').type('n').should('have.value', 'Chicken');
+        cy.get('[tuiOption]').should('have.length', ITEMS.flat().length);
+
+        cy.get('@valueChanges').should('have.been.calledOnceWith', 'Chicken');
+
+        ITEMS.flat().forEach((item) => {
+            cy.get('tui-data-list').contains(item);
+        });
+    });
+});

--- a/projects/demo-playwright/tests/kit/input-chip/multi-select-filter-by-input.pw.spec.ts
+++ b/projects/demo-playwright/tests/kit/input-chip/multi-select-filter-by-input.pw.spec.ts
@@ -1,0 +1,43 @@
+import {DemoRoute} from '@demo/routes';
+import {TuiDocumentationPagePO, tuiGoto, TuiInputChipPO} from '@demo-playwright/utils';
+import {expect, type Locator, test} from '@playwright/test';
+
+const {beforeEach, describe} = test;
+
+describe('InputChip with Datalist (a.k.a MultiSelect) + FilterByInput pipe', () => {
+    let example: Locator;
+    let inputChip: TuiInputChipPO;
+
+    beforeEach(async ({page}) => {
+        await tuiGoto(page, DemoRoute.FilterByInput);
+
+        example = new TuiDocumentationPagePO(page).getExample('#multiselect');
+        inputChip = new TuiInputChipPO(example);
+    });
+
+    test('all items are visible for empty textfield', async () => {
+        await inputChip.input.click();
+
+        await expect(inputChip.dropdown).toBeVisible();
+        await expect(inputChip.dropdown.locator('[tuiOption]')).toHaveCount(6);
+    });
+
+    test('filter works', async () => {
+        await inputChip.input.click();
+        await inputChip.input.fill('solo');
+
+        await expect(inputChip.dropdown).toBeVisible();
+        await expect(inputChip.dropdown.locator('[tuiOption]')).toHaveCount(2);
+        await expect(inputChip.dropdown).toContainText('Leia Organa Solo');
+        await expect(inputChip.dropdown).toContainText('Han Solo');
+    });
+
+    test('keeps filtering even on exact item match', async () => {
+        await inputChip.input.click();
+        await inputChip.input.fill('Yoda');
+
+        await expect(inputChip.dropdown).toBeVisible();
+        await expect(inputChip.dropdown.locator('[tuiOption]')).toHaveCount(1);
+        await expect(inputChip.dropdown).toHaveText('Yoda');
+    });
+});

--- a/projects/demo/src/modules/pipes/filter-by-input/examples/3/index.html
+++ b/projects/demo/src/modules/pipes/filter-by-input/examples/3/index.html
@@ -1,12 +1,21 @@
-<tui-multi-select
-    placeholder="Ignored text"
-    [formControl]="control"
-    [tuiTextfieldLabelOutside]="true"
+<tui-textfield
+    multi
+    tuiChevron
 >
-    Star Wars persons
+    <label tuiLabel>Star Wars persons</label>
+
+    <input
+        placeholder="Ignored text"
+        tuiInputChip
+        [formControl]="control"
+    />
+
+    <tui-input-chip *tuiItem />
+
     <tui-data-list-wrapper
-        *tuiDataList
+        *tuiTextfieldDropdown
+        new
         tuiMultiSelectGroup
         [items]="items | tuiFilterByInput"
     />
-</tui-multi-select>
+</tui-textfield>

--- a/projects/demo/src/modules/pipes/filter-by-input/examples/3/index.ts
+++ b/projects/demo/src/modules/pipes/filter-by-input/examples/3/index.ts
@@ -1,18 +1,26 @@
 import {Component} from '@angular/core';
 import {FormControl, ReactiveFormsModule} from '@angular/forms';
+import {TuiTextfield} from '@taiga-ui/core';
+import {
+    TuiChevron,
+    TuiDataListWrapper,
+    TuiFilterByInputPipe,
+    TuiInputChip,
+    TuiMultiSelect,
+} from '@taiga-ui/kit';
 import {changeDetection} from '@demo/emulate/change-detection';
 import {encapsulation} from '@demo/emulate/encapsulation';
-import {TuiDataListWrapper, TuiFilterByInputPipe} from '@taiga-ui/kit';
-import {TuiMultiSelectModule, TuiTextfieldControllerModule} from '@taiga-ui/legacy';
 
 @Component({
     standalone: true,
     imports: [
         ReactiveFormsModule,
+        TuiChevron,
         TuiDataListWrapper,
         TuiFilterByInputPipe,
-        TuiMultiSelectModule,
-        TuiTextfieldControllerModule,
+        TuiInputChip,
+        TuiMultiSelect,
+        TuiTextfield,
     ],
     templateUrl: './index.html',
     encapsulation,

--- a/projects/kit/pipes/filter-by-input/filter-by-input.pipe.ts
+++ b/projects/kit/pipes/filter-by-input/filter-by-input.pipe.ts
@@ -19,6 +19,7 @@ import {tuiIsFlat} from '@taiga-ui/kit/utils';
 export class TuiFilterByInputPipe implements PipeTransform {
     // TODO: Remove optional after legacy controls are dropped
     private readonly textfield = inject(TuiTextfieldComponent, {optional: true});
+    private readonly multi = this.textfield?.el.matches('[multi]');
     private readonly host = inject(TUI_DATA_LIST_HOST);
     private readonly itemsHandlers: TuiItemsHandlers<unknown> =
         inject(TUI_ITEMS_HANDLERS);
@@ -101,7 +102,7 @@ export class TuiFilterByInputPipe implements PipeTransform {
         query: string,
     ): T | undefined {
         // TODO: Refactor when tui-textfield[multi] is ready
-        if ((this.host as any).tagValidator) {
+        if ((this.host as any).tagValidator || this.multi) {
             return undefined;
         }
 


### PR DESCRIPTION
Cherry-picks:
* https://github.com/taiga-family/taiga-ui/pull/12666/changes#diff-d6d41c3e662a46624072d7260b0ed69bfe3ecfa1b6ed11f84964ed0253b1a32a
* https://github.com/taiga-family/taiga-ui/pull/13438

Relates:
* https://github.com/taiga-family/taiga-ui/issues/11504#issuecomment-3143622041