### PR TITLE
fix(kit): improve example `Virtual scroll` for `ComboBox` to support paste of exact value

### DIFF
--- a/projects/demo-playwright/tests/kit/combo-box/combo-box.pw.spec.ts
+++ b/projects/demo-playwright/tests/kit/combo-box/combo-box.pw.spec.ts
@@ -380,6 +380,22 @@ describe('ComboBox', () => {
 
                 await expect(comboBox.textfield).toHaveValue('Afghanistan');
             });
+
+            test('paste of exact value', async ({page}) => {
+                // Fill with value that is not in first 20 options
+                await comboBox.textfield.fill('Russia');
+
+                await expect(comboBox.textfield).toHaveValue('Russia');
+
+                await expect(
+                    comboBox.dropdown.locator('[tuiOption]', {hasText: 'Russia'}),
+                ).not.toBeAttached();
+
+                await comboBox.textfield.blur();
+                await page.waitForTimeout(100);
+
+                await expect(comboBox.textfield).toHaveValue('Russia');
+            });
         });
     });
 });

--- a/projects/demo/src/pages/components/combo-box/examples/10/index.html
+++ b/projects/demo/src/pages/components/combo-box/examples/10/index.html
@@ -18,7 +18,7 @@
             [minBufferPx]="44 * 5"
             [style.height.px]="(items?.length || 1) * (44 + 4) + 8"
         >
-            <tui-data-list>
+            <tui-data-list withVirtualScroll>
                 <button
                     *cdkVirtualFor="let item of items"
                     tuiOption

--- a/projects/demo/src/pages/components/combo-box/examples/10/index.ts
+++ b/projects/demo/src/pages/components/combo-box/examples/10/index.ts
@@ -6,6 +6,8 @@ import {encapsulation} from '@demo/emulate/encapsulation';
 import {TuiDataList, TuiFilterByInputPipe, TuiScrollable} from '@taiga-ui/core';
 import {TUI_COUNTRIES, TuiChevron, TuiComboBox} from '@taiga-ui/kit';
 
+import {WithVirtualScroll} from './with-virtual-scroll';
+
 @Component({
     imports: [
         FormsModule,
@@ -15,6 +17,7 @@ import {TUI_COUNTRIES, TuiChevron, TuiComboBox} from '@taiga-ui/kit';
         TuiDataList,
         TuiFilterByInputPipe,
         TuiScrollable,
+        WithVirtualScroll,
     ],
     templateUrl: './index.html',
     styleUrl: './index.less',

--- a/projects/demo/src/pages/components/combo-box/examples/10/with-virtual-scroll.ts
+++ b/projects/demo/src/pages/components/combo-box/examples/10/with-virtual-scroll.ts
@@ -1,6 +1,8 @@
 import {CdkVirtualForOf} from '@angular/cdk/scrolling';
-import {contentChild, Directive, effect, signal} from '@angular/core';
+import {contentChild, Directive} from '@angular/core';
+import {toObservable, toSignal} from '@angular/core/rxjs-interop';
 import {tuiAsAuxiliary, type TuiDataListAccessor} from '@taiga-ui/core';
+import {switchMap} from 'rxjs';
 
 @Directive({
     selector: '[withVirtualScroll]',
@@ -9,13 +11,8 @@ import {tuiAsAuxiliary, type TuiDataListAccessor} from '@taiga-ui/core';
 export class WithVirtualScroll<T> implements TuiDataListAccessor<T> {
     private readonly virtualScroll = contentChild.required(CdkVirtualForOf);
 
-    protected readonly $ = effect((onCleanup) => {
-        const subscription = this.virtualScroll().dataStream.subscribe((items) =>
-            this.options.set(items),
-        );
-
-        onCleanup(() => subscription.unsubscribe());
-    });
-
-    public readonly options = signal<readonly T[]>([]);
+    public readonly options = toSignal(
+        toObservable(this.virtualScroll).pipe(switchMap((x) => x.dataStream)),
+        {initialValue: [] as readonly T[]},
+    );
 }

--- a/projects/demo/src/pages/components/combo-box/examples/10/with-virtual-scroll.ts
+++ b/projects/demo/src/pages/components/combo-box/examples/10/with-virtual-scroll.ts
@@ -1,0 +1,21 @@
+import {CdkVirtualForOf} from '@angular/cdk/scrolling';
+import {contentChild, Directive, effect, signal} from '@angular/core';
+import {tuiAsAuxiliary, type TuiDataListAccessor} from '@taiga-ui/core';
+
+@Directive({
+    selector: '[withVirtualScroll]',
+    providers: [tuiAsAuxiliary(WithVirtualScroll)],
+})
+export class WithVirtualScroll<T> implements TuiDataListAccessor<T> {
+    private readonly virtualScroll = contentChild.required(CdkVirtualForOf);
+
+    protected readonly $ = effect((onCleanup) => {
+        const subscription = this.virtualScroll().dataStream.subscribe((items) =>
+            this.options.set(items),
+        );
+
+        onCleanup(() => subscription.unsubscribe());
+    });
+
+    public readonly options = signal<readonly T[]>([]);
+}

--- a/projects/demo/src/pages/components/combo-box/index.html
+++ b/projects/demo/src/pages/components/combo-box/index.html
@@ -21,7 +21,7 @@
         @for (example of examples; track example) {
             <tui-doc-example
                 [component]="$index + 1 | tuiComponent"
-                [content]="$index + 1 | tuiExample: 'html,ts,less' : this[$index]"
+                [content]="$index + 1 | tuiExample: 'html,ts,less' : this[$index + 1]"
                 [description]="description"
                 [heading]="example"
             />

--- a/projects/demo/src/pages/components/combo-box/index.html
+++ b/projects/demo/src/pages/components/combo-box/index.html
@@ -189,6 +189,16 @@
                             &#64;angular/cdk/scrolling
                         </a>
                         .
+
+                        <p>
+                            Virtual scroll renders only a small subset of options in the DOM at a time — the rest don't
+                            exist until scrolled into view. The custom
+                            <code>WithVirtualScroll</code>
+                            directive gives
+                            <code>ComboBox</code>
+                            access to the full list so it can match values typed manually into the textfield, even when
+                            the matching option is off-screen.
+                        </p>
                     }
                     @case (10) {
                         @if (!isMobile) {

--- a/projects/demo/src/pages/components/combo-box/index.ts
+++ b/projects/demo/src/pages/components/combo-box/index.ts
@@ -58,11 +58,17 @@ export default class PageComponent extends Array {
         'Override option component',
     ];
 
-    protected readonly [4] = {
+    protected readonly [5] = {
         'database.ts': import('./examples/5/database.ts?raw', {with: {loader: 'text'}}),
     };
 
-    protected readonly [11] = {
+    protected readonly [10] = {
+        'with-virtual-scroll.ts': import('./examples/10/with-virtual-scroll.ts?raw', {
+            with: {loader: 'text'},
+        }),
+    };
+
+    protected readonly [12] = {
         'option.ts': import('./examples/12/option.ts?raw', {with: {loader: 'text'}}),
     };
 


### PR DESCRIPTION
Fixes #13231
