### PR TITLE
chore(cdk): `InputMonth` migration fix attributes

### DIFF
--- a/projects/cdk/schematics/ng-update/v5/steps/templates/migrate-input-month.ts
+++ b/projects/cdk/schematics/ng-update/v5/steps/templates/migrate-input-month.ts
@@ -2,7 +2,6 @@ import {type UpdateRecorder} from '@angular-devkit/schematics';
 import {type DevkitFileSystem} from 'ng-morph';
 import {type DefaultTreeAdapterTypes} from 'parse5';
 
-import {TODO_MARK} from '../../../../utils/insert-todo';
 import {findElementsByTagName} from '../../../../utils/templates/elements';
 import {
     getTemplateFromTemplateResource,
@@ -17,20 +16,24 @@ type ChildNode = DefaultTreeAdapterTypes.ChildNode;
 
 type Element = DefaultTreeAdapterTypes.Element;
 
-const DOCS_LINK = 'https://taiga-ui.dev/components/input-month';
-
-const INPUT_ATTRS = new Set([
+const CALENDAR_ATTRS = new Set([
+    '[defaultActiveYear]'.toLowerCase(),
+    '[disabledItemHandler]'.toLowerCase(),
     '[max]'.toLowerCase(),
     '[min]'.toLowerCase(),
+    'defaultActiveYear'.toLowerCase(),
     'max'.toLowerCase(),
     'min'.toLowerCase(),
 ]);
 
-const CALENDAR_ATTRS = new Set(['[disabledItemHandler]'.toLowerCase()]);
-
-const NO_EQUIVALENT_ATTRS = new Set([
-    '[defaultActiveYear]'.toLowerCase(),
-    'defaultActiveYear'.toLowerCase(),
+const CALENDAR_ATTR_RENAMES = new Map([
+    ['[defaultActiveYear]'.toLowerCase(), '[year]'],
+    ['[disabledItemHandler]'.toLowerCase(), '[disabledItemHandler]'],
+    ['[max]'.toLowerCase(), '[max]'],
+    ['[min]'.toLowerCase(), '[min]'],
+    ['defaultActiveYear'.toLowerCase(), 'year'],
+    ['max'.toLowerCase(), 'max'],
+    ['min'.toLowerCase(), 'min'],
 ]);
 
 export function migrateInputMonth({
@@ -62,24 +65,11 @@ export function migrateInputMonth({
             /formcontrol|ngmodel/.exec(attr.name.toLocaleLowerCase()),
         );
 
-        const inputAttrs = [...element.attrs].filter((attr) =>
-            INPUT_ATTRS.has(attr.name.toLowerCase()),
-        );
-
         const calendarAttrs = [...element.attrs].filter((attr) =>
             CALENDAR_ATTRS.has(attr.name.toLowerCase()),
         );
 
-        const noEquivalentAttrs = [...element.attrs].filter((attr) =>
-            NO_EQUIVALENT_ATTRS.has(attr.name.toLowerCase()),
-        );
-
-        for (const attr of [
-            ...controlAttrs,
-            ...inputAttrs,
-            ...calendarAttrs,
-            ...noEquivalentAttrs,
-        ]) {
+        for (const attr of [...controlAttrs, ...calendarAttrs]) {
             const {startOffset = 0, endOffset = 0} =
                 element.sourceCodeLocation?.attrs?.[attr.name] ?? {};
 
@@ -102,17 +92,6 @@ export function migrateInputMonth({
             recorder.insertRight(labelTextEnd, '</label>\n');
         }
 
-        if (noEquivalentAttrs.length > 0) {
-            const names = noEquivalentAttrs.map((a) => a.name).join(', ');
-            const todoComment = [
-                `<!-- ${TODO_MARK} tui-input-month migration (see ${DOCS_LINK}):`,
-                `     - ${names}: no direct equivalent in v5. Remove and update component logic. -->`,
-            ].join('\n');
-            const insertAt = (sourceCodeLocation?.startOffset ?? 0) + templateOffset;
-
-            recorder.insertLeft(insertAt, `${todoComment}\n`);
-        }
-
         const insertOffset =
             (sourceCodeLocation?.endTag?.startOffset ?? 0) + templateOffset;
 
@@ -120,16 +99,16 @@ export function migrateInputMonth({
             (node: ChildNode): node is Element => node.nodeName === 'input',
         );
 
-        const migrationAttrs = [...controlAttrs, ...inputAttrs].reduce((result, attr) => {
+        const migrationAttrs = controlAttrs.reduce((result, attr) => {
             const name = normalizeAttrName(attr.name);
 
             return attr.value ? `${result} ${name}="${attr.value}"` : `${result} ${name}`;
         }, '');
 
         const calendarAttrStr = calendarAttrs.reduce((result, attr) => {
-            return attr.value
-                ? `${result} ${attr.name}="${attr.value}"`
-                : `${result} ${attr.name}`;
+            const name = CALENDAR_ATTR_RENAMES.get(attr.name.toLowerCase()) ?? attr.name;
+
+            return attr.value ? `${result} ${name}="${attr.value}"` : `${result} ${name}`;
         }, '');
 
         if (!inputs.length) {

--- a/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-input-month.spec.ts.snap
+++ b/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-input-month.spec.ts.snap
@@ -1,31 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`ng-update adds TODO for [defaultActiveYear]: test.html 1`] = `
-{
-  "0. Before": "
-                <tui-input-month
-                    [defaultActiveYear]="initialYear"
-                    formControlName="month"
-                >
-                    Month
-                </tui-input-month>",
-  "1. After": "
-                <!-- TODO: (Taiga UI migration) tui-input-month migration (see https://taiga-ui.dev/components/input-month):
-     - [defaultactiveyear]: no direct equivalent in v5. Remove and update component logic. -->
-<tui-textfield
-                    
-                    
-                >
-<label tuiLabel>
-                    Month
-                </label>
-
-<input tuiInputMonth formControlName="month" />
-<tui-calendar-month *tuiDropdown />
-</tui-textfield>",
-}
-`;
-
 exports[`ng-update migrate TuiInputMonthModule to TuiInputMonth: test.html 1`] = `
 {
   "0. Before": "
@@ -152,11 +126,39 @@ exports[`ng-update migrate TuiInputMonthModule to TuiInputMonth: test.ts 1`] = `
 }
 `;
 
-exports[`ng-update moves [disabledItemHandler] to <tui-calendar-month *tuiDropdown>: test.html 1`] = `
+exports[`ng-update moves [min], [max], [disabledItemHandler] to <tui-calendar-month *tuiDropdown>: test.html 1`] = `
 {
   "0. Before": "
                 <tui-input-month
+                    [min]="minMonth"
+                    [max]="maxMonth"
                     [disabledItemHandler]="disabledHandler"
+                    formControlName="month"
+                >
+                    Month
+                </tui-input-month>",
+  "1. After": "
+                <tui-textfield
+                    
+                    
+                    
+                    
+                >
+<label tuiLabel>
+                    Month
+                </label>
+
+<input tuiInputMonth formControlName="month" />
+<tui-calendar-month *tuiDropdown [min]="minMonth" [max]="maxMonth" [disabledItemHandler]="disabledHandler" />
+</tui-textfield>",
+}
+`;
+
+exports[`ng-update renames [defaultActiveYear] to [year] on <tui-calendar-month *tuiDropdown>: test.html 1`] = `
+{
+  "0. Before": "
+                <tui-input-month
+                    [defaultActiveYear]="initialYear"
                     formControlName="month"
                 >
                     Month
@@ -171,33 +173,7 @@ exports[`ng-update moves [disabledItemHandler] to <tui-calendar-month *tuiDropdo
                 </label>
 
 <input tuiInputMonth formControlName="month" />
-<tui-calendar-month *tuiDropdown [disableditemhandler]="disabledHandler" />
-</tui-textfield>",
-}
-`;
-
-exports[`ng-update moves [min] and [max] to <input tuiInputMonth>: test.html 1`] = `
-{
-  "0. Before": "
-                <tui-input-month
-                    [min]="minMonth"
-                    [max]="maxMonth"
-                    formControlName="month"
-                >
-                    Month
-                </tui-input-month>",
-  "1. After": "
-                <tui-textfield
-                    
-                    
-                    
-                >
-<label tuiLabel>
-                    Month
-                </label>
-
-<input tuiInputMonth formControlName="month" [min]="minMonth" [max]="maxMonth" />
-<tui-calendar-month *tuiDropdown />
+<tui-calendar-month *tuiDropdown [year]="initialYear" />
 </tui-textfield>",
 }
 `;

--- a/projects/cdk/schematics/ng-update/v5/tests/schematic-migrate-input-month.spec.ts
+++ b/projects/cdk/schematics/ng-update/v5/tests/schematic-migrate-input-month.spec.ts
@@ -64,24 +64,12 @@ describe('ng-update', () => {
     );
 
     it(
-        'moves [min] and [max] to <input tuiInputMonth>',
+        'moves [min], [max], [disabledItemHandler] to <tui-calendar-month *tuiDropdown>',
         migrate({
             template: `
                 <tui-input-month
                     [min]="minMonth"
                     [max]="maxMonth"
-                    formControlName="month"
-                >
-                    Month
-                </tui-input-month>`,
-        }),
-    );
-
-    it(
-        'moves [disabledItemHandler] to <tui-calendar-month *tuiDropdown>',
-        migrate({
-            template: `
-                <tui-input-month
                     [disabledItemHandler]="disabledHandler"
                     formControlName="month"
                 >
@@ -91,7 +79,7 @@ describe('ng-update', () => {
     );
 
     it(
-        'adds TODO for [defaultActiveYear]',
+        'renames [defaultActiveYear] to [year] on <tui-calendar-month *tuiDropdown>',
         migrate({
             template: `
                 <tui-input-month


### PR DESCRIPTION
Part of #11917

## What was wrong

The previous `TuiInputMonth` migration had incorrect attribute routing:

- `[min]` / `[max]` were moved to `<input tuiInputMonth>`, but in v5 these inputs belong to `<tui-calendar-month>`
- `[defaultActiveYear]` was marked as "no equivalent" and generated a TODO comment — but in v5 it exists as `[year]` on `<tui-calendar-month>`
- `[disabledItemHandler]` was routed to the calendar, but its name was lowercased by the HTML parser (resulting in `[disableditemhandler]`)

## What was fixed

| v4 attribute | Before | After |
|---|---|---|
| `[min]`, `[max]` | → `<input tuiInputMonth>` ❌ | → `<tui-calendar-month *tuiDropdown>` ✅ |
| `[defaultActiveYear]` | → TODO comment ❌ | → `[year]` on `<tui-calendar-month *tuiDropdown>` ✅ |
| `[disabledItemHandler]` | → calendar (lowercased) ❌ | → calendar with correct casing ✅ |

All calendar-bound attributes now go through a rename map that preserves correct Angular binding casing.