### PR TITLE
fix(core): prevent overscroll bounce in modal and sheet-dialog

### DIFF
--- a/projects/addon-mobile/components/sheet-dialog/sheet-dialog.style.less
+++ b/projects/addon-mobile/components/sheet-dialog/sheet-dialog.style.less
@@ -12,6 +12,7 @@
     flex-direction: column;
     font: var(--tui-typography-body-m);
     overflow-y: scroll;
+    overscroll-behavior: none;
     scroll-snap-type: y mandatory;
     margin: ~'max(var(--tui-offset), env(safe-area-inset-top))' auto 0;
     border-radius: 0.75rem 0.75rem 0 0;

--- a/projects/core/portals/modal/modal.style.less
+++ b/projects/core/portals/modal/modal.style.less
@@ -21,7 +21,7 @@ tui-modal {
     place-items: center;
     outline: none;
     overflow: auto;
-    overscroll-behavior: none contain;
+    overscroll-behavior: none;
     transition-timing-function: linear;
     animation-timing-function: cubic-bezier(0.14, 0.52, 0.35, 0.84) !important;
     perspective: 10rem;


### PR DESCRIPTION
### Before


https://github.com/user-attachments/assets/5c6415b9-2afd-428b-91f2-a288153c1652


https://github.com/user-attachments/assets/888f114f-734e-4ae5-8e91-527eeef75c48

### After


https://github.com/user-attachments/assets/a1fc2b81-4f40-41d4-bcdc-f3e7b086d575


https://github.com/user-attachments/assets/3630871c-cd02-4828-aaac-2e4a9f03227d

