### PR TITLE
fix(core): `SelectLike` fails to clear value on Backspace/Delete if caret is at the beginning/end

### DIFF
--- a/projects/core/components/textfield/select-like.directive.ts
+++ b/projects/core/components/textfield/select-like.directive.ts
@@ -16,6 +16,8 @@ import {TUI_TEXTFIELD_OPTIONS} from './textfield.options';
         '(beforeinput)':
             'options.cleaner() && $event.inputType.includes("delete") || $event.preventDefault()',
         '(input.capture)': '$event.inputType?.includes("delete") && clear()',
+        '(keydown.backspace)': 'options.cleaner() && clear()', // No (input) event if caret is at the beginning
+        '(keydown.delete)': 'options.cleaner() && clear()', // No (input) event if caret is at the end
         // Hide Android text select handle (bubble marker below transparent caret)
         '(mousedown)': 'prevent($event)',
     },

--- a/projects/demo-playwright/tests/kit/select/select.pw.spec.ts
+++ b/projects/demo-playwright/tests/kit/select/select.pw.spec.ts
@@ -52,7 +52,7 @@ describe('Select', () => {
 
             beforeEach(async ({page}) => {
                 await tuiGoto(page, `${DemoRoute.Select}/API?tuiTextfieldCleaner=true`);
-                example = new TuiDocumentationPagePO(page).demo;
+                example = new TuiDocumentationPagePO(page).apiPageExample;
                 select = new TuiSelectPO(
                     example.locator('tui-textfield:has([tuiSelect])'),
                 );

--- a/projects/demo-playwright/tests/kit/select/select.pw.spec.ts
+++ b/projects/demo-playwright/tests/kit/select/select.pw.spec.ts
@@ -45,5 +45,46 @@ describe('Select', () => {
                 });
             });
         });
+
+        describe('[tuiTextfieldCleaner=true]', () => {
+            let example!: Locator;
+            let select!: TuiSelectPO;
+
+            beforeEach(async ({page}) => {
+                await tuiGoto(page, `${DemoRoute.Select}/API?tuiTextfieldCleaner=true`);
+                example = new TuiDocumentationPagePO(page).demo;
+                select = new TuiSelectPO(
+                    example.locator('tui-textfield:has([tuiSelect])'),
+                );
+            });
+
+            test('click on label + Backspace => Empty textfield', async ({page}) => {
+                await expect(select.textfield).toHaveValue('USA');
+
+                // eslint-disable-next-line playwright/no-force-option
+                await select.host.locator('[tuiLabel]').click({force: true});
+
+                await expect(select.textfield).toBeFocused();
+                await expect(select.dropdown).toBeVisible();
+
+                await page.keyboard.press('Backspace');
+
+                await expect(select.textfield).toHaveValue('');
+            });
+
+            test('click on label + Delete => Empty textfield', async ({page}) => {
+                await expect(select.textfield).toHaveValue('USA');
+
+                // eslint-disable-next-line playwright/no-force-option
+                await select.host.locator('[tuiLabel]').click({force: true});
+
+                await expect(select.textfield).toBeFocused();
+                await expect(select.dropdown).toBeVisible();
+
+                await page.keyboard.press('Delete');
+
+                await expect(select.textfield).toHaveValue('');
+            });
+        });
     });
 });

--- a/projects/demo-playwright/utils/page-objects/textfield-with-data-list.po.ts
+++ b/projects/demo-playwright/utils/page-objects/textfield-with-data-list.po.ts
@@ -11,7 +11,7 @@ export class TuiTextfieldWithDataListPO {
         .page()
         .locator('tui-dropdown,tui-dropdown-mobile');
 
-    constructor(protected readonly host: Locator) {}
+    constructor(public readonly host: Locator) {}
 
     public async getOptions(): Promise<Locator[]> {
         await expect(this.dropdown).toBeAttached();


### PR DESCRIPTION
Cherry-pick:
* https://github.com/taiga-family/taiga-ui/pull/13873