### PR TITLE
chore(demo): improve API page for `ProgressSegmented` documentation

### DIFF
--- a/projects/demo/src/pages/directives/progress-segmented/index.ts
+++ b/projects/demo/src/pages/directives/progress-segmented/index.ts
@@ -34,7 +34,8 @@ export default class Page {
         ['#39b54a', '#ffd450', '#ffd450', '#fcc521', '#fab619', '#f8a34d', '#e01f19'],
         Array.from(
             {length: 20},
-            (_, index) => `var(--tui-chart-categorical-0${index + 1})`,
+            (_, index) =>
+                `var(--tui-chart-categorical-${String(index + 1).padStart(2, '0')})`,
         ),
     ];
 


### PR DESCRIPTION
https://taiga-ui.dev/next/components/progress-segmented/API?tuiProgressColorSegments$=2&segments=10&value=7&max=10

### Previous behavior
<img width="525" height="231" alt="previous" src="https://github.com/user-attachments/assets/44d8e174-01c8-40e6-8ba3-1c0a4ad2beac" />

### New behavior
<img width="525" height="231" alt="new" src="https://github.com/user-attachments/assets/5267274c-766b-443f-a14a-b2d44437a6bb" />


### Why
<img width="1154" height="346" alt="why" src="https://github.com/user-attachments/assets/d02c2f97-af4c-4224-9226-b417dc8debfa" />
