### PR TITLE
fix(kit): unsubscribe segmented controls on destroy

### DIFF
--- a/projects/kit/components/segmented/segmented.directive.ts
+++ b/projects/kit/components/segmented/segmented.directive.ts
@@ -2,21 +2,23 @@ import {
     type AfterContentChecked,
     type AfterContentInit,
     contentChildren,
+    DestroyRef,
     Directive,
     ElementRef,
     inject,
 } from '@angular/core';
-import {toObservable} from '@angular/core/rxjs-interop';
+import {takeUntilDestroyed, toObservable} from '@angular/core/rxjs-interop';
 import {NgControl, RadioControlValueAccessor} from '@angular/forms';
 import {RouterLinkActive} from '@angular/router';
 import {tuiControlValue} from '@taiga-ui/cdk/observables';
 import {tuiInjectElement} from '@taiga-ui/cdk/utils/dom';
-import {map, switchMap} from 'rxjs';
+import {EMPTY, map, switchMap} from 'rxjs';
 
 import {TuiSegmented} from './segmented.component';
 
 @Directive({host: {'(click)': 'update($event.target)'}})
 export class TuiSegmentedDirective implements AfterContentChecked, AfterContentInit {
+    private readonly destroyRef = inject(DestroyRef);
     private readonly component = inject(TuiSegmented);
     private readonly el = tuiInjectElement();
     private readonly links = contentChildren(RouterLinkActive);
@@ -31,12 +33,11 @@ export class TuiSegmentedDirective implements AfterContentChecked, AfterContentI
     public ngAfterContentInit(): void {
         this.controls$
             .pipe(
-                switchMap(([control]) => tuiControlValue(control)),
+                switchMap(([control]) => (control ? tuiControlValue(control) : EMPTY)),
                 map((value) => this.radios().findIndex((c) => c.value === value)),
+                takeUntilDestroyed(this.destroyRef),
             )
-            .subscribe((index) => {
-                this.component.update(index);
-            });
+            .subscribe((index) => this.component.update(index));
     }
 
     public ngAfterContentChecked(): void {
@@ -47,9 +48,11 @@ export class TuiSegmentedDirective implements AfterContentChecked, AfterContentI
         }
     }
 
-    protected update(target: Element | null): void {
+    protected update(target: EventTarget | null): void {
         this.component.update(
-            Array.from(this.el.children).findIndex((tab) => tab.contains(target)),
+            Array.from(this.el.children).findIndex((tab) =>
+                tab.contains(target as Node | null),
+            ),
         );
     }
 }


### PR DESCRIPTION
Fixes #13872 

### Before


https://github.com/user-attachments/assets/367bcf9d-a5fa-48c8-862a-6f58081ea20a

### After


https://github.com/user-attachments/assets/0906e4b6-32a4-460e-8207-7d8fb1baffc6


