### PR TITLE
fix(kit): apply overscroll-behavior only when there is an extra element inside the t-ghost

### DIFF
--- a/projects/core/styles/components/textfield.less
+++ b/projects/core/styles/components/textfield.less
@@ -270,7 +270,6 @@ tui-textfield {
         box-sizing: border-box;
         border-radius: inherit;
         border-width: 0;
-        overscroll-behavior: none;
         // StackBlitz changes "0rem" to "0" breaking calc
         padding-inline-start: calc(var(--t-start, ~'0rem') + var(--t-padding));
         padding-inline-end: calc(var(--t-end, ~'0rem') + var(--t-side) + var(--t-padding));

--- a/projects/demo-playwright/tests/legacy/textarea/textarea.pw.spec.ts
+++ b/projects/demo-playwright/tests/legacy/textarea/textarea.pw.spec.ts
@@ -67,4 +67,20 @@ test.describe('Textarea', () => {
             .soft(textAreaComponent)
             .toHaveScreenshot('textarea-line-break-disabled.png');
     });
+
+    test('overscroll-behavior', async ({page}) => {
+        await tuiGoto(page, DemoRoute.Textarea);
+
+        const basicTextarea = new TuiDocumentationPagePO(page)
+            .getExample('#basic')
+            .locator('textarea[tuiTextarea]')
+            .first();
+
+        const limitTextarea = new TuiDocumentationPagePO(page)
+            .getExample('#limit')
+            .locator('textarea[tuiTextarea]');
+
+        await expect(basicTextarea).not.toHaveCSS('overscroll-behavior', 'none');
+        await expect(limitTextarea).toHaveCSS('overscroll-behavior', 'none');
+    });
 });

--- a/projects/kit/components/textarea/textarea-limit.directive.ts
+++ b/projects/kit/components/textarea/textarea-limit.directive.ts
@@ -24,17 +24,20 @@ import {
 import {injectContext, PolymorpheusComponent} from '@taiga-ui/polymorpheus';
 
 import {tuiTextareaOptionsProvider} from './textarea.options';
+import {NgIf} from '@angular/common';
 
 @Component({
     standalone: true,
     template: `
-        <span [textContent]="context.$implicit.slice(0, limit())"></span>
+        <ng-container>{{ context.$implicit.slice(0, limit()) }}</ng-container>
         <span
+            *ngIf="context.$implicit.length > limit()"
             style="background: linear-gradient(transparent 0.25rem, var(--tui-status-negative-pale) 0.25rem, var(--tui-status-negative-pale) 100%)"
-            [textContent]="context.$implicit.slice(limit())"
+            [innerHtml]="context.$implicit.slice(limit())"
         ></span>
     `,
     changeDetection: ChangeDetectionStrategy.OnPush,
+    imports: [NgIf],
 })
 export class TuiTextareaLimitComponent {
     protected readonly limit = inject(TuiTextareaLimit).limit;

--- a/projects/kit/components/textarea/textarea-limit.directive.ts
+++ b/projects/kit/components/textarea/textarea-limit.directive.ts
@@ -26,19 +26,14 @@ import {injectContext, PolymorpheusComponent} from '@taiga-ui/polymorpheus';
 import {tuiTextareaOptionsProvider} from './textarea.options';
 import {NgIf} from '@angular/common';
 
-@Component({
-    standalone: true,
-    template: `
+@Component({standalone: true,imports: [NgIf],template: `
         <ng-container>{{ context.$implicit.slice(0, limit()) }}</ng-container>
         <span
             *ngIf="context.$implicit.length > limit()"
             style="background: linear-gradient(transparent 0.25rem, var(--tui-status-negative-pale) 0.25rem, var(--tui-status-negative-pale) 100%)"
             [innerHtml]="context.$implicit.slice(limit())"
         ></span>
-    `,
-    changeDetection: ChangeDetectionStrategy.OnPush,
-    imports: [NgIf],
-})
+    `,changeDetection: ChangeDetectionStrategy.OnPush})
 export class TuiTextareaLimitComponent {
     protected readonly limit = inject(TuiTextareaLimit).limit;
     protected readonly context = injectContext<TuiContext<string>>();

--- a/projects/kit/components/textarea/textarea-limit.directive.ts
+++ b/projects/kit/components/textarea/textarea-limit.directive.ts
@@ -34,7 +34,7 @@ import {NgIf} from '@angular/common';
         <span
             *ngIf="context.$implicit.length >= limit()"
             style="background: linear-gradient(transparent 0.25rem, var(--tui-status-negative-pale) 0.25rem, var(--tui-status-negative-pale) 100%)"
-            [innerHtml]="context.$implicit.slice(limit())"
+            [textContent]="context.$implicit.slice(limit())"
         ></span>
     `,
     changeDetection: ChangeDetectionStrategy.OnPush,

--- a/projects/kit/components/textarea/textarea-limit.directive.ts
+++ b/projects/kit/components/textarea/textarea-limit.directive.ts
@@ -26,14 +26,19 @@ import {injectContext, PolymorpheusComponent} from '@taiga-ui/polymorpheus';
 import {tuiTextareaOptionsProvider} from './textarea.options';
 import {NgIf} from '@angular/common';
 
-@Component({standalone: true,imports: [NgIf],template: `
+@Component({
+    standalone: true,
+    imports: [NgIf],
+    template: `
         <ng-container>{{ context.$implicit.slice(0, limit()) }}</ng-container>
         <span
             *ngIf="context.$implicit.length > limit()"
             style="background: linear-gradient(transparent 0.25rem, var(--tui-status-negative-pale) 0.25rem, var(--tui-status-negative-pale) 100%)"
             [innerHtml]="context.$implicit.slice(limit())"
         ></span>
-    `,changeDetection: ChangeDetectionStrategy.OnPush})
+    `,
+    changeDetection: ChangeDetectionStrategy.OnPush,
+})
 export class TuiTextareaLimitComponent {
     protected readonly limit = inject(TuiTextareaLimit).limit;
     protected readonly context = injectContext<TuiContext<string>>();

--- a/projects/kit/components/textarea/textarea-limit.directive.ts
+++ b/projects/kit/components/textarea/textarea-limit.directive.ts
@@ -32,7 +32,7 @@ import {NgIf} from '@angular/common';
     template: `
         <ng-container>{{ context.$implicit.slice(0, limit()) }}</ng-container>
         <span
-            *ngIf="context.$implicit.length > limit()"
+            *ngIf="context.$implicit.length >= limit()"
             style="background: linear-gradient(transparent 0.25rem, var(--tui-status-negative-pale) 0.25rem, var(--tui-status-negative-pale) 100%)"
             [innerHtml]="context.$implicit.slice(limit())"
         ></span>

--- a/projects/kit/components/textarea/textarea.style.less
+++ b/projects/kit/components/textarea/textarea.style.less
@@ -29,7 +29,7 @@
     padding-block-end: 0.375rem;
 }
 
-:host-context(tui-textfield:has(.t-ghost > *)) {
+:host-context(tui-textfield:has(.t-ghost > * > span)) {
     overscroll-behavior: none;
 }
 

--- a/projects/kit/components/textarea/textarea.style.less
+++ b/projects/kit/components/textarea/textarea.style.less
@@ -29,6 +29,10 @@
     padding-block-end: 0.375rem;
 }
 
+:host-context(tui-textfield:has(.t-ghost > *)) {
+    overscroll-behavior: none;
+}
+
 :host {
     word-break: break-word;
     border: 0 solid transparent;


### PR DESCRIPTION
…

Fixes #13774 