### PR TITLE
fix(kit): use CSS variable --tui-status-negative for tui-badge-notification background

### DIFF
--- a/projects/kit/components/badge-notification/badge-notification.style.less
+++ b/projects/kit/components/badge-notification/badge-notification.style.less
@@ -16,7 +16,7 @@
     font: var(--tui-typography-body-s);
     max-inline-size: 100%;
     padding: 0 0.25rem;
-    background: #f52222;
+    background: var(--tui-status-negative);
     block-size: var(--t-size);
     min-inline-size: var(--t-size);
 

--- a/projects/styles/theme/palette.less
+++ b/projects/styles/theme/palette.less
@@ -20,9 +20,9 @@
     --tui-border-hover: rgba(255, 255, 255, 0.6);
     --tui-border-focus: rgba(255, 255, 255, 0.64);
     // Statuses
-    --tui-status-negative: rgba(255, 140, 103, 1);
-    --tui-status-negative-pale: rgba(244, 87, 37, 0.32);
-    --tui-status-negative-pale-hover: rgba(244, 87, 37, 0.4);
+    --tui-status-negative: #ff4d4d;
+    --tui-status-negative-pale: rgba(255, 77, 77, 0.24);
+    --tui-status-negative-pale-hover: rgba(255, 77, 77, 0.32);
     --tui-status-positive: rgb(74, 201, 155);
     --tui-status-positive-pale: rgba(74, 201, 155, 0.32);
     --tui-status-positive-pale-hover: rgba(74, 201, 155, 0.4);
@@ -41,8 +41,8 @@
     --tui-text-action-hover: #526ed3;
     --tui-text-positive: #44c596;
     --tui-text-positive-hover: #3aa981;
-    --tui-text-negative: #ff8c67;
-    --tui-text-negative-hover: #bb593a;
+    --tui-text-negative: #ff4d4d;
+    --tui-text-negative-hover: #f66;
 }
 
 .light() {
@@ -75,9 +75,9 @@
     --tui-border-hover: rgba(0, 0, 0, 0.16);
     --tui-border-focus: rgba(51, 51, 51, 0.64);
     // Statuses
-    --tui-status-negative: rgba(244, 87, 37, 1);
-    --tui-status-negative-pale: rgba(244, 87, 37, 0.12);
-    --tui-status-negative-pale-hover: rgba(244, 87, 37, 0.24);
+    --tui-status-negative: #ff291a;
+    --tui-status-negative-pale: rgba(245, 34, 34, 0.08);
+    --tui-status-negative-pale-hover: rgba(245, 34, 34, 0.16);
     --tui-status-positive: rgba(74, 201, 155, 1);
     --tui-status-positive-pale: rgba(74, 201, 155, 0.12);
     --tui-status-positive-pale-hover: rgba(74, 201, 155, 0.24);
@@ -98,8 +98,8 @@
     --tui-text-action-hover: #6c86e2;
     --tui-text-positive: #3aa981;
     --tui-text-positive-hover: #7ac5aa;
-    --tui-text-negative: #dd4c1e;
-    --tui-text-negative-hover: #e38163;
+    --tui-text-negative: #ff291a;
+    --tui-text-negative-hover: #ff4d4d;
     // Charts
     --tui-chart-categorical-00: var(--tui-background-accent-1);
     --tui-chart-categorical-01: #ea97c4;


### PR DESCRIPTION
- Replace hardcoded background color #f52222 with var(--tui-status-negative)
- Allows integrators to customize badge notification background via CSS variables
- Maintains visual consistency with negative/error status semantics

Fixes # <!-- link to a relevant issue. -->
