### PR TITLE
chore(kit): `Tabs` drop hardcoded line-height

### DIFF
--- a/projects/kit/components/tabs/tabs.style.less
+++ b/projects/kit/components/tabs/tabs.style.less
@@ -9,7 +9,6 @@
     flex-shrink: 0;
     box-sizing: border-box;
     justify-content: space-between;
-    line-height: 1.5rem;
     align-items: center;
     white-space: nowrap;
     cursor: pointer;


### PR DESCRIPTION
Fixes # <!-- link to a relevant issue. -->
