### PR TITLE
chore(demo-cypress): problem with typings

### DIFF
--- a/projects/demo-cypress/src/tests/input-range/input-range-ticks.cy.ts
+++ b/projects/demo-cypress/src/tests/input-range/input-range-ticks.cy.ts
@@ -38,7 +38,7 @@ describe('InputRange | With segments + tick labels', () => {
         cy.viewport(300, 110);
     });
 
-    const cases = [
+    const cases: ReadonlyArray<[number, number]> = [
         [0, 0],
         [0, 25],
         [0, 50],

--- a/projects/demo-cypress/src/tests/range/range-ticks.cy.ts
+++ b/projects/demo-cypress/src/tests/range/range-ticks.cy.ts
@@ -35,7 +35,7 @@ describe('Range | With segments + tick labels', () => {
         cy.viewport(300, 75);
     });
 
-    const cases = [
+    const cases: ReadonlyArray<[number, number]> = [
         [0, 0],
         [0, 25],
         [0, 50],


### PR DESCRIPTION
```
 ERROR in src/tests/range/range-ticks.cy.ts:51:54 - error TS2322: Type 'number[]' is not assignable to type '[number, number] | WritableSignal<[number, number] | undefined> |  
  InputSignal<[number, number] | undefined> | undefined'.                                                                                                                        
    Type 'number[]' is not assignable to type 'WritableSignal<[number, number] | undefined> | InputSignal<[number, number] | undefined>'.                                        
                                                                                                                                                                                 
  51             cy.mount(SandBox, {componentProperties: {value}});  
```