### PR TITLE
fix(addon-commerce): keep thumbnails icons visible in disabled content

### DIFF
--- a/projects/demo-playwright/tests/addon-commerce/thumbnail-card.pw.spec.ts
+++ b/projects/demo-playwright/tests/addon-commerce/thumbnail-card.pw.spec.ts
@@ -7,6 +7,18 @@ const {describe, beforeEach} = test;
 describe('ThumbnailCard', () => {
     let documentationPage: TuiDocumentationPagePO;
 
+    test('keep icons visible in disabled content', async ({page}) => {
+        await tuiGoto(page, DemoRoute.ThumbnailCard);
+
+        const example = new TuiDocumentationPagePO(page).getExample('#textfield');
+
+        await example.getByRole('button', {name: 'disabled'}).click();
+
+        await expect(
+            example.locator('[tuiThumbnailCard] tui-icon').first(),
+        ).toBeVisible();
+    });
+
     describe('Different width digits for different card sizes', () => {
         test.use({viewport: {width: 150, height: 300}});
 

--- a/projects/styles/components/textfield.less
+++ b/projects/styles/components/textfield.less
@@ -174,7 +174,7 @@ tui-textfield:where(*&) {
             opacity: 1;
         }
 
-        tui-icon {
+        & > .t-content > tui-icon {
             display: none;
         }
     }


### PR DESCRIPTION
Fixes #14236 