### PR TITLE
Revert "feat(cdk): `tuiSum` supports `bigint` (#13890)"

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -88,7 +88,6 @@ jobs:
 
       - name: Run tests for current state
         run: npx nx component-test demo-cypress
-        continue-on-error: true
 
       - uses: taiga-family/ci/actions/setup/cypress-combine-failed-screenshot@v1.200.0
 

--- a/projects/cdk/utils/math/sum.ts
+++ b/projects/cdk/utils/math/sum.ts
@@ -1,24 +1,11 @@
 /**
  * Calculates sum of any number of passed arguments with proper floating point precision
  */
-export function tuiSum(): 0;
-export function tuiSum(...args: number[]): number;
-export function tuiSum(...args: bigint[]): bigint;
-export function tuiSum(...args: ReadonlyArray<bigint | number>): number;
-export function tuiSum(...args: ReadonlyArray<bigint | number>): bigint | number {
-    if (args.length === 0) {
-        return 0;
-    }
-
-    if (args.every((arg) => typeof arg === 'bigint')) {
-        return args.reduce<bigint>((acc, n) => acc + n, BigInt(0));
-    }
-
-    const numbers = args.map((arg) => Number(arg));
-    const decimal = numbers.map((n) => (n.toString().split('.')[1] ?? '').length);
+export function tuiSum(...args: number[]): number {
+    const decimal = args.map((double) => (double.toString().split('.')[1] ?? '').length);
     const maxDecimal = Math.max(0, ...decimal);
     const precision = 10 ** maxDecimal;
-    const sumInt = numbers.reduce((acc, n) => acc + Math.round(n * precision), 0);
+    const sumInt = args.reduce((acc, n) => acc + Math.round(n * precision), 0);
 
     return sumInt / precision;
 }

--- a/projects/cdk/utils/math/test/sum.spec.ts
+++ b/projects/cdk/utils/math/test/sum.spec.ts
@@ -32,72 +32,12 @@ describe('tuiSum', () => {
     });
 
     it('does not accumulate floating point error', () => {
-        expect(tuiSum(0.1, 0.2, 0.3)).toBe(0.6);
+        const result = tuiSum(0.1, 0.2, 0.3);
+
+        expect(result).toBe(0.6);
     });
 
     it('handles trailing zero precision correctly', () => {
         expect(tuiSum(1.2, 0.3)).toBe(1.5);
-    });
-
-    it('returns sum of bigint values', () => {
-        expect(tuiSum(BigInt(1), BigInt(2), BigInt(5))).toBe(BigInt(8));
-    });
-
-    it('returns sum of spread bigint array', () => {
-        const array = [BigInt(1), BigInt(2), BigInt(3), BigInt(4), BigInt(5)];
-
-        expect(tuiSum(...array)).toBe(BigInt(15));
-    });
-
-    it('handles negative bigint values', () => {
-        expect(tuiSum(BigInt(10), BigInt(-3), BigInt(-2))).toBe(BigInt(5));
-    });
-
-    it('handles only negative bigint values', () => {
-        expect(tuiSum(BigInt(-1), BigInt(-2), BigInt(-3))).toBe(BigInt(-6));
-    });
-
-    it('handles zero bigint values', () => {
-        expect(tuiSum(BigInt(0), BigInt(0), BigInt(5))).toBe(BigInt(5));
-    });
-
-    it('handles large bigint values', () => {
-        expect(tuiSum(BigInt('9007199254740993'), BigInt(7))).toBe(
-            BigInt('9007199254741000'),
-        );
-    });
-
-    it('handles mixed integer number and bigint', () => {
-        expect(tuiSum(1, BigInt(2), 5)).toBe(8);
-    });
-
-    it('handles mixed decimal number and bigint', () => {
-        expect(tuiSum(0.5, BigInt(2))).toBe(2.5);
-    });
-
-    it('handles mixed bigint and decimal number in any order', () => {
-        expect(tuiSum(BigInt(2), 0.5)).toBe(2.5);
-    });
-
-    it('handles multiple mixed values', () => {
-        expect(tuiSum(BigInt(1), 2.5, BigInt(3), 0.5)).toBe(7);
-    });
-
-    it('handles negative mixed values', () => {
-        expect(tuiSum(BigInt(10), -0.5, BigInt(-2))).toBe(7.5);
-    });
-
-    it('handles zero in mixed values', () => {
-        expect(tuiSum(BigInt(0), 0.5, 0)).toBe(0.5);
-    });
-
-    it('does not accumulate floating point error in mixed values', () => {
-        expect(tuiSum(BigInt(1), 0.1, 0.2)).toBe(1.3);
-    });
-
-    it('returns sum of spread mixed array', () => {
-        const array = [BigInt(1), 2, BigInt(3), 0.5] as const;
-
-        expect(tuiSum(...array)).toBe(6.5);
     });
 });

--- a/projects/kit/components/input-number/step/input-number-step.directive.ts
+++ b/projects/kit/components/input-number/step/input-number-step.directive.ts
@@ -33,7 +33,10 @@ export class TuiInputNumberStep {
 
     public onStep(step: bigint | number): void {
         const current = this.input.parsed() || 0;
-        const updated = tuiSum(current, step);
+        const updated =
+            typeof current === 'bigint'
+                ? current + BigInt(step)
+                : tuiSum(current, Number(step));
 
         this.input.setValue(tuiClamp(updated, this.mask.min(), this.mask.max()));
 


### PR DESCRIPTION
This reverts commit 7b21438a4c35a695fddf0489f4ae4a40fe61aa41.

Fixes # <!-- link to a relevant issue. -->
