### PR TITLE
chore: revert

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -64,12 +64,11 @@ jobs:
         id: get-pr-body
         shell: bash
         run: |
+          body=$(cat RELEASE_BODY.md)
           delimiter="$(openssl rand -hex 8)"
-          {
-            echo "body<<${delimiter}"
-            cat RELEASE_BODY.md
-            echo "${delimiter}"
-          } >> "$GITHUB_OUTPUT"
+          echo "body<<$delimiter" >> $GITHUB_OUTPUT
+          echo "$body" >> $GITHUB_OUTPUT
+          echo "$delimiter" >> $GITHUB_OUTPUT
 
       - name: Create Pull Request
         if: ${{ !inputs.dry_run }}


### PR DESCRIPTION
https://github.com/taiga-family/taiga-ui/actions/runs/24348152958/job/71094697189

```
Run delimiter="$(openssl rand -hex 8)"
  delimiter="$(openssl rand -hex 8)"
  {
    echo "body<<${delimiter}"
    cat RELEASE_BODY.md
    echo "${delimiter}"
  } >> "$GITHUB_OUTPUT"
  shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
  env:
    NPM_CONFIG_USERCONFIG: /home/runner/work/_temp/.npmrc
    NODE_AUTH_TOKEN: XXXXX-XXXXX-XXXXX-XXXXX
Error: Unable to process file command 'output' successfully.
Error: Invalid value. Matching delimiter not found '781ef54b7aefaefa'
```

- https://github.com/taiga-family/taiga-ui/pull/13727