### PR TITLE
fix(kit): `InputNumber` with `decimalMode=always` should not trim trailing zeroes on blur

### DIFF
--- a/projects/demo-playwright/tests/kit/input-number/input-number.pw.spec.ts
+++ b/projects/demo-playwright/tests/kit/input-number/input-number.pw.spec.ts
@@ -1009,6 +1009,41 @@ describe('InputNumber', () => {
 
                 await expect(inputNumber.textfield).toHaveValue('42.00');
             });
+
+            test('decimalMode=always | pressing Space in the middle of value does not delete a digit', async ({
+                page,
+            }) => {
+                await tuiGoto(
+                    page,
+                    `${DemoRoute.InputNumber}/API?precision=2&decimalMode=always`,
+                );
+
+                await inputNumber.textfield.fill('123');
+                await page.keyboard.press('ArrowLeft');
+                await expect(inputNumber.textfield).toHaveValue('123.00');
+
+                await inputNumber.textfield.blur();
+                await expect(inputNumber.textfield).toHaveValue('123.00');
+
+                await inputNumber.textfield.focus();
+
+                await expect(inputNumber.textfield).toHaveJSProperty(
+                    'selectionStart',
+                    '12'.length,
+                );
+
+                await page.keyboard.press('Space');
+
+                await expect(inputNumber.textfield).toHaveValue('123.00');
+                await expect(inputNumber.textfield).toHaveJSProperty(
+                    'selectionStart',
+                    '12'.length,
+                );
+                await expect(inputNumber.textfield).toHaveJSProperty(
+                    'selectionEnd',
+                    '12'.length,
+                );
+            });
         });
 
         describe('[negativePattern]="minusFirst" with [prefix]="$"', () => {

--- a/projects/demo-playwright/tests/kit/input-number/input-number.pw.spec.ts
+++ b/projects/demo-playwright/tests/kit/input-number/input-number.pw.spec.ts
@@ -986,21 +986,6 @@ describe('InputNumber', () => {
                 await expect(inputNumber.textfield).toHaveValue('42.10');
             });
 
-            test('decimalMode=always | Enter 123 => Blur => 123.00', async ({page}) => {
-                await tuiGoto(
-                    page,
-                    `${DemoRoute.InputNumber}/API?precision=2&decimalMode=always`,
-                );
-
-                await inputNumber.textfield.fill('123');
-
-                await expect(inputNumber.textfield).toHaveValue('123.00');
-
-                await inputNumber.textfield.blur();
-
-                await expect(inputNumber.textfield).toHaveValue('123.00');
-            });
-
             test('decimalMode=always | Enter 42 => 42.00', async ({page}) => {
                 await tuiGoto(
                     page,
@@ -1011,6 +996,18 @@ describe('InputNumber', () => {
                 await expect(inputNumber.textfield).toHaveValue('42.00');
                 await expect(inputNumber.textfield).toHaveJSProperty('selectionStart', 2);
                 await expect(inputNumber.textfield).toHaveJSProperty('selectionEnd', 2);
+            });
+
+            test('decimalMode=always | Enter 42 => Blur => 42.00', async ({page}) => {
+                await tuiGoto(
+                    page,
+                    `${DemoRoute.InputNumber}/API?precision=2&decimalMode=always`,
+                );
+
+                await inputNumber.textfield.fill('42');
+                await inputNumber.textfield.blur();
+
+                await expect(inputNumber.textfield).toHaveValue('42.00');
             });
         });
 

--- a/projects/demo-playwright/tests/kit/input-number/input-number.pw.spec.ts
+++ b/projects/demo-playwright/tests/kit/input-number/input-number.pw.spec.ts
@@ -986,6 +986,21 @@ describe('InputNumber', () => {
                 await expect(inputNumber.textfield).toHaveValue('42.10');
             });
 
+            test('decimalMode=always | Enter 123 => Blur => 123.00', async ({page}) => {
+                await tuiGoto(
+                    page,
+                    `${DemoRoute.InputNumber}/API?precision=2&decimalMode=always`,
+                );
+
+                await inputNumber.textfield.fill('123');
+
+                await expect(inputNumber.textfield).toHaveValue('123.00');
+
+                await inputNumber.textfield.blur();
+
+                await expect(inputNumber.textfield).toHaveValue('123.00');
+            });
+
             test('decimalMode=always | Enter 42 => 42.00', async ({page}) => {
                 await tuiGoto(
                     page,

--- a/projects/kit/components/input-number/number-mask.directive.ts
+++ b/projects/kit/components/input-number/number-mask.directive.ts
@@ -72,6 +72,7 @@ export class TuiNumberMask {
     public stringify(value: bigint | number | null | undefined): string {
         const params = this.params();
         const precision = params.maximumFractionDigits;
+        const {decimalMode} = this.numberFormat();
 
         const rounded =
             typeof value === 'number' &&
@@ -87,8 +88,9 @@ export class TuiNumberMask {
         return maskitoStringifyNumber(rounded ?? null, {
             ...params,
             minimumFractionDigits:
-                String(rounded).includes(params.decimalSeparator) &&
-                this.numberFormat().decimalMode !== 'not-zero'
+                (String(rounded).includes(params.decimalSeparator) &&
+                    decimalMode === 'pad') ||
+                decimalMode === 'always'
                     ? params.maximumFractionDigits
                     : 0,
         });

--- a/projects/kit/components/input-number/number-mask.directive.ts
+++ b/projects/kit/components/input-number/number-mask.directive.ts
@@ -8,6 +8,7 @@ import {
     maskitoStringifyNumber,
 } from '@maskito/kit';
 import {tuiIsSafeToRound, tuiRoundWith} from '@taiga-ui/cdk/utils/math';
+import {tuiIsNumber} from '@taiga-ui/cdk/utils/miscellaneous';
 import {TuiInputDirective} from '@taiga-ui/core/components/input';
 import {TUI_NUMBER_FORMAT} from '@taiga-ui/core/tokens';
 import {tuiMaskito} from '@taiga-ui/kit/utils';
@@ -85,14 +86,15 @@ export class TuiNumberMask {
                   })
                 : value;
 
+        const zeroPadding =
+            (tuiIsNumber(rounded) &&
+                !Number.isInteger(rounded) &&
+                decimalMode === 'pad') ||
+            decimalMode === 'always';
+
         return maskitoStringifyNumber(rounded ?? null, {
             ...params,
-            minimumFractionDigits:
-                (String(rounded).includes(params.decimalSeparator) &&
-                    decimalMode === 'pad') ||
-                decimalMode === 'always'
-                    ? params.maximumFractionDigits
-                    : 0,
+            minimumFractionDigits: zeroPadding ? params.maximumFractionDigits : 0,
         });
     }
 


### PR DESCRIPTION
Fixes #14178
Fixes #14179
