### PR TITLE
chore: stackblitz starter throws `@angular/router@20.3.18/fesm2022/router.mjs does not exist`

### DIFF
--- a/projects/demo/src/modules/app/stackblitz/stackblitz-deps.service.ts
+++ b/projects/demo/src/modules/app/stackblitz/stackblitz-deps.service.ts
@@ -28,7 +28,7 @@ export class StackblitzDepsService {
             '@angular/core': ngVersion,
             '@angular/forms': ngVersion,
             '@angular/platform-browser': ngVersion,
-            '@angular/router': ngVersion,
+            '@angular/router': '20.3.17', // @angular/router@20.3.18 throws `The file '/turbo_modules/@angular/router@20.3.18/fesm2022/router.mjs' does not exist`
             typescript: '5.8.x', // compatible with angular 20
         };
     }


### PR DESCRIPTION
https://taiga-ui.dev/stackblitz

```
Error in src/main.ts
The entrypoint for '@angular/router' could not successfully be resolved.
The file '/turbo_modules/@angular/router@20.3.18/fesm2022/router.mjs'
does not exist. 

Please log an issue with the package author or check for an updated version of the package.
```
