### PR TITLE
chore: fix flaky schematics tests on low-RAM devices

### DIFF
--- a/package.json
+++ b/package.json
@@ -111,7 +111,8 @@
         }
     },
     "jest": {
-        "preset": "@taiga-ui/jest-config"
+        "preset": "@taiga-ui/jest-config",
+        "workerIdleMemoryLimit": "256MB"
     },
     "overrides": {
         "rxjs": "$rxjs"


### PR DESCRIPTION
## Problem
`npx nx test cdk --skip-nx-cache` is flaky — tests fail randomly, always different tests, but pass individually. 

```
 FAIL  projects/cdk/schematics/ng-update/v5/tests/any-random-test-file.spec.ts
  ● Test suite failed to run

    A jest worker process (pid=62273) was terminated by another process: signal=SIGSEGV, exitCode=null. 
    Operating system logs may contain more information on why this occurred.

      at ChildProcessWorker._onExit (node_modules/jest-runner/node_modules/jest-worker/build/workers/ChildProcessWorker.js:370:23)
```

## Solution
The `.env` file sets `NODE_OPTIONS=--max-old-space-size=12288` (12GB heap), designed for CI with ample RAM. On an 8GB machine, this causes jest worker processes to accumulate memory without V8 garbage-collecting aggressively enough (since V8 thinks it has 12GB available), and macOS kills the worker processes with SIGSEGV when physical RAM is exhausted.
The CDK schematics tests are particularly memory-heavy because each test creates a full ts-morph `Project` (TypeScript compiler instance). Over 100+ schematics test suites, memory accumulates significantly.

`workerIdleMemoryLimit: '256MB'` - forces worker process recycling after each memory-heavy schematics test, preventing unbounded memory growth