### PR TITLE
fix(kit): `tuiConnected` vertical line gap on android/ios

### DIFF
--- a/projects/kit/directives/connected/connected.style.less
+++ b/projects/kit/directives/connected/connected.style.less
@@ -11,7 +11,7 @@
     &[tuiCardLarge] {
         &[data-space] [tuiCell] {
             padding: 1rem;
-            margin: -1rem -1rem -0.5rem;
+            margin: -1rem -1rem calc(1rem - var(--t-space));
 
             &:last-of-type {
                 margin-block-end: -1rem;


### PR DESCRIPTION
Fixes # <!-- link to a relevant issue. -->
