### PR TITLE
chore(schematics): migration for `[tuiHintContent]` on legacy textfield controls

### DIFF
--- a/projects/cdk/schematics/ng-update/v5/steps/constants/attr-with-values-to-replace.ts
+++ b/projects/cdk/schematics/ng-update/v5/steps/constants/attr-with-values-to-replace.ts
@@ -4,6 +4,10 @@ import {
 } from '../../../../utils/templates/elements';
 import {type ReplacementAttributeValue} from '../../../interfaces';
 
+function hasNoHintContent(el: Parameters<typeof hasElementAttribute>[0]): boolean {
+    return !hasElementAttribute(el, 'tuiHintContent');
+}
+
 export const ATTR_WITH_VALUES_TO_REPLACE: ReplacementAttributeValue[] = [
     {
         attrNames: ['[pseudo]'],
@@ -37,6 +41,7 @@ export const ATTR_WITH_VALUES_TO_REPLACE: ReplacementAttributeValue[] = [
     },
     {
         attrNames: ['tuiHintDirection'],
+        filterFn: hasNoHintContent,
         valueReplacer: [
             {from: 'bottom-left', to: 'bottom-start'},
             {from: 'bottom-right', to: 'bottom-end'},
@@ -52,6 +57,7 @@ export const ATTR_WITH_VALUES_TO_REPLACE: ReplacementAttributeValue[] = [
     },
     {
         attrNames: ['[tuiHintDirection]'],
+        filterFn: hasNoHintContent,
         valueReplacer: [
             {from: "'bottom-left'", to: "'bottom-start'"},
             {from: "'bottom-right'", to: "'bottom-end'"},

--- a/projects/cdk/schematics/ng-update/v5/steps/migrate-templates.ts
+++ b/projects/cdk/schematics/ng-update/v5/steps/migrate-templates.ts
@@ -39,6 +39,7 @@ import {migrateCloseable} from './templates/migrate-closeable';
 import {migrateComboBox} from './templates/migrate-combo-box';
 import {migrateFieldError} from './templates/migrate-field-error';
 import {migrateFormatPhonePipe} from './templates/migrate-format-phone-pipe';
+import {migrateHintOnLegacyControls} from './templates/migrate-hint-on-legacy-controls';
 import {migrateInput} from './templates/migrate-input';
 import {migrateInputDate} from './templates/migrate-input-date';
 import {migrateInputDateMulti} from './templates/migrate-input-date-multi';
@@ -131,6 +132,7 @@ export function migrateTemplates(fileSystem: DevkitFileSystem, options: TuiSchem
         migrateSidebar,
         migrateFormatPhonePipe,
         ...(hasProprietaryPackage ? [migrateProprietaryTextfieldIcons] : []),
+        migrateHintOnLegacyControls,
         migrateInput,
         migrateTextarea,
     ] as const;

--- a/projects/cdk/schematics/ng-update/v5/steps/templates/migrate-hint-on-legacy-controls.ts
+++ b/projects/cdk/schematics/ng-update/v5/steps/templates/migrate-hint-on-legacy-controls.ts
@@ -1,0 +1,291 @@
+import {type UpdateRecorder} from '@angular-devkit/schematics';
+import {type DevkitFileSystem} from 'ng-morph';
+import {type DefaultTreeAdapterTypes} from 'parse5';
+
+import {addImportToClosestModule} from '../../../../utils/add-import-to-closest-module';
+import {findElementsInTemplateByFn} from '../../../../utils/templates/elements';
+import {migrateAttrValue} from '../../../../utils/templates/migrate-attr-value';
+import {
+    getTemplateFromTemplateResource,
+    getTemplateOffset,
+} from '../../../../utils/templates/template-resource';
+import {type TemplateResource} from '../../../interfaces/template-resource';
+import {buildTuiInputReplacement} from './migrate-input';
+import {buildTuiTextareaReplacement} from './migrate-textarea';
+
+type Element = DefaultTreeAdapterTypes.Element;
+
+/** Legacy controls that contain tuiHintContent and need migration. */
+const LEGACY_CONTROLS = new Set([
+    'tui-combo-box',
+    'tui-input',
+    'tui-input-date',
+    'tui-input-date-range',
+    'tui-input-number',
+    'tui-input-phone',
+    'tui-input-tag',
+    'tui-input-time',
+    'tui-multi-select',
+    'tui-select',
+    'tui-textarea',
+]);
+
+const HINT_ATTR_NAMES = [
+    '[tuiHintAppearance]',
+    '[tuiHintContent]',
+    '[tuiHintDirection]',
+    'tuiHintAppearance',
+    'tuiHintContent',
+    'tuiHintDirection',
+];
+
+function hasHintContent(element: Element): boolean {
+    return element.attrs.some((attr) => {
+        const lower = attr.name.toLowerCase();
+
+        return (
+            lower === 'tuiHintContent'.toLowerCase() ||
+            lower === '[tuiHintContent]'.toLowerCase()
+        );
+    });
+}
+
+function getOriginalAttrText(
+    template: string,
+    element: Element,
+    attrNameLower: string,
+): string | null {
+    const attrLoc = element.sourceCodeLocation?.attrs?.[attrNameLower];
+
+    if (!attrLoc) {
+        return null;
+    }
+
+    return template.slice(attrLoc.startOffset, attrLoc.endOffset);
+}
+
+export function buildTuiIconStr(element: Element, template: string): string {
+    const contentAttr = element.attrs.find((a) => {
+        const lower = a.name.toLowerCase();
+
+        return (
+            lower === '[tuiHintContent]'.toLowerCase() ||
+            lower === 'tuiHintContent'.toLowerCase()
+        );
+    });
+
+    if (!contentAttr) {
+        return '';
+    }
+
+    const isBinding = contentAttr.name.toLowerCase() === '[tuiHintContent]'.toLowerCase();
+    const tooltipAttr = isBinding
+        ? `[tuiTooltip]="${contentAttr.value}"`
+        : `tuiTooltip="${contentAttr.value}"`;
+
+    const appearanceAttr = element.attrs.find((a) => {
+        const lower = a.name.toLowerCase();
+
+        return (
+            lower === '[tuiHintAppearance]'.toLowerCase() ||
+            lower === 'tuiHintAppearance'.toLowerCase()
+        );
+    });
+
+    const directionAttr = element.attrs.find((a) => {
+        const lower = a.name.toLowerCase();
+
+        return (
+            lower === '[tuiHintDirection]'.toLowerCase() ||
+            lower === 'tuiHintDirection'.toLowerCase()
+        );
+    });
+
+    const extraAttrs: string[] = [];
+
+    if (appearanceAttr) {
+        const original = getOriginalAttrText(
+            template,
+            element,
+            appearanceAttr.name.toLowerCase(),
+        );
+
+        extraAttrs.push(
+            original ??
+                (appearanceAttr.value
+                    ? `${appearanceAttr.name}="${appearanceAttr.value}"`
+                    : appearanceAttr.name),
+        );
+    }
+
+    if (directionAttr) {
+        const nameLower = directionAttr.name.toLowerCase();
+        const migratedValue = migrateAttrValue(nameLower, directionAttr.value);
+        const original = getOriginalAttrText(template, element, nameLower);
+        let attrText: string;
+
+        if (original && directionAttr.value !== migratedValue) {
+            attrText = original.replace(
+                `="${directionAttr.value}"`,
+                `="${migratedValue}"`,
+            );
+        } else {
+            attrText =
+                original ??
+                (directionAttr.value
+                    ? `${directionAttr.name}="${migratedValue}"`
+                    : directionAttr.name);
+        }
+
+        extraAttrs.push(attrText);
+    }
+
+    const allAttrs = [tooltipAttr, ...extraAttrs];
+
+    return `<tui-icon ${allAttrs.join(' ')} />`;
+}
+
+function removeAttr(
+    recorder: UpdateRecorder,
+    templateOffset: number,
+    element: Element,
+    name: string,
+    template: string,
+): void {
+    const attrLocation = element.sourceCodeLocation?.attrs?.[name.toLowerCase()];
+
+    if (!attrLocation) {
+        return;
+    }
+
+    const lineStart = template.lastIndexOf('\n', attrLocation.startOffset) + 1;
+    const lineEnd = template.indexOf('\n', attrLocation.endOffset);
+    const attrText = template.slice(attrLocation.startOffset, attrLocation.endOffset);
+    const lineText = lineEnd === -1 ? '' : template.slice(lineStart, lineEnd);
+
+    if (lineText.trim() === attrText.trim() && lineEnd !== -1) {
+        recorder.remove(templateOffset + lineStart, lineEnd - lineStart + 1);
+
+        return;
+    }
+
+    recorder.remove(
+        templateOffset + attrLocation.startOffset - 1,
+        attrLocation.endOffset - attrLocation.startOffset + 1,
+    );
+}
+
+export function migrateHintOnLegacyControls({
+    resource,
+    recorder,
+    fileSystem,
+}: {
+    fileSystem: DevkitFileSystem;
+    recorder: UpdateRecorder;
+    resource: TemplateResource;
+}): void {
+    const template = getTemplateFromTemplateResource(resource, fileSystem);
+    const templateOffset = getTemplateOffset(resource);
+
+    const elements = findElementsInTemplateByFn(
+        template,
+        (el) => LEGACY_CONTROLS.has(el.tagName) && hasHintContent(el),
+    );
+
+    if (elements.length === 0) {
+        return;
+    }
+
+    addImportToClosestModule(resource.componentPath, 'TuiIcon', '@taiga-ui/core');
+    addImportToClosestModule(resource.componentPath, 'TuiTooltip', '@taiga-ui/kit');
+
+    elements.forEach((element) => {
+        const loc = element.sourceCodeLocation;
+
+        if (!loc) {
+            return;
+        }
+
+        const isSelfClosing = !loc.endTag;
+        const tagName = element.tagName;
+        const tuiIconStr = buildTuiIconStr(element, template);
+
+        if (!tuiIconStr) {
+            return;
+        }
+
+        if (!isSelfClosing && tagName === 'tui-input') {
+            const result = buildTuiInputReplacement(template, element, tuiIconStr);
+
+            if (result) {
+                recorder.remove(
+                    templateOffset + result.startOffset,
+                    result.endOffset - result.startOffset,
+                );
+                recorder.insertRight(
+                    templateOffset + result.startOffset,
+                    result.replacement,
+                );
+            }
+
+            return;
+        }
+
+        if (!isSelfClosing && tagName === 'tui-textarea') {
+            const result = buildTuiTextareaReplacement(template, element, tuiIconStr);
+
+            if (result) {
+                recorder.remove(
+                    templateOffset + result.startOffset,
+                    result.endOffset - result.startOffset,
+                );
+                recorder.insertRight(
+                    templateOffset + result.startOffset,
+                    result.replacement,
+                );
+            }
+
+            return;
+        }
+
+        if (isSelfClosing) {
+            const nonHintAttrs = element.attrs
+                .filter(
+                    (attr) =>
+                        !HINT_ATTR_NAMES.some(
+                            (n) => n.toLowerCase() === attr.name.toLowerCase(),
+                        ),
+                )
+                .map((attr) => {
+                    const original = getOriginalAttrText(
+                        template,
+                        element,
+                        attr.name.toLowerCase(),
+                    );
+
+                    return (
+                        original ??
+                        (attr.value ? `${attr.name}="${attr.value}"` : attr.name)
+                    );
+                });
+
+            const attrsStr = nonHintAttrs.length > 0 ? ` ${nonHintAttrs.join(' ')}` : '';
+            const replacement = `<${tagName}${attrsStr}>${tuiIconStr}</${tagName}>`;
+
+            recorder.remove(
+                templateOffset + loc.startOffset,
+                loc.endOffset - loc.startOffset,
+            );
+            recorder.insertRight(templateOffset + loc.startOffset, replacement);
+        } else {
+            for (const attrName of HINT_ATTR_NAMES) {
+                removeAttr(recorder, templateOffset, element, attrName, template);
+            }
+
+            const insertOffset = loc.endTag?.startOffset;
+
+            insertOffset &&
+                recorder.insertRight(templateOffset + insertOffset, `${tuiIconStr}\n`);
+        }
+    });
+}

--- a/projects/cdk/schematics/ng-update/v5/steps/templates/migrate-input.ts
+++ b/projects/cdk/schematics/ng-update/v5/steps/templates/migrate-input.ts
@@ -28,16 +28,19 @@ const CONTROL_ATTR_NAMES = [
 
 const CONTROL_ATTRS = new Set(CONTROL_ATTR_NAMES.map((name) => name.toLowerCase()));
 
-const TEXTFIELD_WRAPPER_ATTRS = new Set([
+const HINT_ATTRS = new Set([
     '[tuiHintAppearance]'.toLowerCase(),
     '[tuiHintContent]'.toLowerCase(),
     '[tuiHintDirection]'.toLowerCase(),
-    '[tuiTextfieldAppearance]'.toLowerCase(),
-    '[tuiTextfieldCleaner]'.toLowerCase(),
-    '[tuiTextfieldSize]'.toLowerCase(),
     'tuiHintAppearance'.toLowerCase(),
     'tuiHintContent'.toLowerCase(),
     'tuiHintDirection'.toLowerCase(),
+]);
+
+const TEXTFIELD_WRAPPER_ATTRS = new Set([
+    '[tuiTextfieldAppearance]'.toLowerCase(),
+    '[tuiTextfieldCleaner]'.toLowerCase(),
+    '[tuiTextfieldSize]'.toLowerCase(),
     'tuiTextfieldAppearance'.toLowerCase(),
     'tuiTextfieldCleaner'.toLowerCase(),
     'tuiTextfieldSize'.toLowerCase(),
@@ -78,6 +81,17 @@ function isDropdownAttr(nameLower: string): boolean {
     return stripped.startsWith(prefix);
 }
 
+function hasHintContent(element: Element): boolean {
+    return element.attrs.some((attr) => {
+        const lower = attr.name.toLowerCase();
+
+        return (
+            lower === 'tuiHintContent'.toLowerCase() ||
+            lower === '[tuiHintContent]'.toLowerCase()
+        );
+    });
+}
+
 export function migrateInput({
     resource,
     recorder,
@@ -92,7 +106,8 @@ export function migrateInput({
     const elements = findElementsByTagName(template, 'tui-input');
 
     const replacements = elements
-        .map((element) => buildReplacement(template, element))
+        .filter((element) => !hasHintContent(element))
+        .map((element) => buildTuiInputReplacement(template, element))
         .filter((x): x is {startOffset: number; endOffset: number; replacement: string} =>
             Boolean(x),
         )
@@ -102,6 +117,14 @@ export function migrateInput({
         recorder.remove(templateOffset + startOffset, endOffset - startOffset);
         recorder.insertRight(templateOffset + startOffset, replacement);
     });
+}
+
+export function buildTuiInputReplacement(
+    template: string,
+    element: Element,
+    hintIconStr = '',
+): {startOffset: number; endOffset: number; replacement: string} | null {
+    return buildReplacement(template, element, hintIconStr);
 }
 
 function getOriginalAttrText(
@@ -133,6 +156,7 @@ interface MigrationContext {
 function buildReplacement(
     template: string,
     element: Element,
+    hintIconStr = '',
 ): {startOffset: number; endOffset: number; replacement: string} | null {
     const loc = element.sourceCodeLocation;
 
@@ -197,6 +221,10 @@ function buildReplacement(
             continue;
         }
 
+        if (HINT_ATTRS.has(nameLower)) {
+            continue;
+        }
+
         if (CONTROL_ATTRS.has(nameLower)) {
             const original = getOriginalAttrText(template, element, nameLower);
 
@@ -234,6 +262,7 @@ function buildReplacement(
         placeholder: ctx.placeholder,
         indent,
         labelOutsideIsTrue: isLabelOutsideTrue,
+        hintIconStr,
     });
     const todoComment = buildTodoComment(ctx);
     // `indent` is added before <tui-textfield> only when there is a TODO — in that case
@@ -310,7 +339,13 @@ function buildInnerContent(
         placeholder,
         indent,
         labelOutsideIsTrue,
-    }: {indent: string; labelOutsideIsTrue: boolean; placeholder: string},
+        hintIconStr,
+    }: {
+        hintIconStr: string;
+        indent: string;
+        labelOutsideIsTrue: boolean;
+        placeholder: string;
+    },
 ): string {
     const childElements = element.childNodes.filter(
         (node: ChildNode): node is Element =>
@@ -323,6 +358,8 @@ function buildInnerContent(
             node.attrs.some((a) => LEGACY_INPUT_ATTRS.has(a.name.toLowerCase())),
     );
 
+    const hintIconLine = hintIconStr ? `${hintIconStr}\n` : '';
+
     if (legacyInnerInput) {
         return migrateInnerInput(
             legacyInnerInput,
@@ -330,6 +367,7 @@ function buildInnerContent(
             inputAttrs,
             childElements,
             indent,
+            hintIconLine,
         );
     }
 
@@ -349,7 +387,7 @@ function buildInnerContent(
         // labelOutside=true: text → placeholder on <input>, no label inside
         const placeholderAttr = placeholder ? ` placeholder="${placeholder}"` : '';
 
-        return `${indent}<input${placeholderAttr}${attrsStr} />\n${otherChildren}`;
+        return `${indent}<input${placeholderAttr}${attrsStr} />\n${otherChildren}${hintIconLine}`;
     }
 
     // labelOutside=false/absent: text → <label tuiLabel> inside (floating label)
@@ -357,7 +395,7 @@ function buildInnerContent(
         ? `${indent}<label tuiLabel>${placeholder}</label>\n`
         : '';
 
-    return `${labelEl}${indent}<input${attrsStr} />\n${otherChildren}`;
+    return `${labelEl}${indent}<input${attrsStr} />\n${otherChildren}${hintIconLine}`;
 }
 
 /**
@@ -370,6 +408,7 @@ function migrateInnerInput(
     attrsToAdd: string[],
     allChildren: Element[],
     indent: string,
+    hintIconLine = '',
 ): string {
     const innerLoc = inner.sourceCodeLocation;
 
@@ -413,7 +452,7 @@ function migrateInnerInput(
         })
         .join('');
 
-    return `${indent}${startTag}\n${siblings}`;
+    return `${indent}${startTag}\n${siblings}${hintIconLine}`;
 }
 
 /**

--- a/projects/cdk/schematics/ng-update/v5/steps/templates/migrate-input.ts
+++ b/projects/cdk/schematics/ng-update/v5/steps/templates/migrate-input.ts
@@ -258,7 +258,10 @@ function buildReplacement(
 
     const wrapperAttrsStr =
         textfieldAttrs.length > 0 ? ` ${textfieldAttrs.join(' ')}` : '';
-    const innerContent = buildInnerContent(element, template, inputAttrs, {
+    const innerContent = buildInnerContent({
+        element,
+        template,
+        inputAttrs,
         placeholder: ctx.placeholder,
         indent,
         labelOutsideIsTrue: isLabelOutsideTrue,
@@ -331,22 +334,23 @@ function buildTodoComment(ctx: MigrationContext): string {
     return `${lines.join('\n')}\n`;
 }
 
-function buildInnerContent(
-    element: Element,
-    template: string,
-    inputAttrs: string[],
-    {
-        placeholder,
-        indent,
-        labelOutsideIsTrue,
-        hintIconStr,
-    }: {
-        hintIconStr: string;
-        indent: string;
-        labelOutsideIsTrue: boolean;
-        placeholder: string;
-    },
-): string {
+function buildInnerContent({
+    element,
+    template,
+    inputAttrs,
+    placeholder,
+    indent,
+    labelOutsideIsTrue,
+    hintIconStr,
+}: {
+    element: Element;
+    hintIconStr: string;
+    indent: string;
+    inputAttrs: string[];
+    labelOutsideIsTrue: boolean;
+    placeholder: string;
+    template: string;
+}): string {
     const childElements = element.childNodes.filter(
         (node: ChildNode): node is Element =>
             node.nodeName !== '#text' && node.nodeName !== '#comment',
@@ -361,14 +365,14 @@ function buildInnerContent(
     const hintIconLine = hintIconStr ? `${hintIconStr}\n` : '';
 
     if (legacyInnerInput) {
-        return migrateInnerInput(
-            legacyInnerInput,
+        return migrateInnerInput({
+            inner: legacyInnerInput,
             template,
-            inputAttrs,
-            childElements,
+            attrsToAdd: inputAttrs,
+            allChildren: childElements,
             indent,
             hintIconLine,
-        );
+        });
     }
 
     const attrsStr = inputAttrs.length > 0 ? ` ${inputAttrs.join(' ')}` : '';
@@ -402,14 +406,21 @@ function buildInnerContent(
  * Rewrites an existing <input tuiTextfieldLegacy> to <input tuiInput ...>
  * by replacing the legacy directive attr and appending form control attrs.
  */
-function migrateInnerInput(
-    inner: Element,
-    template: string,
-    attrsToAdd: string[],
-    allChildren: Element[],
-    indent: string,
+function migrateInnerInput({
+    inner,
+    template,
+    attrsToAdd,
+    allChildren,
+    indent,
     hintIconLine = '',
-): string {
+}: {
+    allChildren: Element[];
+    attrsToAdd: string[];
+    hintIconLine?: string;
+    indent: string;
+    inner: Element;
+    template: string;
+}): string {
     const innerLoc = inner.sourceCodeLocation;
 
     if (!innerLoc?.startTag) {

--- a/projects/cdk/schematics/ng-update/v5/steps/templates/migrate-textarea.ts
+++ b/projects/cdk/schematics/ng-update/v5/steps/templates/migrate-textarea.ts
@@ -241,14 +241,14 @@ function buildReplacement(
 
     const wrapperAttrsStr =
         textfieldAttrs.length > 0 ? ` ${textfieldAttrs.join(' ')}` : '';
-    const innerContent = buildInnerContent(
+    const innerContent = buildInnerContent({
         element,
         template,
         textareaAttrs,
         ctx,
         indent,
         hintIconStr,
-    );
+    });
     const todoComment = buildTodoComment(ctx);
 
     const replacement = `${todoComment}${indent}<tui-textfield${wrapperAttrsStr}>\n${innerContent}${indent}</tui-textfield>`;
@@ -329,14 +329,21 @@ const LEGACY_TEXTAREA_ATTRS = new Set([
     'tuiTextfieldLegacy'.toLowerCase(),
 ]);
 
-function buildInnerContent(
-    element: Element,
-    template: string,
-    textareaAttrs: string[],
-    ctx: MigrationContext,
-    indent: string,
+function buildInnerContent({
+    element,
+    template,
+    textareaAttrs,
+    ctx,
+    indent,
     hintIconStr = '',
-): string {
+}: {
+    ctx: MigrationContext;
+    element: Element;
+    hintIconStr?: string;
+    indent: string;
+    template: string;
+    textareaAttrs: string[];
+}): string {
     const {placeholder, labelOutside} = ctx;
     const childElements = element.childNodes.filter(
         (node: ChildNode): node is Element =>
@@ -361,14 +368,14 @@ function buildInnerContent(
     );
 
     if (legacyInnerTextarea) {
-        return `${labelEl}${migrateInnerTextarea(
-            legacyInnerTextarea,
+        return `${labelEl}${migrateInnerTextarea({
+            inner: legacyInnerTextarea,
             template,
-            textareaAttrs,
-            childElements,
+            attrsToAdd: textareaAttrs,
+            allChildren: childElements,
             indent,
             hintIconLine,
-        )}`;
+        })}`;
     }
 
     const attrsStr = textareaAttrs.length > 0 ? ` ${textareaAttrs.join(' ')}` : '';
@@ -394,14 +401,21 @@ function buildInnerContent(
  * Rewrites an existing <textarea tuiTextfieldLegacy> to <textarea tuiTextarea ...>
  * by replacing the legacy directive attr and appending form control attrs.
  */
-function migrateInnerTextarea(
-    inner: Element,
-    template: string,
-    attrsToAdd: string[],
-    allChildren: Element[],
-    indent: string,
+function migrateInnerTextarea({
+    inner,
+    template,
+    attrsToAdd,
+    allChildren,
+    indent,
     hintIconLine = '',
-): string {
+}: {
+    allChildren: Element[];
+    attrsToAdd: string[];
+    hintIconLine?: string;
+    indent: string;
+    inner: Element;
+    template: string;
+}): string {
     const innerLoc = inner.sourceCodeLocation;
 
     if (!innerLoc?.startTag) {

--- a/projects/cdk/schematics/ng-update/v5/steps/templates/migrate-textarea.ts
+++ b/projects/cdk/schematics/ng-update/v5/steps/templates/migrate-textarea.ts
@@ -31,24 +31,46 @@ const CONTROL_ATTR_NAMES = [
 const CONTROL_ATTRS = new Set(CONTROL_ATTR_NAMES.map((name) => name.toLowerCase()));
 
 const TEXTFIELD_WRAPPER_ATTRS = new Set([
-    '[tuiHintAppearance]'.toLowerCase(),
-    '[tuiHintContent]'.toLowerCase(),
-    '[tuiHintDirection]'.toLowerCase(),
     '[tuiTextfieldAppearance]'.toLowerCase(),
     '[tuiTextfieldCleaner]'.toLowerCase(),
     '[tuiTextfieldSize]'.toLowerCase(),
-    'tuiHintAppearance'.toLowerCase(),
-    'tuiHintContent'.toLowerCase(),
-    'tuiHintDirection'.toLowerCase(),
     'tuiTextfieldAppearance'.toLowerCase(),
     'tuiTextfieldCleaner'.toLowerCase(),
     'tuiTextfieldSize'.toLowerCase(),
+]);
+
+const HINT_ATTRS = new Set([
+    '[tuiHintAppearance]'.toLowerCase(),
+    '[tuiHintContent]'.toLowerCase(),
+    '[tuiHintDirection]'.toLowerCase(),
+    'tuiHintAppearance'.toLowerCase(),
+    'tuiHintContent'.toLowerCase(),
+    'tuiHintDirection'.toLowerCase(),
 ]);
 
 const ATTRS_TO_DROP = new Set([
     '[tuiTextfieldLabelOutside]'.toLowerCase(),
     'tuiTextfieldLabelOutside'.toLowerCase(),
 ]);
+
+function hasHintContent(element: Element): boolean {
+    return element.attrs.some((attr) => {
+        const lower = attr.name.toLowerCase();
+
+        return (
+            lower === 'tuiHintContent'.toLowerCase() ||
+            lower === '[tuiHintContent]'.toLowerCase()
+        );
+    });
+}
+
+export function buildTuiTextareaReplacement(
+    template: string,
+    element: Element,
+    hintIconStr = '',
+): {startOffset: number; endOffset: number; replacement: string} | null {
+    return buildReplacement(template, element, hintIconStr);
+}
 
 export function migrateTextarea({
     resource,
@@ -64,6 +86,7 @@ export function migrateTextarea({
     const elements = findElementsByTagName(template, 'tui-textarea');
 
     const replacements = elements
+        .filter((element) => !hasHintContent(element))
         .map((element) => buildReplacement(template, element))
         .filter((x): x is {startOffset: number; endOffset: number; replacement: string} =>
             Boolean(x),
@@ -104,6 +127,7 @@ interface MigrationContext {
 function buildReplacement(
     template: string,
     element: Element,
+    hintIconStr = '',
 ): {startOffset: number; endOffset: number; replacement: string} | null {
     const loc = element.sourceCodeLocation;
 
@@ -143,6 +167,10 @@ function buildReplacement(
                 ctx.labelOutside = 'dynamic';
             }
 
+            continue;
+        }
+
+        if (HINT_ATTRS.has(nameLower)) {
             continue;
         }
 
@@ -213,7 +241,14 @@ function buildReplacement(
 
     const wrapperAttrsStr =
         textfieldAttrs.length > 0 ? ` ${textfieldAttrs.join(' ')}` : '';
-    const innerContent = buildInnerContent(element, template, textareaAttrs, ctx, indent);
+    const innerContent = buildInnerContent(
+        element,
+        template,
+        textareaAttrs,
+        ctx,
+        indent,
+        hintIconStr,
+    );
     const todoComment = buildTodoComment(ctx);
 
     const replacement = `${todoComment}${indent}<tui-textfield${wrapperAttrsStr}>\n${innerContent}${indent}</tui-textfield>`;
@@ -300,6 +335,7 @@ function buildInnerContent(
     textareaAttrs: string[],
     ctx: MigrationContext,
     indent: string,
+    hintIconStr = '',
 ): string {
     const {placeholder, labelOutside} = ctx;
     const childElements = element.childNodes.filter(
@@ -313,6 +349,8 @@ function buildInnerContent(
         placeholder && labelOutside !== true
             ? `${indent}<label tuiLabel>${placeholder}</label>\n`
             : '';
+
+    const hintIconLine = hintIconStr ? `${hintIconStr}\n` : '';
 
     // If user already put an explicit <textarea tuiTextfieldLegacy> inside,
     // reuse it instead of generating a new one.
@@ -329,6 +367,7 @@ function buildInnerContent(
             textareaAttrs,
             childElements,
             indent,
+            hintIconLine,
         )}`;
     }
 
@@ -348,7 +387,7 @@ function buildInnerContent(
         })
         .join('');
 
-    return `${labelEl}${indent}<textarea${placeholderAttr}${attrsStr}></textarea>\n${otherChildren}`;
+    return `${labelEl}${indent}<textarea${placeholderAttr}${attrsStr}></textarea>\n${otherChildren}${hintIconLine}`;
 }
 
 /**
@@ -361,6 +400,7 @@ function migrateInnerTextarea(
     attrsToAdd: string[],
     allChildren: Element[],
     indent: string,
+    hintIconLine = '',
 ): string {
     const innerLoc = inner.sourceCodeLocation;
 
@@ -411,7 +451,7 @@ function migrateInnerTextarea(
         })
         .join('');
 
-    return `${indent}${innerContent}\n${siblings}`;
+    return `${indent}${innerContent}\n${siblings}${hintIconLine}`;
 }
 
 function getPlaceholderText(element: Element): string {

--- a/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-hint-on-legacy-controls.spec.ts.snap
+++ b/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-hint-on-legacy-controls.spec.ts.snap
@@ -1,0 +1,906 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ng-update hint on legacy controls basic tuiHintContent migration moves [tuiHintContent] to tui-icon with tuiTooltip: test.html 1`] = `
+{
+  "0. Before": "<tui-input [tuiHintContent]="hint" />",
+  "1. After": "<tui-input><tui-icon [tuiTooltip]="hint" /></tui-input>",
+}
+`;
+
+exports[`ng-update hint on legacy controls basic tuiHintContent migration moves [tuiHintContent] to tui-icon with tuiTooltip: test.ts 1`] = `
+{
+  "0. Before": "
+            import {Component} from '@angular/core';
+            import {TuiInputModule} from '@taiga-ui/legacy';
+
+            @Component({
+                standalone: true,
+                templateUrl: './test.html',
+                imports: [TuiInputModule],
+            })
+            export class Test {}
+        ",
+  "1. After": "import { TuiTooltip } from "@taiga-ui/kit";
+import { TuiInput, TuiIcon } from "@taiga-ui/core";
+
+            import {Component} from '@angular/core';
+
+            @Component({
+                standalone: true,
+                templateUrl: './test.html',
+                imports: [TuiInput, TuiIcon, TuiTooltip],
+            })
+            export class Test {}
+        ",
+}
+`;
+
+exports[`ng-update hint on legacy controls basic tuiHintContent migration moves static tuiHintContent to tui-icon with tuiTooltip: test.html 1`] = `
+{
+  "0. Before": "<tui-input tuiHintContent="Some hint text" />",
+  "1. After": "<tui-input><tui-icon tuiTooltip="Some hint text" /></tui-input>",
+}
+`;
+
+exports[`ng-update hint on legacy controls basic tuiHintContent migration moves static tuiHintContent to tui-icon with tuiTooltip: test.ts 1`] = `
+{
+  "0. Before": "
+            import {Component} from '@angular/core';
+            import {TuiInputModule} from '@taiga-ui/legacy';
+
+            @Component({
+                standalone: true,
+                templateUrl: './test.html',
+                imports: [TuiInputModule],
+            })
+            export class Test {}
+        ",
+  "1. After": "import { TuiTooltip } from "@taiga-ui/kit";
+import { TuiInput, TuiIcon } from "@taiga-ui/core";
+
+            import {Component} from '@angular/core';
+
+            @Component({
+                standalone: true,
+                templateUrl: './test.html',
+                imports: [TuiInput, TuiIcon, TuiTooltip],
+            })
+            export class Test {}
+        ",
+}
+`;
+
+exports[`ng-update hint on legacy controls different legacy controls migrates tuiHintContent on tui-combo-box: test.html 1`] = `
+{
+  "0. Before": "
+                    <tui-combo-box
+                        tuiHintAppearance="dark"
+                        [tuiHintContent]="hint"
+                        [(ngModel)]="value"
+                    >
+                        Label
+                        <tui-data-list-wrapper
+                            *tuiDataList
+                            [items]="items | tuiFilterByInput"
+                        />
+                    </tui-combo-box>
+                ",
+  "1. After": "
+                    <tui-textfield
+                    >
+<label tuiLabel>
+                        Label
+                        </label>
+
+<input tuiComboBox [(ngModel)]="value" />
+<tui-data-list-wrapper
+                            *tuiDropdown
+                            [items]="items | tuiFilterByInput"
+                        />
+                    <tui-icon [tuiTooltip]="hint" tuiHintAppearance="dark" />
+</tui-textfield>
+                ",
+}
+`;
+
+exports[`ng-update hint on legacy controls different legacy controls migrates tuiHintContent on tui-combo-box: test.ts 1`] = `
+{
+  "0. Before": "
+            import {Component} from '@angular/core';
+            import {TuiInputModule} from '@taiga-ui/legacy';
+
+            @Component({
+                standalone: true,
+                templateUrl: './test.html',
+                imports: [TuiInputModule],
+            })
+            export class Test {}
+        ",
+  "1. After": "import { TuiTooltip } from "@taiga-ui/kit";
+import { TuiInput, TuiIcon } from "@taiga-ui/core";
+
+            import {Component} from '@angular/core';
+
+            @Component({
+                standalone: true,
+                templateUrl: './test.html',
+                imports: [TuiInput, TuiIcon, TuiTooltip],
+            })
+            export class Test {}
+        ",
+}
+`;
+
+exports[`ng-update hint on legacy controls different legacy controls migrates tuiHintContent on tui-input-date: test.html 1`] = `
+{
+  "0. Before": "<tui-input-date [tuiHintContent]="hint" tuiHintDirection="bottom">Label</tui-input-date>",
+  "1. After": "<tui-textfield>
+<label tuiLabel>Label</label>
+
+<input tuiInputDate />
+<tui-calendar *tuiDropdown />
+<tui-icon [tuiTooltip]="hint" tuiHintDirection="bottom" />
+</tui-textfield>",
+}
+`;
+
+exports[`ng-update hint on legacy controls different legacy controls migrates tuiHintContent on tui-input-date: test.ts 1`] = `
+{
+  "0. Before": "
+            import {Component} from '@angular/core';
+            import {TuiInputModule} from '@taiga-ui/legacy';
+
+            @Component({
+                standalone: true,
+                templateUrl: './test.html',
+                imports: [TuiInputModule],
+            })
+            export class Test {}
+        ",
+  "1. After": "import { TuiTooltip } from "@taiga-ui/kit";
+import { TuiInput, TuiIcon } from "@taiga-ui/core";
+
+            import {Component} from '@angular/core';
+
+            @Component({
+                standalone: true,
+                templateUrl: './test.html',
+                imports: [TuiInput, TuiIcon, TuiTooltip],
+            })
+            export class Test {}
+        ",
+}
+`;
+
+exports[`ng-update hint on legacy controls different legacy controls migrates tuiHintContent on tui-input-date-range: test.html 1`] = `
+{
+  "0. Before": "<tui-input-date-range [tuiHintContent]="hint">Label</tui-input-date-range>",
+  "1. After": "<tui-textfield>
+<label tuiLabel>Label</label>
+
+<input tuiInputDateRange />
+<tui-calendar-range *tuiDropdown />
+<tui-icon [tuiTooltip]="hint" />
+</tui-textfield>",
+}
+`;
+
+exports[`ng-update hint on legacy controls different legacy controls migrates tuiHintContent on tui-input-date-range: test.ts 1`] = `
+{
+  "0. Before": "
+            import {Component} from '@angular/core';
+            import {TuiInputModule} from '@taiga-ui/legacy';
+
+            @Component({
+                standalone: true,
+                templateUrl: './test.html',
+                imports: [TuiInputModule],
+            })
+            export class Test {}
+        ",
+  "1. After": "import { TuiTooltip } from "@taiga-ui/kit";
+import { TuiInput, TuiIcon } from "@taiga-ui/core";
+
+            import {Component} from '@angular/core';
+
+            @Component({
+                standalone: true,
+                templateUrl: './test.html',
+                imports: [TuiInput, TuiIcon, TuiTooltip],
+            })
+            export class Test {}
+        ",
+}
+`;
+
+exports[`ng-update hint on legacy controls different legacy controls migrates tuiHintContent on tui-input-number: test.html 1`] = `
+{
+  "0. Before": "<tui-input-number [tuiHintContent]="hint" tuiHintDirection="top" />",
+  "1. After": "<tui-input-number><tui-icon [tuiTooltip]="hint" tuiHintDirection="top" /></tui-input-number>",
+}
+`;
+
+exports[`ng-update hint on legacy controls different legacy controls migrates tuiHintContent on tui-input-number: test.ts 1`] = `
+{
+  "0. Before": "
+            import {Component} from '@angular/core';
+            import {TuiInputModule} from '@taiga-ui/legacy';
+
+            @Component({
+                standalone: true,
+                templateUrl: './test.html',
+                imports: [TuiInputModule],
+            })
+            export class Test {}
+        ",
+  "1. After": "import { TuiTooltip } from "@taiga-ui/kit";
+import { TuiInput, TuiIcon } from "@taiga-ui/core";
+
+            import {Component} from '@angular/core';
+
+            @Component({
+                standalone: true,
+                templateUrl: './test.html',
+                imports: [TuiInput, TuiIcon, TuiTooltip],
+            })
+            export class Test {}
+        ",
+}
+`;
+
+exports[`ng-update hint on legacy controls different legacy controls migrates tuiHintContent on tui-input-phone: test.html 1`] = `
+{
+  "0. Before": "<tui-input-phone [tuiHintContent]="hint">Label</tui-input-phone>",
+  "1. After": "<tui-textfield>
+<label tuiLabel>Label</label>
+
+<input tuiInputPhone />
+<tui-icon [tuiTooltip]="hint" />
+</tui-textfield>",
+}
+`;
+
+exports[`ng-update hint on legacy controls different legacy controls migrates tuiHintContent on tui-input-phone: test.ts 1`] = `
+{
+  "0. Before": "
+            import {Component} from '@angular/core';
+            import {TuiInputModule} from '@taiga-ui/legacy';
+
+            @Component({
+                standalone: true,
+                templateUrl: './test.html',
+                imports: [TuiInputModule],
+            })
+            export class Test {}
+        ",
+  "1. After": "import { TuiTooltip } from "@taiga-ui/kit";
+import { TuiInput, TuiIcon } from "@taiga-ui/core";
+
+            import {Component} from '@angular/core';
+
+            @Component({
+                standalone: true,
+                templateUrl: './test.html',
+                imports: [TuiInput, TuiIcon, TuiTooltip],
+            })
+            export class Test {}
+        ",
+}
+`;
+
+exports[`ng-update hint on legacy controls different legacy controls migrates tuiHintContent on tui-input-tag: test.html 1`] = `
+{
+  "0. Before": "<tui-input-tag [tuiHintContent]="hint">Label</tui-input-tag>",
+  "1. After": "<tui-textfield multi>
+<label tuiLabel>Label</label>
+
+<input tuiInputChip />
+<tui-icon [tuiTooltip]="hint" />
+</tui-textfield>",
+}
+`;
+
+exports[`ng-update hint on legacy controls different legacy controls migrates tuiHintContent on tui-input-tag: test.ts 1`] = `
+{
+  "0. Before": "
+            import {Component} from '@angular/core';
+            import {TuiInputModule} from '@taiga-ui/legacy';
+
+            @Component({
+                standalone: true,
+                templateUrl: './test.html',
+                imports: [TuiInputModule],
+            })
+            export class Test {}
+        ",
+  "1. After": "import { TuiTooltip } from "@taiga-ui/kit";
+import { TuiInput, TuiIcon } from "@taiga-ui/core";
+
+            import {Component} from '@angular/core';
+
+            @Component({
+                standalone: true,
+                templateUrl: './test.html',
+                imports: [TuiInput, TuiIcon, TuiTooltip],
+            })
+            export class Test {}
+        ",
+}
+`;
+
+exports[`ng-update hint on legacy controls different legacy controls migrates tuiHintContent on tui-input-time: test.html 1`] = `
+{
+  "0. Before": "<tui-input-time [tuiHintContent]="hint">Label</tui-input-time>",
+  "1. After": "<tui-textfield>
+<label tuiLabel>Label</label>
+
+<input tuiInputTime />
+<tui-icon [tuiTooltip]="hint" />
+</tui-textfield>",
+}
+`;
+
+exports[`ng-update hint on legacy controls different legacy controls migrates tuiHintContent on tui-input-time: test.ts 1`] = `
+{
+  "0. Before": "
+            import {Component} from '@angular/core';
+            import {TuiInputModule} from '@taiga-ui/legacy';
+
+            @Component({
+                standalone: true,
+                templateUrl: './test.html',
+                imports: [TuiInputModule],
+            })
+            export class Test {}
+        ",
+  "1. After": "import { TuiTooltip } from "@taiga-ui/kit";
+import { TuiInput, TuiIcon } from "@taiga-ui/core";
+
+            import {Component} from '@angular/core';
+
+            @Component({
+                standalone: true,
+                templateUrl: './test.html',
+                imports: [TuiInput, TuiIcon, TuiTooltip],
+            })
+            export class Test {}
+        ",
+}
+`;
+
+exports[`ng-update hint on legacy controls different legacy controls migrates tuiHintContent on tui-multi-select: test.html 1`] = `
+{
+  "0. Before": "
+                    <tui-multi-select
+                        tuiHintDirection="right"
+                        [formControl]="control"
+                        [tuiHintContent]="hint"
+                        [(search)]="search"
+                    >
+                        Star Wars persons
+                        <tui-data-list-wrapper
+                            *tuiDataList
+                            tuiMultiSelectGroup
+                            [items]="filter(search)"
+                        />
+                    </tui-multi-select>
+                ",
+  "1. After": "
+                    <tui-textfield multi tuiChevron
+                    >
+                        Star Wars persons
+                        <!-- TODO: (Taiga UI migration) [search] was removed. Use (input) on <input tuiInputChip (input)="onSearch($any($event).target.value)"> to track changes; no direct equivalent for programmatic writes. See: https://taiga-ui.dev/components/input-chip -->
+<input tuiInputChip [formControl]="control" />
+<tui-data-list-wrapper
+                            *tuiDropdown
+                            tuiMultiSelectGroup
+                            [items]="filter(search)"
+                        />
+                    <tui-icon [tuiTooltip]="hint" tuiHintDirection="end" />
+</tui-textfield>
+                ",
+}
+`;
+
+exports[`ng-update hint on legacy controls different legacy controls migrates tuiHintContent on tui-multi-select: test.ts 1`] = `
+{
+  "0. Before": "
+            import {Component} from '@angular/core';
+            import {TuiInputModule} from '@taiga-ui/legacy';
+
+            @Component({
+                standalone: true,
+                templateUrl: './test.html',
+                imports: [TuiInputModule],
+            })
+            export class Test {}
+        ",
+  "1. After": "import { TuiTooltip } from "@taiga-ui/kit";
+import { TuiInput, TuiIcon } from "@taiga-ui/core";
+
+            import {Component} from '@angular/core';
+
+            @Component({
+                standalone: true,
+                templateUrl: './test.html',
+                imports: [TuiInput, TuiIcon, TuiTooltip],
+            })
+            export class Test {}
+        ",
+}
+`;
+
+exports[`ng-update hint on legacy controls different legacy controls migrates tuiHintContent on tui-select: test.html 1`] = `
+{
+  "0. Before": "
+                    <tui-select
+                        [tuiHintContent]="hint"
+                        [(ngModel)]="value"
+                    >
+                        Select user
+                        <tui-data-list-wrapper
+                            *tuiDataList
+                            [items]="items"
+                        />
+                    </tui-select>
+                ",
+  "1. After": "
+                    <!-- TODO: (Taiga UI migration) tui-select was partially migrated. Complete migration manually. See examples: https://taiga-ui.dev/components/select -->
+<tui-textfield tuiChevron
+                    >
+<input placeholder="Select user" tuiSelect [(ngModel)]="value" />
+<tui-data-list-wrapper
+                            *tuiDropdown
+                            [items]="items"
+                        />
+                    <tui-icon [tuiTooltip]="hint" />
+</tui-textfield>
+                ",
+}
+`;
+
+exports[`ng-update hint on legacy controls different legacy controls migrates tuiHintContent on tui-select: test.ts 1`] = `
+{
+  "0. Before": "
+            import {Component} from '@angular/core';
+            import {TuiInputModule} from '@taiga-ui/legacy';
+
+            @Component({
+                standalone: true,
+                templateUrl: './test.html',
+                imports: [TuiInputModule],
+            })
+            export class Test {}
+        ",
+  "1. After": "import { TuiTooltip } from "@taiga-ui/kit";
+import { TuiInput, TuiIcon } from "@taiga-ui/core";
+
+            import {Component} from '@angular/core';
+
+            @Component({
+                standalone: true,
+                templateUrl: './test.html',
+                imports: [TuiInput, TuiIcon, TuiTooltip],
+            })
+            export class Test {}
+        ",
+}
+`;
+
+exports[`ng-update hint on legacy controls different legacy controls migrates tuiHintContent on tui-textarea: test.html 1`] = `
+{
+  "0. Before": "<tui-textarea [tuiHintContent]="hint" />",
+  "1. After": "<tui-textarea><tui-icon [tuiTooltip]="hint" /></tui-textarea>",
+}
+`;
+
+exports[`ng-update hint on legacy controls different legacy controls migrates tuiHintContent on tui-textarea: test.ts 1`] = `
+{
+  "0. Before": "
+            import {Component} from '@angular/core';
+            import {TuiInputModule} from '@taiga-ui/legacy';
+
+            @Component({
+                standalone: true,
+                templateUrl: './test.html',
+                imports: [TuiInputModule],
+            })
+            export class Test {}
+        ",
+  "1. After": "import { TuiTooltip } from "@taiga-ui/kit";
+import { TuiInput, TuiIcon } from "@taiga-ui/core";
+
+            import {Component} from '@angular/core';
+
+            @Component({
+                standalone: true,
+                templateUrl: './test.html',
+                imports: [TuiInput, TuiIcon, TuiTooltip],
+            })
+            export class Test {}
+        ",
+}
+`;
+
+exports[`ng-update hint on legacy controls hint with additional directives moves all tuiHint* directives to tui-icon: test.html 1`] = `
+{
+  "0. Before": "
+                    <tui-input
+                        tuiHintAppearance="dark"
+                        tuiHintDirection="left"
+                        [tuiHintContent]="hint"
+                    >
+                        Label
+                    </tui-input>
+                ",
+  "1. After": "
+                    <tui-textfield>
+                    <label tuiLabel>Label</label>
+                    <input tuiInput />
+<tui-icon [tuiTooltip]="hint" tuiHintAppearance="dark" tuiHintDirection="start" />
+                    </tui-textfield>
+                ",
+}
+`;
+
+exports[`ng-update hint on legacy controls hint with additional directives moves all tuiHint* directives to tui-icon: test.ts 1`] = `
+{
+  "0. Before": "
+            import {Component} from '@angular/core';
+            import {TuiInputModule} from '@taiga-ui/legacy';
+
+            @Component({
+                standalone: true,
+                templateUrl: './test.html',
+                imports: [TuiInputModule],
+            })
+            export class Test {}
+        ",
+  "1. After": "import { TuiTooltip } from "@taiga-ui/kit";
+import { TuiInput, TuiIcon } from "@taiga-ui/core";
+
+            import {Component} from '@angular/core';
+
+            @Component({
+                standalone: true,
+                templateUrl: './test.html',
+                imports: [TuiInput, TuiIcon, TuiTooltip],
+            })
+            export class Test {}
+        ",
+}
+`;
+
+exports[`ng-update hint on legacy controls hint with additional directives moves bound tuiHintDirection and tuiHintAppearance to tui-icon: test.html 1`] = `
+{
+  "0. Before": "
+                    <tui-input
+                        [tuiHintAppearance]="appearance"
+                        [tuiHintContent]="hint"
+                        [tuiHintDirection]="direction"
+                    />
+                ",
+  "1. After": "
+                    <tui-input><tui-icon [tuiTooltip]="hint" [tuiHintAppearance]="appearance" [tuiHintDirection]="direction" /></tui-input>",
+}
+`;
+
+exports[`ng-update hint on legacy controls hint with additional directives moves bound tuiHintDirection and tuiHintAppearance to tui-icon: test.ts 1`] = `
+{
+  "0. Before": "
+            import {Component} from '@angular/core';
+            import {TuiInputModule} from '@taiga-ui/legacy';
+
+            @Component({
+                standalone: true,
+                templateUrl: './test.html',
+                imports: [TuiInputModule],
+            })
+            export class Test {}
+        ",
+  "1. After": "import { TuiTooltip } from "@taiga-ui/kit";
+import { TuiInput, TuiIcon } from "@taiga-ui/core";
+
+            import {Component} from '@angular/core';
+
+            @Component({
+                standalone: true,
+                templateUrl: './test.html',
+                imports: [TuiInput, TuiIcon, TuiTooltip],
+            })
+            export class Test {}
+        ",
+}
+`;
+
+exports[`ng-update hint on legacy controls hint with additional directives moves tuiHintAppearance to tui-icon alongside tuiTooltip: test.html 1`] = `
+{
+  "0. Before": "
+                    <tui-input
+                        tuiHintAppearance="dark"
+                        [tuiHintContent]="hint"
+                    />
+                ",
+  "1. After": "
+                    <tui-input><tui-icon [tuiTooltip]="hint" tuiHintAppearance="dark" /></tui-input>",
+}
+`;
+
+exports[`ng-update hint on legacy controls hint with additional directives moves tuiHintAppearance to tui-icon alongside tuiTooltip: test.ts 1`] = `
+{
+  "0. Before": "
+            import {Component} from '@angular/core';
+            import {TuiInputModule} from '@taiga-ui/legacy';
+
+            @Component({
+                standalone: true,
+                templateUrl: './test.html',
+                imports: [TuiInputModule],
+            })
+            export class Test {}
+        ",
+  "1. After": "import { TuiTooltip } from "@taiga-ui/kit";
+import { TuiInput, TuiIcon } from "@taiga-ui/core";
+
+            import {Component} from '@angular/core';
+
+            @Component({
+                standalone: true,
+                templateUrl: './test.html',
+                imports: [TuiInput, TuiIcon, TuiTooltip],
+            })
+            export class Test {}
+        ",
+}
+`;
+
+exports[`ng-update hint on legacy controls hint with additional directives moves tuiHintDirection to tui-icon alongside tuiTooltip: test.html 1`] = `
+{
+  "0. Before": "
+                    <tui-input
+                        tuiHintDirection="left"
+                        [tuiHintContent]="hint"
+                    >
+                        Label
+                    </tui-input>
+                ",
+  "1. After": "
+                    <tui-textfield>
+                    <label tuiLabel>Label</label>
+                    <input tuiInput />
+<tui-icon [tuiTooltip]="hint" tuiHintDirection="start" />
+                    </tui-textfield>
+                ",
+}
+`;
+
+exports[`ng-update hint on legacy controls hint with additional directives moves tuiHintDirection to tui-icon alongside tuiTooltip: test.ts 1`] = `
+{
+  "0. Before": "
+            import {Component} from '@angular/core';
+            import {TuiInputModule} from '@taiga-ui/legacy';
+
+            @Component({
+                standalone: true,
+                templateUrl: './test.html',
+                imports: [TuiInputModule],
+            })
+            export class Test {}
+        ",
+  "1. After": "import { TuiTooltip } from "@taiga-ui/kit";
+import { TuiInput, TuiIcon } from "@taiga-ui/core";
+
+            import {Component} from '@angular/core';
+
+            @Component({
+                standalone: true,
+                templateUrl: './test.html',
+                imports: [TuiInput, TuiIcon, TuiTooltip],
+            })
+            export class Test {}
+        ",
+}
+`;
+
+exports[`ng-update hint on legacy controls import additions adds TuiTooltip and TuiIcon imports when tuiHintContent is present: test.html 1`] = `
+{
+  "0. Before": "<tui-input [tuiHintContent]="hint" />",
+  "1. After": "<tui-input><tui-icon [tuiTooltip]="hint" /></tui-input>",
+}
+`;
+
+exports[`ng-update hint on legacy controls import additions adds TuiTooltip and TuiIcon imports when tuiHintContent is present: test.ts 1`] = `
+{
+  "0. Before": "
+                    import {Component} from '@angular/core';
+                    import {TuiInputModule} from '@taiga-ui/legacy';
+
+                    @Component({
+                        standalone: true,
+                        templateUrl: './test.html',
+                        imports: [TuiInputModule],
+                    })
+                    export class Test {}
+                ",
+  "1. After": "import { TuiTooltip } from "@taiga-ui/kit";
+import { TuiInput, TuiIcon } from "@taiga-ui/core";
+
+                    import {Component} from '@angular/core';
+
+                    @Component({
+                        standalone: true,
+                        templateUrl: './test.html',
+                        imports: [TuiInput, TuiIcon, TuiTooltip],
+                    })
+                    export class Test {}
+                ",
+}
+`;
+
+exports[`ng-update hint on legacy controls import additions does not duplicate TuiIcon import if already present: test.html 1`] = `
+{
+  "0. Before": "<tui-input [tuiHintContent]="hint" />",
+  "1. After": "<tui-input><tui-icon [tuiTooltip]="hint" /></tui-input>",
+}
+`;
+
+exports[`ng-update hint on legacy controls import additions does not duplicate TuiIcon import if already present: test.ts 1`] = `
+{
+  "0. Before": "
+                    import {Component} from '@angular/core';
+                    import {TuiIcon} from '@taiga-ui/core';
+                    import {TuiInputModule} from '@taiga-ui/legacy';
+
+                    @Component({
+                        standalone: true,
+                        templateUrl: './test.html',
+                        imports: [TuiInputModule, TuiIcon],
+                    })
+                    export class Test {}
+                ",
+  "1. After": "import { TuiTooltip } from "@taiga-ui/kit";
+
+                    import {Component} from '@angular/core';
+                    import { TuiIcon, TuiInput } from '@taiga-ui/core';
+
+                    @Component({
+                        standalone: true,
+                        templateUrl: './test.html',
+                        imports: [TuiInput, TuiIcon, TuiTooltip],
+                    })
+                    export class Test {}
+                ",
+}
+`;
+
+exports[`ng-update hint on legacy controls multiple occurrences migrates multiple elements with tuiHintContent in one template: test.html 1`] = `
+{
+  "0. Before": "
+                    <tui-input
+                        tuiHintDirection="left"
+                        [tuiHintContent]="hint1"
+                    ></tui-input>
+                    <tui-select
+                        tuiHintAppearance="dark"
+                        [tuiHintContent]="hint2"
+                    ></tui-select>
+                ",
+  "1. After": "
+                    <tui-textfield>
+                    <input tuiInput />
+<tui-icon [tuiTooltip]="hint1" tuiHintDirection="start" />
+                    </tui-textfield>
+                    <!-- TODO: (Taiga UI migration) tui-select was partially migrated. Complete migration manually. See examples: https://taiga-ui.dev/components/select -->
+<tui-textfield tuiChevron
+                    >
+<input tuiSelect />
+<tui-icon [tuiTooltip]="hint2" tuiHintAppearance="dark" />
+</tui-textfield>
+                ",
+}
+`;
+
+exports[`ng-update hint on legacy controls multiple occurrences migrates multiple elements with tuiHintContent in one template: test.ts 1`] = `
+{
+  "0. Before": "
+            import {Component} from '@angular/core';
+            import {TuiInputModule} from '@taiga-ui/legacy';
+
+            @Component({
+                standalone: true,
+                templateUrl: './test.html',
+                imports: [TuiInputModule],
+            })
+            export class Test {}
+        ",
+  "1. After": "import { TuiTooltip } from "@taiga-ui/kit";
+import { TuiInput, TuiIcon } from "@taiga-ui/core";
+
+            import {Component} from '@angular/core';
+
+            @Component({
+                standalone: true,
+                templateUrl: './test.html',
+                imports: [TuiInput, TuiIcon, TuiTooltip],
+            })
+            export class Test {}
+        ",
+}
+`;
+
+exports[`ng-update hint on legacy controls should not change does not touch legacy control without tuiHintContent: test.ts 1`] = `
+{
+  "0. Before": "
+            import {Component} from '@angular/core';
+            import {TuiInputModule} from '@taiga-ui/legacy';
+
+            @Component({
+                standalone: true,
+                templateUrl: './test.html',
+                imports: [TuiInputModule],
+            })
+            export class Test {}
+        ",
+  "1. After": "import { TuiInput } from "@taiga-ui/core";
+
+            import {Component} from '@angular/core';
+
+            @Component({
+                standalone: true,
+                templateUrl: './test.html',
+                imports: [TuiInput],
+            })
+            export class Test {}
+        ",
+}
+`;
+
+exports[`ng-update hint on legacy controls should not change does not touch tui-icon that already has tuiTooltip: test.html 1`] = `
+{
+  "0. Before": "
+                    <tui-textfield>
+                        <input tuiInput />
+                        <tui-icon
+                            tuiHintDirection="left"
+                            [tuiTooltip]="hint"
+                        />
+                    </tui-textfield>
+                ",
+  "1. After": "
+                    <tui-textfield>
+                        <input tuiInput />
+                        <tui-icon
+                            tuiHintDirection="start"
+                            [tuiTooltip]="hint"
+                        />
+                    </tui-textfield>
+                ",
+}
+`;
+
+exports[`ng-update hint on legacy controls should not change does not touch tui-icon that already has tuiTooltip: test.ts 1`] = `
+{
+  "0. Before": "
+            import {Component} from '@angular/core';
+            import {TuiInputModule} from '@taiga-ui/legacy';
+
+            @Component({
+                standalone: true,
+                templateUrl: './test.html',
+                imports: [TuiInputModule],
+            })
+            export class Test {}
+        ",
+  "1. After": "import { TuiInput } from "@taiga-ui/core";
+
+            import {Component} from '@angular/core';
+
+            @Component({
+                standalone: true,
+                templateUrl: './test.html',
+                imports: [TuiInput],
+            })
+            export class Test {}
+        ",
+}
+`;

--- a/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-input.spec.ts.snap
+++ b/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-input.spec.ts.snap
@@ -98,9 +98,10 @@ exports[`ng-update legacy input migrates tui-input wrapper attrs and routes them
                 </tui-input>
             ",
   "1. After": "
-                <tui-textfield tuiHintContent="Hint" tuiTextfieldSize="s" [tuiTextfieldCleaner]="true">
+                <tui-textfield tuiTextfieldSize="s" [tuiTextfieldCleaner]="true">
                 <label tuiLabel>Email</label>
                 <input tuiInput formControlName="value" />
+<tui-icon tuiTooltip="Hint" />
                 </tui-textfield>
             ",
 }
@@ -118,9 +119,10 @@ exports[`ng-update legacy input migrates tuiHintDirection value alongside wrappe
                 </tui-input>
             ",
   "1. After": "
-                <tui-textfield tuiHintContent="Hint" tuiHintDirection="bottom-end">
+                <tui-textfield>
                 <label tuiLabel>Label</label>
                 <input tuiInput formControlName="value" />
+<tui-icon tuiTooltip="Hint" tuiHintDirection="bottom-end" />
                 </tui-textfield>
             ",
 }

--- a/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-textarea.spec.ts.snap
+++ b/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-textarea.spec.ts.snap
@@ -33,9 +33,10 @@ exports[`ng-update legacy textarea keeps tuiTextfieldCleaner and tuiHintContent 
      - Text content "Label" became <label tuiLabel> inside <tui-textfield>. Add placeholder on <textarea tuiTextarea> separately if hint text is needed.
      - Legacy tui-textarea had a fixed height of 20 rows by default. New component auto-resizes between [min] (default: 1) and [max] (default: 3) rows. Set min and max explicitly if the previous layout needs to be preserved.
 -->
-                <tui-textfield tuiHintContent="Hint text" tuiHintDirection="bottom-end" [tuiTextfieldCleaner]="true">
+                <tui-textfield [tuiTextfieldCleaner]="true">
                 <label tuiLabel>Label</label>
                 <textarea tuiTextarea formControlName="value"></textarea>
+<tui-icon tuiTooltip="Hint text" tuiHintDirection="bottom-end" />
                 </tui-textfield>
             ",
 }

--- a/projects/cdk/schematics/ng-update/v5/tests/schematic-migrate-hint-on-legacy-controls.spec.ts
+++ b/projects/cdk/schematics/ng-update/v5/tests/schematic-migrate-hint-on-legacy-controls.spec.ts
@@ -1,0 +1,283 @@
+import {join} from 'node:path';
+
+import {resetActiveProject} from 'ng-morph';
+
+import {createMigration} from '../../../utils/run-migration';
+
+describe('ng-update hint on legacy controls', () => {
+    const migrate = createMigration({
+        collection: join(__dirname, '../../../migration.json'),
+        component: `
+            import {Component} from '@angular/core';
+            import {TuiInputModule} from '@taiga-ui/legacy';
+
+            @Component({
+                standalone: true,
+                templateUrl: './test.html',
+                imports: [TuiInputModule],
+            })
+            export class Test {}
+        `,
+    });
+
+    describe('basic tuiHintContent migration', () => {
+        it(
+            'moves [tuiHintContent] to tui-icon with tuiTooltip',
+            migrate({template: '<tui-input [tuiHintContent]="hint" />'}),
+        );
+
+        it(
+            'moves static tuiHintContent to tui-icon with tuiTooltip',
+            migrate({template: '<tui-input tuiHintContent="Some hint text" />'}),
+        );
+    });
+
+    describe('hint with additional directives', () => {
+        it(
+            'moves tuiHintDirection to tui-icon alongside tuiTooltip',
+            migrate({
+                template: /* HTML */ `
+                    <tui-input
+                        tuiHintDirection="left"
+                        [tuiHintContent]="hint"
+                    >
+                        Label
+                    </tui-input>
+                `,
+            }),
+        );
+
+        it(
+            'moves tuiHintAppearance to tui-icon alongside tuiTooltip',
+            migrate({
+                template: /* HTML */ `
+                    <tui-input
+                        tuiHintAppearance="dark"
+                        [tuiHintContent]="hint"
+                    />
+                `,
+            }),
+        );
+
+        it(
+            'moves all tuiHint* directives to tui-icon',
+            migrate({
+                template: /* HTML */ `
+                    <tui-input
+                        tuiHintAppearance="dark"
+                        tuiHintDirection="left"
+                        [tuiHintContent]="hint"
+                    >
+                        Label
+                    </tui-input>
+                `,
+            }),
+        );
+
+        it(
+            'moves bound tuiHintDirection and tuiHintAppearance to tui-icon',
+            migrate({
+                template: /* HTML */ `
+                    <tui-input
+                        [tuiHintAppearance]="appearance"
+                        [tuiHintContent]="hint"
+                        [tuiHintDirection]="direction"
+                    />
+                `,
+            }),
+        );
+    });
+
+    describe('different legacy controls', () => {
+        it(
+            'migrates tuiHintContent on tui-input-number',
+            migrate({
+                template:
+                    '<tui-input-number [tuiHintContent]="hint" tuiHintDirection="top" />',
+            }),
+        );
+
+        it(
+            'migrates tuiHintContent on tui-combo-box',
+            migrate({
+                template: /* HTML */ `
+                    <tui-combo-box
+                        tuiHintAppearance="dark"
+                        [tuiHintContent]="hint"
+                        [(ngModel)]="value"
+                    >
+                        Label
+                        <tui-data-list-wrapper
+                            *tuiDataList
+                            [items]="items | tuiFilterByInput"
+                        />
+                    </tui-combo-box>
+                `,
+            }),
+        );
+
+        it(
+            'migrates tuiHintContent on tui-select',
+            migrate({
+                template: /* HTML */ `
+                    <tui-select
+                        [tuiHintContent]="hint"
+                        [(ngModel)]="value"
+                    >
+                        Select user
+                        <tui-data-list-wrapper
+                            *tuiDataList
+                            [items]="items"
+                        />
+                    </tui-select>
+                `,
+            }),
+        );
+
+        it(
+            'migrates tuiHintContent on tui-multi-select',
+            migrate({
+                template: /* HTML */ `
+                    <tui-multi-select
+                        tuiHintDirection="right"
+                        [formControl]="control"
+                        [tuiHintContent]="hint"
+                        [(search)]="search"
+                    >
+                        Star Wars persons
+                        <tui-data-list-wrapper
+                            *tuiDataList
+                            tuiMultiSelectGroup
+                            [items]="filter(search)"
+                        />
+                    </tui-multi-select>
+                `,
+            }),
+        );
+
+        it(
+            'migrates tuiHintContent on tui-textarea',
+            migrate({template: '<tui-textarea [tuiHintContent]="hint" />'}),
+        );
+
+        it(
+            'migrates tuiHintContent on tui-input-date',
+            migrate({
+                template:
+                    '<tui-input-date [tuiHintContent]="hint" tuiHintDirection="bottom">Label</tui-input-date>',
+            }),
+        );
+
+        it(
+            'migrates tuiHintContent on tui-input-date-range',
+            migrate({
+                template:
+                    '<tui-input-date-range [tuiHintContent]="hint">Label</tui-input-date-range>',
+            }),
+        );
+
+        it(
+            'migrates tuiHintContent on tui-input-phone',
+            migrate({
+                template:
+                    '<tui-input-phone [tuiHintContent]="hint">Label</tui-input-phone>',
+            }),
+        );
+
+        it(
+            'migrates tuiHintContent on tui-input-tag',
+            migrate({
+                template: '<tui-input-tag [tuiHintContent]="hint">Label</tui-input-tag>',
+            }),
+        );
+
+        it(
+            'migrates tuiHintContent on tui-input-time',
+            migrate({
+                template:
+                    '<tui-input-time [tuiHintContent]="hint">Label</tui-input-time>',
+            }),
+        );
+    });
+
+    describe('multiple occurrences', () => {
+        it(
+            'migrates multiple elements with tuiHintContent in one template',
+            migrate({
+                template: /* HTML */ `
+                    <tui-input
+                        tuiHintDirection="left"
+                        [tuiHintContent]="hint1"
+                    ></tui-input>
+                    <tui-select
+                        tuiHintAppearance="dark"
+                        [tuiHintContent]="hint2"
+                    ></tui-select>
+                `,
+            }),
+        );
+    });
+
+    describe('import additions', () => {
+        it(
+            'adds TuiTooltip and TuiIcon imports when tuiHintContent is present',
+            migrate({
+                component: `
+                    import {Component} from '@angular/core';
+                    import {TuiInputModule} from '@taiga-ui/legacy';
+
+                    @Component({
+                        standalone: true,
+                        templateUrl: './test.html',
+                        imports: [TuiInputModule],
+                    })
+                    export class Test {}
+                `,
+                template: '<tui-input [tuiHintContent]="hint" />',
+            }),
+        );
+
+        it(
+            'does not duplicate TuiIcon import if already present',
+            migrate({
+                component: `
+                    import {Component} from '@angular/core';
+                    import {TuiIcon} from '@taiga-ui/core';
+                    import {TuiInputModule} from '@taiga-ui/legacy';
+
+                    @Component({
+                        standalone: true,
+                        templateUrl: './test.html',
+                        imports: [TuiInputModule, TuiIcon],
+                    })
+                    export class Test {}
+                `,
+                template: '<tui-input [tuiHintContent]="hint" />',
+            }),
+        );
+    });
+
+    describe('should not change', () => {
+        it(
+            'does not touch legacy control without tuiHintContent',
+            migrate({template: '<tui-input formControlName="value" />'}),
+        );
+
+        it(
+            'does not touch tui-icon that already has tuiTooltip',
+            migrate({
+                template: /* HTML */ `
+                    <tui-textfield>
+                        <input tuiInput />
+                        <tui-icon
+                            tuiHintDirection="left"
+                            [tuiTooltip]="hint"
+                        />
+                    </tui-textfield>
+                `,
+            }),
+        );
+    });
+
+    afterEach(() => resetActiveProject());
+});

--- a/projects/cdk/schematics/utils/add-import-to-closest-module.ts
+++ b/projects/cdk/schematics/utils/add-import-to-closest-module.ts
@@ -81,4 +81,6 @@ export function saveAddedImports(options: TuiSchema): void {
                 );
         }
     });
+
+    importsToAdd.clear();
 }


### PR DESCRIPTION
```html
<tui-input
    [tuiHintContent]="hint" 
    tuiHintDirection="left" 
    tuiHintAppearance="dark"
></tui-input>
```

⬇️ 
```html
<tui-textfield>
    <input tuiInput [(ngModel)]="value" />

    <tui-icon
        [tuiTooltip]="hint"
        tuiHintDirection="left" 
        tuiHintAppearance="dark"
    />
</tui-textfield>
```

Fixes #13773
