### PR TITLE
fix(core): expose dropdown hover state via public getter

### DIFF
--- a/projects/core/portals/dropdown/dropdown-hover.directive.ts
+++ b/projects/core/portals/dropdown/dropdown-hover.directive.ts
@@ -5,9 +5,9 @@ import {
     ElementRef,
     inject,
     input,
+    type Signal,
     signal,
-    Signal,
-    WritableSignal,
+    type WritableSignal,
 } from '@angular/core';
 import {toObservable} from '@angular/core/rxjs-interop';
 import {TuiActiveZone} from '@taiga-ui/cdk/directives/active-zone';
@@ -49,12 +49,12 @@ export class TuiDropdownHover extends TuiDriver {
         read: ElementRef,
     });
 
-    public readonly hovered: Signal<boolean> = signal(false);
     private readonly el = tuiInjectElement();
     private readonly doc = inject(DOCUMENT);
     private readonly options = inject(TUI_DROPDOWN_HOVER_OPTIONS);
     private readonly activeZone = inject(TuiActiveZone);
     private readonly open = inject(TuiDropdownOpen, {optional: true});
+
     private readonly stream$ = merge(
         /**
          * Dropdown can be removed not only via click/touch –
@@ -90,6 +90,7 @@ export class TuiDropdownHover extends TuiDriver {
         share(),
     );
 
+    public readonly hovered: Signal<boolean> = signal(false);
     public readonly tuiDropdownShowDelay = input(this.options.showDelay);
     public readonly tuiDropdownHideDelay = input(this.options.hideDelay);
     public readonly type = 'dropdown';

--- a/projects/core/portals/dropdown/dropdown-hover.directive.ts
+++ b/projects/core/portals/dropdown/dropdown-hover.directive.ts
@@ -41,6 +41,9 @@ export class TuiDropdownHover extends TuiDriver {
     });
 
     private hovered = false;
+    public get hoveredState(): boolean {
+        return this.hovered;
+    }
     private readonly el = tuiInjectElement();
     private readonly doc = inject(DOCUMENT);
     private readonly options = inject(TUI_DROPDOWN_HOVER_OPTIONS);

--- a/projects/core/portals/dropdown/dropdown-hover.directive.ts
+++ b/projects/core/portals/dropdown/dropdown-hover.directive.ts
@@ -1,5 +1,14 @@
 import {DOCUMENT} from '@angular/common';
-import {contentChild, Directive, ElementRef, inject, input} from '@angular/core';
+import {
+    contentChild,
+    Directive,
+    ElementRef,
+    inject,
+    input,
+    signal,
+    Signal,
+    WritableSignal,
+} from '@angular/core';
 import {toObservable} from '@angular/core/rxjs-interop';
 import {TuiActiveZone} from '@taiga-ui/cdk/directives/active-zone';
 import {tuiTypedFromEvent, tuiZoneOptimized} from '@taiga-ui/cdk/observables';
@@ -40,10 +49,7 @@ export class TuiDropdownHover extends TuiDriver {
         read: ElementRef,
     });
 
-    private hovered = false;
-    public get hoveredState(): boolean {
-        return this.hovered;
-    }
+    public readonly hovered: Signal<boolean> = signal(false);
     private readonly el = tuiInjectElement();
     private readonly doc = inject(DOCUMENT);
     private readonly options = inject(TUI_DROPDOWN_HOVER_OPTIONS);
@@ -55,7 +61,7 @@ export class TuiDropdownHover extends TuiDriver {
          * swipe on mobile devices removes dropdown sheet without triggering new mouseover / mouseout events.
          */
         toObservable(inject(TuiDropdownDirective).ref).pipe(
-            filter((x) => !x && this.hovered),
+            filter((x) => !x && this.hovered()),
             switchMap(() =>
                 tuiTypedFromEvent(this.doc, 'pointerdown').pipe(
                     map(tuiGetActualTarget),
@@ -78,7 +84,7 @@ export class TuiDropdownHover extends TuiDriver {
         ),
         tuiZoneOptimized(),
         tap((hovered) => {
-            this.hovered = hovered;
+            (this.hovered as WritableSignal<boolean>).set(hovered);
             this.open?.toggle(hovered);
         }),
         share(),
@@ -93,7 +99,7 @@ export class TuiDropdownHover extends TuiDriver {
     }
 
     protected onClick(event: MouseEvent): void {
-        if (this.hovered && this.open) {
+        if (this.hovered() && this.open) {
             event.preventDefault();
         }
     }


### PR DESCRIPTION
Fixes #13714 

 Exposed the hover state via a public getter to make it accessible externally.
