### PR TITLE
chore: add CLAUDE.md as symlink to AGENTS.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,4 +40,3 @@ migrations.json
 blob-report
 .cursor/rules/nx-rules.mdc
 .github/instructions/nx.instructions.md
-CLAUDE.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md


### PR DESCRIPTION
Claude Code reads only CLAUDE.md for project-level instructions, while other AI tools (OpenAI Codex, Gemini CLI, etc.) rely on AGENTS.md. A symlink keeps a single source of truth: contributors maintain one file and every AI assistant picks it up without duplication or drift.
