### PR TITLE
chore(demo): change breakpoints path

### DIFF
--- a/projects/demo/src/pages/markup/breakpoints/index.html
+++ b/projects/demo/src/pages/markup/breakpoints/index.html
@@ -1,7 +1,5 @@
 <tui-doc-page
     header="Breakpoints"
-    package="CORE"
-    path="core/styles/variables"
     type="markup"
 >
     <ng-template pageTab>


### PR DESCRIPTION
Fixes # <!-- link to a relevant issue. -->

The current button leads to the package on GitHub where these variables were previously contained

<img width="1598" height="795" alt="image" src="https://github.com/user-attachments/assets/a75bf15b-8106-4831-b6f2-25d8ccc5a550" />
<img width="903" height="347" alt="image" src="https://github.com/user-attachments/assets/23e94ec1-3167-428f-b35c-8860224f55a4" />
