### PR TITLE
chore(demo-playwright): improve naming for deep tests (better DX)

### DIFF
--- a/projects/demo-playwright/tests/deep/deep-select.pw.spec.ts
+++ b/projects/demo-playwright/tests/deep/deep-select.pw.spec.ts
@@ -64,8 +64,14 @@ test.describe('Deep / Select', () => {
                     await page.waitForTimeout(path.includes('charts') ? 500 : 100);
 
                     const example = api.demo;
+                    const query = decodeURIComponent(
+                        String(new URL(page.url()).searchParams),
+                    );
+
                     const makeName = (dir: string): string =>
-                        `deep-${path}-${name}-row-${rowIndex}-select-option-${index}.${dir}.png`;
+                        `deep-${path}-${name}-row-${rowIndex}-select-option-${index}-${dir}-----${query}`
+                            .slice(0, 250)
+                            .concat('.png');
 
                     await expect.soft(example).toHaveScreenshot(makeName('ltr'));
                     await example.evaluate((node) => node.setAttribute('dir', 'rtl'));

--- a/projects/demo-playwright/tests/deep/deep-toggle.pw.spec.ts
+++ b/projects/demo-playwright/tests/deep/deep-toggle.pw.spec.ts
@@ -40,8 +40,13 @@ test.describe('Deep / Toggle', () => {
                 }
 
                 const example = api.demo;
+                const query = decodeURIComponent(
+                    String(new URL(page.url()).searchParams),
+                );
                 const makeName = (dir: string): string =>
-                    `deep-${path}-${name}-row-${rowIndex}-toggled.${dir}.png`;
+                    `deep-${path}-${name}-row-${rowIndex}-toggled-${dir}-----${query}`
+                        .slice(0, 250)
+                        .concat('.png');
 
                 await expect.soft(example).toHaveScreenshot(makeName('ltr'));
                 await example.evaluate((node) => node.setAttribute('dir', 'rtl'));


### PR DESCRIPTION
## Previous behavior
<img width="888" height="561" alt="previous" src="https://github.com/user-attachments/assets/c5f94cbc-966d-44b2-9eac-c17600c8448b" />

It is not convenient to debug

## New bahavior
deep--components-calendar-range--max--row-5-select-option-1-ltr-----**defaultViewedMonth-0-disabledItemHandler-0-items-0-markerHandler-0-min-0-max-1**.png

⬇️ 

http://localhost:3333/components/calendar-range/API?\<here\>
