### PR TITLE
fix(core): `tuiDropdownHover` closes immediately when hovered and clicked simultaneously

### DIFF
--- a/projects/core/directives/dropdown/dropdown-hover.directive.ts
+++ b/projects/core/directives/dropdown/dropdown-hover.directive.ts
@@ -12,6 +12,7 @@ import {tuiAsDriver, TuiDriver} from '@taiga-ui/core/classes';
 import {
     delay,
     distinctUntilChanged,
+    EMPTY,
     filter,
     fromEvent,
     map,
@@ -69,7 +70,12 @@ export class TuiDropdownHover extends TuiDriver {
     ).pipe(
         map((element) => tuiIsElement(element) && this.isHovered(element)),
         distinctUntilChanged(),
-        switchMap((v) => of(v).pipe(delay(v ? this.showDelay : this.hideDelay))),
+        switchMap((visible) =>
+            of(visible).pipe(
+                delay(visible ? this.showDelay : this.hideDelay),
+                takeUntil(this.open ? fromEvent(this.el, 'pointerdown') : EMPTY),
+            ),
+        ),
         tuiZoneOptimized(),
         tap((hovered) => {
             this.hovered = hovered;

--- a/projects/demo-playwright/tests/kit/dropdown-hover/dropdown-hover.pw.spec.ts
+++ b/projects/demo-playwright/tests/kit/dropdown-hover/dropdown-hover.pw.spec.ts
@@ -16,6 +16,45 @@ test.describe('DropdownHover', () => {
             await tuiGoto(page, DemoRoute.DropdownHover);
         });
 
+        describe('With DropdownOpen', () => {
+            let example!: Locator;
+
+            beforeEach(async ({page}) => {
+                example = new TuiDocumentationPagePO(page).getExample('#dropdown-open');
+
+                await example.scrollIntoViewIfNeeded();
+            });
+
+            test('opens dropdown after hover and hide after click', async ({page}) => {
+                const button = example.locator('button', {hasText: 'Hoverable'});
+                const dropdown = page.locator('tui-dropdown');
+
+                await button.hover();
+                await page.waitForTimeout(300);
+                await expect(dropdown).toBeAttached();
+
+                await button.click();
+                await expect(dropdown).not.toBeAttached();
+            });
+
+            test('opens dropdown after hover and instantly click', async ({page}) => {
+                const button = example.locator('button', {hasText: 'Hoverable'});
+                const dropdown = page.locator('tui-dropdown');
+
+                await button.evaluate((el) => {
+                    el.dispatchEvent(new MouseEvent('mouseover', {bubbles: true}));
+                    el.dispatchEvent(new PointerEvent('pointerdown', {bubbles: true}));
+                    el.dispatchEvent(new MouseEvent('click', {bubbles: true}));
+                });
+
+                await expect(dropdown).toBeAttached();
+
+                await page.waitForTimeout(300);
+                await button.click();
+                await expect(dropdown).not.toBeAttached();
+            });
+        });
+
         describe('With DropdownMobile', () => {
             let example!: Locator;
             let mobileCalendar: TuiMobileDropdownPO;


### PR DESCRIPTION


Fixes #13434
