### PR TITLE
chore(cdk): `TuiTextfieldLabelOutside` fix migration

### DIFF
--- a/projects/cdk/schematics/ng-update/utils/templates/remove-attr.ts
+++ b/projects/cdk/schematics/ng-update/utils/templates/remove-attr.ts
@@ -1,0 +1,40 @@
+import {type UpdateRecorder} from '@angular-devkit/schematics';
+import {type DefaultTreeAdapterTypes} from 'parse5';
+
+type Element = DefaultTreeAdapterTypes.Element;
+
+/**
+ * Finds an attribute on a parsed element by name (checks both `attrName` and `[attrName]` forms),
+ * removes it via the recorder, and returns the value.
+ *
+ * @returns `value` is `null` when the attribute was not present.
+ */
+export function removeAttr(
+    element: Element,
+    attrName: string,
+    recorder: UpdateRecorder,
+    templateOffset: number,
+): {value: string | null; isBinding: boolean} {
+    const nameLower = attrName.toLowerCase();
+    const bindingLower = `[${nameLower}]`;
+
+    for (const attr of element.attrs) {
+        const attrNameLower = attr.name.toLowerCase();
+
+        if (attrNameLower !== nameLower && attrNameLower !== bindingLower) {
+            continue;
+        }
+
+        const {startOffset = 0, endOffset = 0} =
+            element.sourceCodeLocation?.attrs?.[attr.name] ?? {};
+
+        recorder.remove(templateOffset + startOffset, endOffset - startOffset);
+
+        return {
+            value: attr.value,
+            isBinding: attrNameLower.startsWith('['),
+        };
+    }
+
+    return {value: null, isBinding: false};
+}

--- a/projects/cdk/schematics/ng-update/v5/steps/templates/migrate-combo-box.ts
+++ b/projects/cdk/schematics/ng-update/v5/steps/templates/migrate-combo-box.ts
@@ -138,6 +138,15 @@ export function migrateComboBox({
             (node: ChildNode): node is Element => node.nodeName === 'input',
         );
 
+        const isBinding = labelOutsideAttr?.name.startsWith('[') ?? false;
+        const isLabelOutsideTrue =
+            labelOutsideAttr?.value === 'true' ||
+            (!!labelOutsideAttr && !isBinding && labelOutsideAttr.value === '');
+        const isLabelOutsideDynamic =
+            !!labelOutsideAttr &&
+            !isLabelOutsideTrue &&
+            labelOutsideAttr.value !== 'false';
+
         if (inputs.length) {
             handleExistingInput({
                 inputs,
@@ -147,11 +156,8 @@ export function migrateComboBox({
                 controlAttrs,
                 inputAttrs,
                 searchHandler,
+                placeholder: isLabelOutsideTrue ? getPlaceholderText(element) : '',
             });
-
-            if (!labelOutsideAttr || labelOutsideAttr.value === 'false') {
-                wrapTextInLabel(recorder, templateOffset, element);
-            }
         } else {
             handleGeneratedInput({
                 element,
@@ -161,8 +167,17 @@ export function migrateComboBox({
                 inputAttrs,
                 searchHandler,
                 sourceCodeLocation,
-                labelOutside: labelOutsideAttr?.value ?? '',
+                isLabelOutsideTrue,
+                template,
             });
+        }
+
+        if (!labelOutsideAttr || labelOutsideAttr.value === 'false') {
+            wrapTextInLabel(recorder, templateOffset, element);
+        } else if (isLabelOutsideTrue && inputs.length) {
+            removeTextNode(recorder, templateOffset, element);
+        } else if (isLabelOutsideDynamic) {
+            addLabelOutsideTodo(recorder, templateOffset, element, template);
         }
     });
 }
@@ -175,10 +190,12 @@ function handleExistingInput({
     controlAttrs,
     inputAttrs,
     searchHandler,
+    placeholder,
 }: {
     controlAttrs: Array<{name: string; value: string}>;
     inputAttrs: Array<{name: string; value: string}>;
     inputs: Element[];
+    placeholder: string;
     recorder: UpdateRecorder;
     searchHandler: string;
     template: string;
@@ -209,10 +226,11 @@ function handleExistingInput({
             (input.sourceCodeLocation?.startTag?.startOffset ?? 0) + '<input'.length;
         const formAttrs = formatControlAttrs(controlAttrs);
         const inputAttrStr = formatInputAttrs(inputAttrs);
+        const placeholderAttr = placeholder ? ` placeholder="${placeholder}"` : '';
 
         recorder.insertRight(
             templateOffset + insertOffset,
-            ` tuiComboBox${formAttrs}${inputAttrStr}${searchHandler}`,
+            ` tuiComboBox${formAttrs}${inputAttrStr}${searchHandler}${placeholderAttr}`,
         );
     });
 }
@@ -225,12 +243,12 @@ function handleGeneratedInput({
     inputAttrs,
     searchHandler,
     sourceCodeLocation,
-    labelOutside,
+    isLabelOutsideTrue,
 }: {
     controlAttrs: Array<{name: string; value: string}>;
     element: Element;
     inputAttrs: Array<{name: string; value: string}>;
-    labelOutside: string;
+    isLabelOutsideTrue: boolean;
     recorder: UpdateRecorder;
     searchHandler: string;
     sourceCodeLocation: Element['sourceCodeLocation'];
@@ -239,12 +257,9 @@ function handleGeneratedInput({
     const formAttrs = formatControlAttrs(controlAttrs);
     const inputAttrStr = formatInputAttrs(inputAttrs);
 
-    const labelNode = element.childNodes.find(
-        (node): node is TextNode =>
-            node.nodeName === '#text' && !!(node as TextNode).value.trim(),
-    );
+    const labelNode = findTextNode(element);
 
-    if (labelOutside === 'true' && labelNode) {
+    if (isLabelOutsideTrue && labelNode) {
         const labelText = labelNode.value.trim();
         const textStart = labelNode.sourceCodeLocation?.startOffset ?? 0;
         const textEnd = labelNode.sourceCodeLocation?.endOffset ?? 0;
@@ -259,11 +274,6 @@ function handleGeneratedInput({
         return;
     }
 
-    if (!labelOutside || labelOutside === 'false') {
-        wrapTextInLabel(recorder, templateOffset, element);
-    }
-    // labelOutside === 'true': text → placeholder on <input> — fully automatic, no TODO needed
-
     const insertOffset = labelNode
         ? (labelNode.sourceCodeLocation?.endOffset ?? 0)
         : (sourceCodeLocation?.endTag?.startOffset ?? 0);
@@ -274,15 +284,56 @@ function handleGeneratedInput({
     );
 }
 
+function findTextNode(element: Element): TextNode | undefined {
+    return element.childNodes.find(
+        (node: ChildNode): node is TextNode =>
+            node.nodeName === '#text' && !!(node as TextNode).value.trim(),
+    );
+}
+
+function getPlaceholderText(element: Element): string {
+    return findTextNode(element)?.value.trim() ?? '';
+}
+
+function removeTextNode(
+    recorder: UpdateRecorder,
+    templateOffset: number,
+    element: Element,
+): void {
+    const labelNode = findTextNode(element);
+
+    if (!labelNode) {
+        return;
+    }
+
+    const textStart = labelNode.sourceCodeLocation?.startOffset ?? 0;
+    const textEnd = labelNode.sourceCodeLocation?.endOffset ?? 0;
+
+    recorder.remove(templateOffset + textStart, textEnd - textStart);
+}
+
+function addLabelOutsideTodo(
+    recorder: UpdateRecorder,
+    templateOffset: number,
+    element: Element,
+    template: string,
+): void {
+    const elementStart = element.sourceCodeLocation?.startOffset ?? 0;
+    const lineStart = template.lastIndexOf('\n', elementStart - 1) + 1;
+    const indent = template.slice(lineStart, elementStart);
+
+    recorder.insertRight(
+        templateOffset + elementStart,
+        `<!-- ${TODO_MARK} [tuiTextfieldLabelOutside] is dynamic and cannot be migrated automatically. Use <label tuiLabel> inside <tui-textfield> for floating label or input[placeholder] for outside label -->\n${indent}`,
+    );
+}
+
 function wrapTextInLabel(
     recorder: UpdateRecorder,
     templateOffset: number,
     element: Element,
 ): void {
-    const labelNode = element.childNodes.find(
-        (node: ChildNode): node is TextNode =>
-            node.nodeName === '#text' && !!(node as TextNode).value.trim(),
-    );
+    const labelNode = findTextNode(element);
 
     if (!labelNode) {
         return;

--- a/projects/cdk/schematics/ng-update/v5/steps/templates/migrate-combo-box.ts
+++ b/projects/cdk/schematics/ng-update/v5/steps/templates/migrate-combo-box.ts
@@ -158,7 +158,21 @@ export function migrateComboBox({
                 searchHandler,
                 placeholder: isLabelOutsideTrue ? getPlaceholderText(element) : '',
             });
+
+            if (!labelOutsideAttr || labelOutsideAttr.value === 'false') {
+                wrapTextInLabel(recorder, templateOffset, element);
+            } else if (isLabelOutsideTrue) {
+                removeTextNode(recorder, templateOffset, element);
+            } else if (isLabelOutsideDynamic) {
+                addLabelOutsideTodo(recorder, templateOffset, element, template);
+            }
         } else {
+            if (!labelOutsideAttr || labelOutsideAttr.value === 'false') {
+                wrapTextInLabel(recorder, templateOffset, element);
+            } else if (isLabelOutsideDynamic) {
+                addLabelOutsideTodo(recorder, templateOffset, element, template);
+            }
+
             handleGeneratedInput({
                 element,
                 recorder,
@@ -168,16 +182,7 @@ export function migrateComboBox({
                 searchHandler,
                 sourceCodeLocation,
                 isLabelOutsideTrue,
-                template,
             });
-        }
-
-        if (!labelOutsideAttr || labelOutsideAttr.value === 'false') {
-            wrapTextInLabel(recorder, templateOffset, element);
-        } else if (isLabelOutsideTrue && inputs.length) {
-            removeTextNode(recorder, templateOffset, element);
-        } else if (isLabelOutsideDynamic) {
-            addLabelOutsideTodo(recorder, templateOffset, element, template);
         }
     });
 }

--- a/projects/cdk/schematics/ng-update/v5/steps/templates/migrate-combo-box.ts
+++ b/projects/cdk/schematics/ng-update/v5/steps/templates/migrate-combo-box.ts
@@ -162,7 +162,6 @@ export function migrateComboBox({
                 searchHandler,
                 sourceCodeLocation,
                 labelOutside: labelOutsideAttr?.value ?? '',
-                template,
             });
         }
     });
@@ -227,7 +226,6 @@ function handleGeneratedInput({
     searchHandler,
     sourceCodeLocation,
     labelOutside,
-    template,
 }: {
     controlAttrs: Array<{name: string; value: string}>;
     element: Element;
@@ -236,7 +234,6 @@ function handleGeneratedInput({
     recorder: UpdateRecorder;
     searchHandler: string;
     sourceCodeLocation: Element['sourceCodeLocation'];
-    template: string;
     templateOffset: number;
 }): void {
     const formAttrs = formatControlAttrs(controlAttrs);
@@ -264,17 +261,8 @@ function handleGeneratedInput({
 
     if (!labelOutside || labelOutside === 'false') {
         wrapTextInLabel(recorder, templateOffset, element);
-    } else if (labelNode) {
-        const elementStart = element.sourceCodeLocation?.startOffset ?? 0;
-        const lineStart = template.lastIndexOf('\n', elementStart - 1) + 1;
-        const indent = template.slice(lineStart, elementStart);
-        const textStart = labelNode.sourceCodeLocation?.startOffset ?? 0;
-
-        recorder.insertRight(
-            templateOffset + textStart + 1,
-            `${indent}<!-- ${TODO_MARK} Use <label tuiLabel> element inside <tui-textfield> for a floating label or input[placeholder] for empty value label -->\n`,
-        );
     }
+    // labelOutside === 'true': text → placeholder on <input> — fully automatic, no TODO needed
 
     const insertOffset = labelNode
         ? (labelNode.sourceCodeLocation?.endOffset ?? 0)

--- a/projects/cdk/schematics/ng-update/v5/steps/templates/migrate-input-color.ts
+++ b/projects/cdk/schematics/ng-update/v5/steps/templates/migrate-input-color.ts
@@ -9,6 +9,7 @@ import {
     getTemplateOffset,
 } from '../../../../utils/templates/template-resource';
 import {type TemplateResource} from '../../../interfaces/template-resource';
+import {removeAttr} from '../../../utils/templates/remove-attr';
 import {replaceTag} from '../../../utils/templates/replace-tag';
 
 type TextNode = DefaultTreeAdapterTypes.TextNode;
@@ -54,6 +55,17 @@ export function migrateInputColor({
             NO_EQUIVALENT_ATTRS.has(attr.name.toLowerCase()),
         );
 
+        const {value: labelOutside, isBinding: labelOutsideIsBinding} = removeAttr(
+            element,
+            'tuiTextfieldLabelOutside',
+            recorder,
+            templateOffset,
+        );
+        const isLabelOutsideTrue =
+            labelOutside === 'true' || (!labelOutsideIsBinding && labelOutside === '');
+        const isDynamic =
+            labelOutside !== null && !isLabelOutsideTrue && labelOutside !== 'false';
+
         for (const attr of [...controlAttrs, ...noEquivalentAttrs]) {
             const {startOffset = 0, endOffset = 0} =
                 element.sourceCodeLocation?.attrs?.[attr.name] ?? {};
@@ -66,15 +78,32 @@ export function migrateInputColor({
                 node.nodeName === '#text' && (node as TextNode)?.value.trim(),
         );
 
+        let placeholderAttr = '';
+
         if (labelIndex !== -1) {
             const labelNode = element.childNodes[labelIndex];
+            const labelText = (labelNode as TextNode).value.trim();
             const labelTextStart =
                 (labelNode?.sourceCodeLocation?.startOffset ?? 0) + templateOffset;
             const labelTextEnd =
                 (labelNode?.sourceCodeLocation?.endOffset ?? 0) + templateOffset;
 
-            recorder.insertRight(labelTextStart, '\n<label tuiLabel>');
-            recorder.insertRight(labelTextEnd, '</label>\n');
+            if (isLabelOutsideTrue) {
+                recorder.remove(labelTextStart, labelTextEnd - labelTextStart);
+                placeholderAttr = ` placeholder="${labelText}"`;
+            } else if (!isDynamic) {
+                recorder.insertRight(labelTextStart, '\n<label tuiLabel>');
+                recorder.insertRight(labelTextEnd, '</label>\n');
+            }
+        }
+
+        if (isDynamic) {
+            const insertAt = (sourceCodeLocation?.startOffset ?? 0) + templateOffset;
+
+            recorder.insertLeft(
+                insertAt,
+                `<!-- ${TODO_MARK} [tuiTextfieldLabelOutside] is dynamic — cannot be migrated automatically. Use <label tuiLabel> inside <tui-textfield> for label-outside pattern.\n-->\n`,
+            );
         }
 
         if (noEquivalentAttrs.length > 0) {
@@ -102,7 +131,7 @@ export function migrateInputColor({
 
         recorder.insertRight(
             insertOffset,
-            `\n<input tuiInputColor${migrationAttrs} />\n`,
+            `\n<input tuiInputColor${migrationAttrs}${placeholderAttr} />\n`,
         );
     });
 }

--- a/projects/cdk/schematics/ng-update/v5/steps/templates/migrate-input-date-multi.ts
+++ b/projects/cdk/schematics/ng-update/v5/steps/templates/migrate-input-date-multi.ts
@@ -99,7 +99,16 @@ export function migrateInputDateMulti({
             templateOffset,
         );
 
-        removeAttr(element, 'tuiTextfieldLabelOutside', recorder, templateOffset);
+        const {value: labelOutside, isBinding: labelOutsideIsBinding} = removeAttr(
+            element,
+            'tuiTextfieldLabelOutside',
+            recorder,
+            templateOffset,
+        );
+        const isLabelOutsideTrue =
+            labelOutside === 'true' || (!labelOutsideIsBinding && labelOutside === '');
+        const isDynamic =
+            labelOutside !== null && !isLabelOutsideTrue && labelOutside !== 'false';
 
         const allAttrs = [...element.attrs];
 
@@ -176,15 +185,32 @@ export function migrateInputDateMulti({
                 node.nodeName === '#text' && (node as TextNode)?.value.trim(),
         );
 
+        let placeholderAttr = '';
+
         if (labelIndex !== -1) {
             const labelNode = element.childNodes[labelIndex];
+            const labelText = (labelNode as TextNode).value.trim();
             const labelTextStart =
                 (labelNode?.sourceCodeLocation?.startOffset ?? 0) + templateOffset;
             const labelTextEnd =
                 (labelNode?.sourceCodeLocation?.endOffset ?? 0) + templateOffset;
 
-            recorder.insertRight(labelTextStart, '\n<label tuiLabel>');
-            recorder.insertRight(labelTextEnd, '</label>\n');
+            if (isLabelOutsideTrue) {
+                recorder.remove(labelTextStart, labelTextEnd - labelTextStart);
+                placeholderAttr = ` placeholder="${labelText}"`;
+            } else {
+                recorder.insertRight(labelTextStart, '\n<label tuiLabel>');
+                recorder.insertRight(labelTextEnd, '</label>\n');
+            }
+        }
+
+        if (isDynamic) {
+            const insertAt = (sourceCodeLocation?.startOffset ?? 0) + templateOffset;
+
+            recorder.insertLeft(
+                insertAt,
+                `<!-- ${TODO_MARK} [tuiTextfieldLabelOutside] is dynamic — cannot be migrated automatically. Use <label tuiLabel> inside <tui-textfield> for label-outside pattern.\n-->\n`,
+            );
         }
 
         if (todoAttrs.length > 0) {
@@ -235,7 +261,7 @@ export function migrateInputDateMulti({
         } else {
             recorder.insertRight(
                 insertOffset,
-                `\n<input tuiInputDateMulti${migrationAttrs} />\n<tui-calendar *tuiDropdown${calendarAttrStr} />\n`,
+                `\n<input tuiInputDateMulti${migrationAttrs}${placeholderAttr} />\n<tui-calendar *tuiDropdown${calendarAttrStr} />\n`,
             );
         }
 
@@ -252,7 +278,7 @@ export function migrateInputDateMulti({
 
                     recorder.insertRight(
                         templateOffset + startOffset,
-                        `tuiInputDateMulti${migrationAttrs}`,
+                        `tuiInputDateMulti${migrationAttrs}${placeholderAttr}`,
                     );
                 }
             });

--- a/projects/cdk/schematics/ng-update/v5/steps/templates/migrate-input-date-multi.ts
+++ b/projects/cdk/schematics/ng-update/v5/steps/templates/migrate-input-date-multi.ts
@@ -198,7 +198,7 @@ export function migrateInputDateMulti({
             if (isLabelOutsideTrue) {
                 recorder.remove(labelTextStart, labelTextEnd - labelTextStart);
                 placeholderAttr = ` placeholder="${labelText}"`;
-            } else {
+            } else if (!isDynamic) {
                 recorder.insertRight(labelTextStart, '\n<label tuiLabel>');
                 recorder.insertRight(labelTextEnd, '</label>\n');
             }

--- a/projects/cdk/schematics/ng-update/v5/steps/templates/migrate-input-date-multi.ts
+++ b/projects/cdk/schematics/ng-update/v5/steps/templates/migrate-input-date-multi.ts
@@ -9,6 +9,7 @@ import {
     getTemplateOffset,
 } from '../../../../utils/templates/template-resource';
 import {type TemplateResource} from '../../../interfaces/template-resource';
+import {removeAttr} from '../../../utils/templates/remove-attr';
 import {replaceTag} from '../../../utils/templates/replace-tag';
 
 type TextNode = DefaultTreeAdapterTypes.TextNode;
@@ -97,6 +98,8 @@ export function migrateInputDateMulti({
             template,
             templateOffset,
         );
+
+        removeAttr(element, 'tuiTextfieldLabelOutside', recorder, templateOffset);
 
         const allAttrs = [...element.attrs];
 

--- a/projects/cdk/schematics/ng-update/v5/steps/templates/migrate-input-date-range.ts
+++ b/projects/cdk/schematics/ng-update/v5/steps/templates/migrate-input-date-range.ts
@@ -2,6 +2,7 @@ import {type UpdateRecorder} from '@angular-devkit/schematics';
 import {type DevkitFileSystem} from 'ng-morph';
 import {type DefaultTreeAdapterTypes} from 'parse5';
 
+import {TODO_MARK} from '../../../../utils/insert-todo';
 import {findElementsByTagName} from '../../../../utils/templates/elements';
 import {
     getTemplateFromTemplateResource,
@@ -67,7 +68,16 @@ export function migrateInputDateRange({
             templateOffset,
         );
 
-        removeAttr(element, 'tuiTextfieldLabelOutside', recorder, templateOffset);
+        const {value: labelOutside, isBinding: labelOutsideIsBinding} = removeAttr(
+            element,
+            'tuiTextfieldLabelOutside',
+            recorder,
+            templateOffset,
+        );
+        const isLabelOutsideTrue =
+            labelOutside === 'true' || (!labelOutsideIsBinding && labelOutside === '');
+        const isDynamic =
+            labelOutside !== null && !isLabelOutsideTrue && labelOutside !== 'false';
 
         const controlAttrs = [...element.attrs].filter((attr) =>
             /formcontrol|ngmodel/.exec(attr.name.toLocaleLowerCase()),
@@ -93,15 +103,32 @@ export function migrateInputDateRange({
                 node.nodeName === '#text' && (node as TextNode)?.value.trim(),
         );
 
+        let placeholderAttr = '';
+
         if (labelIndex !== -1) {
             const labelNode = element.childNodes[labelIndex];
+            const labelText = (labelNode as TextNode).value.trim();
             const labelTextStart =
                 (labelNode?.sourceCodeLocation?.startOffset ?? 0) + templateOffset;
             const labelTextEnd =
                 (labelNode?.sourceCodeLocation?.endOffset ?? 0) + templateOffset;
 
-            recorder.insertRight(labelTextStart, '\n<label tuiLabel>');
-            recorder.insertRight(labelTextEnd, '</label>\n');
+            if (isLabelOutsideTrue) {
+                recorder.remove(labelTextStart, labelTextEnd - labelTextStart);
+                placeholderAttr = ` placeholder="${labelText}"`;
+            } else {
+                recorder.insertRight(labelTextStart, '\n<label tuiLabel>');
+                recorder.insertRight(labelTextEnd, '</label>\n');
+            }
+        }
+
+        if (isDynamic) {
+            const insertAt = (sourceCodeLocation?.startOffset ?? 0) + templateOffset;
+
+            recorder.insertLeft(
+                insertAt,
+                `<!-- ${TODO_MARK} [tuiTextfieldLabelOutside] is dynamic — cannot be migrated automatically. Use <label tuiLabel> inside <tui-textfield> for label-outside pattern.\n-->\n`,
+            );
         }
 
         const insertOffset =
@@ -131,7 +158,7 @@ export function migrateInputDateRange({
         } else {
             recorder.insertRight(
                 insertOffset,
-                `\n<input tuiInputDateRange${migrationAttrs} />\n<tui-calendar-range *tuiDropdown${calendarAttrStr} />\n`,
+                `\n<input tuiInputDateRange${migrationAttrs}${placeholderAttr} />\n<tui-calendar-range *tuiDropdown${calendarAttrStr} />\n`,
             );
         }
 
@@ -148,7 +175,7 @@ export function migrateInputDateRange({
 
                     recorder.insertRight(
                         templateOffset + startOffset,
-                        `tuiInputDateRange${migrationAttrs}`,
+                        `tuiInputDateRange${migrationAttrs}${placeholderAttr}`,
                     );
                 }
             });

--- a/projects/cdk/schematics/ng-update/v5/steps/templates/migrate-input-date-range.ts
+++ b/projects/cdk/schematics/ng-update/v5/steps/templates/migrate-input-date-range.ts
@@ -8,6 +8,7 @@ import {
     getTemplateOffset,
 } from '../../../../utils/templates/template-resource';
 import {type TemplateResource} from '../../../interfaces/template-resource';
+import {removeAttr} from '../../../utils/templates/remove-attr';
 import {replaceTag} from '../../../utils/templates/replace-tag';
 
 type TextNode = DefaultTreeAdapterTypes.TextNode;
@@ -65,6 +66,8 @@ export function migrateInputDateRange({
             template,
             templateOffset,
         );
+
+        removeAttr(element, 'tuiTextfieldLabelOutside', recorder, templateOffset);
 
         const controlAttrs = [...element.attrs].filter((attr) =>
             /formcontrol|ngmodel/.exec(attr.name.toLocaleLowerCase()),

--- a/projects/cdk/schematics/ng-update/v5/steps/templates/migrate-input-date-range.ts
+++ b/projects/cdk/schematics/ng-update/v5/steps/templates/migrate-input-date-range.ts
@@ -116,7 +116,7 @@ export function migrateInputDateRange({
             if (isLabelOutsideTrue) {
                 recorder.remove(labelTextStart, labelTextEnd - labelTextStart);
                 placeholderAttr = ` placeholder="${labelText}"`;
-            } else {
+            } else if (!isDynamic) {
                 recorder.insertRight(labelTextStart, '\n<label tuiLabel>');
                 recorder.insertRight(labelTextEnd, '</label>\n');
             }

--- a/projects/cdk/schematics/ng-update/v5/steps/templates/migrate-input-date.ts
+++ b/projects/cdk/schematics/ng-update/v5/steps/templates/migrate-input-date.ts
@@ -123,7 +123,7 @@ export function migrateInputDate({
             if (isLabelOutsideTrue) {
                 recorder.remove(labelTextStart, labelTextEnd - labelTextStart);
                 placeholderAttr = ` placeholder="${labelText}"`;
-            } else {
+            } else if (!isDynamic) {
                 recorder.insertRight(labelTextStart, '\n<label tuiLabel>');
                 recorder.insertRight(labelTextEnd, '</label>\n');
             }

--- a/projects/cdk/schematics/ng-update/v5/steps/templates/migrate-input-date.ts
+++ b/projects/cdk/schematics/ng-update/v5/steps/templates/migrate-input-date.ts
@@ -9,6 +9,7 @@ import {
     getTemplateOffset,
 } from '../../../../utils/templates/template-resource';
 import {type TemplateResource} from '../../../interfaces/template-resource';
+import {removeAttr} from '../../../utils/templates/remove-attr';
 import {replaceTag} from '../../../utils/templates/replace-tag';
 
 type TextNode = DefaultTreeAdapterTypes.TextNode;
@@ -64,6 +65,8 @@ export function migrateInputDate({
             template,
             templateOffset,
         );
+
+        removeAttr(element, 'tuiTextfieldLabelOutside', recorder, templateOffset);
 
         const controlAttrs = [...element.attrs].filter((attr) =>
             /formcontrol|ngmodel/.exec(attr.name.toLocaleLowerCase()),

--- a/projects/cdk/schematics/ng-update/v5/steps/templates/migrate-input-date.ts
+++ b/projects/cdk/schematics/ng-update/v5/steps/templates/migrate-input-date.ts
@@ -66,7 +66,16 @@ export function migrateInputDate({
             templateOffset,
         );
 
-        removeAttr(element, 'tuiTextfieldLabelOutside', recorder, templateOffset);
+        const {value: labelOutside, isBinding: labelOutsideIsBinding} = removeAttr(
+            element,
+            'tuiTextfieldLabelOutside',
+            recorder,
+            templateOffset,
+        );
+        const isLabelOutsideTrue =
+            labelOutside === 'true' || (!labelOutsideIsBinding && labelOutside === '');
+        const isDynamic =
+            labelOutside !== null && !isLabelOutsideTrue && labelOutside !== 'false';
 
         const controlAttrs = [...element.attrs].filter((attr) =>
             /formcontrol|ngmodel/.exec(attr.name.toLocaleLowerCase()),
@@ -101,15 +110,32 @@ export function migrateInputDate({
                 node.nodeName === '#text' && (node as TextNode)?.value.trim(),
         );
 
+        let placeholderAttr = '';
+
         if (labelIndex !== -1) {
             const labelNode = element.childNodes[labelIndex];
+            const labelText = (labelNode as TextNode).value.trim();
             const labelTextStart =
                 (labelNode?.sourceCodeLocation?.startOffset ?? 0) + templateOffset;
             const labelTextEnd =
                 (labelNode?.sourceCodeLocation?.endOffset ?? 0) + templateOffset;
 
-            recorder.insertRight(labelTextStart, '\n<label tuiLabel>');
-            recorder.insertRight(labelTextEnd, '</label>\n');
+            if (isLabelOutsideTrue) {
+                recorder.remove(labelTextStart, labelTextEnd - labelTextStart);
+                placeholderAttr = ` placeholder="${labelText}"`;
+            } else {
+                recorder.insertRight(labelTextStart, '\n<label tuiLabel>');
+                recorder.insertRight(labelTextEnd, '</label>\n');
+            }
+        }
+
+        if (isDynamic) {
+            const insertAt = (sourceCodeLocation?.startOffset ?? 0) + templateOffset;
+
+            recorder.insertLeft(
+                insertAt,
+                `<!-- ${TODO_MARK} [tuiTextfieldLabelOutside] is dynamic — cannot be migrated automatically. Use <label tuiLabel> inside <tui-textfield> for label-outside pattern.\n-->\n`,
+            );
         }
 
         if (noEquivalentAttrs.length > 0) {
@@ -150,7 +176,7 @@ export function migrateInputDate({
         } else {
             recorder.insertRight(
                 insertOffset,
-                `\n<input tuiInputDate${migrationAttrs} />\n<tui-calendar *tuiDropdown${calendarAttrStr} />\n`,
+                `\n<input tuiInputDate${migrationAttrs}${placeholderAttr} />\n<tui-calendar *tuiDropdown${calendarAttrStr} />\n`,
             );
         }
 
@@ -167,7 +193,7 @@ export function migrateInputDate({
 
                     recorder.insertRight(
                         templateOffset + startOffset,
-                        `tuiInputDate${migrationAttrs}`,
+                        `tuiInputDate${migrationAttrs}${placeholderAttr}`,
                     );
                 }
             });

--- a/projects/cdk/schematics/ng-update/v5/steps/templates/migrate-input-month.ts
+++ b/projects/cdk/schematics/ng-update/v5/steps/templates/migrate-input-month.ts
@@ -8,6 +8,7 @@ import {
     getTemplateOffset,
 } from '../../../../utils/templates/template-resource';
 import {type TemplateResource} from '../../../interfaces/template-resource';
+import {removeAttr} from '../../../utils/templates/remove-attr';
 import {replaceTag} from '../../../utils/templates/replace-tag';
 
 type TextNode = DefaultTreeAdapterTypes.TextNode;
@@ -59,6 +60,8 @@ export function migrateInputMonth({
             template,
             templateOffset,
         );
+
+        removeAttr(element, 'tuiTextfieldLabelOutside', recorder, templateOffset);
 
         const controlAttrs = [...element.attrs].filter((attr) =>
             /formcontrol|ngmodel/.exec(attr.name.toLocaleLowerCase()),

--- a/projects/cdk/schematics/ng-update/v5/steps/templates/migrate-input-month.ts
+++ b/projects/cdk/schematics/ng-update/v5/steps/templates/migrate-input-month.ts
@@ -110,7 +110,7 @@ export function migrateInputMonth({
             if (isLabelOutsideTrue) {
                 recorder.remove(labelTextStart, labelTextEnd - labelTextStart);
                 placeholderAttr = ` placeholder="${labelText}"`;
-            } else {
+            } else if (!isDynamic) {
                 recorder.insertRight(labelTextStart, '\n<label tuiLabel>');
                 recorder.insertRight(labelTextEnd, '</label>\n');
             }

--- a/projects/cdk/schematics/ng-update/v5/steps/templates/migrate-input-month.ts
+++ b/projects/cdk/schematics/ng-update/v5/steps/templates/migrate-input-month.ts
@@ -2,6 +2,7 @@ import {type UpdateRecorder} from '@angular-devkit/schematics';
 import {type DevkitFileSystem} from 'ng-morph';
 import {type DefaultTreeAdapterTypes} from 'parse5';
 
+import {TODO_MARK} from '../../../../utils/insert-todo';
 import {findElementsByTagName} from '../../../../utils/templates/elements';
 import {
     getTemplateFromTemplateResource,
@@ -61,7 +62,16 @@ export function migrateInputMonth({
             templateOffset,
         );
 
-        removeAttr(element, 'tuiTextfieldLabelOutside', recorder, templateOffset);
+        const {value: labelOutside, isBinding: labelOutsideIsBinding} = removeAttr(
+            element,
+            'tuiTextfieldLabelOutside',
+            recorder,
+            templateOffset,
+        );
+        const isLabelOutsideTrue =
+            labelOutside === 'true' || (!labelOutsideIsBinding && labelOutside === '');
+        const isDynamic =
+            labelOutside !== null && !isLabelOutsideTrue && labelOutside !== 'false';
 
         const controlAttrs = [...element.attrs].filter((attr) =>
             /formcontrol|ngmodel/.exec(attr.name.toLocaleLowerCase()),
@@ -87,15 +97,32 @@ export function migrateInputMonth({
                 node.nodeName === '#text' && (node as TextNode)?.value.trim(),
         );
 
+        let placeholderAttr = '';
+
         if (labelIndex !== -1) {
             const labelNode = element.childNodes[labelIndex];
+            const labelText = (labelNode as TextNode).value.trim();
             const labelTextStart =
                 (labelNode?.sourceCodeLocation?.startOffset ?? 0) + templateOffset;
             const labelTextEnd =
                 (labelNode?.sourceCodeLocation?.endOffset ?? 0) + templateOffset;
 
-            recorder.insertRight(labelTextStart, '\n<label tuiLabel>');
-            recorder.insertRight(labelTextEnd, '</label>\n');
+            if (isLabelOutsideTrue) {
+                recorder.remove(labelTextStart, labelTextEnd - labelTextStart);
+                placeholderAttr = ` placeholder="${labelText}"`;
+            } else {
+                recorder.insertRight(labelTextStart, '\n<label tuiLabel>');
+                recorder.insertRight(labelTextEnd, '</label>\n');
+            }
+        }
+
+        if (isDynamic) {
+            const insertAt = (sourceCodeLocation?.startOffset ?? 0) + templateOffset;
+
+            recorder.insertLeft(
+                insertAt,
+                `<!-- ${TODO_MARK} [tuiTextfieldLabelOutside] is dynamic — cannot be migrated automatically. Use <label tuiLabel> inside <tui-textfield> for label-outside pattern.\n-->\n`,
+            );
         }
 
         const insertOffset =
@@ -125,7 +152,7 @@ export function migrateInputMonth({
         } else {
             recorder.insertRight(
                 insertOffset,
-                `\n<input tuiInputMonth${migrationAttrs} />\n<tui-calendar-month *tuiDropdown${calendarAttrStr} />\n`,
+                `\n<input tuiInputMonth${migrationAttrs}${placeholderAttr} />\n<tui-calendar-month *tuiDropdown${calendarAttrStr} />\n`,
             );
         }
 
@@ -142,7 +169,7 @@ export function migrateInputMonth({
 
                     recorder.insertRight(
                         templateOffset + startOffset,
-                        `tuiInputMonth${migrationAttrs}`,
+                        `tuiInputMonth${migrationAttrs}${placeholderAttr}`,
                     );
                 }
             });

--- a/projects/cdk/schematics/ng-update/v5/steps/templates/migrate-input-password.ts
+++ b/projects/cdk/schematics/ng-update/v5/steps/templates/migrate-input-password.ts
@@ -9,6 +9,7 @@ import {
     getTemplateOffset,
 } from '../../../../utils/templates/template-resource';
 import {type TemplateResource} from '../../../interfaces/template-resource';
+import {removeAttr} from '../../../utils/templates/remove-attr';
 import {replaceTag} from '../../../utils/templates/replace-tag';
 
 type ChildNode = DefaultTreeAdapterTypes.ChildNode;
@@ -16,11 +17,6 @@ type ChildNode = DefaultTreeAdapterTypes.ChildNode;
 type TextNode = DefaultTreeAdapterTypes.TextNode;
 
 type Element = DefaultTreeAdapterTypes.Element;
-
-const LABEL_OUTSIDE_ATTRS = new Set([
-    '[tuiTextfieldLabelOutside]'.toLowerCase(),
-    'tuiTextfieldLabelOutside'.toLowerCase(),
-]);
 
 export function migrateInputPassword({
     resource,
@@ -58,24 +54,12 @@ export function migrateInputPassword({
             recorder.remove(templateOffset + startOffset, endOffset - startOffset);
         }
 
-        // --- Handle tuiTextfieldLabelOutside ---
-        let labelOutsideValue: string | null = null;
-        let labelOutsideIsBinding = false;
-
-        for (const attr of element.attrs) {
-            const nameLower = attr.name.toLowerCase();
-
-            if (LABEL_OUTSIDE_ATTRS.has(nameLower)) {
-                labelOutsideValue = attr.value || 'true';
-                labelOutsideIsBinding = nameLower.startsWith('[');
-
-                const {startOffset = 0, endOffset = 0} =
-                    element.sourceCodeLocation?.attrs?.[attr.name] ?? {};
-
-                recorder.remove(templateOffset + startOffset, endOffset - startOffset);
-                break;
-            }
-        }
+        const {value: labelOutsideValue, isBinding: labelOutsideIsBinding} = removeAttr(
+            element,
+            'tuiTextfieldLabelOutside',
+            recorder,
+            templateOffset,
+        );
 
         const isLabelOutsideTrue =
             labelOutsideValue === 'true' ||

--- a/projects/cdk/schematics/ng-update/v5/steps/templates/migrate-input-password.ts
+++ b/projects/cdk/schematics/ng-update/v5/steps/templates/migrate-input-password.ts
@@ -88,11 +88,9 @@ export function migrateInputPassword({
                 (labelNode?.sourceCodeLocation?.endOffset ?? 0) + templateOffset;
 
             if (isLabelOutsideTrue) {
-                // labelOutside=true: remove text, it will become placeholder on <input>
                 recorder.remove(labelTextStart, labelTextEnd - labelTextStart);
                 placeholderAttr = ` placeholder="${labelText}"`;
-            } else {
-                // labelOutside=false/absent/dynamic: text → <label tuiLabel> inside
+            } else if (!isDynamic) {
                 recorder.insertRight(labelTextStart, '\n<label tuiLabel>');
                 recorder.insertRight(labelTextEnd, '</label>\n');
             }

--- a/projects/cdk/schematics/ng-update/v5/steps/templates/migrate-input-password.ts
+++ b/projects/cdk/schematics/ng-update/v5/steps/templates/migrate-input-password.ts
@@ -2,6 +2,7 @@ import {type UpdateRecorder} from '@angular-devkit/schematics';
 import {type DevkitFileSystem} from 'ng-morph';
 import {type DefaultTreeAdapterTypes} from 'parse5';
 
+import {TODO_MARK} from '../../../../utils/insert-todo';
 import {findElementsByTagName} from '../../../../utils/templates/elements';
 import {
     getTemplateFromTemplateResource,
@@ -15,6 +16,11 @@ type ChildNode = DefaultTreeAdapterTypes.ChildNode;
 type TextNode = DefaultTreeAdapterTypes.TextNode;
 
 type Element = DefaultTreeAdapterTypes.Element;
+
+const LABEL_OUTSIDE_ATTRS = new Set([
+    '[tuiTextfieldLabelOutside]'.toLowerCase(),
+    'tuiTextfieldLabelOutside'.toLowerCase(),
+]);
 
 export function migrateInputPassword({
     resource,
@@ -52,22 +58,85 @@ export function migrateInputPassword({
             recorder.remove(templateOffset + startOffset, endOffset - startOffset);
         }
 
+        // --- Handle tuiTextfieldLabelOutside ---
+        let labelOutsideValue: string | null = null;
+        let labelOutsideIsBinding = false;
+
+        for (const attr of element.attrs) {
+            const nameLower = attr.name.toLowerCase();
+
+            if (LABEL_OUTSIDE_ATTRS.has(nameLower)) {
+                labelOutsideValue = attr.value || 'true';
+                labelOutsideIsBinding = nameLower.startsWith('[');
+
+                const {startOffset = 0, endOffset = 0} =
+                    element.sourceCodeLocation?.attrs?.[attr.name] ?? {};
+
+                recorder.remove(templateOffset + startOffset, endOffset - startOffset);
+                break;
+            }
+        }
+
+        const isLabelOutsideTrue =
+            labelOutsideValue === 'true' ||
+            (!labelOutsideIsBinding && labelOutsideValue === '');
+
+        const isDynamic =
+            labelOutsideValue !== null &&
+            labelOutsideValue !== 'true' &&
+            labelOutsideValue !== 'false' &&
+            labelOutsideValue !== '';
+
+        // --- Handle label text ---
         const labelIndex = element.childNodes.findIndex(
             (node: ChildNode) =>
                 node.nodeName === '#text' && (node as TextNode)?.value.trim(),
         );
 
+        let placeholderAttr = '';
+
         if (labelIndex !== -1) {
             const labelNode = element.childNodes[labelIndex];
+            const labelText = (labelNode as TextNode).value.trim();
             const labelTextStart =
                 (labelNode?.sourceCodeLocation?.startOffset ?? 0) + templateOffset;
             const labelTextEnd =
                 (labelNode?.sourceCodeLocation?.endOffset ?? 0) + templateOffset;
 
-            recorder.insertRight(labelTextStart, '\n<label tuiLabel>');
-            recorder.insertRight(labelTextEnd, '</label>\n');
+            if (isLabelOutsideTrue) {
+                // labelOutside=true: remove text, it will become placeholder on <input>
+                recorder.remove(labelTextStart, labelTextEnd - labelTextStart);
+                placeholderAttr = ` placeholder="${labelText}"`;
+            } else {
+                // labelOutside=false/absent/dynamic: text → <label tuiLabel> inside
+                recorder.insertRight(labelTextStart, '\n<label tuiLabel>');
+                recorder.insertRight(labelTextEnd, '</label>\n');
+            }
         }
 
+        // --- Build TODO comment ---
+        const todoNotes: string[] = [];
+
+        if (isLabelOutsideTrue && labelIndex !== -1) {
+            todoNotes.push(
+                'tuiTextfieldLabelOutside was true — text became placeholder. Wrap <tui-textfield> in <label tuiLabel> for label-outside pattern if needed.',
+            );
+        }
+
+        if (isDynamic) {
+            todoNotes.push(
+                `[tuiTextfieldLabelOutside]="${labelOutsideValue}" is dynamic and cannot be migrated automatically. Use <label tuiLabel> inside <tui-textfield> for floating label or outside for static label.`,
+            );
+        }
+
+        if (todoNotes.length > 0) {
+            const startOffset = (sourceCodeLocation?.startOffset ?? 0) + templateOffset;
+            const todoComment = `<!-- ${TODO_MARK} tui-input-password migration:\n${todoNotes.map((n) => `     - ${n}`).join('\n')}\n-->\n`;
+
+            recorder.insertLeft(startOffset, todoComment);
+        }
+
+        // --- Insert <input> and <tui-icon tuiPassword /> ---
         const insertOffset =
             (sourceCodeLocation?.endTag?.startOffset ?? 0) + templateOffset;
 
@@ -87,7 +156,7 @@ export function migrateInputPassword({
         if (!inputs.length) {
             recorder.insertRight(
                 insertOffset,
-                `\n<input tuiInput type="password"${migrationAttrs} />\n<tui-icon tuiPassword />\n`,
+                `\n<input tuiInput type="password"${migrationAttrs}${placeholderAttr} />\n<tui-icon tuiPassword />\n`,
             );
         }
 
@@ -104,7 +173,7 @@ export function migrateInputPassword({
 
                     recorder.insertRight(
                         templateOffset + startOffset,
-                        `tuiInput type="password"${migrationAttrs}`,
+                        `tuiInput type="password"${migrationAttrs}${placeholderAttr}`,
                     );
 
                     const inputEndOffset =

--- a/projects/cdk/schematics/ng-update/v5/steps/templates/migrate-input-password.ts
+++ b/projects/cdk/schematics/ng-update/v5/steps/templates/migrate-input-password.ts
@@ -99,12 +99,6 @@ export function migrateInputPassword({
         // --- Build TODO comment ---
         const todoNotes: string[] = [];
 
-        if (isLabelOutsideTrue && labelIndex !== -1) {
-            todoNotes.push(
-                'tuiTextfieldLabelOutside was true — text became placeholder. Wrap <tui-textfield> in <label tuiLabel> for label-outside pattern if needed.',
-            );
-        }
-
         if (isDynamic) {
             todoNotes.push(
                 `[tuiTextfieldLabelOutside]="${labelOutsideValue}" is dynamic and cannot be migrated automatically. Use <label tuiLabel> inside <tui-textfield> for floating label or outside for static label.`,

--- a/projects/cdk/schematics/ng-update/v5/steps/templates/migrate-input-phone-international.ts
+++ b/projects/cdk/schematics/ng-update/v5/steps/templates/migrate-input-phone-international.ts
@@ -2,12 +2,12 @@ import {type UpdateRecorder} from '@angular-devkit/schematics';
 import {type DevkitFileSystem} from 'ng-morph';
 import {type DefaultTreeAdapterTypes} from 'parse5';
 
+import {TODO_MARK} from '../../../../utils/insert-todo';
 import {findElementsByTagName} from '../../../../utils/templates/elements';
 import {
     getTemplateFromTemplateResource,
     getTemplateOffset,
 } from '../../../../utils/templates/template-resource';
-import {TODO_MARK} from '../../../../utils/insert-todo';
 import {type TemplateResource} from '../../../interfaces/template-resource';
 import {removeAttr} from '../../../utils/templates/remove-attr';
 import {replaceTag} from '../../../utils/templates/replace-tag';

--- a/projects/cdk/schematics/ng-update/v5/steps/templates/migrate-input-phone-international.ts
+++ b/projects/cdk/schematics/ng-update/v5/steps/templates/migrate-input-phone-international.ts
@@ -7,7 +7,9 @@ import {
     getTemplateFromTemplateResource,
     getTemplateOffset,
 } from '../../../../utils/templates/template-resource';
+import {TODO_MARK} from '../../../../utils/insert-todo';
 import {type TemplateResource} from '../../../interfaces/template-resource';
+import {removeAttr} from '../../../utils/templates/remove-attr';
 import {replaceTag} from '../../../utils/templates/replace-tag';
 
 type TextNode = DefaultTreeAdapterTypes.TextNode;
@@ -58,6 +60,17 @@ export function migrateInputPhoneInternational({
             INPUT_ATTRS.has(attr.name.toLowerCase()),
         );
 
+        const {value: labelOutside, isBinding: labelOutsideIsBinding} = removeAttr(
+            element,
+            'tuiTextfieldLabelOutside',
+            recorder,
+            templateOffset,
+        );
+        const isLabelOutsideTrue =
+            labelOutside === 'true' || (!labelOutsideIsBinding && labelOutside === '');
+        const isDynamic =
+            labelOutside !== null && !isLabelOutsideTrue && labelOutside !== 'false';
+
         for (const attr of [...controlAttrs, ...inputAttrs]) {
             const {startOffset = 0, endOffset = 0} =
                 element.sourceCodeLocation?.attrs?.[attr.name] ?? {};
@@ -70,15 +83,32 @@ export function migrateInputPhoneInternational({
                 node.nodeName === '#text' && (node as TextNode)?.value.trim(),
         );
 
+        let placeholderAttr = '';
+
         if (labelIndex !== -1) {
             const labelNode = element.childNodes[labelIndex];
+            const labelText = (labelNode as TextNode).value.trim();
             const labelTextStart =
                 (labelNode?.sourceCodeLocation?.startOffset ?? 0) + templateOffset;
             const labelTextEnd =
                 (labelNode?.sourceCodeLocation?.endOffset ?? 0) + templateOffset;
 
-            recorder.insertRight(labelTextStart, '\n<label tuiLabel>');
-            recorder.insertRight(labelTextEnd, '</label>\n');
+            if (isLabelOutsideTrue) {
+                recorder.remove(labelTextStart, labelTextEnd - labelTextStart);
+                placeholderAttr = ` placeholder="${labelText}"`;
+            } else if (!isDynamic) {
+                recorder.insertRight(labelTextStart, '\n<label tuiLabel>');
+                recorder.insertRight(labelTextEnd, '</label>\n');
+            }
+        }
+
+        if (isDynamic) {
+            const insertAt = (sourceCodeLocation?.startOffset ?? 0) + templateOffset;
+
+            recorder.insertLeft(
+                insertAt,
+                `<!-- ${TODO_MARK} [tuiTextfieldLabelOutside] is dynamic — cannot be migrated automatically. Use <label tuiLabel> inside <tui-textfield> for label-outside pattern.\n-->\n`,
+            );
         }
 
         const insertOffset =
@@ -97,7 +127,7 @@ export function migrateInputPhoneInternational({
         if (!inputs.length) {
             recorder.insertRight(
                 insertOffset,
-                `\n<input tuiInputPhoneInternational${migrationAttrs} />\n`,
+                `\n<input tuiInputPhoneInternational${migrationAttrs}${placeholderAttr} />\n`,
             );
         }
 
@@ -114,7 +144,7 @@ export function migrateInputPhoneInternational({
 
                     recorder.insertRight(
                         templateOffset + startOffset,
-                        `tuiInputPhoneInternational${migrationAttrs}`,
+                        `tuiInputPhoneInternational${migrationAttrs}${placeholderAttr}`,
                     );
                 }
             });

--- a/projects/cdk/schematics/ng-update/v5/steps/templates/migrate-input-phone.ts
+++ b/projects/cdk/schematics/ng-update/v5/steps/templates/migrate-input-phone.ts
@@ -52,7 +52,16 @@ export function migrateInputPhone({
             templateOffset,
         );
 
-        removeAttr(element, 'tuiTextfieldLabelOutside', recorder, templateOffset);
+        const {value: labelOutside, isBinding: labelOutsideIsBinding} = removeAttr(
+            element,
+            'tuiTextfieldLabelOutside',
+            recorder,
+            templateOffset,
+        );
+        const isLabelOutsideTrue =
+            labelOutside === 'true' || (!labelOutsideIsBinding && labelOutside === '');
+        const isDynamic =
+            labelOutside !== null && !isLabelOutsideTrue && labelOutside !== 'false';
 
         const controlAttrs = [...element.attrs].filter((attr) =>
             /formcontrol|ngmodel/.exec(attr.name.toLocaleLowerCase()),
@@ -78,15 +87,32 @@ export function migrateInputPhone({
                 node.nodeName === '#text' && (node as TextNode)?.value.trim(),
         );
 
+        let placeholderAttr = '';
+
         if (labelIndex !== -1) {
             const labelNode = element.childNodes[labelIndex];
+            const labelText = (labelNode as TextNode).value.trim();
             const labelTextStart =
                 (labelNode?.sourceCodeLocation?.startOffset ?? 0) + templateOffset;
             const labelTextEnd =
                 (labelNode?.sourceCodeLocation?.endOffset ?? 0) + templateOffset;
 
-            recorder.insertRight(labelTextStart, '\n<label tuiLabel>');
-            recorder.insertRight(labelTextEnd, '</label>\n');
+            if (isLabelOutsideTrue) {
+                recorder.remove(labelTextStart, labelTextEnd - labelTextStart);
+                placeholderAttr = ` placeholder="${labelText}"`;
+            } else {
+                recorder.insertRight(labelTextStart, '\n<label tuiLabel>');
+                recorder.insertRight(labelTextEnd, '</label>\n');
+            }
+        }
+
+        if (isDynamic) {
+            const insertAt = (sourceCodeLocation?.startOffset ?? 0) + templateOffset;
+
+            recorder.insertLeft(
+                insertAt,
+                `<!-- ${TODO_MARK} [tuiTextfieldLabelOutside] is dynamic — cannot be migrated automatically. Use <label tuiLabel> inside <tui-textfield> for label-outside pattern.\n-->\n`,
+            );
         }
 
         const inputInsertOffset =
@@ -118,7 +144,9 @@ export function migrateInputPhone({
 
         recorder.insertRight(
             inputInsertOffset,
-            inputs.length ? '' : `\n<input tuiInputPhone${migrationAttrs} />\n`,
+            inputs.length
+                ? ''
+                : `\n<input tuiInputPhone${migrationAttrs}${placeholderAttr} />\n`,
         );
 
         for (const input of inputs) {
@@ -134,7 +162,7 @@ export function migrateInputPhone({
 
                     recorder.insertRight(
                         templateOffset + startOffset,
-                        `tuiInputPhone${migrationAttrs}`,
+                        `tuiInputPhone${migrationAttrs}${placeholderAttr}`,
                     );
                 }
             });

--- a/projects/cdk/schematics/ng-update/v5/steps/templates/migrate-input-phone.ts
+++ b/projects/cdk/schematics/ng-update/v5/steps/templates/migrate-input-phone.ts
@@ -100,7 +100,7 @@ export function migrateInputPhone({
             if (isLabelOutsideTrue) {
                 recorder.remove(labelTextStart, labelTextEnd - labelTextStart);
                 placeholderAttr = ` placeholder="${labelText}"`;
-            } else {
+            } else if (!isDynamic) {
                 recorder.insertRight(labelTextStart, '\n<label tuiLabel>');
                 recorder.insertRight(labelTextEnd, '</label>\n');
             }

--- a/projects/cdk/schematics/ng-update/v5/steps/templates/migrate-input-phone.ts
+++ b/projects/cdk/schematics/ng-update/v5/steps/templates/migrate-input-phone.ts
@@ -9,6 +9,7 @@ import {
     getTemplateOffset,
 } from '../../../../utils/templates/template-resource';
 import {type TemplateResource} from '../../../interfaces/template-resource';
+import {removeAttr} from '../../../utils/templates/remove-attr';
 import {replaceTag} from '../../../utils/templates/replace-tag';
 
 type TextNode = DefaultTreeAdapterTypes.TextNode;
@@ -50,6 +51,8 @@ export function migrateInputPhone({
             template,
             templateOffset,
         );
+
+        removeAttr(element, 'tuiTextfieldLabelOutside', recorder, templateOffset);
 
         const controlAttrs = [...element.attrs].filter((attr) =>
             /formcontrol|ngmodel/.exec(attr.name.toLocaleLowerCase()),

--- a/projects/cdk/schematics/ng-update/v5/steps/templates/migrate-input-tag.ts
+++ b/projects/cdk/schematics/ng-update/v5/steps/templates/migrate-input-tag.ts
@@ -156,7 +156,7 @@ export function migrateInputTag({
             if (isLabelOutsideTrue) {
                 recorder.remove(labelTextStart, labelTextEnd - labelTextStart);
                 placeholderAttr = ` placeholder="${labelText}"`;
-            } else {
+            } else if (!isDynamic) {
                 recorder.insertRight(labelTextStart, '\n<label tuiLabel>');
                 recorder.insertRight(labelTextEnd, '</label>\n');
             }

--- a/projects/cdk/schematics/ng-update/v5/steps/templates/migrate-input-tag.ts
+++ b/projects/cdk/schematics/ng-update/v5/steps/templates/migrate-input-tag.ts
@@ -81,7 +81,16 @@ export function migrateInputTag({
             templateOffset,
         );
 
-        removeAttr(element, 'tuiTextfieldLabelOutside', recorder, templateOffset);
+        const {value: labelOutside, isBinding: labelOutsideIsBinding} = removeAttr(
+            element,
+            'tuiTextfieldLabelOutside',
+            recorder,
+            templateOffset,
+        );
+        const isLabelOutsideTrue =
+            labelOutside === 'true' || (!labelOutsideIsBinding && labelOutside === '');
+        const isDynamic =
+            labelOutside !== null && !isLabelOutsideTrue && labelOutside !== 'false';
 
         const openTagEnd = sourceCodeLocation?.startTag?.endOffset ?? 0;
 
@@ -134,15 +143,32 @@ export function migrateInputTag({
                 node.nodeName === '#text' && (node as TextNode)?.value.trim(),
         );
 
+        let placeholderAttr = '';
+
         if (labelIndex !== -1) {
             const labelNode = element.childNodes[labelIndex];
+            const labelText = (labelNode as TextNode).value.trim();
             const labelTextStart =
                 (labelNode?.sourceCodeLocation?.startOffset ?? 0) + templateOffset;
             const labelTextEnd =
                 (labelNode?.sourceCodeLocation?.endOffset ?? 0) + templateOffset;
 
-            recorder.insertRight(labelTextStart, '\n<label tuiLabel>');
-            recorder.insertRight(labelTextEnd, '</label>\n');
+            if (isLabelOutsideTrue) {
+                recorder.remove(labelTextStart, labelTextEnd - labelTextStart);
+                placeholderAttr = ` placeholder="${labelText}"`;
+            } else {
+                recorder.insertRight(labelTextStart, '\n<label tuiLabel>');
+                recorder.insertRight(labelTextEnd, '</label>\n');
+            }
+        }
+
+        if (isDynamic) {
+            const insertAt = (sourceCodeLocation?.startOffset ?? 0) + templateOffset;
+
+            recorder.insertLeft(
+                insertAt,
+                `<!-- ${TODO_MARK} [tuiTextfieldLabelOutside] is dynamic — cannot be migrated automatically. Use <label tuiLabel> inside <tui-textfield> for label-outside pattern.\n-->\n`,
+            );
         }
 
         if (todoAttrs.length > 0) {
@@ -170,7 +196,10 @@ export function migrateInputTag({
             return attr.value ? `${result} ${name}="${attr.value}"` : `${result} ${name}`;
         }, '');
 
-        recorder.insertRight(insertOffset, `\n<input tuiInputChip${migrationAttrs} />\n`);
+        recorder.insertRight(
+            insertOffset,
+            `\n<input tuiInputChip${migrationAttrs}${placeholderAttr} />\n`,
+        );
     });
 }
 

--- a/projects/cdk/schematics/ng-update/v5/steps/templates/migrate-input-tag.ts
+++ b/projects/cdk/schematics/ng-update/v5/steps/templates/migrate-input-tag.ts
@@ -9,6 +9,7 @@ import {
     getTemplateOffset,
 } from '../../../../utils/templates/template-resource';
 import {type TemplateResource} from '../../../interfaces/template-resource';
+import {removeAttr} from '../../../utils/templates/remove-attr';
 import {replaceTag} from '../../../utils/templates/replace-tag';
 
 type TextNode = DefaultTreeAdapterTypes.TextNode;
@@ -79,6 +80,8 @@ export function migrateInputTag({
             template,
             templateOffset,
         );
+
+        removeAttr(element, 'tuiTextfieldLabelOutside', recorder, templateOffset);
 
         const openTagEnd = sourceCodeLocation?.startTag?.endOffset ?? 0;
 

--- a/projects/cdk/schematics/ng-update/v5/steps/templates/migrate-input-time.ts
+++ b/projects/cdk/schematics/ng-update/v5/steps/templates/migrate-input-time.ts
@@ -65,7 +65,16 @@ export function migrateInputTime({
             templateOffset,
         );
 
-        removeAttr(element, 'tuiTextfieldLabelOutside', recorder, templateOffset);
+        const {value: labelOutside, isBinding: labelOutsideIsBinding} = removeAttr(
+            element,
+            'tuiTextfieldLabelOutside',
+            recorder,
+            templateOffset,
+        );
+        const isLabelOutsideTrue =
+            labelOutside === 'true' || (!labelOutsideIsBinding && labelOutside === '');
+        const isDynamic =
+            labelOutside !== null && !isLabelOutsideTrue && labelOutside !== 'false';
 
         const controlAttrs = [...element.attrs].filter((attr) =>
             /formcontrol|ngmodel/.exec(attr.name.toLocaleLowerCase()),
@@ -100,15 +109,32 @@ export function migrateInputTime({
                 node.nodeName === '#text' && (node as TextNode)?.value.trim(),
         );
 
+        let placeholderAttr = '';
+
         if (labelIndex !== -1) {
             const labelNode = element.childNodes[labelIndex];
+            const labelText = (labelNode as TextNode).value.trim();
             const labelTextStart =
                 (labelNode?.sourceCodeLocation?.startOffset ?? 0) + templateOffset;
             const labelTextEnd =
                 (labelNode?.sourceCodeLocation?.endOffset ?? 0) + templateOffset;
 
-            recorder.insertRight(labelTextStart, '\n<label tuiLabel>');
-            recorder.insertRight(labelTextEnd, '</label>\n');
+            if (isLabelOutsideTrue) {
+                recorder.remove(labelTextStart, labelTextEnd - labelTextStart);
+                placeholderAttr = ` placeholder="${labelText}"`;
+            } else {
+                recorder.insertRight(labelTextStart, '\n<label tuiLabel>');
+                recorder.insertRight(labelTextEnd, '</label>\n');
+            }
+        }
+
+        if (isDynamic) {
+            const insertAt = (sourceCodeLocation?.startOffset ?? 0) + templateOffset;
+
+            recorder.insertLeft(
+                insertAt,
+                `<!-- ${TODO_MARK} [tuiTextfieldLabelOutside] is dynamic — cannot be migrated automatically. Use <label tuiLabel> inside <tui-textfield> for label-outside pattern.\n-->\n`,
+            );
         }
 
         // Build TODO notes for attrs that need manual follow-up
@@ -159,7 +185,7 @@ export function migrateInputTime({
         if (!inputs.length) {
             recorder.insertRight(
                 insertOffset,
-                `\n<input tuiInputTime${migrationAttrs} />\n`,
+                `\n<input tuiInputTime${migrationAttrs}${placeholderAttr} />\n`,
             );
         }
 
@@ -176,7 +202,7 @@ export function migrateInputTime({
 
                     recorder.insertRight(
                         templateOffset + startOffset,
-                        `tuiInputTime${migrationAttrs}`,
+                        `tuiInputTime${migrationAttrs}${placeholderAttr}`,
                     );
                 }
             });

--- a/projects/cdk/schematics/ng-update/v5/steps/templates/migrate-input-time.ts
+++ b/projects/cdk/schematics/ng-update/v5/steps/templates/migrate-input-time.ts
@@ -9,6 +9,7 @@ import {
     getTemplateOffset,
 } from '../../../../utils/templates/template-resource';
 import {type TemplateResource} from '../../../interfaces/template-resource';
+import {removeAttr} from '../../../utils/templates/remove-attr';
 import {replaceTag} from '../../../utils/templates/replace-tag';
 
 type TextNode = DefaultTreeAdapterTypes.TextNode;
@@ -63,6 +64,8 @@ export function migrateInputTime({
             template,
             templateOffset,
         );
+
+        removeAttr(element, 'tuiTextfieldLabelOutside', recorder, templateOffset);
 
         const controlAttrs = [...element.attrs].filter((attr) =>
             /formcontrol|ngmodel/.exec(attr.name.toLocaleLowerCase()),

--- a/projects/cdk/schematics/ng-update/v5/steps/templates/migrate-input-time.ts
+++ b/projects/cdk/schematics/ng-update/v5/steps/templates/migrate-input-time.ts
@@ -122,7 +122,7 @@ export function migrateInputTime({
             if (isLabelOutsideTrue) {
                 recorder.remove(labelTextStart, labelTextEnd - labelTextStart);
                 placeholderAttr = ` placeholder="${labelText}"`;
-            } else {
+            } else if (!isDynamic) {
                 recorder.insertRight(labelTextStart, '\n<label tuiLabel>');
                 recorder.insertRight(labelTextEnd, '</label>\n');
             }

--- a/projects/cdk/schematics/ng-update/v5/steps/templates/migrate-input-year.ts
+++ b/projects/cdk/schematics/ng-update/v5/steps/templates/migrate-input-year.ts
@@ -8,6 +8,7 @@ import {
     getTemplateOffset,
 } from '../../../../utils/templates/template-resource';
 import {type TemplateResource} from '../../../interfaces/template-resource';
+import {removeAttr} from '../../../utils/templates/remove-attr';
 import {replaceTag} from '../../../utils/templates/replace-tag';
 
 type TextNode = DefaultTreeAdapterTypes.TextNode;
@@ -40,6 +41,8 @@ export function migrateInputYear({
             template,
             templateOffset,
         );
+
+        removeAttr(element, 'tuiTextfieldLabelOutside', recorder, templateOffset);
 
         const attrs = [...element.attrs].filter((attr) =>
             /formcontrol|ngmodel|min|max/.exec(attr.name.toLocaleLowerCase()),

--- a/projects/cdk/schematics/ng-update/v5/steps/templates/migrate-input-year.ts
+++ b/projects/cdk/schematics/ng-update/v5/steps/templates/migrate-input-year.ts
@@ -2,6 +2,7 @@ import {type UpdateRecorder} from '@angular-devkit/schematics';
 import {type DevkitFileSystem} from 'ng-morph';
 import {type DefaultTreeAdapterTypes} from 'parse5';
 
+import {TODO_MARK} from '../../../../utils/insert-todo';
 import {findElementsByTagName} from '../../../../utils/templates/elements';
 import {
     getTemplateFromTemplateResource,
@@ -42,7 +43,16 @@ export function migrateInputYear({
             templateOffset,
         );
 
-        removeAttr(element, 'tuiTextfieldLabelOutside', recorder, templateOffset);
+        const {value: labelOutside, isBinding: labelOutsideIsBinding} = removeAttr(
+            element,
+            'tuiTextfieldLabelOutside',
+            recorder,
+            templateOffset,
+        );
+        const isLabelOutsideTrue =
+            labelOutside === 'true' || (!labelOutsideIsBinding && labelOutside === '');
+        const isDynamic =
+            labelOutside !== null && !isLabelOutsideTrue && labelOutside !== 'false';
 
         const attrs = [...element.attrs].filter((attr) =>
             /formcontrol|ngmodel|min|max/.exec(attr.name.toLocaleLowerCase()),
@@ -60,15 +70,32 @@ export function migrateInputYear({
                 node.nodeName === '#text' && (node as TextNode)?.value.trim(),
         );
 
+        let placeholderAttr = '';
+
         if (labelIndex !== -1) {
             const labelNode = element.childNodes[labelIndex];
+            const labelText = (labelNode as TextNode).value.trim();
             const labelTextStart =
                 (labelNode?.sourceCodeLocation?.startOffset ?? 0) + templateOffset;
             const labelTextEnd =
                 (labelNode?.sourceCodeLocation?.endOffset ?? 0) + templateOffset;
 
-            recorder.insertRight(labelTextStart, '\n<label tuiLabel>');
-            recorder.insertRight(labelTextEnd, '</label>\n');
+            if (isLabelOutsideTrue) {
+                recorder.remove(labelTextStart, labelTextEnd - labelTextStart);
+                placeholderAttr = ` placeholder="${labelText}"`;
+            } else {
+                recorder.insertRight(labelTextStart, '\n<label tuiLabel>');
+                recorder.insertRight(labelTextEnd, '</label>\n');
+            }
+        }
+
+        if (isDynamic) {
+            const insertAt = (sourceCodeLocation?.startOffset ?? 0) + templateOffset;
+
+            recorder.insertLeft(
+                insertAt,
+                `<!-- ${TODO_MARK} [tuiTextfieldLabelOutside] is dynamic — cannot be migrated automatically. Use <label tuiLabel> inside <tui-textfield> for label-outside pattern.\n-->\n`,
+            );
         }
 
         const calendarInsertOffset =
@@ -91,7 +118,7 @@ export function migrateInputYear({
             calendarInsertOffset,
             inputs.length
                 ? '\n<tui-calendar-year *tuiDropdown />\n'
-                : `\n<input tuiInputYear${migrationAttrs} />\n<tui-calendar-year *tuiDropdown />\n`,
+                : `\n<input tuiInputYear${migrationAttrs}${placeholderAttr} />\n<tui-calendar-year *tuiDropdown />\n`,
         );
 
         for (const input of inputs) {
@@ -107,7 +134,7 @@ export function migrateInputYear({
 
                     recorder.insertRight(
                         templateOffset + startOffset,
-                        `tuiInputYear${migrationAttrs}`,
+                        `tuiInputYear${migrationAttrs}${placeholderAttr}`,
                     );
                 }
             });

--- a/projects/cdk/schematics/ng-update/v5/steps/templates/migrate-input-year.ts
+++ b/projects/cdk/schematics/ng-update/v5/steps/templates/migrate-input-year.ts
@@ -83,7 +83,7 @@ export function migrateInputYear({
             if (isLabelOutsideTrue) {
                 recorder.remove(labelTextStart, labelTextEnd - labelTextStart);
                 placeholderAttr = ` placeholder="${labelText}"`;
-            } else {
+            } else if (!isDynamic) {
                 recorder.insertRight(labelTextStart, '\n<label tuiLabel>');
                 recorder.insertRight(labelTextEnd, '</label>\n');
             }

--- a/projects/cdk/schematics/ng-update/v5/steps/templates/migrate-input.ts
+++ b/projects/cdk/schematics/ng-update/v5/steps/templates/migrate-input.ts
@@ -398,10 +398,11 @@ function buildInnerContent({
 
     // labelOutside=false/absent: text → <label tuiLabel> inside (floating label)
     // dynamic: text left as-is, only TODO comment is added
-    const labelEl =
-        placeholder && !labelOutsideIsDynamic
-            ? `${indent}<label tuiLabel>${placeholder}</label>\n`
-            : '';
+    const labelEl = !placeholder
+        ? ''
+        : labelOutsideIsDynamic
+          ? `${indent}${placeholder}\n`
+          : `${indent}<label tuiLabel>${placeholder}</label>\n`;
 
     return `${labelEl}${indent}<input${attrsStr} />\n${otherChildren}${hintIconLine}`;
 }

--- a/projects/cdk/schematics/ng-update/v5/steps/templates/migrate-input.ts
+++ b/projects/cdk/schematics/ng-update/v5/steps/templates/migrate-input.ts
@@ -295,12 +295,7 @@ function buildTodoComment(ctx: MigrationContext): string {
         ctx.labelOutsideValue === 'true' ||
         (!ctx.labelOutsideIsBinding && ctx.labelOutsideValue === '');
 
-    if (ctx.placeholder) {
-        if (isLabelOutsideTrue) {
-            notes.push(
-                'tuiTextfieldLabelOutside was true — text became placeholder. Wrap <tui-textfield> in <label tuiLabel> for label-outside pattern if needed.',
-            );
-        }
+    if (ctx.placeholder && !isLabelOutsideTrue) {
         // labelOutside=false/absent: text → <label tuiLabel> inside — fully automatic, no note needed
     }
 

--- a/projects/cdk/schematics/ng-update/v5/steps/templates/migrate-input.ts
+++ b/projects/cdk/schematics/ng-update/v5/steps/templates/migrate-input.ts
@@ -298,7 +298,7 @@ function buildTodoComment(ctx: MigrationContext): string {
     if (ctx.placeholder) {
         if (isLabelOutsideTrue) {
             notes.push(
-                `Text content "${ctx.placeholder}" became placeholder on <input> (labelOutside=true). Add <label tuiLabel> outside <tui-textfield> if a static label is needed.`,
+                'tuiTextfieldLabelOutside was true — text became placeholder. Wrap <tui-textfield> in <label tuiLabel> for label-outside pattern if needed.',
             );
         }
         // labelOutside=false/absent: text → <label tuiLabel> inside — fully automatic, no note needed

--- a/projects/cdk/schematics/ng-update/v5/steps/templates/migrate-input.ts
+++ b/projects/cdk/schematics/ng-update/v5/steps/templates/migrate-input.ts
@@ -255,6 +255,10 @@ function buildReplacement(
     const isLabelOutsideTrue =
         ctx.labelOutsideValue === 'true' ||
         (!ctx.labelOutsideIsBinding && ctx.labelOutsideValue === '');
+    const isLabelOutsideDynamic =
+        ctx.labelOutsideValue !== null &&
+        !isLabelOutsideTrue &&
+        ctx.labelOutsideValue !== 'false';
 
     const wrapperAttrsStr =
         textfieldAttrs.length > 0 ? ` ${textfieldAttrs.join(' ')}` : '';
@@ -265,6 +269,7 @@ function buildReplacement(
         placeholder: ctx.placeholder,
         indent,
         labelOutsideIsTrue: isLabelOutsideTrue,
+        labelOutsideIsDynamic: isLabelOutsideDynamic,
         hintIconStr,
     });
     const todoComment = buildTodoComment(ctx);
@@ -341,12 +346,14 @@ function buildInnerContent({
     placeholder,
     indent,
     labelOutsideIsTrue,
+    labelOutsideIsDynamic,
     hintIconStr,
 }: {
     element: Element;
     hintIconStr: string;
     indent: string;
     inputAttrs: string[];
+    labelOutsideIsDynamic: boolean;
     labelOutsideIsTrue: boolean;
     placeholder: string;
     template: string;
@@ -395,9 +402,11 @@ function buildInnerContent({
     }
 
     // labelOutside=false/absent: text → <label tuiLabel> inside (floating label)
-    const labelEl = placeholder
-        ? `${indent}<label tuiLabel>${placeholder}</label>\n`
-        : '';
+    // dynamic: text left as-is, only TODO comment is added
+    const labelEl =
+        placeholder && !labelOutsideIsDynamic
+            ? `${indent}<label tuiLabel>${placeholder}</label>\n`
+            : '';
 
     return `${labelEl}${indent}<input${attrsStr} />\n${otherChildren}${hintIconLine}`;
 }

--- a/projects/cdk/schematics/ng-update/v5/steps/templates/migrate-input.ts
+++ b/projects/cdk/schematics/ng-update/v5/steps/templates/migrate-input.ts
@@ -398,11 +398,13 @@ function buildInnerContent({
 
     // labelOutside=false/absent: text → <label tuiLabel> inside (floating label)
     // dynamic: text left as-is, only TODO comment is added
-    const labelEl = !placeholder
-        ? ''
-        : labelOutsideIsDynamic
-          ? `${indent}${placeholder}\n`
-          : `${indent}<label tuiLabel>${placeholder}</label>\n`;
+    let labelEl = '';
+
+    if (placeholder && labelOutsideIsDynamic) {
+        labelEl = `${indent}${placeholder}\n`;
+    } else if (placeholder) {
+        labelEl = `${indent}<label tuiLabel>${placeholder}</label>\n`;
+    }
 
     return `${labelEl}${indent}<input${attrsStr} />\n${otherChildren}${hintIconLine}`;
 }

--- a/projects/cdk/schematics/ng-update/v5/steps/templates/migrate-multi-select.ts
+++ b/projects/cdk/schematics/ng-update/v5/steps/templates/migrate-multi-select.ts
@@ -21,7 +21,6 @@ const CONTENT_ATTR = 'content';
 const TEXTFIELD_LABEL_OUTSIDE_ATTR = 'tuiTextfieldLabelOutside';
 const AUTO_COLOR_ATTR = 'autoColor';
 const AUTO_COLOR_TODO = `<!-- ${TODO_MARK} [autoColor] was removed. Use tuiChip with auto-color appearance instead. See https://taiga-ui.dev/components/chip#auto-color -->\n`;
-const LABEL_OUTSIDE_TODO = `<!-- ${TODO_MARK} tuiTextfieldLabelOutside was removed. In v5, wrap <tui-textfield> in <label tuiLabel> for label-outside pattern. See: https://taiga-ui.dev/components/label -->\n`;
 const PLACEHOLDER_ATTR = 'placeholder';
 const PLACEHOLDER_BINDING_ATTR = '[placeholder]';
 const EDITABLE_ATTR = 'editable';
@@ -68,15 +67,6 @@ export function migrateMultiSelect({
         );
         renameAttr(recorder, templateOffset, element, VALUE_CONTENT_ATTR, CONTENT_ATTR);
 
-        const labelOutsideAttr = element.attrs.find((attr) =>
-            [
-                `[${TEXTFIELD_LABEL_OUTSIDE_ATTR}]`.toLowerCase(),
-                TEXTFIELD_LABEL_OUTSIDE_ATTR.toLowerCase(),
-            ].includes(attr.name.toLowerCase()),
-        );
-        const labelOutsideTruthy =
-            labelOutsideAttr !== undefined && labelOutsideAttr.value !== 'false';
-
         removeAttr(
             recorder,
             templateOffset,
@@ -91,17 +81,6 @@ export function migrateMultiSelect({
             TEXTFIELD_LABEL_OUTSIDE_ATTR,
             template,
         );
-
-        if (labelOutsideTruthy && typeof startOffset === 'number') {
-            const lineStart = template.lastIndexOf('\n', startOffset) + 1;
-            const indent =
-                /^[ \t]*/.exec(template.slice(lineStart, startOffset))?.[0] ?? '';
-
-            recorder.insertLeft(
-                templateOffset + startOffset,
-                `${LABEL_OUTSIDE_TODO}${indent}`,
-            );
-        }
 
         const hasAutoColor = element.attrs.some((attr) =>
             [

--- a/projects/cdk/schematics/ng-update/v5/steps/templates/migrate-select.ts
+++ b/projects/cdk/schematics/ng-update/v5/steps/templates/migrate-select.ts
@@ -115,27 +115,7 @@ export function migrateSelect({
             (node: ChildNode): node is Element => node.nodeName === 'input',
         );
 
-        if (!inputs.length) {
-            const formAttrs = formatControlAttrs(controlAttrs);
-            const firstElementChildOffset = element.childNodes.find(
-                (node): node is Element => node.nodeName !== '#text',
-            )?.sourceCodeLocation?.startOffset;
-            const insertOffset =
-                firstElementChildOffset ??
-                element.sourceCodeLocation?.endTag?.startOffset ??
-                0;
-            const placeholderAttr =
-                isLabelOutsideTrue && placeholder ? ` placeholder="${placeholder}"` : '';
-            const inputTemplate = `\n<input${placeholderAttr} tuiSelect${formAttrs ? ` ${formAttrs}` : ''} />\n`;
-
-            if (isLabelOutsideTrue) {
-                removeTextContent(recorder, templateOffset, element);
-            } else if (!isLabelOutsideDynamic) {
-                wrapTextInLabel(recorder, templateOffset, element);
-            }
-
-            recorder.insertRight(templateOffset + insertOffset, inputTemplate);
-        } else {
+        if (inputs.length) {
             if (isLabelOutsideTrue && placeholder) {
                 removeTextContent(recorder, templateOffset, element);
             } else if (!isLabelOutsideDynamic && !isLabelOutsideTrue) {
@@ -175,6 +155,26 @@ export function migrateSelect({
                     );
                 }
             });
+        } else {
+            const formAttrs = formatControlAttrs(controlAttrs);
+            const firstElementChildOffset = element.childNodes.find(
+                (node): node is Element => node.nodeName !== '#text',
+            )?.sourceCodeLocation?.startOffset;
+            const insertOffset =
+                firstElementChildOffset ??
+                element.sourceCodeLocation?.endTag?.startOffset ??
+                0;
+            const placeholderAttr =
+                isLabelOutsideTrue && placeholder ? ` placeholder="${placeholder}"` : '';
+            const inputTemplate = `\n<input${placeholderAttr} tuiSelect${formAttrs ? ` ${formAttrs}` : ''} />\n`;
+
+            if (isLabelOutsideTrue) {
+                removeTextContent(recorder, templateOffset, element);
+            } else if (!isLabelOutsideDynamic) {
+                wrapTextInLabel(recorder, templateOffset, element);
+            }
+
+            recorder.insertRight(templateOffset + insertOffset, inputTemplate);
         }
 
         if (isLabelOutsideDynamic && typeof startOffset === 'number') {

--- a/projects/cdk/schematics/ng-update/v5/steps/templates/migrate-select.ts
+++ b/projects/cdk/schematics/ng-update/v5/steps/templates/migrate-select.ts
@@ -62,6 +62,21 @@ export function migrateSelect({
             `[${CONTENT_ATTR}]`,
         );
         renameAttr(recorder, templateOffset, element, VALUE_CONTENT_ATTR, CONTENT_ATTR);
+        const labelOutsideAttr = element.attrs.find(
+            (attr) =>
+                attr.name.toLowerCase() ===
+                    `[${TEXTFIELD_LABEL_OUTSIDE_ATTR}]`.toLowerCase() ||
+                attr.name.toLowerCase() === TEXTFIELD_LABEL_OUTSIDE_ATTR.toLowerCase(),
+        );
+        const isBinding = labelOutsideAttr?.name.startsWith('[') ?? false;
+        const isLabelOutsideTrue =
+            labelOutsideAttr?.value === 'true' ||
+            (!!labelOutsideAttr && !isBinding && labelOutsideAttr.value === '');
+        const isLabelOutsideDynamic =
+            !!labelOutsideAttr &&
+            !isLabelOutsideTrue &&
+            labelOutsideAttr.value !== 'false';
+
         removeAttr(
             recorder,
             templateOffset,
@@ -94,12 +109,13 @@ export function migrateSelect({
             hasChevron ? [] : ['tuiChevron'],
         );
 
+        const placeholder = getPlaceholderText(element);
+
         const inputs = element.childNodes.filter(
             (node: ChildNode): node is Element => node.nodeName === 'input',
         );
 
         if (!inputs.length) {
-            const placeholder = getPlaceholderText(element);
             const formAttrs = formatControlAttrs(controlAttrs);
             const firstElementChildOffset = element.childNodes.find(
                 (node): node is Element => node.nodeName !== '#text',
@@ -108,38 +124,69 @@ export function migrateSelect({
                 firstElementChildOffset ??
                 element.sourceCodeLocation?.endTag?.startOffset ??
                 0;
-            const inputTemplate = `\n<input${placeholder ? ` placeholder="${placeholder}"` : ''} tuiSelect${formAttrs ? ` ${formAttrs}` : ''} />\n`;
+            const placeholderAttr =
+                isLabelOutsideTrue && placeholder ? ` placeholder="${placeholder}"` : '';
+            const inputTemplate = `\n<input${placeholderAttr} tuiSelect${formAttrs ? ` ${formAttrs}` : ''} />\n`;
 
-            removeTextContent(recorder, templateOffset, element);
-            recorder.insertRight(templateOffset + insertOffset, inputTemplate);
-
-            return;
-        }
-
-        inputs.forEach((input) => {
-            input.attrs.forEach((attr) => {
-                if (!/^tuitextfieldlegacy$|^tuitextfield$/i.test(attr.name)) {
-                    return;
-                }
-
-                const {startOffset = 0, endOffset = 0} =
-                    input.sourceCodeLocation?.attrs?.[attr.name] ?? {};
-
-                recorder.remove(templateOffset + startOffset, endOffset - startOffset);
-                recorder.insertRight(templateOffset + startOffset, 'tuiSelect');
-            });
-
-            const formAttrs = formatControlAttrs(controlAttrs);
-
-            if (!formAttrs) {
-                return;
+            if (isLabelOutsideTrue) {
+                removeTextContent(recorder, templateOffset, element);
+            } else if (!isLabelOutsideDynamic) {
+                wrapTextInLabel(recorder, templateOffset, element);
             }
 
-            const insertOffset =
-                (input.sourceCodeLocation?.startTag?.startOffset ?? 0) + '<input'.length;
+            recorder.insertRight(templateOffset + insertOffset, inputTemplate);
+        } else {
+            if (isLabelOutsideTrue && placeholder) {
+                removeTextContent(recorder, templateOffset, element);
+            } else if (!isLabelOutsideDynamic && !isLabelOutsideTrue) {
+                wrapTextInLabel(recorder, templateOffset, element);
+            }
 
-            recorder.insertRight(templateOffset + insertOffset, ` ${formAttrs}`);
-        });
+            inputs.forEach((input) => {
+                input.attrs.forEach((attr) => {
+                    if (!/^tuitextfieldlegacy$|^tuitextfield$/i.test(attr.name)) {
+                        return;
+                    }
+
+                    const {startOffset = 0, endOffset = 0} =
+                        input.sourceCodeLocation?.attrs?.[attr.name] ?? {};
+
+                    recorder.remove(
+                        templateOffset + startOffset,
+                        endOffset - startOffset,
+                    );
+                    recorder.insertRight(templateOffset + startOffset, 'tuiSelect');
+                });
+
+                const formAttrs = formatControlAttrs(controlAttrs);
+                const placeholderAttr =
+                    isLabelOutsideTrue && placeholder
+                        ? ` placeholder="${placeholder}"`
+                        : '';
+
+                const insertOffset =
+                    (input.sourceCodeLocation?.startTag?.startOffset ?? 0) +
+                    '<input'.length;
+
+                if (formAttrs || placeholderAttr) {
+                    recorder.insertRight(
+                        templateOffset + insertOffset,
+                        `${placeholderAttr}${formAttrs ? ` ${formAttrs}` : ''}`,
+                    );
+                }
+            });
+        }
+
+        if (isLabelOutsideDynamic && typeof startOffset === 'number') {
+            const lineStart = template.lastIndexOf('\n', startOffset - 1) + 1;
+            const indent =
+                /^[ \t]*/.exec(template.slice(lineStart, startOffset))?.[0] ?? '';
+
+            recorder.insertRight(
+                templateOffset + startOffset,
+                `<!-- ${TODO_MARK} [tuiTextfieldLabelOutside] is dynamic and cannot be migrated automatically. Use <label tuiLabel> inside <tui-textfield> for floating label or input[placeholder] for outside label -->\n${indent}`,
+            );
+        }
     });
 }
 
@@ -247,6 +294,26 @@ function normalizeAttrName(name: string): string {
         default:
             return name;
     }
+}
+
+function wrapTextInLabel(
+    recorder: UpdateRecorder,
+    templateOffset: number,
+    element: Element,
+): void {
+    const textNode = element.childNodes.find(
+        (node): node is TextNode => isTextNode(node) && !!node.value.trim(),
+    );
+
+    if (!textNode) {
+        return;
+    }
+
+    const start = (textNode.sourceCodeLocation?.startOffset ?? 0) + templateOffset;
+    const end = (textNode.sourceCodeLocation?.endOffset ?? 0) + templateOffset;
+
+    recorder.insertRight(start, '\n<label tuiLabel>');
+    recorder.insertRight(end, '</label>\n');
 }
 
 function isTextNode(node: ChildNode): node is TextNode {

--- a/projects/cdk/schematics/ng-update/v5/steps/templates/migrate-textarea.ts
+++ b/projects/cdk/schematics/ng-update/v5/steps/templates/migrate-textarea.ts
@@ -266,17 +266,14 @@ function buildTodoComment(ctx: MigrationContext): string {
     if (ctx.placeholder) {
         if (ctx.labelOutside === true) {
             notes.push(
-                `Text content "${ctx.placeholder}" became placeholder on <textarea>. Previously [tuiTextfieldLabelOutside]=true — for label-outside pattern, wrap <tui-textfield> with: <label tuiLabel>${ctx.placeholder}<tui-textfield>...</tui-textfield></label>.`,
+                'tuiTextfieldLabelOutside was true — text became placeholder. Wrap <tui-textfield> in <label tuiLabel> for label-outside pattern if needed.',
             );
         } else if (ctx.labelOutside === 'dynamic') {
             notes.push(
-                `Text content "${ctx.placeholder}" became <label tuiLabel> inside <tui-textfield> and placeholder on <textarea>. [tuiTextfieldLabelOutside] was dynamic — for label-outside pattern, move <label tuiLabel> to wrap <tui-textfield> instead.`,
-            );
-        } else {
-            notes.push(
-                `Text content "${ctx.placeholder}" became <label tuiLabel> inside <tui-textfield>. Add placeholder on <textarea tuiTextarea> separately if hint text is needed.`,
+                '[tuiTextfieldLabelOutside] was dynamic and cannot be migrated automatically. Use <label tuiLabel> inside <tui-textfield> for floating label or outside for static label.',
             );
         }
+        // labelOutside=false/absent: text → <label tuiLabel> inside — fully automatic, no note needed
     }
 
     if (ctx.expandableValue !== null) {

--- a/projects/cdk/schematics/ng-update/v5/steps/templates/migrate-textarea.ts
+++ b/projects/cdk/schematics/ng-update/v5/steps/templates/migrate-textarea.ts
@@ -263,18 +263,13 @@ function buildReplacement(
 function buildTodoComment(ctx: MigrationContext): string {
     const notes: string[] = [];
 
-    if (ctx.placeholder) {
-        if (ctx.labelOutside === true) {
-            notes.push(
-                'tuiTextfieldLabelOutside was true — text became placeholder. Wrap <tui-textfield> in <label tuiLabel> for label-outside pattern if needed.',
-            );
-        } else if (ctx.labelOutside === 'dynamic') {
-            notes.push(
-                '[tuiTextfieldLabelOutside] was dynamic and cannot be migrated automatically. Use <label tuiLabel> inside <tui-textfield> for floating label or outside for static label.',
-            );
-        }
-        // labelOutside=false/absent: text → <label tuiLabel> inside — fully automatic, no note needed
+    if (ctx.placeholder && ctx.labelOutside === 'dynamic') {
+        notes.push(
+            '[tuiTextfieldLabelOutside] was dynamic and cannot be migrated automatically. Use <label tuiLabel> inside <tui-textfield> for floating label or outside for static label.',
+        );
     }
+    // labelOutside=true: text → placeholder — fully automatic, no note needed
+    // labelOutside=false/absent: text → <label tuiLabel> inside — fully automatic, no note needed
 
     if (ctx.expandableValue !== null) {
         const wasFixed = ctx.expandableValue === 'false' || ctx.expandableValue === '';

--- a/projects/cdk/schematics/ng-update/v5/steps/templates/migrate-textarea.ts
+++ b/projects/cdk/schematics/ng-update/v5/steps/templates/migrate-textarea.ts
@@ -351,9 +351,9 @@ function buildInnerContent({
     );
 
     // Auto-add <label tuiLabel> inside <tui-textfield> when text content is present
-    // and labelOutside is not true (label-outside pattern requires manual DOM restructure)
+    // and labelOutside is false/absent (dynamic: left as-is with only TODO comment)
     const labelEl =
-        placeholder && labelOutside !== true
+        placeholder && labelOutside === false
             ? `${indent}<label tuiLabel>${placeholder}</label>\n`
             : '';
 

--- a/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-combo-box.spec.ts.snap
+++ b/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-combo-box.spec.ts.snap
@@ -20,9 +20,9 @@ exports[`ng-update ComboBox [stringify] / [identityMatcher] / [disabledItemHandl
                 >
 <label tuiLabel>
                     Label
-                
+                </label>
+
 <input tuiComboBox [formControl]="control" />
-</label>
 </tui-textfield>
             ",
 }
@@ -43,9 +43,9 @@ exports[`ng-update ComboBox [valueContent] => tui-textfield[content]: test.html 
                 >
 <label tuiLabel>
                     Label
-                
+                </label>
+
 <input tuiComboBox [formControl]="control" />
-</label>
 </tui-textfield>
             ",
 }
@@ -70,9 +70,9 @@ exports[`ng-update ComboBox adds TODO for [search] and (searchChange): test.html
                 >
 <label tuiLabel>
                     Label
-                
+                </label>
+
 <input tuiComboBox [formControl]="control" (input)="onSearch($event.target.value)" />
-</label>
 </tui-textfield>
             ",
 }
@@ -93,17 +93,17 @@ exports[`ng-update ComboBox handles multiple combo-boxes in the same template: t
             ",
   "1. After": "
                 <tui-textfield>
-<label tuiLabel>First
+<label tuiLabel>First</label>
+
 <input tuiComboBox [formControl]="first" />
-</label>
 </tui-textfield>
 
                 <tui-textfield>
 <label tuiLabel>
                     Second
-                    
+                    </label>
+
 <input tuiComboBox [(ngModel)]="second" />
-</label>
 <tui-data-list-wrapper
                         *tuiDropdown
                         [items]="items"
@@ -128,9 +128,9 @@ exports[`ng-update ComboBox keeps [strict] on input: test.html 1`] = `
                 >
 <label tuiLabel>
                     Label
-                
+                </label>
+
 <input tuiComboBox [formControl]="control" [strict]="false" />
-</label>
 </tui-textfield>
             ",
 }
@@ -155,9 +155,9 @@ exports[`ng-update ComboBox migrates *tuiDataList to *tuiDropdown: test.html 1`]
                 <tui-textfield>
 <label tuiLabel>
                     Label
-                    
+                    </label>
+
 <input tuiComboBox [formControl]="control" />
-</label>
 <tui-data-list *tuiDropdown>
                         <button
                             tuiOption
@@ -186,9 +186,9 @@ exports[`ng-update ComboBox migrates TuiComboBoxModule import and basic tui-comb
                 <tui-textfield>
 <label tuiLabel>
                     Many words label
-                    
+                    </label>
+
 <input tuiComboBox [formControl]="control" />
-</label>
 <tui-data-list-wrapper
                         *tuiDropdown
                         [items]="items"
@@ -314,9 +314,9 @@ exports[`ng-update ComboBox moves [(ngModel)] to generated input when input is a
                 <tui-textfield>
 <label tuiLabel>
                     Choose an option
-                    
+                    </label>
+
 <input tuiComboBox [(ngModel)]="value" />
-</label>
 <tui-data-list-wrapper
                         *tuiDropdown
                         [items]="items"
@@ -341,9 +341,9 @@ exports[`ng-update ComboBox moves formControlName to generated input: test.html 
                 <tui-textfield>
 <label tuiLabel>
                     Label
-                    
+                    </label>
+
 <input tuiComboBox formControlName="myField" />
-</label>
 <tui-data-list-wrapper
                         *tuiDropdown
                         [items]="items"
@@ -369,9 +369,9 @@ exports[`ng-update ComboBox moves tuiTextfieldSize to tui-textfield wrapper: tes
                 >
 <label tuiLabel>
                     Label
-                
+                </label>
+
 <input tuiComboBox [formControl]="control" />
-</label>
 </tui-textfield>
             ",
 }
@@ -465,9 +465,9 @@ exports[`ng-update ComboBox renames [strictMatcher] to [matcher]: test.html 1`] 
                 >
 <label tuiLabel>
                     Label
-                
+                </label>
+
 <input tuiComboBox [formControl]="control" [matcher]="myMatcher" />
-</label>
 </tui-textfield>
             ",
 }
@@ -492,9 +492,9 @@ exports[`ng-update ComboBox wraps text node in label[tuiLabel] when [tuiTextfiel
                 >
 <label tuiLabel>
                     City
-                    
+                    </label>
+
 <input tuiComboBox [formControl]="control" />
-</label>
 <tui-data-list-wrapper
                         *tuiDropdown
                         [items]="cities"

--- a/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-combo-box.spec.ts.snap
+++ b/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-combo-box.spec.ts.snap
@@ -417,7 +417,6 @@ exports[`ng-update ComboBox removes TuiTextfieldControllerModule and drops [tuiT
   "1. After": "
                 <tui-textfield
                 >
-                <!-- TODO: (Taiga UI migration) Use <label tuiLabel> element inside <tui-textfield> for a floating label or input[placeholder] for empty value label -->
                     Label
                 
 <input tuiComboBox [formControl]="control" />

--- a/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-combo-box.spec.ts.snap
+++ b/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-combo-box.spec.ts.snap
@@ -20,9 +20,9 @@ exports[`ng-update ComboBox [stringify] / [identityMatcher] / [disabledItemHandl
                 >
 <label tuiLabel>
                     Label
-                </label>
-
+                
 <input tuiComboBox [formControl]="control" />
+</label>
 </tui-textfield>
             ",
 }
@@ -43,9 +43,9 @@ exports[`ng-update ComboBox [valueContent] => tui-textfield[content]: test.html 
                 >
 <label tuiLabel>
                     Label
-                </label>
-
+                
 <input tuiComboBox [formControl]="control" />
+</label>
 </tui-textfield>
             ",
 }
@@ -70,9 +70,9 @@ exports[`ng-update ComboBox adds TODO for [search] and (searchChange): test.html
                 >
 <label tuiLabel>
                     Label
-                </label>
-
+                
 <input tuiComboBox [formControl]="control" (input)="onSearch($event.target.value)" />
+</label>
 </tui-textfield>
             ",
 }
@@ -93,17 +93,17 @@ exports[`ng-update ComboBox handles multiple combo-boxes in the same template: t
             ",
   "1. After": "
                 <tui-textfield>
-<label tuiLabel>First</label>
-
+<label tuiLabel>First
 <input tuiComboBox [formControl]="first" />
+</label>
 </tui-textfield>
 
                 <tui-textfield>
 <label tuiLabel>
                     Second
-                    </label>
-
+                    
 <input tuiComboBox [(ngModel)]="second" />
+</label>
 <tui-data-list-wrapper
                         *tuiDropdown
                         [items]="items"
@@ -128,9 +128,9 @@ exports[`ng-update ComboBox keeps [strict] on input: test.html 1`] = `
                 >
 <label tuiLabel>
                     Label
-                </label>
-
+                
 <input tuiComboBox [formControl]="control" [strict]="false" />
+</label>
 </tui-textfield>
             ",
 }
@@ -155,9 +155,9 @@ exports[`ng-update ComboBox migrates *tuiDataList to *tuiDropdown: test.html 1`]
                 <tui-textfield>
 <label tuiLabel>
                     Label
-                    </label>
-
+                    
 <input tuiComboBox [formControl]="control" />
+</label>
 <tui-data-list *tuiDropdown>
                         <button
                             tuiOption
@@ -186,9 +186,9 @@ exports[`ng-update ComboBox migrates TuiComboBoxModule import and basic tui-comb
                 <tui-textfield>
 <label tuiLabel>
                     Many words label
-                    </label>
-
+                    
 <input tuiComboBox [formControl]="control" />
+</label>
 <tui-data-list-wrapper
                         *tuiDropdown
                         [items]="items"
@@ -314,9 +314,9 @@ exports[`ng-update ComboBox moves [(ngModel)] to generated input when input is a
                 <tui-textfield>
 <label tuiLabel>
                     Choose an option
-                    </label>
-
+                    
 <input tuiComboBox [(ngModel)]="value" />
+</label>
 <tui-data-list-wrapper
                         *tuiDropdown
                         [items]="items"
@@ -341,9 +341,9 @@ exports[`ng-update ComboBox moves formControlName to generated input: test.html 
                 <tui-textfield>
 <label tuiLabel>
                     Label
-                    </label>
-
+                    
 <input tuiComboBox formControlName="myField" />
+</label>
 <tui-data-list-wrapper
                         *tuiDropdown
                         [items]="items"
@@ -369,9 +369,9 @@ exports[`ng-update ComboBox moves tuiTextfieldSize to tui-textfield wrapper: tes
                 >
 <label tuiLabel>
                     Label
-                </label>
-
+                
 <input tuiComboBox [formControl]="control" />
+</label>
 </tui-textfield>
             ",
 }
@@ -415,6 +415,7 @@ exports[`ng-update ComboBox removes TuiTextfieldControllerModule and drops [tuiT
                 </tui-combo-box>
             ",
   "1. After": "
+                <!-- TODO: (Taiga UI migration) [tuiTextfieldLabelOutside] is dynamic and cannot be migrated automatically. Use <label tuiLabel> inside <tui-textfield> for floating label or input[placeholder] for outside label -->
                 <tui-textfield
                 >
                     Label
@@ -464,9 +465,9 @@ exports[`ng-update ComboBox renames [strictMatcher] to [matcher]: test.html 1`] 
                 >
 <label tuiLabel>
                     Label
-                </label>
-
+                
 <input tuiComboBox [formControl]="control" [matcher]="myMatcher" />
+</label>
 </tui-textfield>
             ",
 }
@@ -491,9 +492,9 @@ exports[`ng-update ComboBox wraps text node in label[tuiLabel] when [tuiTextfiel
                 >
 <label tuiLabel>
                     City
-                    </label>
-
+                    
 <input tuiComboBox [formControl]="control" />
+</label>
 <tui-data-list-wrapper
                         *tuiDropdown
                         [items]="cities"

--- a/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-hint-on-legacy-controls.spec.ts.snap
+++ b/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-hint-on-legacy-controls.spec.ts.snap
@@ -90,9 +90,9 @@ exports[`ng-update hint on legacy controls different legacy controls migrates tu
                     >
 <label tuiLabel>
                         Label
-                        
+                        </label>
+
 <input tuiComboBox [(ngModel)]="value" />
-</label>
 <tui-data-list-wrapper
                             *tuiDropdown
                             [items]="items | tuiFilterByInput"

--- a/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-hint-on-legacy-controls.spec.ts.snap
+++ b/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-hint-on-legacy-controls.spec.ts.snap
@@ -90,9 +90,9 @@ exports[`ng-update hint on legacy controls different legacy controls migrates tu
                     >
 <label tuiLabel>
                         Label
-                        </label>
-
+                        
 <input tuiComboBox [(ngModel)]="value" />
+</label>
 <tui-data-list-wrapper
                             *tuiDropdown
                             [items]="items | tuiFilterByInput"
@@ -448,7 +448,11 @@ exports[`ng-update hint on legacy controls different legacy controls migrates tu
                     <!-- TODO: (Taiga UI migration) tui-select was partially migrated. Complete migration manually. See examples: https://taiga-ui.dev/components/select -->
 <tui-textfield tuiChevron
                     >
-<input placeholder="Select user" tuiSelect [(ngModel)]="value" />
+<label tuiLabel>
+                        Select user
+                        </label>
+
+<input tuiSelect [(ngModel)]="value" />
 <tui-data-list-wrapper
                             *tuiDropdown
                             [items]="items"

--- a/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-input-date-multi.spec.ts.snap
+++ b/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-input-date-multi.spec.ts.snap
@@ -298,11 +298,7 @@ exports[`ng-update removes [tuiTextfieldLabelOutside] from tui-input-date (multi
                     
                     
                  multi>
-<label tuiLabel>
-                    Choose dates
-                </label>
-
-<input tuiInputDateMulti [formControl]="control" />
+<input tuiInputDateMulti [formControl]="control" placeholder="Choose dates" />
 <tui-calendar *tuiDropdown />
 </tui-textfield>
             ",

--- a/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-input-date-multi.spec.ts.snap
+++ b/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-input-date-multi.spec.ts.snap
@@ -281,6 +281,34 @@ exports[`ng-update moves placeholder to <input tuiInputDateMulti>: test.html 1`]
 }
 `;
 
+exports[`ng-update removes [tuiTextfieldLabelOutside] from tui-input-date (multi): test.html 1`] = `
+{
+  "0. Before": "
+                <tui-input-date
+                    multiple
+                    [formControl]="control"
+                    [tuiTextfieldLabelOutside]="true"
+                >
+                    Choose dates
+                </tui-input-date>
+            ",
+  "1. After": "
+                <tui-textfield
+                    
+                    
+                    
+                 multi>
+<label tuiLabel>
+                    Choose dates
+                </label>
+
+<input tuiInputDateMulti [formControl]="control" />
+<tui-calendar *tuiDropdown />
+</tui-textfield>
+            ",
+}
+`;
+
 exports[`ng-update silently removes [editable] and [inputHidden]: test.html 1`] = `
 {
   "0. Before": "

--- a/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-input-date-range.spec.ts.snap
+++ b/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-input-date-range.spec.ts.snap
@@ -187,11 +187,7 @@ exports[`ng-update removes [tuiTextfieldLabelOutside] from tui-input-date-range:
                     
                     
                 >
-<label tuiLabel>
-                    Choose a range
-                </label>
-
-<input tuiInputDateRange [formControl]="control" />
+<input tuiInputDateRange [formControl]="control" placeholder="Choose a range" />
 <tui-calendar-range *tuiDropdown />
 </tui-textfield>
             ",

--- a/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-input-date-range.spec.ts.snap
+++ b/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-input-date-range.spec.ts.snap
@@ -171,3 +171,29 @@ exports[`ng-update moves [min], [max], [minLength], [maxLength] to <input tuiInp
             ",
 }
 `;
+
+exports[`ng-update removes [tuiTextfieldLabelOutside] from tui-input-date-range: test.html 1`] = `
+{
+  "0. Before": "
+                <tui-input-date-range
+                    [formControl]="control"
+                    [tuiTextfieldLabelOutside]="true"
+                >
+                    Choose a range
+                </tui-input-date-range>
+            ",
+  "1. After": "
+                <tui-textfield
+                    
+                    
+                >
+<label tuiLabel>
+                    Choose a range
+                </label>
+
+<input tuiInputDateRange [formControl]="control" />
+<tui-calendar-range *tuiDropdown />
+</tui-textfield>
+            ",
+}
+`;

--- a/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-input-date.spec.ts.snap
+++ b/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-input-date.spec.ts.snap
@@ -176,11 +176,7 @@ exports[`ng-update removes [tuiTextfieldLabelOutside] from tui-input-date: test.
                     
                     
                 >
-<label tuiLabel>
-                    Choose a date
-                </label>
-
-<input tuiInputDate [formControl]="control" />
+<input tuiInputDate [formControl]="control" placeholder="Choose a date" />
 <tui-calendar *tuiDropdown />
 </tui-textfield>
             ",

--- a/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-input-date.spec.ts.snap
+++ b/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-input-date.spec.ts.snap
@@ -161,6 +161,32 @@ exports[`ng-update moves [min] and [max] to <input tuiInputDate>: test.html 1`] 
 }
 `;
 
+exports[`ng-update removes [tuiTextfieldLabelOutside] from tui-input-date: test.html 1`] = `
+{
+  "0. Before": "
+                <tui-input-date
+                    [formControl]="control"
+                    [tuiTextfieldLabelOutside]="true"
+                >
+                    Choose a date
+                </tui-input-date>
+            ",
+  "1. After": "
+                <tui-textfield
+                    
+                    
+                >
+<label tuiLabel>
+                    Choose a date
+                </label>
+
+<input tuiInputDate [formControl]="control" />
+<tui-calendar *tuiDropdown />
+</tui-textfield>
+            ",
+}
+`;
+
 exports[`ng-update renames [defaultActiveYearMonth] to [month] on <tui-calendar *tuiDropdown>: test.html 1`] = `
 {
   "0. Before": "

--- a/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-input-month.spec.ts.snap
+++ b/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-input-month.spec.ts.snap
@@ -153,11 +153,7 @@ exports[`ng-update removes [tuiTextfieldLabelOutside] from tui-input-month: test
                     
                     
                 >
-<label tuiLabel>
-                    Choose a month
-                </label>
-
-<input tuiInputMonth [formControl]="control" />
+<input tuiInputMonth [formControl]="control" placeholder="Choose a month" />
 <tui-calendar-month *tuiDropdown />
 </tui-textfield>
             ",

--- a/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-input-month.spec.ts.snap
+++ b/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-input-month.spec.ts.snap
@@ -138,6 +138,32 @@ exports[`ng-update moves [min] and [max] to <input tuiInputMonth>, [disabledItem
 }
 `;
 
+exports[`ng-update removes [tuiTextfieldLabelOutside] from tui-input-month: test.html 1`] = `
+{
+  "0. Before": "
+                <tui-input-month
+                    [formControl]="control"
+                    [tuiTextfieldLabelOutside]="true"
+                >
+                    Choose a month
+                </tui-input-month>
+            ",
+  "1. After": "
+                <tui-textfield
+                    
+                    
+                >
+<label tuiLabel>
+                    Choose a month
+                </label>
+
+<input tuiInputMonth [formControl]="control" />
+<tui-calendar-month *tuiDropdown />
+</tui-textfield>
+            ",
+}
+`;
+
 exports[`ng-update renames [defaultActiveYear] to [year] on <tui-calendar-month *tuiDropdown>: test.html 1`] = `
 {
   "0. Before": "

--- a/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-input-password.spec.ts.snap
+++ b/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-input-password.spec.ts.snap
@@ -181,10 +181,7 @@ exports[`ng-update removes [tuiTextfieldLabelOutside]="true" and converts text t
                 </tui-input-password>
             ",
   "1. After": "
-                <!-- TODO: (Taiga UI migration) tui-input-password migration:
-     - tuiTextfieldLabelOutside was true — text became placeholder. Wrap <tui-textfield> in <label tuiLabel> for label-outside pattern if needed.
--->
-<tui-textfield
+                <tui-textfield
                     
                     
                 >
@@ -210,10 +207,7 @@ exports[`ng-update removes [tuiTextfieldLabelOutside]="true" with inner input: t
                 </tui-input-password>
             ",
   "1. After": "
-                <!-- TODO: (Taiga UI migration) tui-input-password migration:
-     - tuiTextfieldLabelOutside was true — text became placeholder. Wrap <tui-textfield> in <label tuiLabel> for label-outside pattern if needed.
--->
-<tui-textfield
+                <tui-textfield
                     
                     
                 ><input
@@ -238,10 +232,7 @@ exports[`ng-update removes bare tuiTextfieldLabelOutside and converts text to pl
                 </tui-input-password>
             ",
   "1. After": "
-                <!-- TODO: (Taiga UI migration) tui-input-password migration:
-     - tuiTextfieldLabelOutside was true — text became placeholder. Wrap <tui-textfield> in <label tuiLabel> for label-outside pattern if needed.
--->
-<tui-textfield
+                <tui-textfield
                     
                     
                 >

--- a/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-input-password.spec.ts.snap
+++ b/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-input-password.spec.ts.snap
@@ -1,5 +1,34 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`ng-update handles dynamic [tuiTextfieldLabelOutside] with TODO: test.html 1`] = `
+{
+  "0. Before": "
+                <tui-input-password
+                    [tuiTextfieldLabelOutside]="isOutside"
+                    [(ngModel)]="value"
+                >
+                    Enter password
+                </tui-input-password>
+            ",
+  "1. After": "
+                <!-- TODO: (Taiga UI migration) tui-input-password migration:
+     - [tuiTextfieldLabelOutside]="isOutside" is dynamic and cannot be migrated automatically. Use <label tuiLabel> inside <tui-textfield> for floating label or outside for static label.
+-->
+<tui-textfield
+                    
+                    
+                >
+<label tuiLabel>
+                    Enter password
+                </label>
+
+<input tuiInput type="password" [(ngModel)]="value" />
+<tui-icon tuiPassword />
+</tui-textfield>
+            ",
+}
+`;
+
 exports[`ng-update migrate TuiInputPasswordModule to TuiPassword: test.html 1`] = `
 {
   "0. Before": "
@@ -113,6 +142,114 @@ import { TuiIcon, TuiInput } from "@taiga-ui/core";
                   // ...
                 })
                 export class MyComponent {}
+            ",
+}
+`;
+
+exports[`ng-update removes [tuiTextfieldLabelOutside]="false" and keeps label inside: test.html 1`] = `
+{
+  "0. Before": "
+                <tui-input-password
+                    [tuiTextfieldLabelOutside]="false"
+                    [(ngModel)]="value"
+                >
+                    Enter password
+                </tui-input-password>
+            ",
+  "1. After": "
+                <tui-textfield
+                    
+                    
+                >
+<label tuiLabel>
+                    Enter password
+                </label>
+
+<input tuiInput type="password" [(ngModel)]="value" />
+<tui-icon tuiPassword />
+</tui-textfield>
+            ",
+}
+`;
+
+exports[`ng-update removes [tuiTextfieldLabelOutside]="true" and converts text to placeholder: test.html 1`] = `
+{
+  "0. Before": "
+                <tui-input-password
+                    [tuiTextfieldLabelOutside]="true"
+                    [(ngModel)]="value"
+                >
+                    Enter password
+                </tui-input-password>
+            ",
+  "1. After": "
+                <!-- TODO: (Taiga UI migration) tui-input-password migration:
+     - tuiTextfieldLabelOutside was true — text became placeholder. Wrap <tui-textfield> in <label tuiLabel> for label-outside pattern if needed.
+-->
+<tui-textfield
+                    
+                    
+                >
+<input tuiInput type="password" [(ngModel)]="value" placeholder="Enter password" />
+<tui-icon tuiPassword />
+</tui-textfield>
+            ",
+}
+`;
+
+exports[`ng-update removes [tuiTextfieldLabelOutside]="true" with inner input: test.html 1`] = `
+{
+  "0. Before": "
+                <tui-input-password
+                    [tuiTextfieldLabelOutside]="true"
+                    [(ngModel)]="value"
+                >
+                    Enter password
+                    <input
+                        tuiTextfieldLegacy
+                        type="password"
+                    />
+                </tui-input-password>
+            ",
+  "1. After": "
+                <!-- TODO: (Taiga UI migration) tui-input-password migration:
+     - tuiTextfieldLabelOutside was true — text became placeholder. Wrap <tui-textfield> in <label tuiLabel> for label-outside pattern if needed.
+-->
+<tui-textfield
+                    
+                    
+                ><input
+                        tuiInput type="password" [(ngModel)]="value" placeholder="Enter password"
+                        type="password"
+                    />
+<tui-icon tuiPassword />
+
+                </tui-textfield>
+            ",
+}
+`;
+
+exports[`ng-update removes bare tuiTextfieldLabelOutside and converts text to placeholder: test.html 1`] = `
+{
+  "0. Before": "
+                <tui-input-password
+                    tuiTextfieldLabelOutside
+                    [(ngModel)]="value"
+                >
+                    Enter password
+                </tui-input-password>
+            ",
+  "1. After": "
+                <!-- TODO: (Taiga UI migration) tui-input-password migration:
+     - tuiTextfieldLabelOutside was true — text became placeholder. Wrap <tui-textfield> in <label tuiLabel> for label-outside pattern if needed.
+-->
+<tui-textfield
+                    
+                    
+                >
+<input tuiInput type="password" [(ngModel)]="value" placeholder="Enter password" />
+<tui-icon tuiPassword />
+</tui-textfield>
             ",
 }
 `;

--- a/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-input-password.spec.ts.snap
+++ b/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-input-password.spec.ts.snap
@@ -18,10 +18,8 @@ exports[`ng-update handles dynamic [tuiTextfieldLabelOutside] with TODO: test.ht
                     
                     
                 >
-<label tuiLabel>
                     Enter password
-                </label>
-
+                
 <input tuiInput type="password" [(ngModel)]="value" />
 <tui-icon tuiPassword />
 </tui-textfield>

--- a/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-input-phone-international.spec.ts.snap
+++ b/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-input-phone-international.spec.ts.snap
@@ -248,3 +248,24 @@ exports[`ng-update moves [countries] to <input tuiInputPhoneInternational>: test
             ",
 }
 `;
+
+exports[`ng-update removes [tuiTextfieldLabelOutside] from tui-input-phone-international: test.html 1`] = `
+{
+  "0. Before": "
+                <tui-input-phone-international
+                    [formControl]="control"
+                    [tuiTextfieldLabelOutside]="true"
+                >
+                    Phone number
+                </tui-input-phone-international>
+            ",
+  "1. After": "
+                <tui-textfield
+                    
+                    
+                >
+<input tuiInputPhoneInternational [formControl]="control" placeholder="Phone number" />
+</tui-textfield>
+            ",
+}
+`;

--- a/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-input-phone.spec.ts.snap
+++ b/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-input-phone.spec.ts.snap
@@ -241,11 +241,7 @@ exports[`ng-update removes [tuiTextfieldLabelOutside] from tui-input-phone: test
                     
                     
                 >
-<label tuiLabel>
-                    Phone number
-                </label>
-
-<input tuiInputPhone [formControl]="control" />
+<input tuiInputPhone [formControl]="control" placeholder="Phone number" />
 </tui-textfield>
             ",
 }

--- a/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-input-phone.spec.ts.snap
+++ b/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-input-phone.spec.ts.snap
@@ -225,3 +225,28 @@ exports[`ng-update moves [allowText] to <input tuiInputPhone>: test.html 1`] = `
 </tui-textfield>",
 }
 `;
+
+exports[`ng-update removes [tuiTextfieldLabelOutside] from tui-input-phone: test.html 1`] = `
+{
+  "0. Before": "
+                <tui-input-phone
+                    [formControl]="control"
+                    [tuiTextfieldLabelOutside]="true"
+                >
+                    Phone number
+                </tui-input-phone>
+            ",
+  "1. After": "
+                <tui-textfield
+                    
+                    
+                >
+<label tuiLabel>
+                    Phone number
+                </label>
+
+<input tuiInputPhone [formControl]="control" />
+</tui-textfield>
+            ",
+}
+`;

--- a/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-input-tag.spec.ts.snap
+++ b/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-input-tag.spec.ts.snap
@@ -231,6 +231,31 @@ exports[`ng-update moves placeholder to <input tuiInputChip>: test.html 1`] = `
 }
 `;
 
+exports[`ng-update removes [tuiTextfieldLabelOutside] from tui-input-tag: test.html 1`] = `
+{
+  "0. Before": "
+                <tui-input-tag
+                    [formControl]="control"
+                    [tuiTextfieldLabelOutside]="true"
+                >
+                    Enter tags
+                </tui-input-tag>
+            ",
+  "1. After": "
+                <tui-textfield
+                    
+                    
+                 multi>
+<label tuiLabel>
+                    Enter tags
+                </label>
+
+<input tuiInputChip [formControl]="control" />
+</tui-textfield>
+            ",
+}
+`;
+
 exports[`ng-update renames [maxLength] to [maxlength] on <input tuiInputChip>: test.html 1`] = `
 {
   "0. Before": "

--- a/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-input-tag.spec.ts.snap
+++ b/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-input-tag.spec.ts.snap
@@ -246,11 +246,7 @@ exports[`ng-update removes [tuiTextfieldLabelOutside] from tui-input-tag: test.h
                     
                     
                  multi>
-<label tuiLabel>
-                    Enter tags
-                </label>
-
-<input tuiInputChip [formControl]="control" />
+<input tuiInputChip [formControl]="control" placeholder="Enter tags" />
 </tui-textfield>
             ",
 }

--- a/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-input-time.spec.ts.snap
+++ b/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-input-time.spec.ts.snap
@@ -165,11 +165,7 @@ exports[`ng-update removes [tuiTextfieldLabelOutside] from tui-input-time: test.
                     
                     
                 >
-<label tuiLabel>
-                    Choose time
-                </label>
-
-<input tuiInputTime [formControl]="control" />
+<input tuiInputTime [formControl]="control" placeholder="Choose time" />
 </tui-textfield>
             ",
 }

--- a/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-input-time.spec.ts.snap
+++ b/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-input-time.spec.ts.snap
@@ -150,6 +150,31 @@ exports[`ng-update moves [mode] to <input tuiInputTime>: test.html 1`] = `
 }
 `;
 
+exports[`ng-update removes [tuiTextfieldLabelOutside] from tui-input-time: test.html 1`] = `
+{
+  "0. Before": "
+                <tui-input-time
+                    [formControl]="control"
+                    [tuiTextfieldLabelOutside]="true"
+                >
+                    Choose time
+                </tui-input-time>
+            ",
+  "1. After": "
+                <tui-textfield
+                    
+                    
+                >
+<label tuiLabel>
+                    Choose time
+                </label>
+
+<input tuiInputTime [formControl]="control" />
+</tui-textfield>
+            ",
+}
+`;
+
 exports[`ng-update renames [items] to [accept] and adds TODO about data-list-wrapper: test.html 1`] = `
 {
   "0. Before": "

--- a/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-input-year.spec.ts.snap
+++ b/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-input-year.spec.ts.snap
@@ -166,3 +166,29 @@ import { TuiInputYear } from "@taiga-ui/kit";
             ",
 }
 `;
+
+exports[`ng-update removes [tuiTextfieldLabelOutside] from tui-input-year: test.html 1`] = `
+{
+  "0. Before": "
+                <tui-input-year
+                    [formControl]="control"
+                    [tuiTextfieldLabelOutside]="true"
+                >
+                    Choose a year
+                </tui-input-year>
+            ",
+  "1. After": "
+                <tui-textfield
+                    
+                    
+                >
+<label tuiLabel>
+                    Choose a year
+                </label>
+
+<input tuiInputYear [formControl]="control" />
+<tui-calendar-year *tuiDropdown />
+</tui-textfield>
+            ",
+}
+`;

--- a/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-input-year.spec.ts.snap
+++ b/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-input-year.spec.ts.snap
@@ -182,11 +182,7 @@ exports[`ng-update removes [tuiTextfieldLabelOutside] from tui-input-year: test.
                     
                     
                 >
-<label tuiLabel>
-                    Choose a year
-                </label>
-
-<input tuiInputYear [formControl]="control" />
+<input tuiInputYear [formControl]="control" placeholder="Choose a year" />
 <tui-calendar-year *tuiDropdown />
 </tui-textfield>
             ",

--- a/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-input.spec.ts.snap
+++ b/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-input.spec.ts.snap
@@ -23,9 +23,6 @@ exports[`ng-update legacy input converts text to placeholder when [tuiTextfieldL
                 </tui-input>
             ",
   "1. After": "
-                <!-- TODO: (Taiga UI migration) tui-input migration (see https://taiga-ui.dev/components/input):
-     - tuiTextfieldLabelOutside was true — text became placeholder. Wrap <tui-textfield> in <label tuiLabel> for label-outside pattern if needed.
--->
                 <tui-textfield>
                 <input placeholder="Email" tuiInput formControlName="value" />
                 </tui-textfield>

--- a/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-input.spec.ts.snap
+++ b/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-input.spec.ts.snap
@@ -24,7 +24,7 @@ exports[`ng-update legacy input converts text to placeholder when [tuiTextfieldL
             ",
   "1. After": "
                 <!-- TODO: (Taiga UI migration) tui-input migration (see https://taiga-ui.dev/components/input):
-     - Text content "Email" became placeholder on <input> (labelOutside=true). Add <label tuiLabel> outside <tui-textfield> if a static label is needed.
+     - tuiTextfieldLabelOutside was true — text became placeholder. Wrap <tui-textfield> in <label tuiLabel> for label-outside pattern if needed.
 -->
                 <tui-textfield>
                 <input placeholder="Email" tuiInput formControlName="value" />

--- a/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-input.spec.ts.snap
+++ b/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-input.spec.ts.snap
@@ -7,6 +7,7 @@ exports[`ng-update legacy input adds TODO for dynamic [tuiTextfieldLabelOutside]
      - [tuiTextfieldLabelOutside]="isOutside" is dynamic and cannot be migrated automatically. Use <label tuiLabel> inside <tui-textfield> for floating label or outside for static label.
 -->
 <tui-textfield>
+Label
 <input tuiInput formControlName="value" />
 </tui-textfield>",
 }

--- a/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-input.spec.ts.snap
+++ b/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-input.spec.ts.snap
@@ -7,9 +7,29 @@ exports[`ng-update legacy input adds TODO for dynamic [tuiTextfieldLabelOutside]
      - [tuiTextfieldLabelOutside]="isOutside" is dynamic and cannot be migrated automatically. Use <label tuiLabel> inside <tui-textfield> for floating label or outside for static label.
 -->
 <tui-textfield>
-<label tuiLabel>Label</label>
 <input tuiInput formControlName="value" />
 </tui-textfield>",
+}
+`;
+
+exports[`ng-update legacy input converts text to placeholder when [tuiTextfieldLabelOutside]="true": test.html 1`] = `
+{
+  "0. Before": "
+                <tui-input
+                    formControlName="value"
+                    [tuiTextfieldLabelOutside]="true"
+                >
+                    Email
+                </tui-input>
+            ",
+  "1. After": "
+                <!-- TODO: (Taiga UI migration) tui-input migration (see https://taiga-ui.dev/components/input):
+     - Text content "Email" became placeholder on <input> (labelOutside=true). Add <label tuiLabel> outside <tui-textfield> if a static label is needed.
+-->
+                <tui-textfield>
+                <input placeholder="Email" tuiInput formControlName="value" />
+                </tui-textfield>
+            ",
 }
 `;
 
@@ -217,27 +237,6 @@ exports[`ng-update legacy input routes dropdown attrs to wrapper and adds TODO f
                 <tui-textfield tuiDropdownDirection="top" tuiTextfieldPostfix="USD" tuiTextfieldPrefix="$" [tuiDropdownLimitWidth]="'fixed'">
                 <label tuiLabel>Amount</label>
                 <input tuiInput formControlName="value" />
-                </tui-textfield>
-            ",
-}
-`;
-
-exports[`ng-update legacy input wraps in <label tuiLabel> when [tuiTextfieldLabelOutside]="true": test.html 1`] = `
-{
-  "0. Before": "
-                <tui-input
-                    formControlName="value"
-                    [tuiTextfieldLabelOutside]="true"
-                >
-                    Email
-                </tui-input>
-            ",
-  "1. After": "
-                <!-- TODO: (Taiga UI migration) tui-input migration (see https://taiga-ui.dev/components/input):
-     - Text content "Email" became placeholder on <input> (labelOutside=true). Add <label tuiLabel> outside <tui-textfield> if a static label is needed.
--->
-                <tui-textfield>
-                <input placeholder="Email" tuiInput formControlName="value" />
                 </tui-textfield>
             ",
 }

--- a/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-multi-select.spec.ts.snap
+++ b/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-multi-select.spec.ts.snap
@@ -251,7 +251,6 @@ exports[`ng-update legacy multi-select migrates full-featured tui-multi-select: 
                 </tui-multi-select>
             ",
   "1. After": "
-                <!-- TODO: (Taiga UI migration) tuiTextfieldLabelOutside was removed. In v5, wrap <tui-textfield> in <label tuiLabel> for label-outside pattern. See: https://taiga-ui.dev/components/label -->
                 <!-- TODO: (Taiga UI migration) [autoColor] was removed. Use tuiChip with auto-color appearance instead. See https://taiga-ui.dev/components/chip#auto-color -->
                 <tui-textfield multi tuiChevron
                     [identityMatcher]="matcher"
@@ -420,7 +419,6 @@ exports[`ng-update legacy multi-select removes tuiTextfieldLabelOutside and [tui
                 ></tui-multi-select>
             ",
   "1. After": "
-                <!-- TODO: (Taiga UI migration) tuiTextfieldLabelOutside was removed. In v5, wrap <tui-textfield> in <label tuiLabel> for label-outside pattern. See: https://taiga-ui.dev/components/label -->
                 <tui-textfield multi tuiChevron
                 ><input tuiInputChip formControlName="items" />
 </tui-textfield>

--- a/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-select.spec.ts.snap
+++ b/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-select.spec.ts.snap
@@ -1,5 +1,36 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`ng-update legacy select handles dynamic [tuiTextfieldLabelOutside] expression: test.html 1`] = `
+{
+  "0. Before": "
+                <tui-select
+                    [formControl]="control"
+                    [tuiTextfieldLabelOutside]="computedValue"
+                >
+                    Choose an option
+                    <tui-data-list-wrapper
+                        *tuiDataList
+                        [items]="items"
+                    />
+                </tui-select>
+            ",
+  "1. After": "
+                <!-- TODO: (Taiga UI migration) tui-select was partially migrated. Complete migration manually. See examples: https://taiga-ui.dev/components/select -->
+<!-- TODO: (Taiga UI migration) [tuiTextfieldLabelOutside] is dynamic and cannot be migrated automatically. Use <label tuiLabel> inside <tui-textfield> for floating label or input[placeholder] for outside label -->
+                <tui-textfield tuiChevron
+                >
+                    Choose an option
+                    
+<input tuiSelect [formControl]="control" />
+<tui-data-list-wrapper
+                        *tuiDropdown
+                        [items]="items"
+                    />
+                </tui-textfield>
+            ",
+}
+`;
+
 exports[`ng-update legacy select migrates TuiSelectModule import and tui-select template: test.html 1`] = `
 {
   "0. Before": "
@@ -59,8 +90,10 @@ exports[`ng-update legacy select migrates complex tui-select template with legac
 <tui-textfield tuiChevron
                     tuiTextfieldSize="s"
                 >
+<label tuiLabel>
                     Character
-                    <input [formControl]="testValue"
+                    </label>
+<input [formControl]="testValue"
                         placeholder="Choose your hero"
                         tuiSelect
                     />
@@ -87,7 +120,11 @@ exports[`ng-update legacy select moves [(ngModel)] to generated input when input
   "1. After": "
                 <!-- TODO: (Taiga UI migration) tui-select was partially migrated. Complete migration manually. See examples: https://taiga-ui.dev/components/select -->
 <tui-textfield tuiChevron>
-<input placeholder="Choose an option" tuiSelect [(ngModel)]="value" />
+<label tuiLabel>
+                    Choose an option
+                    </label>
+
+<input tuiSelect [(ngModel)]="value" />
 <tui-data-list-wrapper
                         *tuiDropdown
                         [items]="items"
@@ -152,6 +189,38 @@ exports[`ng-update legacy select renames valueContent to content, removes labelO
                   templateUrl: './test.html',
                 })
                 export class TestComponent {}
+            ",
+}
+`;
+
+exports[`ng-update legacy select wraps text in label when [tuiTextfieldLabelOutside] is false: test.html 1`] = `
+{
+  "0. Before": "
+                <tui-select
+                    [formControl]="control"
+                    [tuiTextfieldLabelOutside]="false"
+                >
+                    Choose an option
+                    <tui-data-list-wrapper
+                        *tuiDataList
+                        [items]="items"
+                    />
+                </tui-select>
+            ",
+  "1. After": "
+                <!-- TODO: (Taiga UI migration) tui-select was partially migrated. Complete migration manually. See examples: https://taiga-ui.dev/components/select -->
+<tui-textfield tuiChevron
+                >
+<label tuiLabel>
+                    Choose an option
+                    </label>
+
+<input tuiSelect [formControl]="control" />
+<tui-data-list-wrapper
+                        *tuiDropdown
+                        [items]="items"
+                    />
+                </tui-textfield>
             ",
 }
 `;

--- a/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-textarea.spec.ts.snap
+++ b/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-textarea.spec.ts.snap
@@ -30,7 +30,6 @@ exports[`ng-update legacy textarea keeps tuiTextfieldCleaner and tuiHintContent 
             ",
   "1. After": "
                 <!-- TODO: (Taiga UI migration) tui-textarea migration (see https://taiga-ui.dev/components/textarea):
-     - Text content "Label" became <label tuiLabel> inside <tui-textfield>. Add placeholder on <textarea tuiTextarea> separately if hint text is needed.
      - Legacy tui-textarea had a fixed height of 20 rows by default. New component auto-resizes between [min] (default: 1) and [max] (default: 3) rows. Set min and max explicitly if the previous layout needs to be preserved.
 -->
                 <tui-textfield [tuiTextfieldCleaner]="true">
@@ -49,7 +48,6 @@ exports[`ng-update legacy textarea migrates TuiTextareaModule import and simple 
             ",
   "1. After": "
                 <!-- TODO: (Taiga UI migration) tui-textarea migration (see https://taiga-ui.dev/components/textarea):
-     - Text content "Type a text" became <label tuiLabel> inside <tui-textfield>. Add placeholder on <textarea tuiTextarea> separately if hint text is needed.
      - Legacy tui-textarea had a fixed height of 20 rows by default. New component auto-resizes between [min] (default: 1) and [max] (default: 3) rows. Set min and max explicitly if the previous layout needs to be preserved.
 -->
                 <tui-textfield>
@@ -92,7 +90,6 @@ exports[`ng-update legacy textarea migrates multiple tui-textarea elements in on
             ",
   "1. After": "
                 <!-- TODO: (Taiga UI migration) tui-textarea migration (see https://taiga-ui.dev/components/textarea):
-     - Text content "First" became <label tuiLabel> inside <tui-textfield>. Add placeholder on <textarea tuiTextarea> separately if hint text is needed.
      - Legacy tui-textarea had a fixed height of 20 rows by default. New component auto-resizes between [min] (default: 1) and [max] (default: 3) rows. Set min and max explicitly if the previous layout needs to be preserved.
 -->
                 <tui-textfield>
@@ -100,7 +97,6 @@ exports[`ng-update legacy textarea migrates multiple tui-textarea elements in on
                 <textarea tuiTextarea formControlName="a"></textarea>
                 </tui-textfield>
                 <!-- TODO: (Taiga UI migration) tui-textarea migration (see https://taiga-ui.dev/components/textarea):
-     - Text content "Second" became <label tuiLabel> inside <tui-textfield>. Add placeholder on <textarea tuiTextarea> separately if hint text is needed.
      - Legacy tui-textarea had a fixed height of 20 rows by default. New component auto-resizes between [min] (default: 1) and [max] (default: 3) rows. Set min and max explicitly if the previous layout needs to be preserved.
 -->
                 <tui-textfield>
@@ -115,7 +111,6 @@ exports[`ng-update legacy textarea migrates rows without expandable and adds TOD
 {
   "0. Before": "<tui-textarea formControlName="value" rows="5">Comment</tui-textarea>",
   "1. After": "<!-- TODO: (Taiga UI migration) tui-textarea migration (see https://taiga-ui.dev/components/textarea):
-     - Text content "Comment" became <label tuiLabel> inside <tui-textfield>. Add placeholder on <textarea tuiTextarea> separately if hint text is needed.
      - [rows] was migrated to max="5". Legacy tui-textarea had fixed height by default (expandable=false). To restore fixed height, also add the same value for [min] on <textarea tuiTextarea>.
 -->
 <tui-textfield>
@@ -139,7 +134,7 @@ exports[`ng-update legacy textarea migrates tui-textarea attributes: wrapper att
             ",
   "1. After": "
                 <!-- TODO: (Taiga UI migration) tui-textarea migration (see https://taiga-ui.dev/components/textarea):
-     - Text content "Label" became placeholder on <textarea>. Previously [tuiTextfieldLabelOutside]=true — for label-outside pattern, wrap <tui-textfield> with: <label tuiLabel>Label<tui-textfield>...</tui-textfield></label>.
+     - tuiTextfieldLabelOutside was true — text became placeholder. Wrap <tui-textfield> in <label tuiLabel> for label-outside pattern if needed.
      - Legacy tui-textarea had a fixed height of 20 rows by default. New component auto-resizes between [min] (default: 1) and [max] (default: 3) rows. Set min and max explicitly if the previous layout needs to be preserved.
 -->
                 <tui-textfield tuiTextfieldSize="s">
@@ -161,7 +156,6 @@ exports[`ng-update legacy textarea migrates tui-textarea with labelOutside=false
             ",
   "1. After": "
                 <!-- TODO: (Taiga UI migration) tui-textarea migration (see https://taiga-ui.dev/components/textarea):
-     - Text content "Label" became <label tuiLabel> inside <tui-textfield>. Add placeholder on <textarea tuiTextarea> separately if hint text is needed.
      - Legacy tui-textarea had a fixed height of 20 rows by default. New component auto-resizes between [min] (default: 1) and [max] (default: 3) rows. Set min and max explicitly if the previous layout needs to be preserved.
 -->
                 <tui-textfield>
@@ -176,7 +170,6 @@ exports[`ng-update legacy textarea places unknown attributes on tui-textfield an
 {
   "0. Before": "<tui-textarea formControlName="value" someCustomDirective [anotherDirective]="config">Label</tui-textarea>",
   "1. After": "<!-- TODO: (Taiga UI migration) tui-textarea migration (see https://taiga-ui.dev/components/textarea):
-     - Text content "Label" became <label tuiLabel> inside <tui-textfield>. Add placeholder on <textarea tuiTextarea> separately if hint text is needed.
      - Legacy tui-textarea had a fixed height of 20 rows by default. New component auto-resizes between [min] (default: 1) and [max] (default: 3) rows. Set min and max explicitly if the previous layout needs to be preserved.
      - Unrecognized attribute "someCustomDirective" was placed on <tui-textfield>. Move it to <textarea tuiTextarea> if it targets the native element.
      - Unrecognized attribute "[anotherDirective]="config"" was placed on <tui-textfield>. Move it to <textarea tuiTextarea> if it targets the native element.
@@ -201,7 +194,6 @@ exports[`ng-update legacy textarea removes [expandable] and maps [rows] to [max]
             ",
   "1. After": "
                 <!-- TODO: (Taiga UI migration) tui-textarea migration (see https://taiga-ui.dev/components/textarea):
-     - Text content "Type here" became <label tuiLabel> inside <tui-textfield>. Add placeholder on <textarea tuiTextarea> separately if hint text is needed.
      - [expandable] was removed. New component always auto-resizes between [min] (default: 1) and [max] (default: 3) rows. [rows] was migrated to [max]="10".
 -->
                 <tui-textfield>
@@ -216,7 +208,6 @@ exports[`ng-update legacy textarea removes expandable="false" and maps static ro
 {
   "0. Before": "<tui-textarea formControlName="value" expandable="false" rows="5">Text</tui-textarea>",
   "1. After": "<!-- TODO: (Taiga UI migration) tui-textarea migration (see https://taiga-ui.dev/components/textarea):
-     - Text content "Text" became <label tuiLabel> inside <tui-textfield>. Add placeholder on <textarea tuiTextarea> separately if hint text is needed.
      - expandable="false" was removed. New component always auto-resizes. To restore fixed height, also add the same value for [min] on <textarea tuiTextarea> (max="5" was already migrated).
 -->
 <tui-textfield>
@@ -240,7 +231,6 @@ exports[`ng-update legacy textarea reuses inner <textarea tuiTextfieldLegacy> in
             ",
   "1. After": "
                 <!-- TODO: (Taiga UI migration) tui-textarea migration (see https://taiga-ui.dev/components/textarea):
-     - Text content "Bio" became <label tuiLabel> inside <tui-textfield>. Add placeholder on <textarea tuiTextarea> separately if hint text is needed.
      - Legacy tui-textarea had a fixed height of 20 rows by default. New component auto-resizes between [min] (default: 1) and [max] (default: 3) rows. Set min and max explicitly if the previous layout needs to be preserved.
 -->
                 <tui-textfield>

--- a/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-textarea.spec.ts.snap
+++ b/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-textarea.spec.ts.snap
@@ -134,7 +134,6 @@ exports[`ng-update legacy textarea migrates tui-textarea attributes: wrapper att
             ",
   "1. After": "
                 <!-- TODO: (Taiga UI migration) tui-textarea migration (see https://taiga-ui.dev/components/textarea):
-     - tuiTextfieldLabelOutside was true — text became placeholder. Wrap <tui-textfield> in <label tuiLabel> for label-outside pattern if needed.
      - Legacy tui-textarea had a fixed height of 20 rows by default. New component auto-resizes between [min] (default: 1) and [max] (default: 3) rows. Set min and max explicitly if the previous layout needs to be preserved.
 -->
                 <tui-textfield tuiTextfieldSize="s">

--- a/projects/cdk/schematics/ng-update/v5/tests/schematic-migrate-input-color.spec.ts
+++ b/projects/cdk/schematics/ng-update/v5/tests/schematic-migrate-input-color.spec.ts
@@ -61,5 +61,19 @@ describe('ng-update', () => {
         }),
     );
 
+    it(
+        'removes [tuiTextfieldLabelOutside] from tui-input-color',
+        migrate({
+            template: /* HTML */ `
+                <tui-input-color
+                    [formControl]="control"
+                    [tuiTextfieldLabelOutside]="true"
+                >
+                    Pick color
+                </tui-input-color>
+            `,
+        }),
+    );
+
     afterEach(() => resetActiveProject());
 });

--- a/projects/cdk/schematics/ng-update/v5/tests/schematic-migrate-input-date-multi.spec.ts
+++ b/projects/cdk/schematics/ng-update/v5/tests/schematic-migrate-input-date-multi.spec.ts
@@ -163,5 +163,20 @@ describe('ng-update', () => {
         }),
     );
 
+    it(
+        'removes [tuiTextfieldLabelOutside] from tui-input-date (multi)',
+        migrate({
+            template: /* HTML */ `
+                <tui-input-date
+                    multiple
+                    [formControl]="control"
+                    [tuiTextfieldLabelOutside]="true"
+                >
+                    Choose dates
+                </tui-input-date>
+            `,
+        }),
+    );
+
     afterEach(() => resetActiveProject());
 });

--- a/projects/cdk/schematics/ng-update/v5/tests/schematic-migrate-input-date-range.spec.ts
+++ b/projects/cdk/schematics/ng-update/v5/tests/schematic-migrate-input-date-range.spec.ts
@@ -89,5 +89,19 @@ describe('ng-update', () => {
         }),
     );
 
+    it(
+        'removes [tuiTextfieldLabelOutside] from tui-input-date-range',
+        migrate({
+            template: /* HTML */ `
+                <tui-input-date-range
+                    [formControl]="control"
+                    [tuiTextfieldLabelOutside]="true"
+                >
+                    Choose a range
+                </tui-input-date-range>
+            `,
+        }),
+    );
+
     afterEach(() => resetActiveProject());
 });

--- a/projects/cdk/schematics/ng-update/v5/tests/schematic-migrate-input-date.spec.ts
+++ b/projects/cdk/schematics/ng-update/v5/tests/schematic-migrate-input-date.spec.ts
@@ -96,5 +96,19 @@ describe('ng-update', () => {
         }),
     );
 
+    it(
+        'removes [tuiTextfieldLabelOutside] from tui-input-date',
+        migrate({
+            template: /* HTML */ `
+                <tui-input-date
+                    [formControl]="control"
+                    [tuiTextfieldLabelOutside]="true"
+                >
+                    Choose a date
+                </tui-input-date>
+            `,
+        }),
+    );
+
     afterEach(() => resetActiveProject());
 });

--- a/projects/cdk/schematics/ng-update/v5/tests/schematic-migrate-input-month.spec.ts
+++ b/projects/cdk/schematics/ng-update/v5/tests/schematic-migrate-input-month.spec.ts
@@ -84,5 +84,19 @@ describe('ng-update', () => {
         }),
     );
 
+    it(
+        'removes [tuiTextfieldLabelOutside] from tui-input-month',
+        migrate({
+            template: /* HTML */ `
+                <tui-input-month
+                    [formControl]="control"
+                    [tuiTextfieldLabelOutside]="true"
+                >
+                    Choose a month
+                </tui-input-month>
+            `,
+        }),
+    );
+
     afterEach(() => resetActiveProject());
 });

--- a/projects/cdk/schematics/ng-update/v5/tests/schematic-migrate-input-password.spec.ts
+++ b/projects/cdk/schematics/ng-update/v5/tests/schematic-migrate-input-password.spec.ts
@@ -58,5 +58,79 @@ describe('ng-update', () => {
         }),
     );
 
+    it(
+        'removes [tuiTextfieldLabelOutside]="true" and converts text to placeholder',
+        migrate({
+            template: /* HTML */ `
+                <tui-input-password
+                    [tuiTextfieldLabelOutside]="true"
+                    [(ngModel)]="value"
+                >
+                    Enter password
+                </tui-input-password>
+            `,
+        }),
+    );
+
+    it(
+        'removes bare tuiTextfieldLabelOutside and converts text to placeholder',
+        migrate({
+            template: /* HTML */ `
+                <tui-input-password
+                    tuiTextfieldLabelOutside
+                    [(ngModel)]="value"
+                >
+                    Enter password
+                </tui-input-password>
+            `,
+        }),
+    );
+
+    it(
+        'removes [tuiTextfieldLabelOutside]="false" and keeps label inside',
+        migrate({
+            template: /* HTML */ `
+                <tui-input-password
+                    [tuiTextfieldLabelOutside]="false"
+                    [(ngModel)]="value"
+                >
+                    Enter password
+                </tui-input-password>
+            `,
+        }),
+    );
+
+    it(
+        'handles dynamic [tuiTextfieldLabelOutside] with TODO',
+        migrate({
+            template: /* HTML */ `
+                <tui-input-password
+                    [tuiTextfieldLabelOutside]="isOutside"
+                    [(ngModel)]="value"
+                >
+                    Enter password
+                </tui-input-password>
+            `,
+        }),
+    );
+
+    it(
+        'removes [tuiTextfieldLabelOutside]="true" with inner input',
+        migrate({
+            template: /* HTML */ `
+                <tui-input-password
+                    [tuiTextfieldLabelOutside]="true"
+                    [(ngModel)]="value"
+                >
+                    Enter password
+                    <input
+                        tuiTextfieldLegacy
+                        type="password"
+                    />
+                </tui-input-password>
+            `,
+        }),
+    );
+
     afterEach(() => resetActiveProject());
 });

--- a/projects/cdk/schematics/ng-update/v5/tests/schematic-migrate-input-phone-international.spec.ts
+++ b/projects/cdk/schematics/ng-update/v5/tests/schematic-migrate-input-phone-international.spec.ts
@@ -127,5 +127,19 @@ describe('ng-update', () => {
         }),
     );
 
+    it(
+        'removes [tuiTextfieldLabelOutside] from tui-input-phone-international',
+        migrate({
+            template: /* HTML */ `
+                <tui-input-phone-international
+                    [formControl]="control"
+                    [tuiTextfieldLabelOutside]="true"
+                >
+                    Phone number
+                </tui-input-phone-international>
+            `,
+        }),
+    );
+
     afterEach(() => resetActiveProject());
 });

--- a/projects/cdk/schematics/ng-update/v5/tests/schematic-migrate-input-phone.spec.ts
+++ b/projects/cdk/schematics/ng-update/v5/tests/schematic-migrate-input-phone.spec.ts
@@ -118,5 +118,19 @@ describe('ng-update', () => {
         }),
     );
 
+    it(
+        'removes [tuiTextfieldLabelOutside] from tui-input-phone',
+        migrate({
+            template: /* HTML */ `
+                <tui-input-phone
+                    [formControl]="control"
+                    [tuiTextfieldLabelOutside]="true"
+                >
+                    Phone number
+                </tui-input-phone>
+            `,
+        }),
+    );
+
     afterEach(() => resetActiveProject());
 });

--- a/projects/cdk/schematics/ng-update/v5/tests/schematic-migrate-input-tag.spec.ts
+++ b/projects/cdk/schematics/ng-update/v5/tests/schematic-migrate-input-tag.spec.ts
@@ -138,5 +138,19 @@ describe('ng-update', () => {
         }),
     );
 
+    it(
+        'removes [tuiTextfieldLabelOutside] from tui-input-tag',
+        migrate({
+            template: /* HTML */ `
+                <tui-input-tag
+                    [formControl]="control"
+                    [tuiTextfieldLabelOutside]="true"
+                >
+                    Enter tags
+                </tui-input-tag>
+            `,
+        }),
+    );
+
     afterEach(() => resetActiveProject());
 });

--- a/projects/cdk/schematics/ng-update/v5/tests/schematic-migrate-input-time.spec.ts
+++ b/projects/cdk/schematics/ng-update/v5/tests/schematic-migrate-input-time.spec.ts
@@ -93,5 +93,19 @@ describe('ng-update', () => {
         }),
     );
 
+    it(
+        'removes [tuiTextfieldLabelOutside] from tui-input-time',
+        migrate({
+            template: /* HTML */ `
+                <tui-input-time
+                    [formControl]="control"
+                    [tuiTextfieldLabelOutside]="true"
+                >
+                    Choose time
+                </tui-input-time>
+            `,
+        }),
+    );
+
     afterEach(() => resetActiveProject());
 });

--- a/projects/cdk/schematics/ng-update/v5/tests/schematic-migrate-input-year.spec.ts
+++ b/projects/cdk/schematics/ng-update/v5/tests/schematic-migrate-input-year.spec.ts
@@ -83,5 +83,19 @@ describe('ng-update', () => {
         }),
     );
 
+    it(
+        'removes [tuiTextfieldLabelOutside] from tui-input-year',
+        migrate({
+            template: /* HTML */ `
+                <tui-input-year
+                    [formControl]="control"
+                    [tuiTextfieldLabelOutside]="true"
+                >
+                    Choose a year
+                </tui-input-year>
+            `,
+        }),
+    );
+
     afterEach(() => resetActiveProject());
 });

--- a/projects/cdk/schematics/ng-update/v5/tests/schematic-migrate-input.spec.ts
+++ b/projects/cdk/schematics/ng-update/v5/tests/schematic-migrate-input.spec.ts
@@ -41,7 +41,7 @@ describe('ng-update legacy input', () => {
     );
 
     it(
-        'wraps in <label tuiLabel> when [tuiTextfieldLabelOutside]="true"',
+        'converts text to placeholder when [tuiTextfieldLabelOutside]="true"',
         migrate({
             template: /* HTML */ `
                 <tui-input

--- a/projects/cdk/schematics/ng-update/v5/tests/schematic-migrate-select.spec.ts
+++ b/projects/cdk/schematics/ng-update/v5/tests/schematic-migrate-select.spec.ts
@@ -96,5 +96,41 @@ describe('ng-update legacy select', () => {
         }),
     );
 
+    it(
+        'wraps text in label when [tuiTextfieldLabelOutside] is false',
+        migrate({
+            template: /* HTML */ `
+                <tui-select
+                    [formControl]="control"
+                    [tuiTextfieldLabelOutside]="false"
+                >
+                    Choose an option
+                    <tui-data-list-wrapper
+                        *tuiDataList
+                        [items]="items"
+                    />
+                </tui-select>
+            `,
+        }),
+    );
+
+    it(
+        'handles dynamic [tuiTextfieldLabelOutside] expression',
+        migrate({
+            template: /* HTML */ `
+                <tui-select
+                    [formControl]="control"
+                    [tuiTextfieldLabelOutside]="computedValue"
+                >
+                    Choose an option
+                    <tui-data-list-wrapper
+                        *tuiDataList
+                        [items]="items"
+                    />
+                </tui-select>
+            `,
+        }),
+    );
+
     afterEach(() => resetActiveProject());
 });


### PR DESCRIPTION
Partially solved #11917
Fixes #13822

## What changed

Unified `[tuiTextfieldLabelOutside]` migration logic across all input components:

| Case | Result |
|------|--------|
| `[tuiTextfieldLabelOutside]="true"` / bare attr | Attr removed, text content → `placeholder` on `<input>` (no TODO) |
| `[tuiTextfieldLabelOutside]="false"` | Attr silently removed |
| `[tuiTextfieldLabelOutside]="expr"` (dynamic) | Attr removed + TODO comment |

**Components:** `tui-input`, `tui-input-color`, `tui-input-date`, `tui-input-date` (multiple), `tui-input-date-range`, `tui-input-month`, `tui-input-password`, `tui-input-phone`, `tui-input-phone-international`, `tui-input-tag`, `tui-input-time`, `tui-input-year`, `tui-combo-box`, `tui-multi-select`, `tui-textarea`

Also extracted a shared `removeAttr` helper and removed now-incorrect TODO bullet points from `tui-textarea` / `tui-multi-select` migrations.