### PR TITLE
fix(kit): `InputTime` incorrectly parses control value for `mode` without leading hours segment

### DIFF
--- a/projects/cdk/date-time/time.ts
+++ b/projects/cdk/date-time/time.ts
@@ -112,7 +112,15 @@ export class TuiTime implements TuiTimeLike {
     }
 
     /**
-     * Parses string into TuiTime object
+     * @deprecated Use `TuiTime.fromAbsoluteMilliseconds` + `maskitoParseTime` instead
+     * ```ts
+     * const params: MaskitoTimeParams = {mode: '...'};
+     *
+     * TuiTime.fromAbsoluteMilliseconds(
+     *     maskitoParseTime(x, params)
+     * ) // TuiTime
+     * ```
+     * TODO(v6): delete
      */
     public static fromString(time: string): TuiTime {
         const hours = this.parseHours(time);

--- a/projects/demo-playwright/tests/kit/input-time/input-time.pw.spec.ts
+++ b/projects/demo-playwright/tests/kit/input-time/input-time.pw.spec.ts
@@ -1,16 +1,27 @@
 import {DemoRoute} from '@demo/routes';
-import {TuiDocumentationPagePO, tuiGoto, TuiInputTimePO} from '@demo-playwright/utils';
+import {
+    TuiDocumentationPagePO,
+    tuiGoto,
+    TuiInputTimePO,
+    type TuiTimeLike,
+} from '@demo-playwright/utils';
 import {expect, type Locator, test} from '@playwright/test';
 
 import {TUI_PLAYWRIGHT_MOBILE} from '../../../playwright.options';
+
+const {describe, beforeEach} = test;
 
 test.describe('InputTime', () => {
     test.describe('API', () => {
         let example: Locator;
         let inputTime: TuiInputTimePO;
+        let controlValue: Locator;
 
         test.beforeEach(({page}) => {
-            example = new TuiDocumentationPagePO(page).demo;
+            const documentation = new TuiDocumentationPagePO(page);
+
+            example = documentation.demo;
+            controlValue = documentation.value;
             inputTime = new TuiInputTimePO(
                 example.locator('tui-textfield:has([tuiInputTime])'),
             );
@@ -226,6 +237,123 @@ test.describe('InputTime', () => {
                 check('12:34:56.7', '12:34:56.007');
                 check('12:34:56.78', '12:34:56.078');
                 check('12:34:56.789', '12:34:56.789');
+            });
+        });
+
+        describe('control value contains TuiTime', () => {
+            function stringify(value: TuiTimeLike): string {
+                return JSON.stringify({value}, null, 2);
+            }
+
+            describe('mode=MM:SS', () => {
+                beforeEach(async ({page}) => {
+                    await tuiGoto(
+                        page,
+                        `${DemoRoute.InputTime}/API?mode=MM:SS&sandboxExpanded=true`,
+                    );
+                });
+
+                test('Type 99 => new TuiTime(0, 9, 9)', async () => {
+                    await inputTime.textfield.pressSequentially('99');
+
+                    await expect(inputTime.textfield).toHaveValue('09:09');
+                    await expect(controlValue).toContainText(
+                        stringify({
+                            hours: 0,
+                            minutes: 9,
+                            seconds: 9,
+                            ms: 0,
+                        }),
+                    );
+                });
+
+                test('Type 5959 => new TuiTime(0, 59, 59)', async () => {
+                    await inputTime.textfield.pressSequentially('5959');
+
+                    await expect(inputTime.textfield).toHaveValue('59:59');
+                    await expect(controlValue).toContainText(
+                        stringify({
+                            hours: 0,
+                            minutes: 59,
+                            seconds: 59,
+                            ms: 0,
+                        }),
+                    );
+                });
+            });
+
+            describe('mode=MM:SS.MSS', () => {
+                beforeEach(async ({page}) => {
+                    await tuiGoto(
+                        page,
+                        `${DemoRoute.InputTime}/API?mode=MM:SS.MSS&sandboxExpanded=true`,
+                    );
+                });
+
+                test('Type 99123 => new TuiTime(0, 9, 9, 123)', async () => {
+                    await inputTime.textfield.pressSequentially('99123');
+
+                    await expect(inputTime.textfield).toHaveValue('09:09.123');
+                    await expect(controlValue).toContainText(
+                        stringify({
+                            hours: 0,
+                            minutes: 9,
+                            seconds: 9,
+                            ms: 123,
+                        }),
+                    );
+                });
+
+                test('Type 5959999 => new TuiTime(0, 59, 59, 999)', async () => {
+                    await inputTime.textfield.pressSequentially('5959999');
+
+                    await expect(inputTime.textfield).toHaveValue('59:59.999');
+                    await expect(controlValue).toContainText(
+                        stringify({
+                            hours: 0,
+                            minutes: 59,
+                            seconds: 59,
+                            ms: 999,
+                        }),
+                    );
+                });
+            });
+
+            describe('mode=SS.MSS', () => {
+                beforeEach(async ({page}) => {
+                    await tuiGoto(
+                        page,
+                        `${DemoRoute.InputTime}/API?mode=SS.MSS&sandboxExpanded=true`,
+                    );
+                });
+
+                test('Type 9999 => new TuiTime(0, 0, 9, 999)', async () => {
+                    await inputTime.textfield.pressSequentially('9999');
+
+                    await expect(inputTime.textfield).toHaveValue('09.999');
+                    await expect(controlValue).toContainText(
+                        stringify({
+                            hours: 0,
+                            minutes: 0,
+                            seconds: 9,
+                            ms: 999,
+                        }),
+                    );
+                });
+
+                test('Type 59999 => new TuiTime(0, 0, 59, 999)', async () => {
+                    await inputTime.textfield.pressSequentially('59999');
+
+                    await expect(inputTime.textfield).toHaveValue('59.999');
+                    await expect(controlValue).toContainText(
+                        stringify({
+                            hours: 0,
+                            minutes: 0,
+                            seconds: 59,
+                            ms: 999,
+                        }),
+                    );
+                });
             });
         });
     });

--- a/projects/demo-playwright/utils/common.ts
+++ b/projects/demo-playwright/utils/common.ts
@@ -5,6 +5,12 @@ export const CHAR_EN_DASH = '\u2013';
 export const CHAR_EM_DASH = '\u2014';
 export const CHAR_HYPHEN = '\u002D';
 export const CHAR_ZERO_WIDTH_SPACE = '\u200B';
+export interface TuiTimeLike {
+    readonly hours?: number;
+    readonly minutes?: number;
+    readonly ms?: number;
+    readonly seconds?: number;
+}
 
 // https://github.com/microsoft/playwright/issues/12168
 export const CMD = process.platform === 'darwin' ? 'Meta' : 'Control';

--- a/projects/demo/src/pages/components/input-time/examples/8/index.ts
+++ b/projects/demo/src/pages/components/input-time/examples/8/index.ts
@@ -3,6 +3,7 @@ import {Component} from '@angular/core';
 import {FormsModule} from '@angular/forms';
 import {changeDetection} from '@demo/emulate/change-detection';
 import {encapsulation} from '@demo/emulate/encapsulation';
+import {maskitoParseTime} from '@maskito/kit';
 import {TuiTime} from '@taiga-ui/cdk';
 import {TuiInputTime, tuiInputTimeOptionsProvider} from '@taiga-ui/kit';
 
@@ -15,7 +16,11 @@ import {TuiInputTime, tuiInputTimeOptionsProvider} from '@taiga-ui/kit';
         tuiInputTimeOptionsProvider({
             valueTransformer: {
                 fromControlValue(controlValue: string): TuiTime | null {
-                    return controlValue ? TuiTime.fromString(controlValue) : null;
+                    return controlValue
+                        ? TuiTime.fromAbsoluteMilliseconds(
+                              maskitoParseTime(controlValue, {mode: 'HH:MM'}),
+                          )
+                        : null;
                 },
                 toControlValue(time: TuiTime | null): string {
                     return time ? time.toString() : '';

--- a/projects/demo/src/pages/components/input-time/index.ts
+++ b/projects/demo/src/pages/components/input-time/index.ts
@@ -49,6 +49,8 @@ export default class PageComponent {
         'HH:MM:SS.MSS',
         'HH:MM:SS.MSS AA',
         'MM:SS',
+        'MM:SS.MSS',
+        'SS.MSS',
     ] as const satisfies readonly MaskitoTimeMode[];
 
     protected readonly acceptVariants = [

--- a/projects/kit/components/input-date-time/input-date-time.directive.ts
+++ b/projects/kit/components/input-date-time/input-date-time.directive.ts
@@ -4,6 +4,7 @@ import {type MaskitoOptions} from '@maskito/core';
 import {
     maskitoDateTimeOptionsGenerator,
     type MaskitoDateTimeParams,
+    maskitoParseTime,
     maskitoSelectionChangeHandler,
 } from '@maskito/kit';
 import {tuiAsControl, tuiValueTransformerFrom} from '@taiga-ui/cdk/classes';
@@ -171,7 +172,7 @@ export class TuiInputDateTimeDirective
                 : null;
 
         const parsedTime =
-            time.length === this.timeMode().length ? TuiTime.fromString(time) : null;
+            time.length === this.timeMode().length ? this.parseTime(time) : null;
 
         if (!parsedDate || (time && !parsedTime)) {
             return this.onChange(null);
@@ -199,13 +200,11 @@ export class TuiInputDateTimeDirective
             : dateString;
     }
 
-    protected onBlur(valueWithAffixes: string): void {
-        const [date = '', timeValue = ''] = valueWithAffixes.split(
-            this.options.dateTimeSeparator,
-        );
+    protected onBlur(value: string): void {
+        const [date = '', timeValue = ''] = value.split(this.options.dateTimeSeparator);
 
         if (timeValue && !this.value()) {
-            const time = TuiTime.fromString(timeValue);
+            const time = this.parseTime(timeValue);
 
             const newValue = [
                 TuiDay.normalizeParse(date, this.format().mode),
@@ -263,5 +262,11 @@ export class TuiInputDateTimeDirective
         TuiTime,
     ]): Date {
         return new Date(year, month, day, hours, minutes, seconds, ms);
+    }
+
+    private parseTime(time: string): TuiTime {
+        return TuiTime.fromAbsoluteMilliseconds(
+            maskitoParseTime(time, {mode: this.timeMode()}),
+        );
     }
 }

--- a/projects/kit/components/input-date-time/input-date-time.directive.ts
+++ b/projects/kit/components/input-date-time/input-date-time.directive.ts
@@ -6,8 +6,10 @@ import {
     type MaskitoDateTimeParams,
     maskitoParseTime,
     maskitoSelectionChangeHandler,
+    type MaskitoTimeMode,
 } from '@maskito/kit';
 import {tuiAsControl, tuiValueTransformerFrom} from '@taiga-ui/cdk/classes';
+import {CHAR_NO_BREAK_SPACE} from '@taiga-ui/cdk/constants';
 import {
     DATE_FILLER_LENGTH,
     MILLISECONDS_IN_DAY,
@@ -265,8 +267,29 @@ export class TuiInputDateTimeDirective
     }
 
     private parseTime(time: string): TuiTime {
+        const mode = this.timeMode();
+
         return TuiTime.fromAbsoluteMilliseconds(
-            maskitoParseTime(time, {mode: this.timeMode()}),
+            maskitoParseTime(padTimeSegments(time, mode), {mode}),
         );
     }
+}
+
+/**
+ * TODO: remove me when this fix https://github.com/taiga-family/maskito/issues/2725 is released
+ * and `maskitoParseTime` will do it internally
+ */
+function padTimeSegments(time: string, mode: MaskitoTimeMode): string {
+    if (time.length === mode.length) {
+        return time;
+    }
+
+    const split = (x: string): readonly string[] =>
+        x.split(/([^a-z0-9])/i).filter(Boolean);
+
+    const template = split(mode.replace(`${CHAR_NO_BREAK_SPACE}AA`, ''));
+
+    return split(time)
+        .map((segment, i) => segment.padStart(template[i]!.length, '0'))
+        .join('');
 }

--- a/projects/kit/components/input-time/input-time.component.ts
+++ b/projects/kit/components/input-time/input-time.component.ts
@@ -7,7 +7,7 @@ import {
     inject,
     ViewEncapsulation,
 } from '@angular/core';
-import {type MaskitoTimeMode} from '@maskito/kit';
+import {maskitoParseTime, type MaskitoTimeMode} from '@maskito/kit';
 import {TuiControl} from '@taiga-ui/cdk/classes';
 import {TUI_VERSION} from '@taiga-ui/cdk/constants';
 import {type TuiDay, TuiTime} from '@taiga-ui/cdk/date-time';
@@ -67,6 +67,10 @@ export class TuiInputTimeComponent extends TuiNativeTimePicker {
     protected readonly step = computed(() => this.getStep(this.host.timeMode()));
 
     protected setValue(value: string): void {
-        this.host.setValue(TuiTime.fromString(value));
+        this.host.setValue(
+            TuiTime.fromAbsoluteMilliseconds(
+                maskitoParseTime(value, {mode: 'HH:MM:SS.MSS'}),
+            ),
+        );
     }
 }

--- a/projects/kit/components/input-time/input-time.directive.ts
+++ b/projects/kit/components/input-time/input-time.directive.ts
@@ -13,6 +13,7 @@ import {
 } from '@maskito/kit';
 import {WA_IS_MOBILE} from '@ng-web-apis/platform';
 import {tuiAsControl, TuiControl, tuiValueTransformerFrom} from '@taiga-ui/cdk/classes';
+import {CHAR_NO_BREAK_SPACE} from '@taiga-ui/cdk/constants';
 import {TuiTime} from '@taiga-ui/cdk/date-time';
 import {tuiDirectiveBinding} from '@taiga-ui/cdk/utils/di';
 import {tuiAsOptionContent} from '@taiga-ui/core/components/data-list';
@@ -199,10 +200,31 @@ export class TuiInputTimeDirective
     }
 
     private parse(value: string): TuiTime {
-        return TuiTime.fromAbsoluteMilliseconds(maskitoParseTime(value, this.params()));
+        return TuiTime.fromAbsoluteMilliseconds(
+            maskitoParseTime(padTimeSegments(value, this.timeMode()), this.params()),
+        );
     }
 
     private stringify(time: TuiTime | null): string {
         return `${this.prefix()}${time?.toString(this.timeMode()) || ''}${this.postfix()}`;
     }
+}
+
+/**
+ * TODO: remove me when this fix https://github.com/taiga-family/maskito/issues/2725 is released
+ * and `maskitoParseTime` will do it internally
+ */
+function padTimeSegments(time: string, mode: MaskitoTimeMode): string {
+    if (time.length === mode.length) {
+        return time;
+    }
+
+    const split = (x: string): readonly string[] =>
+        x.split(/([^a-z0-9])/i).filter(Boolean);
+
+    const template = split(mode.replace(`${CHAR_NO_BREAK_SPACE}AA`, ''));
+
+    return split(time)
+        .map((segment, i) => segment.padStart(template[i]!.length, '0'))
+        .join('');
 }

--- a/projects/kit/components/input-time/input-time.directive.ts
+++ b/projects/kit/components/input-time/input-time.directive.ts
@@ -4,6 +4,7 @@ import {type MaskitoOptions} from '@maskito/core';
 import {
     maskitoAddOnFocusPlugin,
     maskitoCaretGuard,
+    maskitoParseTime,
     maskitoRemoveOnBlurPlugin,
     maskitoSelectionChangeHandler,
     type MaskitoTimeMode,
@@ -60,6 +61,15 @@ export class TuiInputTimeDirective
     private readonly open = inject(TuiDropdownOpen).open;
     private readonly options = inject(TUI_INPUT_TIME_OPTIONS);
     private readonly fillers = inject(TUI_TIME_TEXTS);
+
+    private readonly params = computed<Required<MaskitoTimeParams>>(() => ({
+        ...this.options,
+        mode: this.timeMode(),
+        step: this.interactive() && !this.dropdown.content() ? 1 : 0,
+        prefix: this.prefix(),
+        postfix: this.postfix(),
+    }));
+
     protected readonly icon = tuiIconEnd(this.options.icon);
 
     protected readonly dropdownEnabled = tuiDropdownEnabled(
@@ -75,18 +85,7 @@ export class TuiInputTimeDirective
         {},
     );
 
-    protected readonly mask = tuiMaskito(
-        computed(() =>
-            this.computeMask({
-                ...this.options,
-                mode: this.timeMode(),
-                step: this.interactive() && !this.dropdown.content() ? 1 : 0,
-                prefix: this.prefix(),
-                postfix: this.postfix(),
-            }),
-        ),
-    );
-
+    protected readonly mask = tuiMaskito(computed(() => this.computeMask(this.params())));
     public readonly accept = input<readonly TuiTime[]>([]);
     public readonly timeMode = input<MaskitoTimeMode>(this.options.mode, {alias: 'mode'});
     public readonly prefix = input('');
@@ -124,8 +123,7 @@ export class TuiInputTimeDirective
             .replace(this.prefix(), '')
             .replace(this.postfix(), '');
 
-        const time =
-            value.length === this.timeMode().length ? TuiTime.fromString(value) : null;
+        const time = value.length === this.timeMode().length ? this.parse(value) : null;
 
         const newValue =
             this.accept().length && time
@@ -150,7 +148,7 @@ export class TuiInputTimeDirective
             .replace(this.postfix(), '');
 
         if (value && !this.value()) {
-            const time = TuiTime.fromString(value);
+            const time = this.parse(value);
 
             const newValue = this.accept().length
                 ? this.findNearestTime(time, this.accept())
@@ -198,6 +196,10 @@ export class TuiInputTimeDirective
                 ? current
                 : previous,
         );
+    }
+
+    private parse(value: string): TuiTime {
+        return TuiTime.fromAbsoluteMilliseconds(maskitoParseTime(value, this.params()));
     }
 
     private stringify(time: TuiTime | null): string {


### PR DESCRIPTION
Fixes #11587
