### PR TITLE
Potential fix for 1 code quality finding

### DIFF
--- a/projects/demo-cypress/src/support/component-index.html
+++ b/projects/demo-cypress/src/support/component-index.html
@@ -34,14 +34,6 @@
                 font-display: swap;
                 src: url('/assets/manrope-fonts.ttf') format('truetype');
             }
-
-            @font-face {
-                font-family: 'Manrope';
-                font-style: normal;
-                font-weight: 700;
-                font-display: swap;
-                src: url('/assets/manrope-fonts.ttf') format('truetype');
-            }
         </style>
     </body>
 </html>


### PR DESCRIPTION
Both font-weight variants (400 and 700) are using the same font file. The font-weight: 700 variant should either use a separate bold font file or rely on font synthesis. Using the same file for both weights will result in the browser artificially bolding the 400 weight font, which may not produce the intended appearance.