### PR TITLE
feat(layout):  add appearance to default options

### DIFF
--- a/projects/layout/components/card/card.options.ts
+++ b/projects/layout/components/card/card.options.ts
@@ -1,0 +1,15 @@
+import {tuiCreateOptions} from '@taiga-ui/cdk/utils/di';
+import {type TuiAppearanceOptions} from '@taiga-ui/core/directives/appearance';
+
+export interface TuiCardOptions extends TuiAppearanceOptions {
+    space: '' | 'compact' | 'normal';
+}
+
+export const TUI_CARD_DEFAULT_OPTIONS: TuiCardOptions = {
+    appearance: '',
+    space: 'normal',
+};
+
+export const [TUI_CARD_OPTIONS, tuiCardOptionsProvider] = tuiCreateOptions(
+    TUI_CARD_DEFAULT_OPTIONS,
+);

--- a/projects/layout/components/card/index.ts
+++ b/projects/layout/components/card/index.ts
@@ -1,4 +1,5 @@
 export * from './card';
+export * from './card.options';
 export * from './collapsed.directive';
 export * from './large.directive';
 export * from './medium.directive';

--- a/projects/layout/components/card/large.directive.ts
+++ b/projects/layout/components/card/large.directive.ts
@@ -7,14 +7,14 @@ import {
     ViewEncapsulation,
 } from '@angular/core';
 import {TUI_VERSION} from '@taiga-ui/cdk/constants';
-import {tuiCreateOptions} from '@taiga-ui/cdk/utils/di';
 import {tuiWithStyles} from '@taiga-ui/cdk/utils/miscellaneous';
-import {TuiWithAppearance} from '@taiga-ui/core/directives/appearance';
+import {
+    tuiAppearanceOptionsProvider,
+    TuiWithAppearance,
+} from '@taiga-ui/core/directives/appearance';
 import {TuiSurface} from '@taiga-ui/layout/components/surface';
 
-export const [TUI_CARD_OPTIONS, tuiCardOptionsProvider] = tuiCreateOptions({
-    space: 'normal',
-});
+import {TUI_CARD_OPTIONS} from './card.options';
 
 @Component({
     template: '',
@@ -32,6 +32,7 @@ class Styles {}
 
 @Directive({
     selector: '[tuiCardLarge]',
+    providers: [tuiAppearanceOptionsProvider(TUI_CARD_OPTIONS)],
     hostDirectives: [TuiWithAppearance, TuiSurface],
     host: {
         tuiCardLarge: '',
@@ -41,5 +42,5 @@ class Styles {}
 export class TuiCardLarge {
     protected readonly options = inject(TUI_CARD_OPTIONS);
     protected readonly nothing = tuiWithStyles(Styles);
-    public readonly tuiCardLarge = input<'' | 'compact' | 'normal'>('');
+    public readonly tuiCardLarge = input(this.options.space);
 }


### PR DESCRIPTION
Added appearance to default options and provider to override appearance settings globally or more locally. Thus, we can define the desired appearance once and not specify it each time in templates.

Fixes #13990
