### PR TITLE
fix(addon-doc): `DocExample` has hydration problems

### DIFF
--- a/projects/addon-doc/components/example/example.style.less
+++ b/projects/addon-doc/components/example/example.style.less
@@ -43,10 +43,6 @@
     }
 }
 
-.t-description {
-    margin-block-start: 0.5rem;
-}
-
 .t-example {
     position: relative;
     border: 0.25rem solid var(--tui-background-base-alt);

--- a/projects/addon-doc/components/example/example.template.html
+++ b/projects/addon-doc/components/example/example.template.html
@@ -20,7 +20,7 @@
     </header>
 
     @if (description()) {
-        <div class="t-description">
+        <div tuiDescription>
             <ng-container *polymorpheusOutlet="description() as text">
                 {{ text }}
             </ng-container>


### PR DESCRIPTION
Fixes #13732

```
ERROR RuntimeError: NG0500: During hydration Angular expected a comment node but found <p>.

Angular expected this DOM:

<hgroup _ngcontent-ng-c4199146294="" tuititle="" data-tui-version="5.0.0" ng-reflect-tui-title="">
  …
  <h3>…</h3>
  <!-- container -->  <-- AT THIS LOCATION
  …
</hgroup>

Actual DOM is:

<hgroup _ngcontent-ng-c4199146294="" tuititle="" data-tui-version="5.0.0" ng-reflect-tui-title="">
  …
  <p _ngcontent-ng-c4199146294="">…</p>
  <p>…</p>  <-- AT THIS LOCATION
  …
</hgroup>

Note: attributes are only displayed to better represent the DOM but have no effect on hydration mismatches.

To fix this problem:
  * check the "_TuiDocExample" component for hydration-related issues
  * check to see if your template has valid HTML structure <--------------------------------- [our case]
  * or skip hydration by adding the `ngSkipHydration` attribute to its host node in a template
```

The root cause was invalid HTML nesting in
https://github.com/taiga-family/taiga-ui/blob/671f85792b7807489ddd2c06e7810feccd865cb7/projects/addon-doc/components/example/example.template.html#L20-L21

The `<p>` tag wrapped a `polymorpheusOutlet` that could render block-level elements (like `<div tuiNotification>`). Per HTML spec, `<p>` cannot contain block-level elements — the browser auto-closes the `<p>` when it encounters one, restructuring the DOM. This caused the server-rendered DOM to differ from the browser-parsed DOM, triggering Angular's NG0500 hydration mismatch error.
