### PR TITLE
fix(kit): apply overscroll-behavior only when there is an extra element inside the t-ghost

### DIFF
--- a/projects/demo-playwright/tests/kit/textarea/textarea.pw.spec.ts
+++ b/projects/demo-playwright/tests/kit/textarea/textarea.pw.spec.ts
@@ -57,7 +57,7 @@ test.describe('Textarea', () => {
             .getExample('#limit')
             .locator('textarea[tuiTextarea]');
 
-        await expect(basicTextarea).toHaveCSS('overscroll-behavior', 'auto');
+        await expect(basicTextarea).not.toHaveCSS('overscroll-behavior', 'none');
         await expect(limitTextarea).toHaveCSS('overscroll-behavior', 'none');
     });
 });

--- a/projects/demo-playwright/tests/kit/textarea/textarea.pw.spec.ts
+++ b/projects/demo-playwright/tests/kit/textarea/textarea.pw.spec.ts
@@ -44,4 +44,20 @@ test.describe('Textarea', () => {
                 .toHaveScreenshot(`textarea-tuiTextfieldSize-${size}.png`);
         });
     });
+
+    test('overscroll-behavior', async ({page}) => {
+        await tuiGoto(page, DemoRoute.Textarea);
+
+        const basicTextarea = new TuiDocumentationPagePO(page)
+            .getExample('#basic')
+            .locator('textarea[tuiTextarea]')
+            .first();
+
+        const limitTextarea = new TuiDocumentationPagePO(page)
+            .getExample('#limit')
+            .locator('textarea[tuiTextarea]');
+
+        await expect(basicTextarea).toHaveCSS('overscroll-behavior', 'auto');
+        await expect(limitTextarea).toHaveCSS('overscroll-behavior', 'none');
+    });
 });

--- a/projects/kit/components/textarea/textarea.component.ts
+++ b/projects/kit/components/textarea/textarea.component.ts
@@ -30,9 +30,9 @@ import {TUI_TEXTAREA_OPTIONS} from './textarea.options';
     host: {
         ngSkipHydration: 'true',
         '[class._mobile]': 'isMobile',
-        '(scroll.zoneless)': 'onScroll()',
         // To trigger CD for #text
         '(scroll.once)': 'onScroll()',
+        '(scroll.zoneless)': 'onScroll()',
     },
 })
 export class TuiTextareaComponent implements AfterViewInit {
@@ -52,7 +52,8 @@ export class TuiTextareaComponent implements AfterViewInit {
     }
 
     protected onScroll(): void {
-        console.log('scroll');
-        setTimeout(() => this.text()?.nativeElement.scrollTo({top: this.el.scrollTop}));
+        requestAnimationFrame(() => {
+            this.text()?.nativeElement.scrollTo({top: this.el.scrollTop});
+        });
     }
 }

--- a/projects/kit/components/textarea/textarea.component.ts
+++ b/projects/kit/components/textarea/textarea.component.ts
@@ -30,9 +30,9 @@ import {TUI_TEXTAREA_OPTIONS} from './textarea.options';
     host: {
         ngSkipHydration: 'true',
         '[class._mobile]': 'isMobile',
+        '(scroll.zoneless)': 'onScroll()',
         // To trigger CD for #text
         '(scroll.once)': 'onScroll()',
-        '(scroll.zoneless)': 'onScroll()',
     },
 })
 export class TuiTextareaComponent implements AfterViewInit {
@@ -52,6 +52,7 @@ export class TuiTextareaComponent implements AfterViewInit {
     }
 
     protected onScroll(): void {
-        this.text()?.nativeElement.scrollTo({top: this.el.scrollTop});
+        console.log('scroll');
+        setTimeout(() => this.text()?.nativeElement.scrollTo({top: this.el.scrollTop}));
     }
 }

--- a/projects/kit/components/textarea/textarea.directive.ts
+++ b/projects/kit/components/textarea/textarea.directive.ts
@@ -47,7 +47,7 @@ class TuiTextareaCounter {
 @Component({
     template: `
         <ng-container>{{ context.$implicit.slice(0, limit()) }}</ng-container>
-        @if (limit() < context.$implicit.length) {
+        @if (limit() <= context.$implicit.length) {
             <span [textContent]="context.$implicit.slice(limit())"></span>
         }
     `,

--- a/projects/kit/components/textarea/textarea.directive.ts
+++ b/projects/kit/components/textarea/textarea.directive.ts
@@ -46,8 +46,10 @@ class TuiTextareaCounter {
 
 @Component({
     template: `
-        <span [textContent]="context.$implicit.slice(0, limit())"></span>
-        <span [textContent]="context.$implicit.slice(limit())"></span>
+        <ng-container>{{ context.$implicit.slice(0, limit()) }}</ng-container>
+        @if (limit() < context.$implicit.length) {
+            <span [textContent]="context.$implicit.slice(limit())"></span>
+        }
     `,
     styles: `
         span:last-child {

--- a/projects/kit/components/textarea/textarea.directive.ts
+++ b/projects/kit/components/textarea/textarea.directive.ts
@@ -24,7 +24,7 @@ import {injectContext, PolymorpheusComponent} from '@taiga-ui/polymorpheus';
 import {tuiTextareaOptionsProvider} from './textarea.options';
 
 @Component({
-    template: '{{ length() }} / {{ limit() }}',
+    template: '@if (limit()) { {{ length() }} / {{ limit() }} } ',
     styles: `
         :host {
             z-index: 1;

--- a/projects/kit/components/textarea/textarea.style.less
+++ b/projects/kit/components/textarea/textarea.style.less
@@ -25,6 +25,10 @@
     padding-block: 1.125rem 0.375rem;
 }
 
+:host-context(tui-textfield:has(.t-ghost > *)) {
+    overscroll-behavior: none;
+}
+
 :host:host {
     block-size: 100%;
     white-space: pre-wrap;

--- a/projects/kit/components/textarea/textarea.style.less
+++ b/projects/kit/components/textarea/textarea.style.less
@@ -25,7 +25,7 @@
     padding-block: 1.125rem 0.375rem;
 }
 
-:host-context(tui-textfield:has(.t-ghost > *)) {
+:host-context(tui-textfield:has(.t-ghost > * > span)) {
     overscroll-behavior: none;
 }
 
@@ -64,7 +64,7 @@
     word-break: break-word;
     overflow-wrap: break-word;
     padding-inline-start: var(--t-start);
-    padding-inline-end: calc(var(--t-end) + var(--t-side));
+    padding-inline-end: calc(var(--t-end) + var(--t-side) + var(--t-space));
     pointer-events: none;
     box-sizing: content-box;
     overflow: hidden;

--- a/projects/styles/components/textfield.less
+++ b/projects/styles/components/textfield.less
@@ -218,7 +218,6 @@ tui-textfield:where(*&) {
         box-sizing: border-box;
         border-radius: inherit;
         border-width: 0;
-        overscroll-behavior: none;
         padding-inline-start: calc(var(--t-start) + var(--t-padding));
         padding-inline-end: calc(var(--t-end) + var(--t-side) + var(--t-padding) + var(--t-space));
         white-space: nowrap;
@@ -240,12 +239,6 @@ tui-textfield:where(*&) {
         &::-webkit-inner-spin-button,
         &::-webkit-outer-spin-button {
             appearance: none;
-        }
-    }
-
-    &:has(textarea):not(:has(.t-ghost > *)) {
-        [tuiInput] {
-            overscroll-behavior: auto;
         }
     }
 

--- a/projects/styles/components/textfield.less
+++ b/projects/styles/components/textfield.less
@@ -243,6 +243,12 @@ tui-textfield:where(*&) {
         }
     }
 
+    &:has(textarea):not(:has(.t-ghost > *)) {
+        [tuiInput] {
+            overscroll-behavior: auto;
+        }
+    }
+
     &._with-template [tuiInput]:first-of-type {
         color: transparent !important;
     }


### PR DESCRIPTION

Fixes #13774 
