### PR TITLE
feat(addon-doc): unwrap default module for component outlet

### DIFF
--- a/projects/addon-doc/components/example/example.component.ts
+++ b/projects/addon-doc/components/example/example.component.ts
@@ -1,5 +1,5 @@
 import {Clipboard} from '@angular/cdk/clipboard';
-import {AsyncPipe, DOCUMENT, NgComponentOutlet, NgTemplateOutlet} from '@angular/common';
+import {DOCUMENT, NgComponentOutlet, NgTemplateOutlet} from '@angular/common';
 import {
     ChangeDetectionStrategy,
     Component,
@@ -7,6 +7,7 @@ import {
     inject,
     input,
     type OnChanges,
+    resource,
     type Signal,
     signal,
     type Type,
@@ -48,7 +49,6 @@ import {TuiDocExampleGetTabsPipe} from './example-get-tabs.pipe';
 @Component({
     selector: 'tui-doc-example',
     imports: [
-        AsyncPipe,
         NgComponentOutlet,
         NgTemplateOutlet,
         PolymorpheusOutlet,
@@ -118,16 +118,17 @@ export class TuiDocExample implements OnChanges {
         {initialValue: {}},
     );
 
-    protected readonly lazyComponent = computed(async () => {
-        const promise = this.component();
+    protected readonly lazyComponent = resource({
+        request: async () => this.component(),
+        loader: async ({request}) => {
+            if (!request) {
+                return null;
+            }
 
-        if (!promise) {
-            return null;
-        }
+            const component = await request;
 
-        const component = await promise;
-
-        return 'default' in component ? component.default : component;
+            return component && 'default' in component ? component.default : component;
+        },
     });
 
     public readonly heading = input('');

--- a/projects/addon-doc/components/example/example.component.ts
+++ b/projects/addon-doc/components/example/example.component.ts
@@ -118,10 +118,24 @@ export class TuiDocExample implements OnChanges {
         {initialValue: {}},
     );
 
+    protected readonly lazyComponent = computed(async () => {
+        const promise = this.component();
+
+        if (!promise) {
+            return null;
+        }
+
+        const component = await promise;
+
+        return 'default' in component ? component.default : component;
+    });
+
     public readonly heading = input('');
     public readonly description = input<PolymorpheusContent>();
     public readonly fullsize = input(inject(TUI_DOC_EXAMPLE_OPTIONS).fullsize);
-    public readonly component = input<Promise<Type<unknown>>>();
+    public readonly component =
+        input<Promise<Type<unknown> | {default: Type<unknown>}>>();
+
     public readonly content = input<Record<string, TuiRawLoaderContent>>({});
     public readonly preview = input(true);
 

--- a/projects/addon-doc/components/example/example.template.html
+++ b/projects/addon-doc/components/example/example.template.html
@@ -94,7 +94,7 @@
                         [style.display]="activeItemIndex === $index ? 'block' : 'none'"
                     >
                         <ng-container *ngTemplateOutlet="content" />
-                        <ng-container *ngComponentOutlet="component() | async" />
+                        <ng-container *ngComponentOutlet="lazyComponent() | async" />
                     </section>
                 }
                 @let code = processor()[tab] || '';

--- a/projects/addon-doc/components/example/example.template.html
+++ b/projects/addon-doc/components/example/example.template.html
@@ -94,7 +94,7 @@
                         [style.display]="activeItemIndex === $index ? 'block' : 'none'"
                     >
                         <ng-container *ngTemplateOutlet="content" />
-                        <ng-container *ngComponentOutlet="lazyComponent() | async" />
+                        <ng-container *ngComponentOutlet="lazyComponent.value() ?? null" />
                     </section>
                 }
                 @let code = processor()[tab] || '';

--- a/projects/demo/src/utils/component.pipe.ts
+++ b/projects/demo/src/utils/component.pipe.ts
@@ -8,6 +8,6 @@ export class TuiComponentPipe implements PipeTransform {
     public async transform(index: number): Promise<Type<unknown>> {
         return import(
             `../pages/${this.page.type()}/${tuiToKebab(this.page.header())}/examples/${index}/index.ts`
-        ).then((module) => module.default);
+        );
     }
 }


### PR DESCRIPTION
Before

```ts
protected readonly component1 = import('./examples/1').then((m) => m.default);
protected readonly component1 = import('./examples/2').then((m) => m.default);
protected readonly component1 = import('./examples/3').then((m) => m.default);
```

After

```ts
protected readonly component1 = import('./examples/1');
protected readonly component2 = import('./examples/2');
protected readonly component3 = import('./examples/3');
```