### PR TITLE
fix(core): `tuiDropdownHover` closes immediately when hovered and clicked simultaneously

### DIFF
--- a/projects/core/portals/dropdown/dropdown-hover.directive.ts
+++ b/projects/core/portals/dropdown/dropdown-hover.directive.ts
@@ -12,6 +12,7 @@ import {tuiAsDriver, TuiDriver} from '@taiga-ui/core/classes';
 import {
     delay,
     distinctUntilChanged,
+    EMPTY,
     filter,
     fromEvent,
     map,
@@ -69,6 +70,7 @@ export class TuiDropdownHover extends TuiDriver {
         switchMap((v) =>
             of(v).pipe(
                 delay(v ? this.tuiDropdownShowDelay() : this.tuiDropdownHideDelay()),
+                takeUntil(this.open ? fromEvent(this.el, 'pointerdown') : EMPTY),
             ),
         ),
         tuiZoneOptimized(),

--- a/projects/demo-playwright/tests/kit/dropdown-hover/dropdown-hover.pw.spec.ts
+++ b/projects/demo-playwright/tests/kit/dropdown-hover/dropdown-hover.pw.spec.ts
@@ -8,6 +8,47 @@ test.describe('DropdownHover', () => {
     test.describe('Examples', () => {
         test.beforeEach(async ({page}) => tuiGoto(page, DemoRoute.DropdownHover));
 
+        test.describe('With DropdownOpen', () => {
+            let example!: Locator;
+
+            test.beforeEach(async ({page}) => {
+                example = new TuiDocumentationPagePO(page).getExample(
+                    '#with--dropdown-open',
+                );
+
+                await example.scrollIntoViewIfNeeded();
+            });
+
+            test('opens dropdown after hover and hide after click', async ({page}) => {
+                const button = example.locator('button', {hasText: 'Hoverable'});
+                const dropdown = page.locator('tui-dropdown');
+
+                await button.hover();
+                await page.waitForTimeout(300);
+                await expect(dropdown).toBeAttached();
+
+                await button.click();
+                await expect(dropdown).not.toBeAttached();
+            });
+
+            test('opens dropdown after hover and instantly click', async ({page}) => {
+                const button = example.locator('button', {hasText: 'Hoverable'});
+                const dropdown = page.locator('tui-dropdown');
+
+                await button.evaluate((el) => {
+                    el.dispatchEvent(new MouseEvent('mouseover', {bubbles: true}));
+                    el.dispatchEvent(new PointerEvent('pointerdown', {bubbles: true}));
+                    el.dispatchEvent(new MouseEvent('click', {bubbles: true}));
+                });
+
+                await expect(dropdown).toBeAttached();
+
+                await page.waitForTimeout(300);
+                await button.click();
+                await expect(dropdown).not.toBeAttached();
+            });
+        });
+
         test.describe('With DropdownMobile', () => {
             let example!: Locator;
             let po!: TuiDocumentationPagePO;


### PR DESCRIPTION

Fixes https://github.com/taiga-family/taiga-ui/issues/13434