### PR TITLE
chore(cdk): add `Popover` migration for v5

### DIFF
--- a/projects/cdk/schematics/ng-update/v5/steps/constants/identifiers-to-replace.ts
+++ b/projects/cdk/schematics/ng-update/v5/steps/constants/identifiers-to-replace.ts
@@ -713,4 +713,20 @@ export const IDENTIFIERS_TO_REPLACE: ReplacementIdentifierMulti[] = [
             moduleSpecifier: '@taiga-ui/kit',
         },
     },
+    {
+        from: {name: 'TuiPopover', moduleSpecifier: '@taiga-ui/cdk'},
+        to: {name: 'TuiPortalContext', moduleSpecifier: '@taiga-ui/cdk'},
+    },
+    {
+        from: {name: 'TuiPopoverService', moduleSpecifier: '@taiga-ui/cdk'},
+        to: {name: 'TuiPortal', moduleSpecifier: '@taiga-ui/cdk'},
+    },
+    {
+        from: {name: 'TuiPopoverDirective', moduleSpecifier: '@taiga-ui/cdk'},
+        to: {name: 'TuiPortalDirective', moduleSpecifier: '@taiga-ui/cdk'},
+    },
+    {
+        from: {name: 'tuiAsPopover', moduleSpecifier: '@taiga-ui/cdk'},
+        to: {name: 'tuiAsPortal', moduleSpecifier: '@taiga-ui/cdk'},
+    },
 ];

--- a/projects/cdk/schematics/ng-update/v5/steps/constants/migration-warnings.ts
+++ b/projects/cdk/schematics/ng-update/v5/steps/constants/migration-warnings.ts
@@ -62,4 +62,30 @@ export const MIGRATION_WARNINGS: MigrationWarning[] = [
         message:
             'TuiIsoToCountryCodePipe has been removed. Replace pipe usage `isoCode | tuiIsoToCountryCode` with the getCountryCallingCode(isoCode, metadata) function from libphonenumber-js/core.',
     },
+    {
+        name: 'TuiPopoverContext',
+        moduleSpecifier: '@taiga-ui/cdk',
+        message:
+            'TuiPopoverContext<O> is removed. Use TuiPortalContext<T, O> where T=options shape, O=output type.\n' +
+            '// Before: injectContext<TuiPopoverContext<boolean>>()\n' +
+            '// After:  injectContext<TuiPortalContext<MyOptions, boolean>>()',
+    },
+    {
+        name: 'TuiPopoverService',
+        moduleSpecifier: '@taiga-ui/cdk',
+        message:
+            'TuiPopoverService → TuiPortal: constructor args (token, component, defaultOptions) are now abstract class properties; call super(inject(TuiPopupService)).\n' +
+            '// Before: @Injectable({useFactory: () => new MyService(TUI_DIALOGS, MyComponent, defaultOpts)}) class MyService extends TuiPopoverService<T, K> {}\n' +
+            '// After:  @Injectable({providedIn: "root"}) class MyService extends TuiPortal<T, K> { protected readonly component = MyComponent; protected readonly options = defaultOpts; constructor() { super(inject(TuiPopupService)); } }\n' +
+            '// See https://taiga-ui.dev/cdk/portal',
+    },
+    {
+        name: 'TuiPopoverDirective',
+        moduleSpecifier: '@taiga-ui/cdk',
+        message:
+            'TuiPopoverDirective → TuiPortalDirective: do not extend; use hostDirectives + tuiAsPortal() instead.\n' +
+            '// Before: @Directive({inputs:[...], outputs:[...], providers:[{provide:TuiPopoverService,useExisting:MyService}]}) class MyDirective<T> extends TuiPopoverDirective<T> {}\n' +
+            '// After:  @Directive({providers:[tuiAsPortal(MyService)], hostDirectives:[{directive:TuiPortalDirective,inputs:[...],outputs:[...]}]}) class MyDirective {}\n' +
+            '// See https://taiga-ui.dev/cdk/portal',
+    },
 ];

--- a/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-popover.spec.ts.snap
+++ b/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-popover.spec.ts.snap
@@ -1,0 +1,254 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ng-update TuiPopover migration TuiPopover → TuiPortalContext renames TuiPopover type to TuiPortalContext: test.ts 1`] = `
+{
+  "0. Before": "
+                    import {Component} from '@angular/core';
+                    import {type TuiPopover} from '@taiga-ui/cdk';
+                    import {injectContext} from '@taiga-ui/polymorpheus';
+
+                    interface PromptOptions {
+                        heading: string;
+                    }
+
+                    @Component({template: ''})
+                    export class PromptComponent {
+                        protected readonly context = injectContext<TuiPopover<PromptOptions, boolean>>();
+                    }
+                ",
+  "1. After": "import { TuiPortalContext } from "@taiga-ui/cdk";
+
+                    import {Component} from '@angular/core';
+                    import {injectContext} from '@taiga-ui/polymorpheus';
+
+                    interface PromptOptions {
+                        heading: string;
+                    }
+
+                    @Component({template: ''})
+                    export class PromptComponent {
+                        protected readonly context = injectContext<TuiPortalContext<PromptOptions, boolean>>();
+                    }
+                ",
+}
+`;
+
+exports[`ng-update TuiPopover migration TuiPopover → TuiPortalContext renames TuiPopover used as type annotation: test.ts 1`] = `
+{
+  "0. Before": "
+                    import {type TuiPopover} from '@taiga-ui/cdk';
+
+                    export function openDialog(context: TuiPopover<{label: string}, string>): void {}
+                ",
+  "1. After": "import { TuiPortalContext } from "@taiga-ui/cdk";
+
+                                        export function openDialog(context: TuiPortalContext<{label: string}, string>): void {}
+                ",
+}
+`;
+
+exports[`ng-update TuiPopover migration TuiPopoverContext → warning adds TODO comment for TuiPopoverContext (generic params changed): test.ts 1`] = `
+{
+  "0. Before": "
+                    import {Component} from '@angular/core';
+                    import {type TuiPopoverContext} from '@taiga-ui/cdk';
+                    import {injectContext} from '@taiga-ui/polymorpheus';
+
+                    @Component({template: ''})
+                    export class DialogComponent {
+                        protected readonly context = injectContext<TuiPopoverContext<boolean>>();
+                    }
+                ",
+  "1. After": "
+                    import {Component} from '@angular/core';
+// TODO: (Taiga UI migration) TuiPopoverContext<O> is removed. Use TuiPortalContext<T, O> where T=options shape, O=output type.
+// Before: injectContext<TuiPopoverContext<boolean>>()
+// After:  injectContext<TuiPortalContext<MyOptions, boolean>>()
+                    import {type TuiPopoverContext} from '@taiga-ui/cdk';
+                    import {injectContext} from '@taiga-ui/polymorpheus';
+
+                    @Component({template: ''})
+                    export class DialogComponent {
+                        protected readonly context = injectContext<TuiPopoverContext<boolean>>();
+                    }
+                ",
+}
+`;
+
+exports[`ng-update TuiPopover migration TuiPopoverDirective → TuiPortalDirective + warning renames TuiPopoverDirective to TuiPortalDirective and adds TODO comment: test.ts 1`] = `
+{
+  "0. Before": "
+                    import {Directive} from '@angular/core';
+                    import {TuiPopoverDirective, TuiPopoverService} from '@taiga-ui/cdk';
+
+                    import {CustomDialogService} from './custom-dialog.service';
+
+                    @Directive({
+                        selector: 'ng-template[tuiCustomDialog]',
+                        inputs: ['open: tuiCustomDialog', 'options: tuiCustomDialogOptions'],
+                        outputs: ['openChange: tuiCustomDialogChange'],
+                        providers: [
+                            {provide: TuiPopoverService, useExisting: CustomDialogService},
+                        ],
+                    })
+                    export class CustomDialogDirective<T> extends TuiPopoverDirective<T> {}
+                ",
+  "1. After": "
+                    import {Directive} from '@angular/core';
+// TODO: (Taiga UI migration) TuiPopoverService → TuiPortal: constructor args (token, component, defaultOptions) are now abstract class properties; call super(inject(TuiPopupService)).
+// Before: @Injectable({useFactory: () => new MyService(TUI_DIALOGS, MyComponent, defaultOpts)}) class MyService extends TuiPopoverService<T, K> {}
+// After:  @Injectable({providedIn: "root"}) class MyService extends TuiPortal<T, K> { protected readonly component = MyComponent; protected readonly options = defaultOpts; constructor() { super(inject(TuiPopupService)); } }
+// See https://taiga-ui.dev/cdk/portal
+// TODO: (Taiga UI migration) TuiPopoverDirective → TuiPortalDirective: do not extend; use hostDirectives + tuiAsPortal() instead.
+// Before: @Directive({inputs:[...], outputs:[...], providers:[{provide:TuiPopoverService,useExisting:MyService}]}) class MyDirective<T> extends TuiPopoverDirective<T> {}
+// After:  @Directive({providers:[tuiAsPortal(MyService)], hostDirectives:[{directive:TuiPortalDirective,inputs:[...],outputs:[...]}]}) class MyDirective {}
+// See https://taiga-ui.dev/cdk/portal
+                    import { TuiPortal, TuiPortalDirective } from '@taiga-ui/cdk';
+
+                    import {CustomDialogService} from './custom-dialog.service';
+
+                    @Directive({
+                        selector: 'ng-template[tuiCustomDialog]',
+                        inputs: ['open: tuiCustomDialog', 'options: tuiCustomDialogOptions'],
+                        outputs: ['openChange: tuiCustomDialogChange'],
+                        providers: [
+                            {provide: TuiPortal, useExisting: CustomDialogService},
+                        ],
+                    })
+                    export class CustomDialogDirective<T> extends TuiPortalDirective<T> {}
+                ",
+}
+`;
+
+exports[`ng-update TuiPopover migration TuiPopoverService → TuiPortal + warning renames TuiPopoverService in inject() call: test.ts 1`] = `
+{
+  "0. Before": "
+                    import {inject} from '@angular/core';
+                    import {TuiPopoverService} from '@taiga-ui/cdk';
+
+                    export const service = inject(TuiPopoverService);
+                ",
+  "1. After": "import { TuiPortal } from "@taiga-ui/cdk";
+
+                    import {inject} from '@angular/core';
+// TODO: (Taiga UI migration) TuiPopoverService → TuiPortal: constructor args (token, component, defaultOptions) are now abstract class properties; call super(inject(TuiPopupService)).
+// Before: @Injectable({useFactory: () => new MyService(TUI_DIALOGS, MyComponent, defaultOpts)}) class MyService extends TuiPopoverService<T, K> {}
+// After:  @Injectable({providedIn: "root"}) class MyService extends TuiPortal<T, K> { protected readonly component = MyComponent; protected readonly options = defaultOpts; constructor() { super(inject(TuiPopupService)); } }
+// See https://taiga-ui.dev/cdk/portal
+                    export const service = inject(TuiPortal);
+                ",
+}
+`;
+
+exports[`ng-update TuiPopover migration TuiPopoverService → TuiPortal + warning renames TuiPopoverService to TuiPortal and adds TODO comment: test.ts 1`] = `
+{
+  "0. Before": "
+                    import {inject, Injectable} from '@angular/core';
+                    import {TuiPopoverService} from '@taiga-ui/cdk';
+                    import {TUI_DIALOGS} from '@taiga-ui/core';
+
+                    import {PromptComponent} from './prompt.component';
+                    import {type PromptOptions} from './prompt-options';
+
+                    @Injectable({
+                        providedIn: 'root',
+                        useFactory: () =>
+                            new PromptService(TUI_DIALOGS, PromptComponent, {heading: 'Are you sure?'}),
+                    })
+                    export class PromptService extends TuiPopoverService<PromptOptions, boolean> {}
+                ",
+  "1. After": "import { TuiPortal } from "@taiga-ui/cdk";
+
+                    import {inject, Injectable} from '@angular/core';
+// TODO: (Taiga UI migration) TuiPopoverService → TuiPortal: constructor args (token, component, defaultOptions) are now abstract class properties; call super(inject(TuiPopupService)).
+// Before: @Injectable({useFactory: () => new MyService(TUI_DIALOGS, MyComponent, defaultOpts)}) class MyService extends TuiPopoverService<T, K> {}
+// After:  @Injectable({providedIn: "root"}) class MyService extends TuiPortal<T, K> { protected readonly component = MyComponent; protected readonly options = defaultOpts; constructor() { super(inject(TuiPopupService)); } }
+// See https://taiga-ui.dev/cdk/portal
+                    import {TUI_DIALOGS} from '@taiga-ui/core';
+
+                    import {PromptComponent} from './prompt.component';
+                    import {type PromptOptions} from './prompt-options';
+
+                    @Injectable({
+                        providedIn: 'root',
+                        useFactory: () =>
+                            new PromptService(TUI_DIALOGS, PromptComponent, {heading: 'Are you sure?'}),
+                    })
+                    export class PromptService extends TuiPortal<PromptOptions, boolean> {}
+                ",
+}
+`;
+
+exports[`ng-update TuiPopover migration combined usage migrates all popover identifiers in one file: test.ts 1`] = `
+{
+  "0. Before": "
+                    import {inject, Injectable} from '@angular/core';
+                    import {
+                        type TuiPopover,
+                        TuiPopoverDirective,
+                        TuiPopoverService,
+                        tuiAsPopover,
+                    } from '@taiga-ui/cdk';
+                    import {injectContext} from '@taiga-ui/polymorpheus';
+
+                    interface MyOptions {
+                        label: string;
+                    }
+
+                    @Injectable({providedIn: 'root'})
+                    export class MyService extends TuiPopoverService<MyOptions, string> {}
+
+                    export function getContext(): TuiPopover<MyOptions, string> {
+                        return injectContext<TuiPopover<MyOptions, string>>();
+                    }
+
+                    export const providers = [tuiAsPopover(MyService)];
+                ",
+  "1. After": "
+                    import {inject, Injectable} from '@angular/core';
+                    import { TuiPortalContext, TuiPortal, TuiPortalDirective, tuiAsPortal } from '@taiga-ui/cdk';
+                    import {injectContext} from '@taiga-ui/polymorpheus';
+
+                    interface MyOptions {
+                        label: string;
+                    }
+
+                    @Injectable({providedIn: 'root'})
+                    export class MyService extends TuiPortal<MyOptions, string> {}
+
+                    export function getContext(): TuiPortalContext<MyOptions, string> {
+                        return injectContext<TuiPortalContext<MyOptions, string>>();
+                    }
+
+                    export const providers = [tuiAsPortal(MyService)];
+                ",
+}
+`;
+
+exports[`ng-update TuiPopover migration tuiAsPopover → tuiAsPortal renames tuiAsPopover to tuiAsPortal: test.ts 1`] = `
+{
+  "0. Before": "
+                    import {Directive} from '@angular/core';
+                    import {tuiAsPopover} from '@taiga-ui/cdk';
+
+                    import {CustomDialogService} from './custom-dialog.service';
+
+                    @Directive({
+                        selector: 'ng-template[tuiCustomDialog]',
+                        providers: [tuiAsPopover(CustomDialogService)],
+                    })
+                    export class CustomDialog {}
+                ",
+  "1. After": "import { tuiAsPortal } from "@taiga-ui/cdk";
+
+                    import {Directive} from '@angular/core';
+                    import {CustomDialogService} from './custom-dialog.service';
+
+                    @Directive({
+                        selector: 'ng-template[tuiCustomDialog]',
+                        providers: [tuiAsPortal(CustomDialogService)],
+                    })
+                    export class CustomDialog {}
+                ",
+}
+`;

--- a/projects/cdk/schematics/ng-update/v5/tests/schematic-migrate-popover.spec.ts
+++ b/projects/cdk/schematics/ng-update/v5/tests/schematic-migrate-popover.spec.ts
@@ -1,0 +1,198 @@
+import {join} from 'node:path';
+
+import {resetActiveProject} from 'ng-morph';
+
+import {createMigration} from '../../../utils/run-migration';
+
+describe('ng-update TuiPopover migration', () => {
+    const migrate = createMigration({
+        collection: join(__dirname, '../../../migration.json'),
+    });
+
+    afterEach(() => resetActiveProject());
+
+    describe('TuiPopover → TuiPortalContext', () => {
+        it(
+            'renames TuiPopover type to TuiPortalContext',
+            migrate({
+                component: `
+                    import {Component} from '@angular/core';
+                    import {type TuiPopover} from '@taiga-ui/cdk';
+                    import {injectContext} from '@taiga-ui/polymorpheus';
+
+                    interface PromptOptions {
+                        heading: string;
+                    }
+
+                    @Component({template: ''})
+                    export class PromptComponent {
+                        protected readonly context = injectContext<TuiPopover<PromptOptions, boolean>>();
+                    }
+                `,
+            }),
+        );
+
+        it(
+            'renames TuiPopover used as type annotation',
+            migrate({
+                component: `
+                    import {type TuiPopover} from '@taiga-ui/cdk';
+
+                    export function openDialog(context: TuiPopover<{label: string}, string>): void {}
+                `,
+            }),
+        );
+
+        it(
+            'does not rename TuiPopover from unrelated packages',
+            migrate({
+                component: `
+                    import {type TuiPopover} from '@some-other/library';
+
+                    export class SomeClass {
+                        protected context!: TuiPopover<{}, void>;
+                    }
+                `,
+            }),
+        );
+    });
+
+    describe('TuiPopoverContext → warning', () => {
+        it(
+            'adds TODO comment for TuiPopoverContext (generic params changed)',
+            migrate({
+                component: `
+                    import {Component} from '@angular/core';
+                    import {type TuiPopoverContext} from '@taiga-ui/cdk';
+                    import {injectContext} from '@taiga-ui/polymorpheus';
+
+                    @Component({template: ''})
+                    export class DialogComponent {
+                        protected readonly context = injectContext<TuiPopoverContext<boolean>>();
+                    }
+                `,
+            }),
+        );
+    });
+
+    describe('TuiPopoverService → TuiPortal + warning', () => {
+        it(
+            'renames TuiPopoverService to TuiPortal and adds TODO comment',
+            migrate({
+                component: `
+                    import {inject, Injectable} from '@angular/core';
+                    import {TuiPopoverService} from '@taiga-ui/cdk';
+                    import {TUI_DIALOGS} from '@taiga-ui/core';
+
+                    import {PromptComponent} from './prompt.component';
+                    import {type PromptOptions} from './prompt-options';
+
+                    @Injectable({
+                        providedIn: 'root',
+                        useFactory: () =>
+                            new PromptService(TUI_DIALOGS, PromptComponent, {heading: 'Are you sure?'}),
+                    })
+                    export class PromptService extends TuiPopoverService<PromptOptions, boolean> {}
+                `,
+            }),
+        );
+
+        it(
+            'renames TuiPopoverService in inject() call',
+            migrate({
+                component: `
+                    import {inject} from '@angular/core';
+                    import {TuiPopoverService} from '@taiga-ui/cdk';
+
+                    export const service = inject(TuiPopoverService);
+                `,
+            }),
+        );
+    });
+
+    describe('TuiPopoverDirective → TuiPortalDirective + warning', () => {
+        it(
+            'renames TuiPopoverDirective to TuiPortalDirective and adds TODO comment',
+            migrate({
+                component: `
+                    import {Directive} from '@angular/core';
+                    import {TuiPopoverDirective, TuiPopoverService} from '@taiga-ui/cdk';
+
+                    import {CustomDialogService} from './custom-dialog.service';
+
+                    @Directive({
+                        selector: 'ng-template[tuiCustomDialog]',
+                        inputs: ['open: tuiCustomDialog', 'options: tuiCustomDialogOptions'],
+                        outputs: ['openChange: tuiCustomDialogChange'],
+                        providers: [
+                            {provide: TuiPopoverService, useExisting: CustomDialogService},
+                        ],
+                    })
+                    export class CustomDialogDirective<T> extends TuiPopoverDirective<T> {}
+                `,
+            }),
+        );
+    });
+
+    describe('tuiAsPopover → tuiAsPortal', () => {
+        it(
+            'renames tuiAsPopover to tuiAsPortal',
+            migrate({
+                component: `
+                    import {Directive} from '@angular/core';
+                    import {tuiAsPopover} from '@taiga-ui/cdk';
+
+                    import {CustomDialogService} from './custom-dialog.service';
+
+                    @Directive({
+                        selector: 'ng-template[tuiCustomDialog]',
+                        providers: [tuiAsPopover(CustomDialogService)],
+                    })
+                    export class CustomDialog {}
+                `,
+            }),
+        );
+
+        it(
+            'does not rename tuiAsPopover from unrelated packages',
+            migrate({
+                component: `
+                    import {tuiAsPopover} from '@some-other/library';
+
+                    export const providers = [tuiAsPopover(SomeService)];
+                `,
+            }),
+        );
+    });
+
+    describe('combined usage', () => {
+        it(
+            'migrates all popover identifiers in one file',
+            migrate({
+                component: `
+                    import {inject, Injectable} from '@angular/core';
+                    import {
+                        type TuiPopover,
+                        TuiPopoverDirective,
+                        TuiPopoverService,
+                        tuiAsPopover,
+                    } from '@taiga-ui/cdk';
+                    import {injectContext} from '@taiga-ui/polymorpheus';
+
+                    interface MyOptions {
+                        label: string;
+                    }
+
+                    @Injectable({providedIn: 'root'})
+                    export class MyService extends TuiPopoverService<MyOptions, string> {}
+
+                    export function getContext(): TuiPopover<MyOptions, string> {
+                        return injectContext<TuiPopover<MyOptions, string>>();
+                    }
+
+                    export const providers = [tuiAsPopover(MyService)];
+                `,
+            }),
+        );
+    });
+});


### PR DESCRIPTION
Part of #11917

## Summary

- Add `TuiPopover*` / `tuiAsPopover` (`@taiga-ui/cdk`) → `TuiPortal*` / `tuiAsPortal` identifier replacements
- Add migration warnings with TODO comments for identifiers that require manual follow-up

**Identifier replacements (automated):**
| Legacy | New |
|--------|-----|
| `TuiPopover<O, R>` | `TuiPortalContext<O, R>` |
| `TuiPopoverService<O, R>` | `TuiPortal<O, R>` |
| `TuiPopoverDirective<T>` | `TuiPortalDirective<T>` |
| `tuiAsPopover` | `tuiAsPortal` |

**Migration warnings (TODO comment added, manual fix required):**
| Legacy | Reason |
|--------|--------|
| `TuiPopoverContext<O>` | Generic params changed: new `T` (options shape) added before `O`; becomes `TuiPortalContext<T, O>` |
| `TuiPopoverService` | Constructor args `(token, component, defaultOptions)` are now abstract class properties; requires `super(inject(TuiPopupService))` |
| `TuiPopoverDirective` | Extending is no longer supported; use `hostDirectives` + `tuiAsPortal()` instead |