### PR TITLE
[WIP] chore(demo-playwright): `tuiGoto` utility should wait until hydration is over

### DIFF
--- a/projects/addon-table/components/table/tr/tr.template.html
+++ b/projects/addon-table/components/table/tr/tr.template.html
@@ -1,12 +1,12 @@
 @if (items(); as items) {
     @for (key of table.columns(); track key) {
-        <ng-container [ngTemplateOutlet]="(items[key] && items[key].template) || plain" />
-
-        <ng-template #plain>
-            <td tuiTd>
-                {{ item()[key] }}
-            </td>
-        </ng-template>
+        <ng-container [ngTemplateOutlet]="(items[key] && items[key].template) || plain">
+            <ng-template #plain>
+                <td tuiTd>
+                    {{ item()[key] }}
+                </td>
+            </ng-template>
+        </ng-container>
     }
 } @else {
     <td></td>

--- a/projects/demo-playwright/tests/addon-doc/viewport.pw.spec.ts
+++ b/projects/demo-playwright/tests/addon-doc/viewport.pw.spec.ts
@@ -18,11 +18,9 @@ test.describe('Viewport', () => {
             await tuiGoto(page, DemoRoute.Breakpoints, {hideHeader: true});
             const example = new TuiDocumentationPagePO(page).getExample('#usage');
 
-            await expect
-                .soft(example)
-                .toHaveScreenshot(
-                    `01-0${index + 1}-breakpoints-${width}-${height}-viewport.png`,
-                );
+            await expect(example).toHaveScreenshot(
+                `01-0${index + 1}-breakpoints-${width}-${height}-viewport.png`,
+            );
         });
     });
 });

--- a/projects/demo-playwright/utils/goto.ts
+++ b/projects/demo-playwright/utils/goto.ts
@@ -70,6 +70,8 @@ export async function tuiGoto(
     await page.waitForLoadState('domcontentloaded');
     await page.waitForLoadState('load');
     await expect(app).toBeAttached();
+    // Ensure hydration is finished
+    await expect(app.locator('[ngh]')).toHaveCount(0);
 
     await waitIcons({
         page,


### PR DESCRIPTION
## Problem
We have PW test for this documentation page
https://github.com/taiga-family/taiga-ui/blob/e16f116d476d861120395139ebd4c4a9e31fe3b3/projects/demo-playwright/tests/addon-doc/viewport.pw.spec.ts#L18

But this page was actually broken
* https://github.com/taiga-family/taiga-ui/pull/13791

## Why ?
Tests made snapshot before hydration is over (prerendered page from server)