### PR TITLE
feat(addon-doc): defer syntax highlighting until browser idle 

### DIFF
--- a/projects/addon-doc/components/example/example.template.html
+++ b/projects/addon-doc/components/example/example.template.html
@@ -97,16 +97,18 @@
                     </section>
                 }
                 @let code = processor()[tabs[$index] || 0] || '';
-                <tui-doc-code
-                    [code]="code"
-                    [style.display]="activeItemIndex === $index && ($index || !preview()) ? 'block' : 'none'"
-                >
-                    @for (action of codeActions; track action) {
-                        <ng-container *polymorpheusOutlet="action as text; context: {$implicit: code}">
-                            {{ text }}
-                        </ng-container>
-                    }
-                </tui-doc-code>
+                @defer (on idle) {
+                    <tui-doc-code
+                        [code]="code"
+                        [style.display]="activeItemIndex === $index && ($index || !preview()) ? 'block' : 'none'"
+                    >
+                        @for (action of codeActions; track action) {
+                            <ng-container *polymorpheusOutlet="action as text; context: {$implicit: code}">
+                                {{ text }}
+                            </ng-container>
+                        }
+                    </tui-doc-code>
+                }
             </div>
         } @empty {
             <div class="t-content">


### PR DESCRIPTION
### Before

<img width="935" height="747" alt="image" src="https://github.com/user-attachments/assets/ca08e220-a8d3-4463-82fd-7e0dbe0bd506" />

Total Block time: 1,000 ms

### After

<img width="946" height="738" alt="image" src="https://github.com/user-attachments/assets/85e101a9-f939-473f-a3a6-04e5fc4f5711" />

Total Block time: 510 ms
