### PR TITLE
fix(kit): migrating to v5 breaks `TuiSwitch`

### DIFF
--- a/projects/styles/components/switch.less
+++ b/projects/styles/components/switch.less
@@ -19,7 +19,7 @@
  * @see-also
  * Checkbox, Radio
  */
-[tuiSwitch]:where(*&) {
+input[tuiSwitch]:where(*&) {
     .transition(~'background, box-shadow');
 
     display: inline-block;


### PR DESCRIPTION
Fixes #13971 