### PR TITLE
feat(experimental): `Popout` add configurable providers (#13879)

### DIFF
--- a/projects/demo/src/pages/app/app.config.ts
+++ b/projects/demo/src/pages/app/app.config.ts
@@ -46,6 +46,7 @@ import {
     TUI_HINT_OPTIONS,
     tuiNotificationOptionsProvider,
 } from '@taiga-ui/core';
+import {TUI_POPOUT_CONFIG} from '@taiga-ui/experimental';
 import {type TuiLanguageName, tuiLanguageSwitcher} from '@taiga-ui/i18n';
 import {provideHighlightOptions} from 'ngx-highlightjs';
 import {catchError, filter, map, merge, of} from 'rxjs';
@@ -271,6 +272,10 @@ export const config: ApplicationConfig = {
             }
         }),
         provideExperimentalZonelessChangeDetection(),
+        {
+            provide: TUI_POPOUT_CONFIG,
+            useValue: {providers: [provideExperimentalZonelessChangeDetection()]},
+        },
         {
             provide: TUI_DIALOGS_CLOSE,
             useFactory: () =>

--- a/projects/experimental/components/popout/popout.service.ts
+++ b/projects/experimental/components/popout/popout.service.ts
@@ -1,12 +1,13 @@
 import {DOCUMENT} from '@angular/common';
 import {
+    type ApplicationConfig,
     ChangeDetectionStrategy,
     Component,
     inject,
     Injectable,
+    InjectionToken,
     type OnDestroy,
     type OnInit,
-    provideExperimentalZonelessChangeDetection,
 } from '@angular/core';
 import {createApplication} from '@angular/platform-browser';
 import {WA_DOCUMENT_PIP} from '@ng-web-apis/experimental';
@@ -17,6 +18,17 @@ import {injectContext, provideContext} from '@taiga-ui/polymorpheus';
 
 import {TuiPopoutComponent, type TuiPopoutOptions} from './popout.component';
 
+/**
+ * Token for configuring the popout application.
+ * Use it to provide custom providers (e.g., change detection strategy) to the popout window.
+ *
+ * @default Empty providers array (zone-based change detection)
+ */
+export const TUI_POPOUT_CONFIG = new InjectionToken<ApplicationConfig>(
+    'TUI_POPOUT_CONFIG',
+    {factory: () => ({providers: []})},
+);
+
 @Component({
     template: '',
     changeDetection: ChangeDetectionStrategy.OnPush,
@@ -26,6 +38,7 @@ class PopoutComponent implements OnInit, OnDestroy {
     private readonly context = injectContext<TuiPortalContext<TuiPopoutOptions>>();
     private readonly doc = inject(DOCUMENT);
     private readonly options = inject(TUI_OPTIONS);
+    private readonly config = inject(TUI_POPOUT_CONFIG);
     private popout: Window | null = null;
 
     public ngOnInit(): void {
@@ -83,7 +96,7 @@ class PopoutComponent implements OnInit, OnDestroy {
             provideTaiga(this.options),
             provideContext(this.context),
             {provide: DOCUMENT, useValue: this.popout.document},
-            provideExperimentalZonelessChangeDetection(),
+            ...this.config.providers,
         ];
 
         createApplication({providers})


### PR DESCRIPTION
Fixes #13879 
# Add `TUI_POPOUT_CONFIG` token for popout providers configuration

## Summary

Added a new injection token `TUI_POPOUT_CONFIG` that allows configuring the popout window application created via `createApplication()`. This provides flexibility in choosing the change detection strategy for the popout window.

## Motivation

Previously, `provideExperimentalZonelessChangeDetection()` was hardcoded inside the `PopoutComponent`, making it impossible to use zone-based change detection in popout windows. Now, the responsibility for choosing the change detection strategy is delegated to the application developer.

## Changes

### New Token: `TUI_POPOUT_CONFIG`

```ts
export const TUI_POPOUT_CONFIG = new InjectionToken<ApplicationConfig>(
    'TUI_POPOUT_CONFIG',
    {factory: () => ({providers: []})},
);
```

**Default behavior:** Empty providers array (zone-based change detection)

## Usage

### Zone.js applications (default)

No configuration required — works out of the box:

```ts
// app.config.ts
export const config: ApplicationConfig = {
    providers: [
        provideTaiga(),
        // TUI_POPOUT_CONFIG uses factory default (zone-based CD)
    ],
};
```

### Zoneless applications

Explicitly provide the token with zoneless change detection:

```ts
// app.config.ts
import {provideExperimentalZonelessChangeDetection} from '@angular/core';
import {TUI_POPOUT_CONFIG} from '@taiga-ui/experimental';

export const config: ApplicationConfig = {
    providers: [
        provideTaiga(),
        provideExperimentalZonelessChangeDetection(), // main app
        {
            provide: TUI_POPOUT_CONFIG,
            useValue: {
                providers: [provideExperimentalZonelessChangeDetection()],
            },
        },
    ],
};
```

## Benefits

- ✅ **Flexibility**: Choose change detection strategy per application needs
- ✅ **Consistency**: Match popout window CD strategy with main application
- ✅ **No breaking changes**: Zone.js applications work without additional configuration
- ✅ **Clean architecture**: Separation of concerns — service doesn't dictate CD policy