### PR TITLE
fix(kit): `(tuiPresent)` looses initial emission after hydration

### DIFF
--- a/projects/kit/directives/present/present.directive.ts
+++ b/projects/kit/directives/present/present.directive.ts
@@ -1,14 +1,17 @@
-import {Directive, type OnDestroy, output} from '@angular/core';
+import {isPlatformServer} from '@angular/common';
+import {Directive, inject, type OnDestroy, output, PLATFORM_ID} from '@angular/core';
 
 @Directive({
     selector: '[tuiPresent]',
     host: {
-        '[style.animation]': '"tuiPresent 1s infinite"',
+        '[style.animation]': 'isServer ? "" : "tuiPresent 1s infinite"',
         '(animationcancel.self)': 'tuiPresent.emit(false)',
         '(animationstart.self)': 'tuiPresent.emit(true)',
     },
 })
 export class TuiPresent implements OnDestroy {
+    protected readonly isServer = isPlatformServer(inject(PLATFORM_ID));
+
     public readonly tuiPresent = output<boolean>();
 
     public ngOnDestroy(): void {


### PR DESCRIPTION
```ts
import { ChangeDetectionStrategy, Component } from '@angular/core';
import { TuiPresent } from '@taiga-ui/kit';
import { TuiRoot } from '@taiga-ui/core';

@Component({
  selector: 'app-root',
  imports: [TuiPresent, TuiRoot],
  template: `
        <tui-root>
          <div (tuiPresent)="log($event)">123</div>
        </tui-root>
    `,
  changeDetection: ChangeDetectionStrategy.OnPush,
})
export class App {
  log(smth: any) {
    console.log(smth);
  }
}
```

### Without `provideClientHydration`
**Node.js** logs `false`
**Browser** logs `true`

### With `provideClientHydration`
**Node.js** logs `false`
**Browser** logs NOTHING ❌