### PR TITLE
fix(core): `TuiNotification` revert using tui-lh from styles

### DIFF
--- a/projects/core/styles/components/notification.less
+++ b/projects/core/styles/components/notification.less
@@ -39,7 +39,7 @@ tui-notification,
     border-inline-start: var(--t-start) solid transparent;
     border-inline-end: var(--t-end) solid transparent;
 
-    --t-offset: calc((var(--t-height) - var(--tui-lh)) / 2);
+    --t-offset: calc((var(--t-height) - 1.4em) / 2);
     --t-height: var(--tui-height-l);
     --t-start: 0;
     --t-end: 0;
@@ -54,7 +54,7 @@ tui-notification,
 
     &::before {
         position: absolute;
-        top: calc(var(--t-offset) + var(--tui-lh));
+        top: calc(var(--t-offset) + 1.4em);
         left: -1rem;
         inset-inline-start: -1rem;
         transform: translateY(-100%);


### PR DESCRIPTION
Fixes #13862
Styles don't work without explicit inclusion, this is clearly visible in the project
@import '@taiga-ui/core/styles/taiga-ui-theme';

However, if you include it, the palette changes significantly, and even modern styles start to look strange.

I simply removed this variable, and that solved the problem.

But maybe you can suggest a better solution.