### PR TITLE
fix(schematics): preserve label content when migrating legacy control with inner `<input>`

### DIFF
--- a/projects/cdk/schematics/ng-update/v5/steps/templates/migrate-input.ts
+++ b/projects/cdk/schematics/ng-update/v5/steps/templates/migrate-input.ts
@@ -534,12 +534,16 @@ function migrateInnerInput({
 
     const innerStart = innerLoc.startOffset;
     const siblingsAfter = parent.childNodes
-        .filter((c): c is Element => {
-            if (c === inner || c.nodeName === '#text' || c.nodeName === '#comment') {
+        .filter((child): child is Element => {
+            if (
+                child === inner ||
+                child.nodeName === '#text' ||
+                child.nodeName === '#comment'
+            ) {
                 return false;
             }
 
-            const loc = (c as Element).sourceCodeLocation;
+            const loc = (child as Element).sourceCodeLocation;
 
             return !!loc && loc.startOffset > innerStart;
         })

--- a/projects/cdk/schematics/ng-update/v5/steps/templates/migrate-input.ts
+++ b/projects/cdk/schematics/ng-update/v5/steps/templates/migrate-input.ts
@@ -547,8 +547,8 @@ function migrateInnerInput({
 
             return !!loc && loc.startOffset > innerStart;
         })
-        .map((c) => {
-            const loc = c.sourceCodeLocation;
+        .map((child) => {
+            const loc = child.sourceCodeLocation;
 
             return loc ? template.slice(loc.startOffset, loc.endOffset) : '';
         })
@@ -565,21 +565,21 @@ function buildLabelContent(parent: Element, inner: Element, template: string): s
     }
 
     return parent.childNodes
-        .filter((c) => {
-            if (c === inner || c.nodeName === '#comment') {
+        .filter((child) => {
+            if (child === inner || child.nodeName === '#comment') {
                 return false;
             }
 
-            const loc = c.sourceCodeLocation;
+            const loc = child.sourceCodeLocation;
 
             return !!loc && loc.startOffset < innerStart;
         })
-        .map((c) => {
-            if (c.nodeName === '#text') {
-                return (c as DefaultTreeAdapterTypes.TextNode).value;
+        .map((child) => {
+            if (child.nodeName === '#text') {
+                return (child as DefaultTreeAdapterTypes.TextNode).value;
             }
 
-            const loc = (c as Element).sourceCodeLocation;
+            const loc = (child as Element).sourceCodeLocation;
 
             return loc ? template.slice(loc.startOffset, loc.endOffset) : '';
         })

--- a/projects/cdk/schematics/ng-update/v5/steps/templates/migrate-input.ts
+++ b/projects/cdk/schematics/ng-update/v5/steps/templates/migrate-input.ts
@@ -428,11 +428,11 @@ function buildInnerContent({
 
     if (legacyInnerInput) {
         return migrateInnerInput({
+            parent: element,
             inner: legacyInnerInput,
             template,
             attrsToAdd: inputAttrs,
             controlStateStr,
-            allChildren: childElements,
             indent,
             hintIconLine,
             customContentLine,
@@ -476,22 +476,22 @@ function buildInnerContent({
  * by replacing the legacy directive attr and appending form control attrs.
  */
 function migrateInnerInput({
+    parent,
     inner,
     template,
     attrsToAdd,
     controlStateStr,
-    allChildren,
     indent,
     hintIconLine = '',
     customContentLine = '',
 }: {
-    allChildren: Element[];
     attrsToAdd: string[];
     controlStateStr: string;
     customContentLine?: string;
     hintIconLine?: string;
     indent: string;
     inner: Element;
+    parent: Element;
     template: string;
 }): string {
     const innerLoc = inner.sourceCodeLocation;
@@ -527,8 +527,22 @@ function migrateInnerInput({
 
     startTag = `${startTag.slice(0, closePos).trimEnd()}${insertStr}${startTag.slice(closePos)}`;
 
-    const siblings = allChildren
-        .filter((c) => c !== inner)
+    const labelContent = buildLabelContent(parent, inner, template);
+    const labelHtml = labelContent
+        ? `${indent}<label tuiLabel>${labelContent}</label>\n`
+        : '';
+
+    const innerStart = innerLoc.startOffset;
+    const siblingsAfter = parent.childNodes
+        .filter((c): c is Element => {
+            if (c === inner || c.nodeName === '#text' || c.nodeName === '#comment') {
+                return false;
+            }
+
+            const loc = (c as Element).sourceCodeLocation;
+
+            return !!loc && loc.startOffset > innerStart;
+        })
         .map((c) => {
             const loc = c.sourceCodeLocation;
 
@@ -536,7 +550,38 @@ function migrateInnerInput({
         })
         .join('');
 
-    return `${indent}${startTag}\n${siblings}${hintIconLine}${customContentLine}`;
+    return `${labelHtml}${indent}${startTag}\n${siblingsAfter}${hintIconLine}${customContentLine}`;
+}
+
+function buildLabelContent(parent: Element, inner: Element, template: string): string {
+    const innerStart = inner.sourceCodeLocation?.startOffset;
+
+    if (innerStart === undefined) {
+        return '';
+    }
+
+    return parent.childNodes
+        .filter((c) => {
+            if (c === inner || c.nodeName === '#comment') {
+                return false;
+            }
+
+            const loc = c.sourceCodeLocation;
+
+            return !!loc && loc.startOffset < innerStart;
+        })
+        .map((c) => {
+            if (c.nodeName === '#text') {
+                return (c as DefaultTreeAdapterTypes.TextNode).value;
+            }
+
+            const loc = (c as Element).sourceCodeLocation;
+
+            return loc ? template.slice(loc.startOffset, loc.endOffset) : '';
+        })
+        .join('')
+        .replaceAll(/\s+/g, ' ')
+        .trim();
 }
 
 /**

--- a/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-input.spec.ts.snap
+++ b/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-input.spec.ts.snap
@@ -371,6 +371,7 @@ exports[`ng-update legacy input reuses inner <input tuiTextfieldLegacy> and pres
             ",
   "1. After": "
                 <tui-textfield>
+                <label tuiLabel>Email</label>
                 <input
                         autocomplete="email"
                         placeholder="[Email]"

--- a/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-label-on-legacy-controls.spec.ts.snap
+++ b/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-label-on-legacy-controls.spec.ts.snap
@@ -1,36 +1,36 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`ng-update label on legacy controls preserves HTML label content and keeps existing placeholder on inner <input tuiTextfieldLegacy>: test.html 1`] = `
+exports[`ng-update label on legacy controls tui-input preserves HTML label content and keeps existing placeholder on inner <input tuiTextfieldLegacy>: test.html 1`] = `
 {
   "0. Before": "
-                <tui-input
-                    [style.max-width.rem]="30"
-                    [(ngModel)]="value"
-                >
-                    <strong>&pi;</strong>
-                    -value
-                    <input
-                        inputmode="decimal"
-                        placeholder="3,141..."
-                        tuiTextfieldLegacy
-                        [maskito]="maskitoOptions"
-                    />
-                </tui-input>
-            ",
+                    <tui-input
+                        [style.max-width.rem]="30"
+                        [(ngModel)]="value"
+                    >
+                        <strong>&pi;</strong>
+                        -value
+                        <input
+                            inputmode="decimal"
+                            placeholder="3,141..."
+                            tuiTextfieldLegacy
+                            [maskito]="maskitoOptions"
+                        />
+                    </tui-input>
+                ",
   "1. After": "
-                <tui-textfield [style.max-width.rem]="30">
-                <label tuiLabel><strong>&pi;</strong> -value</label>
-                <input
-                        inputmode="decimal"
-                        placeholder="3,141..."
-                        tuiInput
-                        [maskito]="maskitoOptions" [(ngModel)]="value"/>
-                </tui-textfield>
-            ",
+                    <tui-textfield [style.max-width.rem]="30">
+                    <label tuiLabel><strong>&pi;</strong> -value</label>
+                    <input
+                            inputmode="decimal"
+                            placeholder="3,141..."
+                            tuiInput
+                            [maskito]="maskitoOptions" [(ngModel)]="value"/>
+                    </tui-textfield>
+                ",
 }
 `;
 
-exports[`ng-update label on legacy controls preserves HTML label content and keeps existing placeholder on inner <input tuiTextfieldLegacy>: test.ts 1`] = `
+exports[`ng-update label on legacy controls tui-input preserves HTML label content and keeps existing placeholder on inner <input tuiTextfieldLegacy>: test.ts 1`] = `
 {
   "0. Before": "
             import {Component} from '@angular/core';
@@ -57,95 +57,569 @@ exports[`ng-update label on legacy controls preserves HTML label content and kee
 }
 `;
 
-exports[`ng-update label on legacy controls preserves plain text label when inner <input tuiTextfieldLegacy> has no placeholder: test.html 1`] = `
+exports[`ng-update label on legacy controls tui-input preserves plain text label and keeps existing placeholder on inner <input tuiTextfieldLegacy>: test.html 1`] = `
 {
   "0. Before": "
-                <tui-input
-                    [maskito]="maskitoOptions"
-                    [style.max-width.rem]="20"
-                    [(ngModel)]="value"
-                >
-                    Enter number
-
-                    <input
-                        tuiTextfieldLegacy
-                        [maskito]="maskitoOptions"
-                        (change)="log($event)"
-                    />
-                </tui-input>
-            ",
+                    <tui-input
+                        [style.max-width.rem]="30"
+                        [(ngModel)]="value"
+                    >
+                        Japanese yen
+                        <input
+                            inputmode="decimal"
+                            placeholder="¥1,2345,6789"
+                            tuiTextfieldLegacy
+                            [maskito]="maskitoOptions"
+                        />
+                    </tui-input>
+                ",
   "1. After": "
-                <!-- TODO: (Taiga UI migration) tui-input migration (see https://taiga-ui.dev/components/input):
-     - "[maskito]" is an unrecognized attribute and was placed on <tui-textfield>. Move it to <input tuiInput> if it targets the native element.
+                    <tui-textfield [style.max-width.rem]="30">
+                    <label tuiLabel>Japanese yen</label>
+                    <input
+                            inputmode="decimal"
+                            placeholder="¥1,2345,6789"
+                            tuiInput
+                            [maskito]="maskitoOptions" [(ngModel)]="value"/>
+                    </tui-textfield>
+                ",
+}
+`;
+
+exports[`ng-update label on legacy controls tui-input preserves plain text label and keeps existing placeholder on inner <input tuiTextfieldLegacy>: test.ts 1`] = `
+{
+  "0. Before": "
+            import {Component} from '@angular/core';
+            import {TuiInputModule} from '@taiga-ui/legacy';
+
+            @Component({
+                standalone: true,
+                templateUrl: './test.html',
+                imports: [TuiInputModule],
+            })
+            export class Test {}
+        ",
+  "1. After": "import { TuiInput } from "@taiga-ui/core";
+
+            import {Component} from '@angular/core';
+
+            @Component({
+                standalone: true,
+                templateUrl: './test.html',
+                imports: [TuiInput],
+            })
+            export class Test {}
+        ",
+}
+`;
+
+exports[`ng-update label on legacy controls tui-input preserves plain text label when inner <input tuiTextfieldLegacy> has no placeholder: test.html 1`] = `
+{
+  "0. Before": "
+                    <tui-input
+                        [style.max-width.rem]="20"
+                        [(ngModel)]="value"
+                    >
+                        Enter number
+
+                        <input
+                            tuiTextfieldLegacy
+                            [maskito]="maskitoOptions"
+                            (change)="log($event)"
+                        />
+                    </tui-input>
+                ",
+  "1. After": "
+                    <tui-textfield [style.max-width.rem]="20">
+                    <label tuiLabel>Enter number</label>
+                    <input
+                            tuiInput
+                            [maskito]="maskitoOptions"
+                            (change)="log($event)" [(ngModel)]="value"/>
+                    </tui-textfield>
+                ",
+}
+`;
+
+exports[`ng-update label on legacy controls tui-input preserves plain text label when inner <input tuiTextfieldLegacy> has no placeholder: test.ts 1`] = `
+{
+  "0. Before": "
+            import {Component} from '@angular/core';
+            import {TuiInputModule} from '@taiga-ui/legacy';
+
+            @Component({
+                standalone: true,
+                templateUrl: './test.html',
+                imports: [TuiInputModule],
+            })
+            export class Test {}
+        ",
+  "1. After": "import { TuiInput } from "@taiga-ui/core";
+
+            import {Component} from '@angular/core';
+
+            @Component({
+                standalone: true,
+                templateUrl: './test.html',
+                imports: [TuiInput],
+            })
+            export class Test {}
+        ",
+}
+`;
+
+exports[`ng-update label on legacy controls tui-input-date preserves plain text label when inner <input tuiTextfieldLegacy> is present: test.html 1`] = `
+{
+  "0. Before": "
+                    <tui-input-date [(ngModel)]="value">
+                        Choose a date
+                        <input
+                            placeholder="dd.mm.yyyy"
+                            tuiTextfieldLegacy
+                        />
+                    </tui-input-date>
+                ",
+  "1. After": "
+                    <tui-textfield >
+<label tuiLabel>
+                        Choose a date
+                        </label>
+<input
+                            placeholder="dd.mm.yyyy"
+                            tuiInputDate [(ngModel)]="value"
+                        />
+                    
+<tui-calendar *tuiDropdown />
+</tui-textfield>
+                ",
+}
+`;
+
+exports[`ng-update label on legacy controls tui-input-date preserves plain text label when inner <input tuiTextfieldLegacy> is present: test.ts 1`] = `
+{
+  "0. Before": "
+            import {Component} from '@angular/core';
+            import {TuiInputModule} from '@taiga-ui/legacy';
+
+            @Component({
+                standalone: true,
+                templateUrl: './test.html',
+                imports: [TuiInputModule],
+            })
+            export class Test {}
+        ",
+  "1. After": "import { TuiInput } from "@taiga-ui/core";
+
+            import {Component} from '@angular/core';
+
+            @Component({
+                standalone: true,
+                templateUrl: './test.html',
+                imports: [TuiInput],
+            })
+            export class Test {}
+        ",
+}
+`;
+
+exports[`ng-update label on legacy controls tui-input-date-range preserves plain text label when inner <input tuiTextfieldLegacy> is present: test.html 1`] = `
+{
+  "0. Before": "
+                    <tui-input-date-range [(ngModel)]="value">
+                        Choose a range
+                        <input
+                            placeholder="dd.mm.yyyy – dd.mm.yyyy"
+                            tuiTextfieldLegacy
+                        />
+                    </tui-input-date-range>
+                ",
+  "1. After": "
+                    <tui-textfield >
+<label tuiLabel>
+                        Choose a range
+                        </label>
+<input
+                            placeholder="dd.mm.yyyy – dd.mm.yyyy"
+                            tuiInputDateRange [(ngModel)]="value"
+                        />
+                    
+<tui-calendar-range *tuiDropdown />
+</tui-textfield>
+                ",
+}
+`;
+
+exports[`ng-update label on legacy controls tui-input-date-range preserves plain text label when inner <input tuiTextfieldLegacy> is present: test.ts 1`] = `
+{
+  "0. Before": "
+            import {Component} from '@angular/core';
+            import {TuiInputModule} from '@taiga-ui/legacy';
+
+            @Component({
+                standalone: true,
+                templateUrl: './test.html',
+                imports: [TuiInputModule],
+            })
+            export class Test {}
+        ",
+  "1. After": "import { TuiInput } from "@taiga-ui/core";
+
+            import {Component} from '@angular/core';
+
+            @Component({
+                standalone: true,
+                templateUrl: './test.html',
+                imports: [TuiInput],
+            })
+            export class Test {}
+        ",
+}
+`;
+
+exports[`ng-update label on legacy controls tui-input-month preserves plain text label when inner <input tuiTextfieldLegacy> is present: test.html 1`] = `
+{
+  "0. Before": "
+                    <tui-input-month [(ngModel)]="value">
+                        Your month
+                        <input
+                            placeholder="MM.YYYY"
+                            tuiTextfieldLegacy
+                        />
+                    </tui-input-month>
+                ",
+  "1. After": "
+                    <tui-textfield >
+<label tuiLabel>
+                        Your month
+                        </label>
+<input
+                            placeholder="MM.YYYY"
+                            tuiInputMonth [(ngModel)]="value"
+                        />
+                    
+<tui-calendar-month *tuiDropdown />
+</tui-textfield>
+                ",
+}
+`;
+
+exports[`ng-update label on legacy controls tui-input-month preserves plain text label when inner <input tuiTextfieldLegacy> is present: test.ts 1`] = `
+{
+  "0. Before": "
+            import {Component} from '@angular/core';
+            import {TuiInputModule} from '@taiga-ui/legacy';
+
+            @Component({
+                standalone: true,
+                templateUrl: './test.html',
+                imports: [TuiInputModule],
+            })
+            export class Test {}
+        ",
+  "1. After": "import { TuiInput } from "@taiga-ui/core";
+
+            import {Component} from '@angular/core';
+
+            @Component({
+                standalone: true,
+                templateUrl: './test.html',
+                imports: [TuiInput],
+            })
+            export class Test {}
+        ",
+}
+`;
+
+exports[`ng-update label on legacy controls tui-input-password preserves plain text label when inner <input tuiTextfieldLegacy> is present: test.html 1`] = `
+{
+  "0. Before": "
+                    <tui-input-password [(ngModel)]="value">
+                        Password
+                        <input
+                            tuiTextfieldLegacy
+                            type="password"
+                        />
+                    </tui-input-password>
+                ",
+  "1. After": "
+                    <tui-textfield >
+<label tuiLabel>
+                        Password
+                        </label>
+<input
+                            tuiInput type="password" [(ngModel)]="value"
+                            type="password"
+                        />
+<tui-icon tuiPassword />
+
+                    </tui-textfield>
+                ",
+}
+`;
+
+exports[`ng-update label on legacy controls tui-input-password preserves plain text label when inner <input tuiTextfieldLegacy> is present: test.ts 1`] = `
+{
+  "0. Before": "
+            import {Component} from '@angular/core';
+            import {TuiInputModule} from '@taiga-ui/legacy';
+
+            @Component({
+                standalone: true,
+                templateUrl: './test.html',
+                imports: [TuiInputModule],
+            })
+            export class Test {}
+        ",
+  "1. After": "import { TuiInput } from "@taiga-ui/core";
+
+            import {Component} from '@angular/core';
+
+            @Component({
+                standalone: true,
+                templateUrl: './test.html',
+                imports: [TuiInput],
+            })
+            export class Test {}
+        ",
+}
+`;
+
+exports[`ng-update label on legacy controls tui-input-phone preserves plain text label when inner <input tuiTextfieldLegacy> is present: test.html 1`] = `
+{
+  "0. Before": "
+                    <tui-input-phone [(ngModel)]="value">
+                        Your phone
+                        <input
+                            placeholder="+7 (___) ___-__-__"
+                            tuiTextfieldLegacy
+                        />
+                    </tui-input-phone>
+                ",
+  "1. After": "
+                    <tui-textfield >
+<label tuiLabel>
+                        Your phone
+                        </label>
+<input
+                            placeholder="+7 (___) ___-__-__"
+                            tuiInputPhone [(ngModel)]="value"
+                        />
+                    </tui-textfield>
+                ",
+}
+`;
+
+exports[`ng-update label on legacy controls tui-input-phone preserves plain text label when inner <input tuiTextfieldLegacy> is present: test.ts 1`] = `
+{
+  "0. Before": "
+            import {Component} from '@angular/core';
+            import {TuiInputModule} from '@taiga-ui/legacy';
+
+            @Component({
+                standalone: true,
+                templateUrl: './test.html',
+                imports: [TuiInputModule],
+            })
+            export class Test {}
+        ",
+  "1. After": "import { TuiInput } from "@taiga-ui/core";
+
+            import {Component} from '@angular/core';
+
+            @Component({
+                standalone: true,
+                templateUrl: './test.html',
+                imports: [TuiInput],
+            })
+            export class Test {}
+        ",
+}
+`;
+
+exports[`ng-update label on legacy controls tui-input-phone-international preserves plain text label when inner <input tuiTextfieldLegacy> is present: test.html 1`] = `
+{
+  "0. Before": "
+                    <tui-input-phone-international [(ngModel)]="value">
+                        Your phone
+                        <input
+                            placeholder="+7 000 000-00-00"
+                            tuiTextfieldLegacy
+                        />
+                    </tui-input-phone-international>
+                ",
+  "1. After": "
+                    <tui-textfield >
+<label tuiLabel>
+                        Your phone
+                        </label>
+<input
+                            placeholder="+7 000 000-00-00"
+                            tuiInputPhoneInternational [(ngModel)]="value"
+                        />
+                    </tui-textfield>
+                ",
+}
+`;
+
+exports[`ng-update label on legacy controls tui-input-phone-international preserves plain text label when inner <input tuiTextfieldLegacy> is present: test.ts 1`] = `
+{
+  "0. Before": "
+            import {Component} from '@angular/core';
+            import {TuiInputModule} from '@taiga-ui/legacy';
+
+            @Component({
+                standalone: true,
+                templateUrl: './test.html',
+                imports: [TuiInputModule],
+            })
+            export class Test {}
+        ",
+  "1. After": "import { TuiInput } from "@taiga-ui/core";
+
+            import {Component} from '@angular/core';
+
+            @Component({
+                standalone: true,
+                templateUrl: './test.html',
+                imports: [TuiInput],
+            })
+            export class Test {}
+        ",
+}
+`;
+
+exports[`ng-update label on legacy controls tui-input-time preserves plain text label when inner <input tuiTextfieldLegacy> is present: test.html 1`] = `
+{
+  "0. Before": "
+                    <tui-input-time [(ngModel)]="value">
+                        Pick a time
+                        <input
+                            placeholder="hh:mm"
+                            tuiTextfieldLegacy
+                        />
+                    </tui-input-time>
+                ",
+  "1. After": "
+                    <tui-textfield >
+<label tuiLabel>
+                        Pick a time
+                        </label>
+<input
+                            placeholder="hh:mm"
+                            tuiInputTime [(ngModel)]="value"
+                        />
+                    </tui-textfield>
+                ",
+}
+`;
+
+exports[`ng-update label on legacy controls tui-input-time preserves plain text label when inner <input tuiTextfieldLegacy> is present: test.ts 1`] = `
+{
+  "0. Before": "
+            import {Component} from '@angular/core';
+            import {TuiInputModule} from '@taiga-ui/legacy';
+
+            @Component({
+                standalone: true,
+                templateUrl: './test.html',
+                imports: [TuiInputModule],
+            })
+            export class Test {}
+        ",
+  "1. After": "import { TuiInput } from "@taiga-ui/core";
+
+            import {Component} from '@angular/core';
+
+            @Component({
+                standalone: true,
+                templateUrl: './test.html',
+                imports: [TuiInput],
+            })
+            export class Test {}
+        ",
+}
+`;
+
+exports[`ng-update label on legacy controls tui-input-year preserves plain text label when inner <input tuiTextfieldLegacy> is present: test.html 1`] = `
+{
+  "0. Before": "
+                    <tui-input-year [(ngModel)]="value">
+                        Your year
+                        <input
+                            placeholder="Not 2022 please"
+                            tuiTextfieldLegacy
+                        />
+                    </tui-input-year>
+                ",
+  "1. After": "
+                    <tui-textfield >
+<label tuiLabel>
+                        Your year
+                        </label>
+<input
+                            placeholder="Not 2022 please"
+                            tuiInputYear [(ngModel)]="value"
+                        />
+                    
+<tui-calendar-year *tuiDropdown />
+</tui-textfield>
+                ",
+}
+`;
+
+exports[`ng-update label on legacy controls tui-input-year preserves plain text label when inner <input tuiTextfieldLegacy> is present: test.ts 1`] = `
+{
+  "0. Before": "
+            import {Component} from '@angular/core';
+            import {TuiInputModule} from '@taiga-ui/legacy';
+
+            @Component({
+                standalone: true,
+                templateUrl: './test.html',
+                imports: [TuiInputModule],
+            })
+            export class Test {}
+        ",
+  "1. After": "import { TuiInput } from "@taiga-ui/core";
+
+            import {Component} from '@angular/core';
+
+            @Component({
+                standalone: true,
+                templateUrl: './test.html',
+                imports: [TuiInput],
+            })
+            export class Test {}
+        ",
+}
+`;
+
+exports[`ng-update label on legacy controls tui-textarea preserves plain text label when inner <textarea tuiTextfieldLegacy> is present: test.html 1`] = `
+{
+  "0. Before": "
+                    <tui-textarea [(ngModel)]="value">
+                        Bio
+                        <textarea
+                            placeholder="Write a few words"
+                            tuiTextfieldLegacy
+                        ></textarea>
+                    </tui-textarea>
+                ",
+  "1. After": "
+                    <!-- TODO: (Taiga UI migration) tui-textarea migration (see https://taiga-ui.dev/components/textarea):
+     - Legacy tui-textarea had a fixed height of 20 rows by default. New component auto-resizes between [min] (default: 1) and [max] (default: 3) rows. Set min and max explicitly if the previous layout needs to be preserved.
 -->
-                <tui-textfield [maskito]="maskitoOptions" [style.max-width.rem]="20">
-                <label tuiLabel>Enter number</label>
-                <input
-                        tuiInput
-                        [maskito]="maskitoOptions"
-                        (change)="log($event)" [(ngModel)]="value"/>
-                </tui-textfield>
-            ",
+                    <tui-textfield>
+                    <label tuiLabel>Bio</label>
+                    <textarea
+                            placeholder="Write a few words"
+                            tuiTextarea [(ngModel)]="value"></textarea>
+                    </tui-textfield>
+                ",
 }
 `;
 
-exports[`ng-update label on legacy controls preserves plain text label when inner <input tuiTextfieldLegacy> has no placeholder: test.ts 1`] = `
-{
-  "0. Before": "
-            import {Component} from '@angular/core';
-            import {TuiInputModule} from '@taiga-ui/legacy';
-
-            @Component({
-                standalone: true,
-                templateUrl: './test.html',
-                imports: [TuiInputModule],
-            })
-            export class Test {}
-        ",
-  "1. After": "import { TuiInput } from "@taiga-ui/core";
-
-            import {Component} from '@angular/core';
-
-            @Component({
-                standalone: true,
-                templateUrl: './test.html',
-                imports: [TuiInput],
-            })
-            export class Test {}
-        ",
-}
-`;
-
-exports[`ng-update label on legacy controls preserves plain text label and keeps existing placeholder on inner <input tuiTextfieldLegacy>: test.html 1`] = `
-{
-  "0. Before": "
-                <tui-input
-                    [style.max-width.rem]="30"
-                    [(ngModel)]="value"
-                >
-                    Japanese yen
-                    <input
-                        inputmode="decimal"
-                        placeholder="¥1,2345,6789"
-                        tuiTextfieldLegacy
-                        [maskito]="maskitoOptions"
-                    />
-                </tui-input>
-            ",
-  "1. After": "
-                <tui-textfield [style.max-width.rem]="30">
-                <label tuiLabel>Japanese yen</label>
-                <input
-                        inputmode="decimal"
-                        placeholder="¥1,2345,6789"
-                        tuiInput
-                        [maskito]="maskitoOptions" [(ngModel)]="value"/>
-                </tui-textfield>
-            ",
-}
-`;
-
-exports[`ng-update label on legacy controls preserves plain text label and keeps existing placeholder on inner <input tuiTextfieldLegacy>: test.ts 1`] = `
+exports[`ng-update label on legacy controls tui-textarea preserves plain text label when inner <textarea tuiTextfieldLegacy> is present: test.ts 1`] = `
 {
   "0. Before": "
             import {Component} from '@angular/core';

--- a/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-label-on-legacy-controls.spec.ts.snap
+++ b/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-label-on-legacy-controls.spec.ts.snap
@@ -1,0 +1,173 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ng-update label on legacy controls preserves HTML label content and keeps existing placeholder on inner <input tuiTextfieldLegacy>: test.html 1`] = `
+{
+  "0. Before": "
+                <tui-input
+                    [style.max-width.rem]="30"
+                    [(ngModel)]="value"
+                >
+                    <strong>&pi;</strong>
+                    -value
+                    <input
+                        inputmode="decimal"
+                        placeholder="3,141..."
+                        tuiTextfieldLegacy
+                        [maskito]="maskitoOptions"
+                    />
+                </tui-input>
+            ",
+  "1. After": "
+                <tui-textfield [style.max-width.rem]="30">
+                <label tuiLabel><strong>&pi;</strong> -value</label>
+                <input
+                        inputmode="decimal"
+                        placeholder="3,141..."
+                        tuiInput
+                        [maskito]="maskitoOptions" [(ngModel)]="value"/>
+                </tui-textfield>
+            ",
+}
+`;
+
+exports[`ng-update label on legacy controls preserves HTML label content and keeps existing placeholder on inner <input tuiTextfieldLegacy>: test.ts 1`] = `
+{
+  "0. Before": "
+            import {Component} from '@angular/core';
+            import {TuiInputModule} from '@taiga-ui/legacy';
+
+            @Component({
+                standalone: true,
+                templateUrl: './test.html',
+                imports: [TuiInputModule],
+            })
+            export class Test {}
+        ",
+  "1. After": "import { TuiInput } from "@taiga-ui/core";
+
+            import {Component} from '@angular/core';
+
+            @Component({
+                standalone: true,
+                templateUrl: './test.html',
+                imports: [TuiInput],
+            })
+            export class Test {}
+        ",
+}
+`;
+
+exports[`ng-update label on legacy controls preserves plain text label when inner <input tuiTextfieldLegacy> has no placeholder: test.html 1`] = `
+{
+  "0. Before": "
+                <tui-input
+                    [maskito]="maskitoOptions"
+                    [style.max-width.rem]="20"
+                    [(ngModel)]="value"
+                >
+                    Enter number
+
+                    <input
+                        tuiTextfieldLegacy
+                        [maskito]="maskitoOptions"
+                        (change)="log($event)"
+                    />
+                </tui-input>
+            ",
+  "1. After": "
+                <!-- TODO: (Taiga UI migration) tui-input migration (see https://taiga-ui.dev/components/input):
+     - "[maskito]" is an unrecognized attribute and was placed on <tui-textfield>. Move it to <input tuiInput> if it targets the native element.
+-->
+                <tui-textfield [maskito]="maskitoOptions" [style.max-width.rem]="20">
+                <label tuiLabel>Enter number</label>
+                <input
+                        tuiInput
+                        [maskito]="maskitoOptions"
+                        (change)="log($event)" [(ngModel)]="value"/>
+                </tui-textfield>
+            ",
+}
+`;
+
+exports[`ng-update label on legacy controls preserves plain text label when inner <input tuiTextfieldLegacy> has no placeholder: test.ts 1`] = `
+{
+  "0. Before": "
+            import {Component} from '@angular/core';
+            import {TuiInputModule} from '@taiga-ui/legacy';
+
+            @Component({
+                standalone: true,
+                templateUrl: './test.html',
+                imports: [TuiInputModule],
+            })
+            export class Test {}
+        ",
+  "1. After": "import { TuiInput } from "@taiga-ui/core";
+
+            import {Component} from '@angular/core';
+
+            @Component({
+                standalone: true,
+                templateUrl: './test.html',
+                imports: [TuiInput],
+            })
+            export class Test {}
+        ",
+}
+`;
+
+exports[`ng-update label on legacy controls preserves plain text label and keeps existing placeholder on inner <input tuiTextfieldLegacy>: test.html 1`] = `
+{
+  "0. Before": "
+                <tui-input
+                    [style.max-width.rem]="30"
+                    [(ngModel)]="value"
+                >
+                    Japanese yen
+                    <input
+                        inputmode="decimal"
+                        placeholder="¥1,2345,6789"
+                        tuiTextfieldLegacy
+                        [maskito]="maskitoOptions"
+                    />
+                </tui-input>
+            ",
+  "1. After": "
+                <tui-textfield [style.max-width.rem]="30">
+                <label tuiLabel>Japanese yen</label>
+                <input
+                        inputmode="decimal"
+                        placeholder="¥1,2345,6789"
+                        tuiInput
+                        [maskito]="maskitoOptions" [(ngModel)]="value"/>
+                </tui-textfield>
+            ",
+}
+`;
+
+exports[`ng-update label on legacy controls preserves plain text label and keeps existing placeholder on inner <input tuiTextfieldLegacy>: test.ts 1`] = `
+{
+  "0. Before": "
+            import {Component} from '@angular/core';
+            import {TuiInputModule} from '@taiga-ui/legacy';
+
+            @Component({
+                standalone: true,
+                templateUrl: './test.html',
+                imports: [TuiInputModule],
+            })
+            export class Test {}
+        ",
+  "1. After": "import { TuiInput } from "@taiga-ui/core";
+
+            import {Component} from '@angular/core';
+
+            @Component({
+                standalone: true,
+                templateUrl: './test.html',
+                imports: [TuiInput],
+            })
+            export class Test {}
+        ",
+}
+`;

--- a/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-legacy-custom-content.spec.ts.snap
+++ b/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-legacy-custom-content.spec.ts.snap
@@ -271,6 +271,7 @@ import { TuiFlagPipe } from "@taiga-ui/kit";
                         ],
                         template: \`
                             <tui-textfield [style.max-width.rem]="20">
+                            <label tuiLabel>Enter US phone number</label>
                             <input
                                     inputmode="tel"
                                     tuiInput
@@ -355,6 +356,7 @@ exports[`ng-update legacy tuiTextfieldCustomContent across controls imports are 
                         ],
                         template: \`
                             <tui-textfield [style.max-width.rem]="20">
+                            <label tuiLabel>Enter date</label>
                             <input
                                     inputmode="numeric"
                                     tuiInput

--- a/projects/cdk/schematics/ng-update/v5/tests/schematic-migrate-label-on-legacy-controls.spec.ts
+++ b/projects/cdk/schematics/ng-update/v5/tests/schematic-migrate-label-on-legacy-controls.spec.ts
@@ -20,67 +20,221 @@ describe('ng-update label on legacy controls', () => {
         `,
     });
 
-    it(
-        'preserves plain text label when inner <input tuiTextfieldLegacy> has no placeholder',
-        migrate({
-            template: /* HTML */ `
-                <tui-input
-                    [maskito]="maskitoOptions"
-                    [style.max-width.rem]="20"
-                    [(ngModel)]="value"
-                >
-                    Enter number
+    describe('tui-input', () => {
+        it(
+            'preserves plain text label when inner <input tuiTextfieldLegacy> has no placeholder',
+            migrate({
+                template: /* HTML */ `
+                    <tui-input
+                        [style.max-width.rem]="20"
+                        [(ngModel)]="value"
+                    >
+                        Enter number
 
-                    <input
-                        tuiTextfieldLegacy
-                        [maskito]="maskitoOptions"
-                        (change)="log($event)"
-                    />
-                </tui-input>
-            `,
-        }),
-    );
+                        <input
+                            tuiTextfieldLegacy
+                            [maskito]="maskitoOptions"
+                            (change)="log($event)"
+                        />
+                    </tui-input>
+                `,
+            }),
+        );
 
-    it(
-        'preserves plain text label and keeps existing placeholder on inner <input tuiTextfieldLegacy>',
-        migrate({
-            template: /* HTML */ `
-                <tui-input
-                    [style.max-width.rem]="30"
-                    [(ngModel)]="value"
-                >
-                    Japanese yen
-                    <input
-                        inputmode="decimal"
-                        placeholder="¥1,2345,6789"
-                        tuiTextfieldLegacy
-                        [maskito]="maskitoOptions"
-                    />
-                </tui-input>
-            `,
-        }),
-    );
+        it(
+            'preserves plain text label and keeps existing placeholder on inner <input tuiTextfieldLegacy>',
+            migrate({
+                template: /* HTML */ `
+                    <tui-input
+                        [style.max-width.rem]="30"
+                        [(ngModel)]="value"
+                    >
+                        Japanese yen
+                        <input
+                            inputmode="decimal"
+                            placeholder="¥1,2345,6789"
+                            tuiTextfieldLegacy
+                            [maskito]="maskitoOptions"
+                        />
+                    </tui-input>
+                `,
+            }),
+        );
 
-    it(
-        'preserves HTML label content and keeps existing placeholder on inner <input tuiTextfieldLegacy>',
-        migrate({
-            template: /* HTML */ `
-                <tui-input
-                    [style.max-width.rem]="30"
-                    [(ngModel)]="value"
-                >
-                    <strong>&pi;</strong>
-                    -value
-                    <input
-                        inputmode="decimal"
-                        placeholder="3,141..."
-                        tuiTextfieldLegacy
-                        [maskito]="maskitoOptions"
-                    />
-                </tui-input>
-            `,
-        }),
-    );
+        it(
+            'preserves HTML label content and keeps existing placeholder on inner <input tuiTextfieldLegacy>',
+            migrate({
+                template: /* HTML */ `
+                    <tui-input
+                        [style.max-width.rem]="30"
+                        [(ngModel)]="value"
+                    >
+                        <strong>&pi;</strong>
+                        -value
+                        <input
+                            inputmode="decimal"
+                            placeholder="3,141..."
+                            tuiTextfieldLegacy
+                            [maskito]="maskitoOptions"
+                        />
+                    </tui-input>
+                `,
+            }),
+        );
+    });
+
+    describe('tui-input-date', () => {
+        it(
+            'preserves plain text label when inner <input tuiTextfieldLegacy> is present',
+            migrate({
+                template: /* HTML */ `
+                    <tui-input-date [(ngModel)]="value">
+                        Choose a date
+                        <input
+                            placeholder="dd.mm.yyyy"
+                            tuiTextfieldLegacy
+                        />
+                    </tui-input-date>
+                `,
+            }),
+        );
+    });
+
+    describe('tui-input-date-range', () => {
+        it(
+            'preserves plain text label when inner <input tuiTextfieldLegacy> is present',
+            migrate({
+                template: /* HTML */ `
+                    <tui-input-date-range [(ngModel)]="value">
+                        Choose a range
+                        <input
+                            placeholder="dd.mm.yyyy – dd.mm.yyyy"
+                            tuiTextfieldLegacy
+                        />
+                    </tui-input-date-range>
+                `,
+            }),
+        );
+    });
+
+    describe('tui-input-time', () => {
+        it(
+            'preserves plain text label when inner <input tuiTextfieldLegacy> is present',
+            migrate({
+                template: /* HTML */ `
+                    <tui-input-time [(ngModel)]="value">
+                        Pick a time
+                        <input
+                            placeholder="hh:mm"
+                            tuiTextfieldLegacy
+                        />
+                    </tui-input-time>
+                `,
+            }),
+        );
+    });
+
+    describe('tui-input-month', () => {
+        it(
+            'preserves plain text label when inner <input tuiTextfieldLegacy> is present',
+            migrate({
+                template: /* HTML */ `
+                    <tui-input-month [(ngModel)]="value">
+                        Your month
+                        <input
+                            placeholder="MM.YYYY"
+                            tuiTextfieldLegacy
+                        />
+                    </tui-input-month>
+                `,
+            }),
+        );
+    });
+
+    describe('tui-input-year', () => {
+        it(
+            'preserves plain text label when inner <input tuiTextfieldLegacy> is present',
+            migrate({
+                template: /* HTML */ `
+                    <tui-input-year [(ngModel)]="value">
+                        Your year
+                        <input
+                            placeholder="Not 2022 please"
+                            tuiTextfieldLegacy
+                        />
+                    </tui-input-year>
+                `,
+            }),
+        );
+    });
+
+    describe('tui-input-password', () => {
+        it(
+            'preserves plain text label when inner <input tuiTextfieldLegacy> is present',
+            migrate({
+                template: /* HTML */ `
+                    <tui-input-password [(ngModel)]="value">
+                        Password
+                        <input
+                            tuiTextfieldLegacy
+                            type="password"
+                        />
+                    </tui-input-password>
+                `,
+            }),
+        );
+    });
+
+    describe('tui-input-phone', () => {
+        it(
+            'preserves plain text label when inner <input tuiTextfieldLegacy> is present',
+            migrate({
+                template: /* HTML */ `
+                    <tui-input-phone [(ngModel)]="value">
+                        Your phone
+                        <input
+                            placeholder="+7 (___) ___-__-__"
+                            tuiTextfieldLegacy
+                        />
+                    </tui-input-phone>
+                `,
+            }),
+        );
+    });
+
+    describe('tui-input-phone-international', () => {
+        it(
+            'preserves plain text label when inner <input tuiTextfieldLegacy> is present',
+            migrate({
+                template: /* HTML */ `
+                    <tui-input-phone-international [(ngModel)]="value">
+                        Your phone
+                        <input
+                            placeholder="+7 000 000-00-00"
+                            tuiTextfieldLegacy
+                        />
+                    </tui-input-phone-international>
+                `,
+            }),
+        );
+    });
+
+    describe('tui-textarea', () => {
+        it(
+            'preserves plain text label when inner <textarea tuiTextfieldLegacy> is present',
+            migrate({
+                template: /* HTML */ `
+                    <tui-textarea [(ngModel)]="value">
+                        Bio
+                        <textarea
+                            placeholder="Write a few words"
+                            tuiTextfieldLegacy
+                        ></textarea>
+                    </tui-textarea>
+                `,
+            }),
+        );
+    });
 
     afterEach(() => resetActiveProject());
 });

--- a/projects/cdk/schematics/ng-update/v5/tests/schematic-migrate-label-on-legacy-controls.spec.ts
+++ b/projects/cdk/schematics/ng-update/v5/tests/schematic-migrate-label-on-legacy-controls.spec.ts
@@ -1,0 +1,86 @@
+import {join} from 'node:path';
+
+import {resetActiveProject} from 'ng-morph';
+
+import {createMigration} from '../../../utils/run-migration';
+
+describe('ng-update label on legacy controls', () => {
+    const migrate = createMigration({
+        collection: join(__dirname, '../../../migration.json'),
+        component: `
+            import {Component} from '@angular/core';
+            import {TuiInputModule} from '@taiga-ui/legacy';
+
+            @Component({
+                standalone: true,
+                templateUrl: './test.html',
+                imports: [TuiInputModule],
+            })
+            export class Test {}
+        `,
+    });
+
+    it(
+        'preserves plain text label when inner <input tuiTextfieldLegacy> has no placeholder',
+        migrate({
+            template: /* HTML */ `
+                <tui-input
+                    [maskito]="maskitoOptions"
+                    [style.max-width.rem]="20"
+                    [(ngModel)]="value"
+                >
+                    Enter number
+
+                    <input
+                        tuiTextfieldLegacy
+                        [maskito]="maskitoOptions"
+                        (change)="log($event)"
+                    />
+                </tui-input>
+            `,
+        }),
+    );
+
+    it(
+        'preserves plain text label and keeps existing placeholder on inner <input tuiTextfieldLegacy>',
+        migrate({
+            template: /* HTML */ `
+                <tui-input
+                    [style.max-width.rem]="30"
+                    [(ngModel)]="value"
+                >
+                    Japanese yen
+                    <input
+                        inputmode="decimal"
+                        placeholder="¥1,2345,6789"
+                        tuiTextfieldLegacy
+                        [maskito]="maskitoOptions"
+                    />
+                </tui-input>
+            `,
+        }),
+    );
+
+    it(
+        'preserves HTML label content and keeps existing placeholder on inner <input tuiTextfieldLegacy>',
+        migrate({
+            template: /* HTML */ `
+                <tui-input
+                    [style.max-width.rem]="30"
+                    [(ngModel)]="value"
+                >
+                    <strong>&pi;</strong>
+                    -value
+                    <input
+                        inputmode="decimal"
+                        placeholder="3,141..."
+                        tuiTextfieldLegacy
+                        [maskito]="maskitoOptions"
+                    />
+                </tui-input>
+            `,
+        }),
+    );
+
+    afterEach(() => resetActiveProject());
+});


### PR DESCRIPTION
Fixes #13992
