### PR TITLE
feat(core): `Cell` add stretch directive

### DIFF
--- a/projects/core/components/cell/cell-stretch.directive.ts
+++ b/projects/core/components/cell/cell-stretch.directive.ts
@@ -1,0 +1,10 @@
+import {Directive, inject} from '@angular/core';
+import {WA_IS_MOBILE} from '@ng-web-apis/platform';
+
+@Directive({
+    selector: '[tuiCell][tuiCellStretch]',
+    host: {'[style.border-radius]': 'isMobile ? 0 : null'},
+})
+export class TuiCellStretch {
+    protected readonly isMobile = inject(WA_IS_MOBILE);
+}

--- a/projects/core/components/cell/cell.styles.less
+++ b/projects/core/components/cell/cell.styles.less
@@ -199,6 +199,11 @@
         }
     }
 
+    &[tuiCellStretch] {
+        inline-size: 100%;
+        margin-inline: -1rem;
+    }
+
     &:hover [tuiCellActions] ~ * {
         opacity: 0;
     }

--- a/projects/core/components/cell/index.ts
+++ b/projects/core/components/cell/index.ts
@@ -1,2 +1,3 @@
 export * from './cell.directive';
 export * from './cell.options';
+export * from './cell-stretch.directive';

--- a/projects/demo/src/pages/components/cell/examples/10/index.html
+++ b/projects/demo/src/pages/components/cell/examples/10/index.html
@@ -1,0 +1,87 @@
+<button
+    tuiButton
+    type="button"
+    (click)="open = true"
+>
+    Open Sheet Dialog
+</button>
+
+<ng-template
+    let-observer
+    [tuiSheetDialogOptions]="options"
+    [(tuiSheetDialog)]="open"
+>
+    <nav>
+        <button
+            tuiCell="l"
+            tuiCellStretch
+            type="button"
+        >
+            <div
+                appearance="primary"
+                tuiAvatar="@tui.home"
+            ></div>
+            <div tuiTitle>
+                Home
+                <div tuiSubtitle>Main page</div>
+            </div>
+        </button>
+
+        <button
+            tuiCell="l"
+            tuiCellStretch
+            type="button"
+        >
+            <div
+                appearance="accent"
+                tuiAvatar="@tui.user"
+            ></div>
+            <div tuiTitle>
+                Profile
+                <div tuiSubtitle>Account settings</div>
+            </div>
+        </button>
+
+        <button
+            tuiCell="l"
+            tuiCellStretch
+            type="button"
+        >
+            <div
+                appearance="positive"
+                tuiAvatar="@tui.heart"
+            ></div>
+            <div tuiTitle>
+                Favorites
+                <div tuiSubtitle>Saved items</div>
+            </div>
+            <tui-badge-notification>3</tui-badge-notification>
+        </button>
+
+        <button
+            tuiCell="l"
+            tuiCellStretch
+            type="button"
+        >
+            <div
+                appearance="warning"
+                tuiAvatar="@tui.star"
+            ></div>
+            <div tuiTitle>
+                Premium
+                <div tuiSubtitle>Upgrade your plan</div>
+            </div>
+        </button>
+    </nav>
+
+    <footer>
+        <button
+            size="m"
+            tuiButton
+            type="button"
+            (click)="observer.complete()"
+        >
+            Close
+        </button>
+    </footer>
+</ng-template>

--- a/projects/demo/src/pages/components/cell/examples/10/index.ts
+++ b/projects/demo/src/pages/components/cell/examples/10/index.ts
@@ -1,0 +1,29 @@
+import {Component} from '@angular/core';
+import {changeDetection} from '@demo/emulate/change-detection';
+import {encapsulation} from '@demo/emulate/encapsulation';
+import {TuiSheetDialog, type TuiSheetDialogOptions} from '@taiga-ui/addon-mobile';
+import {TuiButton, TuiCell, TuiCellStretch, TuiTitle} from '@taiga-ui/core';
+import {TuiAvatar, TuiBadgeNotification} from '@taiga-ui/kit';
+
+@Component({
+    imports: [
+        TuiAvatar,
+        TuiBadgeNotification,
+        TuiButton,
+        TuiCell,
+        TuiCellStretch,
+        TuiSheetDialog,
+        TuiTitle,
+    ],
+    templateUrl: './index.html',
+    encapsulation,
+    changeDetection,
+})
+export default class Example {
+    protected open = false;
+
+    protected readonly options: Partial<TuiSheetDialogOptions> = {
+        label: 'Navigation',
+        closable: true,
+    };
+}

--- a/projects/demo/src/pages/components/cell/index.ts
+++ b/projects/demo/src/pages/components/cell/index.ts
@@ -28,5 +28,6 @@ export default class Example {
         'Combinations',
         'Connected',
         'Disabled state',
+        'Stretch',
     ];
 }


### PR DESCRIPTION
# TuiCellStretch Directive

## Problem

When using `tuiCell` inside containers with padding (like `tui-sheet-dialog` with `padding: 0 1rem`), cells have unwanted gaps. Previously, developers had to use CSS hacks:

```css
/* Hack */
.cell {
  margin: 0 -1rem;
  border-radius: 0;
}
```

## Solution

The `tuiCellStretch` directive provides a native way to stretch cells to full container width:

```html
<button tuiCell tuiCellStretch>Full Width Cell</button>
```

<img width="442" height="372" alt="image" src="https://github.com/user-attachments/assets/4cdf808b-1ba6-4083-9a32-0c47589ce0ce" />


## Usage

### In Sheet Dialog

```html
<tui-sheet-dialog>
  <button tuiCell tuiCellStretch>
    <div tuiAvatar="@tui.home"></div>
    <div tuiTitle>
      Home
      <div tuiSubtitle>Main page</div>
    </div>
  </button>
  
  <button tuiCell tuiCellStretch>
    <div tuiAvatar="@tui.user"></div>
    <div tuiTitle>
      Profile
      <div tuiSubtitle>Account settings</div>
    </div>
  </button>
</tui-sheet-dialog>
```

## How It Works

- `inline-size: 100%` — full width
- `margin-inline: -1rem` — compensates parent padding
- `border-radius: 0` (mobile only) — edge-to-edge on mobile devices

Mobile detection uses `WA_IS_MOBILE` (user agent), not screen size.

## Import

```ts
import {TuiCellStretch} from '@taiga-ui/core';
```
