### PR TITLE
ci: extends permissions for Screenshot Report bot

### DIFF
--- a/.github/workflows/screenshot-bot.yml
+++ b/.github/workflows/screenshot-bot.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       actions: read
-      contents: read
+      contents: write
       pull-requests: write
     steps:
       - uses: taiga-family/argus@main


### PR DESCRIPTION
Explore logs from https://github.com/taiga-family/taiga-ui/actions/runs/22956528933

```
HttpError: Resource not accessible by integration - https://docs.github.com/rest/git/blobs#create-a-blob
```

https://docs.github.com/rest/git/blobs#create-a-blob contains

<img width="1486" height="427" alt="github-doc" src="https://github.com/user-attachments/assets/84036135-1d43-4162-9314-020234b3ff93" />
