### PR TITLE
fix(core): `Notification` fix label overlapping close button on long text (#14114)

### DIFF
--- a/projects/core/components/notification/notification.style.less
+++ b/projects/core/components/notification/notification.style.less
@@ -17,6 +17,6 @@
     clip-path: inset(0.375rem 0 round var(--tui-radius-m));
 }
 
-.t-closable {
+.t-closable[data-size] {
     padding-inline-end: 2.5rem;
 }


### PR DESCRIPTION
Fixes #14114

BEFORE
<img width="732" height="390" alt="Xnip2026-05-19_13-17-31" src="https://github.com/user-attachments/assets/82c67cc4-464b-4d73-adfb-7abfc160fece" />

AFTER
<img width="726" height="388" alt="Xnip2026-05-19_13-18-44" src="https://github.com/user-attachments/assets/d93deee4-f71e-483d-93b8-58aabaf40ae7" />


