### PR TITLE
fix(core): `ModalService` throws SSR error `TypeError: el?.getAnimations is not a function`

### DIFF
--- a/projects/core/portals/modal/modal.service.ts
+++ b/projects/core/portals/modal/modal.service.ts
@@ -36,5 +36,5 @@ export abstract class TuiModalService<T, K = void> extends TuiPortal<T, K> {
 }
 
 function getAnimations(el: Element | null): ReadonlyArray<Promise<unknown>> {
-    return el?.getAnimations().map(async ({finished}) => finished) || [];
+    return el?.getAnimations?.().map(async ({finished}) => finished) || [];
 }


### PR DESCRIPTION
Similar to this line
https://github.com/taiga-family/taiga-ui/blob/c7b505f7b776dfa0a38c7c569ea9877dcd07a6b5/projects/cdk/directives/animated/animated.directive.ts#L38
