### PR TITLE
chore(cdk): `Input` migration add migrateAttrValue for correct attrs migration

### DIFF
--- a/projects/cdk/schematics/ng-update/v5/steps/templates/migrate-input.ts
+++ b/projects/cdk/schematics/ng-update/v5/steps/templates/migrate-input.ts
@@ -4,6 +4,7 @@ import {type DefaultTreeAdapterTypes} from 'parse5';
 
 import {TODO_MARK} from '../../../../utils/insert-todo';
 import {findElementsByTagName} from '../../../../utils/templates/elements';
+import {migrateAttrValue} from '../../../../utils/templates/migrate-attr-value';
 import {
     getTemplateFromTemplateResource,
     getTemplateOffset,
@@ -181,10 +182,18 @@ function buildReplacement(
 
         if (TEXTFIELD_WRAPPER_ATTRS.has(nameLower) || isDropdownAttr(nameLower)) {
             const original = getOriginalAttrText(template, element, nameLower);
+            const migratedValue = migrateAttrValue(nameLower, attr.value);
+            let attrText: string;
 
-            textfieldAttrs.push(
-                original ?? (attr.value ? `${attr.name}="${attr.value}"` : attr.name),
-            );
+            if (original) {
+                attrText = original.replace(`="${attr.value}"`, `="${migratedValue}"`);
+            } else if (attr.value) {
+                attrText = `${attr.name}="${migratedValue}"`;
+            } else {
+                attrText = attr.name;
+            }
+
+            textfieldAttrs.push(attrText);
             continue;
         }
 

--- a/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-input.spec.ts.snap
+++ b/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-input.spec.ts.snap
@@ -106,6 +106,26 @@ exports[`ng-update legacy input migrates tui-input wrapper attrs and routes them
 }
 `;
 
+exports[`ng-update legacy input migrates tuiHintDirection value alongside wrapper attrs: test.html 1`] = `
+{
+  "0. Before": "
+                <tui-input
+                    formControlName="value"
+                    tuiHintContent="Hint"
+                    tuiHintDirection="bottom-right"
+                >
+                    Label
+                </tui-input>
+            ",
+  "1. After": "
+                <tui-textfield tuiHintContent="Hint" tuiHintDirection="bottom-end">
+                <label tuiLabel>Label</label>
+                <input tuiInput formControlName="value" />
+                </tui-textfield>
+            ",
+}
+`;
+
 exports[`ng-update legacy input places unrecognized attributes on <tui-textfield> with TODO per attr: test.html 1`] = `
 {
   "0. Before": "<tui-input formControlName="value" someCustomDir [anotherDir]="config">Label</tui-input>",

--- a/projects/cdk/schematics/ng-update/v5/tests/schematic-migrate-input.spec.ts
+++ b/projects/cdk/schematics/ng-update/v5/tests/schematic-migrate-input.spec.ts
@@ -141,6 +141,21 @@ describe('ng-update legacy input', () => {
     );
 
     it(
+        'migrates tuiHintDirection value alongside wrapper attrs',
+        migrate({
+            template: /* HTML */ `
+                <tui-input
+                    formControlName="value"
+                    tuiHintContent="Hint"
+                    tuiHintDirection="bottom-right"
+                >
+                    Label
+                </tui-input>
+            `,
+        }),
+    );
+
+    it(
         'migrates multiple tui-input elements in one template',
         migrate({
             template: /* HTML */ `


### PR DESCRIPTION
Part of https://github.com/taiga-family/taiga-ui/issues/11917
