### PR TITLE
fix(addon-table): `Table` does not display cell with default plain template

### DIFF
--- a/projects/addon-table/components/table/tr/tr.template.html
+++ b/projects/addon-table/components/table/tr/tr.template.html
@@ -4,7 +4,7 @@
 
         <ng-template #plain>
             <td tuiTd>
-                {{ items[key] }}
+                {{ item()[key] }}
             </td>
         </ng-template>
     }

--- a/projects/demo-playwright/tests/core/breakpoint/breakpoint.pw.spec.ts
+++ b/projects/demo-playwright/tests/core/breakpoint/breakpoint.pw.spec.ts
@@ -3,6 +3,14 @@ import {TuiDocumentationPagePO, tuiGoto} from '@demo-playwright/utils';
 import {expect, test} from '@playwright/test';
 
 test.describe('Breakpoint token', () => {
+    test('Breakpoints table', async ({page}) => {
+        await tuiGoto(page, DemoRoute.Breakpoints);
+
+        await expect
+            .soft(page.locator('[tuiTable]').first())
+            .toHaveScreenshot('breakpoints-table.png');
+    });
+
     [
         // smartphone (mobile)
         {width: 320, height: 480},


### PR DESCRIPTION
Reverts:
* https://github.com/taiga-family/taiga-ui/pull/13802

## Previous behavior
https://taiga-ui.dev/breakpoints
<img height="300" alt="previous" src="https://github.com/user-attachments/assets/b1755a18-36b3-40be-b1a5-f0563b9fb31c" />

## New behavior
<img height="300" alt="new" src="https://github.com/user-attachments/assets/d1be2518-f869-4baf-a2db-0d3dd4e2eac2" />
