### PR TITLE
chore(cdk): `InputDate` migration fix attributes

### DIFF
--- a/projects/cdk/schematics/ng-update/v5/steps/templates/migrate-input-date.ts
+++ b/projects/cdk/schematics/ng-update/v5/steps/templates/migrate-input-date.ts
@@ -26,16 +26,14 @@ const INPUT_ATTRS = new Set([
     'min'.toLowerCase(),
 ]);
 
-const CALENDAR_ATTRS = new Set([
-    '[disabledItemHandler]'.toLowerCase(),
-    '[markerHandler]'.toLowerCase(),
+const CALENDAR_ATTR_RENAMES = new Map([
+    ['[defaultActiveYearMonth]'.toLowerCase(), '[month]'],
+    ['[disabledItemHandler]'.toLowerCase(), '[disabledItemHandler]'],
+    ['[markerHandler]'.toLowerCase(), '[markerHandler]'],
+    ['defaultActiveYearMonth'.toLowerCase(), 'month'],
 ]);
 
-const NO_EQUIVALENT_ATTRS = new Set([
-    '[defaultActiveYearMonth]'.toLowerCase(),
-    '[items]'.toLowerCase(),
-    'defaultActiveYearMonth'.toLowerCase(),
-]);
+const NO_EQUIVALENT_ATTRS = new Set(['[items]'.toLowerCase()]);
 
 export function migrateInputDate({
     resource,
@@ -76,7 +74,7 @@ export function migrateInputDate({
         );
 
         const calendarAttrs = [...element.attrs].filter((attr) =>
-            CALENDAR_ATTRS.has(attr.name.toLowerCase()),
+            CALENDAR_ATTR_RENAMES.has(attr.name.toLowerCase()),
         );
 
         const noEquivalentAttrs = [...element.attrs].filter((attr) =>
@@ -112,10 +110,10 @@ export function migrateInputDate({
         }
 
         if (noEquivalentAttrs.length > 0) {
-            const names = noEquivalentAttrs.map((a) => a.name).join(', ');
             const todoComment = [
                 `<!-- ${TODO_MARK} tui-input-date migration (see ${DOCS_LINK}):`,
-                `     - ${names}: no direct equivalent in v5. Remove and update component logic. -->`,
+                '     - [items]: TuiNamedDay type is removed in v5. Use <datalist> + <section *tuiDropdown>',
+                `       for named dates. See example: ${DOCS_LINK}#datalist -->`,
             ].join('\n');
             const insertAt = (sourceCodeLocation?.startOffset ?? 0) + templateOffset;
 
@@ -136,9 +134,9 @@ export function migrateInputDate({
         }, '');
 
         const calendarAttrStr = calendarAttrs.reduce((result, attr) => {
-            return attr.value
-                ? `${result} ${attr.name}="${attr.value}"`
-                : `${result} ${attr.name}`;
+            const name = CALENDAR_ATTR_RENAMES.get(attr.name.toLowerCase()) ?? attr.name;
+
+            return attr.value ? `${result} ${name}="${attr.value}"` : `${result} ${name}`;
         }, '');
 
         if (!inputs.length) {
@@ -178,6 +176,10 @@ function normalizeAttrName(name: string): string {
     switch (name.toLowerCase()) {
         case '[formControl]'.toLowerCase():
             return '[formControl]';
+        case '[max]'.toLowerCase():
+            return '[max]';
+        case '[min]'.toLowerCase():
+            return '[min]';
         case '[ngModel]'.toLowerCase():
             return '[ngModel]';
         case 'formControl'.toLowerCase():

--- a/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-input-date.spec.ts.snap
+++ b/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-input-date.spec.ts.snap
@@ -1,20 +1,19 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`ng-update adds TODO for [items] and [defaultActiveYearMonth]: test.html 1`] = `
+exports[`ng-update adds TODO for [items] (no v5 equivalent): test.html 1`] = `
 {
   "0. Before": "
                 <tui-input-date
                     [items]="namedDays"
-                    [defaultActiveYearMonth]="initialMonth"
                     formControlName="date"
                 >
                     Date
                 </tui-input-date>",
   "1. After": "
                 <!-- TODO: (Taiga UI migration) tui-input-date migration (see https://taiga-ui.dev/components/input-date):
-     - [items], [defaultactiveyearmonth]: no direct equivalent in v5. Remove and update component logic. -->
+     - [items]: TuiNamedDay type is removed in v5. Use <datalist> + <section *tuiDropdown>
+       for named dates. See example: https://taiga-ui.dev/components/input-date#datalist -->
 <tui-textfield
-                    
                     
                     
                 >
@@ -147,7 +146,7 @@ exports[`ng-update moves [disabledItemHandler] and [markerHandler] to <tui-calen
                 </label>
 
 <input tuiInputDate formControlName="date" />
-<tui-calendar *tuiDropdown [disableditemhandler]="disabledHandler" [markerhandler]="markerHandler" />
+<tui-calendar *tuiDropdown [disabledItemHandler]="disabledHandler" [markerHandler]="markerHandler" />
 </tui-textfield>",
 }
 `;
@@ -174,6 +173,30 @@ exports[`ng-update moves [min] and [max] to <input tuiInputDate>: test.html 1`] 
 
 <input tuiInputDate formControlName="date" [min]="minDate" [max]="maxDate" />
 <tui-calendar *tuiDropdown />
+</tui-textfield>",
+}
+`;
+
+exports[`ng-update renames [defaultActiveYearMonth] to [month] on <tui-calendar *tuiDropdown>: test.html 1`] = `
+{
+  "0. Before": "
+                <tui-input-date
+                    [defaultActiveYearMonth]="initialMonth"
+                    formControlName="date"
+                >
+                    Date
+                </tui-input-date>",
+  "1. After": "
+                <tui-textfield
+                    
+                    
+                >
+<label tuiLabel>
+                    Date
+                </label>
+
+<input tuiInputDate formControlName="date" />
+<tui-calendar *tuiDropdown [month]="initialMonth" />
 </tui-textfield>",
 }
 `;

--- a/projects/cdk/schematics/ng-update/v5/tests/schematic-migrate-input-date.spec.ts
+++ b/projects/cdk/schematics/ng-update/v5/tests/schematic-migrate-input-date.spec.ts
@@ -78,11 +78,23 @@ describe('ng-update', () => {
     );
 
     it(
-        'adds TODO for [items] and [defaultActiveYearMonth]',
+        'adds TODO for [items] (no v5 equivalent)',
         migrate({
             template: `
                 <tui-input-date
                     [items]="namedDays"
+                    formControlName="date"
+                >
+                    Date
+                </tui-input-date>`,
+        }),
+    );
+
+    it(
+        'renames [defaultActiveYearMonth] to [month] on <tui-calendar *tuiDropdown>',
+        migrate({
+            template: `
+                <tui-input-date
                     [defaultActiveYearMonth]="initialMonth"
                     formControlName="date"
                 >


### PR DESCRIPTION
Part of #11917

## What was wrong

The previous `TuiInputDate` migration had two issues:

- `[defaultActiveYearMonth]` was marked as "no equivalent" and generated a TODO comment — but in v5 it exists as `[month]` on `<tui-calendar *tuiDropdown>`
- `[disabledItemHandler]` and `[markerHandler]` were routed to the calendar but their names were lowercased by the HTML parser

## What was fixed

| v4 attribute | Before | After |
|---|---|---|
| `[defaultActiveYearMonth]` | → TODO comment ❌ | → `[month]` on `<tui-calendar *tuiDropdown>` ✅ |
| `[disabledItemHandler]`, `[markerHandler]` | → calendar (lowercased) ❌ | → calendar with correct casing ✅ |
| `[items]` (`TuiNamedDay[]`) | → TODO ✅ | TODO improved with link to `#datalist` example ✅ |

All calendar-bound attributes now go through a rename map that preserves correct Angular binding casing.