### PR TITLE
chore(schematics): add migration `NG_EVENT_PLUGINS` => `provideTaiga`

### DIFF
--- a/projects/cdk/schematics/ng-update/v5/steps/constants/identifiers-to-replace.ts
+++ b/projects/cdk/schematics/ng-update/v5/steps/constants/identifiers-to-replace.ts
@@ -349,6 +349,16 @@ export const IDENTIFIERS_TO_REPLACE: ReplacementIdentifierMulti[] = [
     },
     {
         from: {
+            name: 'NG_EVENT_PLUGINS',
+            moduleSpecifier: '@taiga-ui/event-plugins',
+        },
+        to: {
+            name: 'provideTaiga',
+            moduleSpecifier: '@taiga-ui/core',
+        },
+    },
+    {
+        from: {
             name: 'TuiIslandDirective',
             moduleSpecifier: '@taiga-ui/legacy',
         },


### PR DESCRIPTION
Handle in the same way as modern alternative
https://github.com/taiga-family/taiga-ui/blob/efa3480bf42abbfb7512c3210d1b3916196b7be4/projects/cdk/schematics/ng-update/v5/steps/constants/identifiers-to-replace.ts#L340-L349

https://github.com/taiga-family/maskito/blob/268edecc00e3d15d55d12ec36ef3d8f71cdb97fe/projects/demo/src/app/app.config.ts#L45