### PR TITLE
fix(addon-mobile): keep sheet dropdown open on input blur

### DIFF
--- a/projects/addon-mobile/directives/dropdown-mobile/dropdown-mobile.directive.ts
+++ b/projects/addon-mobile/directives/dropdown-mobile/dropdown-mobile.directive.ts
@@ -1,17 +1,29 @@
-import {computed, Directive, inject, Input} from '@angular/core';
+import {computed, Directive, inject, Injectable, Input, signal} from '@angular/core';
 import {TUI_IS_MOBILE} from '@taiga-ui/cdk/tokens';
 import {tuiIsHTMLElement} from '@taiga-ui/cdk/utils/dom';
 import {
+    TUI_DROPDOWN_ACTIVE_ZONE_CLOSE_GUARD,
     TUI_DROPDOWN_COMPONENT,
     TuiDropdownDirective,
 } from '@taiga-ui/core/directives/dropdown';
 
 import {TuiDropdownMobileComponent} from './dropdown-mobile.component';
 
+@Injectable()
+class TuiDropdownMobileActiveZoneCloseGuard {
+    public readonly canClose = signal(true);
+}
+
 @Directive({
     standalone: true,
     selector: '[tuiDropdownMobile]',
     providers: [
+        TuiDropdownMobileActiveZoneCloseGuard,
+        {
+            provide: TUI_DROPDOWN_ACTIVE_ZONE_CLOSE_GUARD,
+            useExisting: TuiDropdownMobileActiveZoneCloseGuard,
+            multi: true,
+        },
         {
             provide: TUI_DROPDOWN_COMPONENT,
             useFactory: () =>
@@ -26,7 +38,10 @@ import {TuiDropdownMobileComponent} from './dropdown-mobile.component';
     },
 })
 export class TuiDropdownMobile {
+    private readonly closeGuard = inject(TuiDropdownMobileActiveZoneCloseGuard);
     private readonly isMobile = inject(TUI_IS_MOBILE);
+    private sheetTitle = '';
+
     private readonly dropdown = inject(TuiDropdownDirective, {
         optional: true,
         self: true,
@@ -35,7 +50,14 @@ export class TuiDropdownMobile {
     protected readonly visible = computed(() => !this.dropdown || this.dropdown.ref());
 
     @Input()
-    public tuiDropdownMobile = '';
+    public set tuiDropdownMobile(value: string | null | undefined) {
+        this.sheetTitle = value ?? '';
+        this.closeGuard.canClose.set(!this.sheetTitle);
+    }
+
+    public get tuiDropdownMobile(): string {
+        return this.sheetTitle;
+    }
 
     protected onMouseDown(event: MouseEvent): void {
         if (

--- a/projects/core/directives/dropdown/dropdown-open.directive.ts
+++ b/projects/core/directives/dropdown/dropdown-open.directive.ts
@@ -38,7 +38,10 @@ import {filter, fromEvent, merge} from 'rxjs';
 
 import {TuiDropdownDirective} from './dropdown.directive';
 import {TuiDropdownDriver} from './dropdown.driver';
-import {TUI_DROPDOWN_HOST} from './dropdown.providers';
+import {
+    TUI_DROPDOWN_HOST,
+    TUI_DROPDOWN_ACTIVE_ZONE_CLOSE_GUARD,
+} from './dropdown.providers';
 
 @Directive({
     standalone: true,
@@ -70,6 +73,7 @@ export class TuiDropdownOpen implements OnChanges, ElementRef<Element> {
     @ContentChild('tuiDropdownHost', {descendants: true, read: ElementRef})
     private readonly dropdownHost?: ElementRef<HTMLElement>;
 
+    private readonly activeZoneCloseGuards = inject(TUI_DROPDOWN_ACTIVE_ZONE_CLOSE_GUARD);
     private readonly directive = inject(TuiDropdownDirective);
     private readonly el = tuiInjectElement();
     private readonly obscured = inject(TuiObscured);
@@ -97,7 +101,12 @@ export class TuiDropdownOpen implements OnChanges, ElementRef<Element> {
                 merge(
                     tuiCloseWatcher(),
                     this.obscured.tuiObscured.pipe(filter(Boolean)),
-                    this.activeZone.tuiActiveZoneChange.pipe(filter((a) => !a)),
+                    this.activeZone.tuiActiveZoneChange.pipe(
+                        filter((active) => !active),
+                        filter(() =>
+                            this.activeZoneCloseGuards.every(({canClose}) => canClose()),
+                        ),
+                    ),
                     fromEvent(this.el, 'focusin').pipe(
                         filter(
                             (event) =>

--- a/projects/core/directives/dropdown/dropdown.providers.ts
+++ b/projects/core/directives/dropdown/dropdown.providers.ts
@@ -19,3 +19,13 @@ export const TUI_DROPDOWN_CONTEXT = new InjectionToken<Record<any, any>>(
 export const TUI_DROPDOWN_HOST = new InjectionToken<ElementRef<Element>>(
     ngDevMode ? 'TUI_DROPDOWN_HOST' : '',
 );
+
+export interface TuiDropdownActiveZoneCloseGuard {
+    readonly canClose: () => boolean;
+}
+
+export const TUI_DROPDOWN_ACTIVE_ZONE_CLOSE_GUARD = new InjectionToken<
+    readonly TuiDropdownActiveZoneCloseGuard[]
+>(ngDevMode ? 'TUI_DROPDOWN_ACTIVE_ZONE_CLOSE_GUARD' : '', {
+    factory: () => [],
+});

--- a/projects/demo-playwright/tests/core/dropdown/dropdown-mobile.pw.spec.ts
+++ b/projects/demo-playwright/tests/core/dropdown/dropdown-mobile.pw.spec.ts
@@ -1,0 +1,28 @@
+import {expect, test} from '@playwright/test';
+import {tuiGoto} from '@demo-playwright/utils';
+import {TUI_PLAYWRIGHT_MOBILE_USER_AGENT} from '../../../playwright.options';
+
+test.describe('DropdownMobile', () => {
+    test.use({
+        viewport: {width: 390, height: 844},
+        userAgent: TUI_PLAYWRIGHT_MOBILE_USER_AGENT,
+    });
+
+    test('does not close sheet dropdown when input inside is blurred', async ({page}) => {
+        await tuiGoto(page, 'directives/dropdown#mobile');
+        await page.getByRole('button', {name: 'Open dropdown with input'}).click();
+
+        const dropdown = page.locator('tui-dropdown-mobile');
+        const input = dropdown.getByPlaceholder('Type something and tap Done');
+
+        await expect(dropdown.getByText('Input inside dropdown')).toBeVisible();
+        await expect(input).toBeVisible();
+        await input.focus();
+        await expect(input).toBeFocused();
+        await input.evaluate((element: HTMLInputElement) => element.blur());
+        await expect(dropdown.getByText('Input inside dropdown')).toBeVisible();
+        await expect(input).toBeVisible();
+        await dropdown.locator('.t-filler').click();
+        await expect(dropdown).toHaveCount(0);
+    });
+});

--- a/projects/demo/src/modules/directives/dropdown/examples/5/index.html
+++ b/projects/demo/src/modules/directives/dropdown/examples/5/index.html
@@ -1,3 +1,46 @@
+<button
+    tuiButton
+    tuiDropdownLimitWidth="fixed"
+    tuiDropdownMobile="Input inside dropdown"
+    type="button"
+    class="tui-space_vertical-4"
+    [style.width.%]="100"
+    [tuiDropdown]="dropdown"
+    [tuiDropdownOpen]="dropdownOpen()"
+    (tuiDropdownOpenChange)="dropdownOpen.set($event)"
+>
+    Open dropdown with input
+
+    <ng-template
+        #dropdown
+        let-close
+    >
+        <div [style.padding.rem]="1">
+            <tui-textfield>
+                <label tuiLabel>Input</label>
+                <input
+                    placeholder="Type something and tap Done"
+                    tuiTextfield
+                    [(ngModel)]="input"
+                />
+            </tui-textfield>
+
+            <p class="tui-text_body-s tui-space_top-3">
+                On iOS, tapping Done on the virtual keyboard should not close this dropdown.
+            </p>
+
+            <button
+                tuiButton
+                tuiDropdownButton
+                type="button"
+                (click)="close()"
+            >
+                Close
+            </button>
+        </div>
+    </ng-template>
+</button>
+
 <tui-combo-box
     tuiDropdownMobile
     [tuiTextfieldCleaner]="true"

--- a/projects/demo/src/modules/directives/dropdown/examples/5/index.ts
+++ b/projects/demo/src/modules/directives/dropdown/examples/5/index.ts
@@ -63,8 +63,10 @@ export default class Example {
     protected selected: readonly User[] = [];
     protected sum = null;
     protected user: User | null = null;
+    protected input = '';
 
     protected readonly open = signal(false);
+    protected readonly dropdownOpen = signal(false);
 
     protected readonly countries$ = inject(TUI_COUNTRIES).pipe(map(Object.values));
 


### PR DESCRIPTION
Fixes #12975

### Before


https://github.com/user-attachments/assets/2ee9928f-ad24-407a-b30c-ca45ddad4799




### After


https://github.com/user-attachments/assets/88f1e6ac-e43a-4ad5-9589-53d5e880108c


The previous approach changed `TUI_ACTIVE_ELEMENT`, but that is too broad because `focusout` with `relatedTarget === null` is also a valid signal for manual `blur()`. Some components rely on this behavior to detect that focus has left the active zone.

There is no reliable DOM event for the iOS virtual keyboard `Done` button. `enterkeyhint="done"` only changes the virtual keyboard action label and does not prevent the same `blur` / `focusout` flow.

This fix keeps `TUI_ACTIVE_ELEMENT` and `TuiActiveZone` behavior unchanged. Instead, it handles the issue locally for `tuiDropdownMobile="..."` sheet mode: the sheet is no longer closed only because `TuiActiveZoneChange(false)` was emitted after an input blur.

This is safer because mobile sheet dropdowns already have explicit close interactions: backdrop/filler tap, swipe down, `close()` from dropdown context, and option/button actions. Regular dropdowns and non-sheet mobile dropdowns keep the existing active-zone close behavior.
