### PR TITLE
fix(kit): update `tui-line-clamp` properly when toggling between empty and non-empty content

### DIFF
--- a/projects/demo/src/modules/components/line-clamp/examples/1/index.html
+++ b/projects/demo/src/modules/components/line-clamp/examples/1/index.html
@@ -45,6 +45,23 @@
     </ng-template>
 </div>
 
+<div class="tui-space_bottom-4">
+    <tui-line-clamp
+        [content]="value()"
+        [linesLimit]="2"
+    />
+
+    <button
+        *ngIf="!value()"
+        size="s"
+        tuiButton
+        type="button"
+        (click)="update()"
+    >
+        Load dynamic value
+    </button>
+</div>
+
 <div
     *ngIf="value$ | async as value; else loading"
     class="wrapper"

--- a/projects/demo/src/modules/components/line-clamp/examples/1/index.ts
+++ b/projects/demo/src/modules/components/line-clamp/examples/1/index.ts
@@ -1,15 +1,15 @@
 import {AsyncPipe, NgIf} from '@angular/common';
-import {Component, inject} from '@angular/core';
+import {Component, inject, signal} from '@angular/core';
 import {changeDetection} from '@demo/emulate/change-detection';
 import {encapsulation} from '@demo/emulate/encapsulation';
 import {TUI_IS_E2E, tuiWatch} from '@taiga-ui/cdk';
-import {TuiNotification} from '@taiga-ui/core';
+import {TuiButton, TuiNotification} from '@taiga-ui/core';
 import {TuiChip, TuiLineClamp} from '@taiga-ui/kit';
 import {map, timer} from 'rxjs';
 
 @Component({
     standalone: true,
-    imports: [AsyncPipe, NgIf, TuiChip, TuiLineClamp, TuiNotification],
+    imports: [AsyncPipe, NgIf, TuiButton, TuiChip, TuiLineClamp, TuiNotification],
     templateUrl: './index.html',
     styleUrls: ['./index.less'],
     encapsulation,
@@ -18,8 +18,16 @@ import {map, timer} from 'rxjs';
 export default class Example {
     private readonly isE2E = inject(TUI_IS_E2E);
 
+    protected readonly value = signal('');
+
     protected value$ = timer(this.isE2E ? 0 : 4000).pipe(
         map(() => `${'async fake value, '.repeat(10)}end!`),
         tuiWatch(),
     );
+
+    public update(): void {
+        this.value.set(
+            'Daenerys of the House Targaryen, the First of Her Name, The Unburnt, Queen of the Andals, the Rhoynar and the First Men, Queen of Meereen, Khaleesi of the Great Grass Sea, Protector of the Realm, Lady Regent of the Seven Kingdoms, Breaker of Chains and Mother of Dragons',
+        );
+    }
 }

--- a/projects/kit/components/line-clamp/line-clamp.component.ts
+++ b/projects/kit/components/line-clamp/line-clamp.component.ts
@@ -1,7 +1,7 @@
 import {
+    type AfterViewChecked,
     ChangeDetectionStrategy,
     Component,
-    type DoCheck,
     ElementRef,
     inject,
     Input,
@@ -57,7 +57,7 @@ import {TuiLineClampPositionDirective} from './line-clamp-position.directive';
         '(resize)': 'update()',
     },
 })
-export class TuiLineClamp implements DoCheck {
+export class TuiLineClamp implements AfterViewChecked {
     @ViewChild(TuiHintDirective, {read: ElementRef})
     private readonly outlet?: ElementRef<HTMLElement>;
 
@@ -100,7 +100,7 @@ export class TuiLineClamp implements DoCheck {
         this.linesLimit$.next(linesLimit);
     }
 
-    public ngDoCheck(): void {
+    public ngAfterViewChecked(): void {
         this.update();
         this.isOverflown$.next(this.overflown);
     }


### PR DESCRIPTION
Fixes #13376