### PR TITLE
chore(cdk): `InputTime` migration fix attributes

### DIFF
--- a/projects/cdk/schematics/ng-update/v5/steps/templates/migrate-input-time.ts
+++ b/projects/cdk/schematics/ng-update/v5/steps/templates/migrate-input-time.ts
@@ -2,6 +2,7 @@ import {type UpdateRecorder} from '@angular-devkit/schematics';
 import {type DevkitFileSystem} from 'ng-morph';
 import {type DefaultTreeAdapterTypes} from 'parse5';
 
+import {TODO_MARK} from '../../../../utils/insert-todo';
 import {findElementsByTagName} from '../../../../utils/templates/elements';
 import {
     getTemplateFromTemplateResource,
@@ -16,20 +17,26 @@ type ChildNode = DefaultTreeAdapterTypes.ChildNode;
 
 type Element = DefaultTreeAdapterTypes.Element;
 
+const DOCS_LINK = 'https://taiga-ui.dev/components/input-time';
+
 const INPUT_ATTR_RENAMES = new Map([
     ['[items]'.toLowerCase(), '[accept]'],
     ['[mode]'.toLowerCase(), '[mode]'],
     ['mode'.toLowerCase(), 'mode'],
 ]);
 
+// Silently dropped — no equivalent in v5
 const DROPPED_ATTRS = new Set([
-    '[disabledItemHandler]'.toLowerCase(),
-    '[itemsHidden]'.toLowerCase(),
     '[itemSize]'.toLowerCase(),
     '[strict]'.toLowerCase(),
-    'itemsHidden'.toLowerCase(),
     'itemSize'.toLowerCase(),
     'strict'.toLowerCase(),
+]);
+
+// Dropped but require a TODO comment pointing to the new dropdown pattern
+const TODO_DROPPED_ATTRS = new Set([
+    '[itemsHidden]'.toLowerCase(),
+    'itemsHidden'.toLowerCase(),
 ]);
 
 export function migrateInputTime({
@@ -69,7 +76,16 @@ export function migrateInputTime({
             DROPPED_ATTRS.has(attr.name.toLowerCase()),
         );
 
-        for (const attr of [...controlAttrs, ...inputAttrs, ...droppedAttrs]) {
+        const todoDroppedAttrs = [...element.attrs].filter((attr) =>
+            TODO_DROPPED_ATTRS.has(attr.name.toLowerCase()),
+        );
+
+        for (const attr of [
+            ...controlAttrs,
+            ...inputAttrs,
+            ...droppedAttrs,
+            ...todoDroppedAttrs,
+        ]) {
             const {startOffset = 0, endOffset = 0} =
                 element.sourceCodeLocation?.attrs?.[attr.name] ?? {};
 
@@ -90,6 +106,36 @@ export function migrateInputTime({
 
             recorder.insertRight(labelTextStart, '\n<label tuiLabel>');
             recorder.insertRight(labelTextEnd, '</label>\n');
+        }
+
+        // Build TODO notes for attrs that need manual follow-up
+        const todoNotes: string[] = [];
+        const hasItems = inputAttrs.some((attr) => attr.name.toLowerCase() === '[items]');
+        const itemsAttr = inputAttrs.find(
+            (attr) => attr.name.toLowerCase() === '[items]',
+        );
+
+        if (hasItems) {
+            todoNotes.push(
+                `[items] was renamed to [accept] on <input tuiInputTime>. For a dropdown list, also add <tui-data-list-wrapper *tuiDropdown [items]="${itemsAttr?.value ?? 'items'} | tuiFilterByInput: matcher" /> inside <tui-textfield>. See: ${DOCS_LINK}#dropdown-with--data-list`,
+            );
+        }
+
+        if (todoDroppedAttrs.length > 0) {
+            todoNotes.push(
+                `[itemsHidden] was removed. Dropdown visibility is now controlled by mounting/detaching <tui-data-list-wrapper *tuiDropdown> into/from DOM inside <tui-textfield>. See: ${DOCS_LINK}#dropdown-with--data-list`,
+            );
+        }
+
+        if (todoNotes.length > 0) {
+            const todoComment = [
+                `<!-- ${TODO_MARK} tui-input-time migration (see ${DOCS_LINK}):`,
+                ...todoNotes.map((n) => `     - ${n}`),
+                '-->',
+            ].join('\n');
+            const insertAt = (sourceCodeLocation?.startOffset ?? 0) + templateOffset;
+
+            recorder.insertLeft(insertAt, `${todoComment}\n`);
         }
 
         const insertOffset =

--- a/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-input-time.spec.ts.snap
+++ b/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-input-time.spec.ts.snap
@@ -1,5 +1,37 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`ng-update keeps [disabledItemHandler] on tui-textfield, adds TODO for [itemsHidden], silently removes strict and [itemSize]: test.html 1`] = `
+{
+  "0. Before": "
+                <tui-input-time
+                    formControlName="time"
+                    [strict]="true"
+                    [itemsHidden]="false"
+                    [itemSize]="'s'"
+                    [disabledItemHandler]="handler"
+                >
+                    Time
+                </tui-input-time>",
+  "1. After": "
+                <!-- TODO: (Taiga UI migration) tui-input-time migration (see https://taiga-ui.dev/components/input-time):
+     - [itemsHidden] was removed. Dropdown visibility is now controlled by mounting/detaching <tui-data-list-wrapper *tuiDropdown> into/from DOM inside <tui-textfield>. See: https://taiga-ui.dev/components/input-time#dropdown-with--data-list
+-->
+<tui-textfield
+                    
+                    
+                    
+                    
+                    [disabledItemHandler]="handler"
+                >
+<label tuiLabel>
+                    Time
+                </label>
+
+<input tuiInputTime formControlName="time" />
+</tui-textfield>",
+}
+`;
+
 exports[`ng-update migrate TuiInputTimeModule to TuiInputTime: test.html 1`] = `
 {
   "0. Before": "
@@ -116,7 +148,7 @@ exports[`ng-update moves [mode] to <input tuiInputTime>: test.html 1`] = `
 }
 `;
 
-exports[`ng-update renames [items] to [accept] on <input tuiInputTime>: test.html 1`] = `
+exports[`ng-update renames [items] to [accept] and adds TODO about data-list-wrapper: test.html 1`] = `
 {
   "0. Before": "
                 <tui-input-time
@@ -126,7 +158,10 @@ exports[`ng-update renames [items] to [accept] on <input tuiInputTime>: test.htm
                     Time
                 </tui-input-time>",
   "1. After": "
-                <tui-textfield
+                <!-- TODO: (Taiga UI migration) tui-input-time migration (see https://taiga-ui.dev/components/input-time):
+     - [items] was renamed to [accept] on <input tuiInputTime>. For a dropdown list, also add <tui-data-list-wrapper *tuiDropdown [items]="timeItems | tuiFilterByInput: matcher" /> inside <tui-textfield>. See: https://taiga-ui.dev/components/input-time#dropdown-with--data-list
+-->
+<tui-textfield
                     
                     
                 >
@@ -135,35 +170,6 @@ exports[`ng-update renames [items] to [accept] on <input tuiInputTime>: test.htm
                 </label>
 
 <input tuiInputTime formControlName="time" [accept]="timeItems" />
-</tui-textfield>",
-}
-`;
-
-exports[`ng-update silently removes strict, itemsHidden, [itemSize], [disabledItemHandler]: test.html 1`] = `
-{
-  "0. Before": "
-                <tui-input-time
-                    formControlName="time"
-                    [strict]="true"
-                    [itemsHidden]="false"
-                    [itemSize]="'s'"
-                    [disabledItemHandler]="handler"
-                >
-                    Time
-                </tui-input-time>",
-  "1. After": "
-                <tui-textfield
-                    
-                    
-                    
-                    
-                    
-                >
-<label tuiLabel>
-                    Time
-                </label>
-
-<input tuiInputTime formControlName="time" />
 </tui-textfield>",
 }
 `;

--- a/projects/cdk/schematics/ng-update/v5/tests/schematic-migrate-input-time.spec.ts
+++ b/projects/cdk/schematics/ng-update/v5/tests/schematic-migrate-input-time.spec.ts
@@ -63,7 +63,7 @@ describe('ng-update', () => {
     );
 
     it(
-        'renames [items] to [accept] on <input tuiInputTime>',
+        'renames [items] to [accept] and adds TODO about data-list-wrapper',
         migrate({
             template: `
                 <tui-input-time
@@ -76,7 +76,7 @@ describe('ng-update', () => {
     );
 
     it(
-        'silently removes strict, itemsHidden, [itemSize], [disabledItemHandler]',
+        'keeps [disabledItemHandler] on tui-textfield, adds TODO for [itemsHidden], silently removes strict and [itemSize]',
         migrate({
             template: `
                 <tui-input-time


### PR DESCRIPTION
Part of #11917

## What was wrong

The previous `TuiInputTime` migration had three issues with dropdown-related attributes:

1. **`[items]`** — renamed to `[accept]` on `<input tuiInputTime>`, but the full dropdown pattern also requires `<tui-data-list-wrapper *tuiDropdown>` inside `<tui-textfield>`. Migration gave no hint about this.
2. **`[disabledItemHandler]`** — was silently removed, but it should stay on `<tui-textfield>` (it is a valid input of the new wrapper component via `TuiWithItemsHandlers`).
3. **`[itemsHidden]`** — was silently removed with no guidance, but visibility is now controlled by mounting/detaching `*tuiDropdown` from the DOM.

## What was fixed

| v4 attribute | Before | After |
|---|---|---|
| `[items]` | → `[accept]` on `<input tuiInputTime>` (no further hint) | → `[accept]` on `<input tuiInputTime>` + TODO about `<tui-data-list-wrapper *tuiDropdown>` ✅ |
| `[disabledItemHandler]` | silently removed ❌ | stays on `<tui-textfield>` ✅ |
| `[itemsHidden]` | silently removed ❌ | removed + TODO about `*tuiDropdown` visibility ✅ |
| `[strict]`, `[itemSize]` | silently removed ✅ | unchanged |
| `[mode]` | → `<input tuiInputTime>` ✅ | unchanged |

**Example TODO generated for `[items]`:**
```html
<!-- TODO: (Taiga UI migration) tui-input-time migration (...):
     - [items] was renamed to [accept] on <input tuiInputTime>.
       For a dropdown list, also add
       <tui-data-list-wrapper *tuiDropdown [items]="timeItems | tuiFilterByInput: matcher" />
       inside <tui-textfield>. See: .../input-time#dropdown-with--data-list
-->
```

**Example TODO generated for `[itemsHidden]`:**
```html
<!-- TODO: (Taiga UI migration) tui-input-time migration (...):
     - [itemsHidden] was removed. Dropdown visibility is now controlled by
       mounting/detaching <tui-data-list-wrapper *tuiDropdown> into/from DOM
       inside <tui-textfield>. See: .../input-time#dropdown-with--data-list
-->
```