### PR TITLE
chore(demo): cache color values in computed signal

### DIFF
--- a/projects/demo/src/pages/markup/colors/examples/table/index.html
+++ b/projects/demo/src/pages/markup/colors/examples/table/index.html
@@ -1,34 +1,34 @@
-@for (color of colors(); track color) {
+@for (row of rows(); track row.color) {
     <tr class="color">
-        @if (getValue(color, platform.tuiPlatform(), darkMode()); as value) {
-            <td>
-                <h3 class="name">
-                    <tui-doc-copy
-                        class="copy"
-                        [cdkCopyToClipboard]="`var(${color})`"
-                    >
-                        Copy
-                    </tui-doc-copy>
-                    {{ color }}
-                </h3>
-            </td>
-            <td class="circle">
-                <div
-                    class="demo"
-                    [style.background]="`var(${color})`"
-                ></div>
-            </td>
-            <td>
-                <div class="value">
-                    <tui-doc-copy
-                        class="copy"
-                        [cdkCopyToClipboard]="value"
-                    >
-                        Copy
-                    </tui-doc-copy>
-                    {{ value }}
-                </div>
-            </td>
-        }
+        <td>
+            <h3 class="name">
+                <tui-doc-copy
+                    class="copy"
+                    [cdkCopyToClipboard]="`var(${row.color})`"
+                >
+                    Copy
+                </tui-doc-copy>
+                {{ row.color }}
+            </h3>
+        </td>
+
+        <td class="circle">
+            <div
+                class="demo"
+                [style.background]="`var(${row.color})`"
+            ></div>
+        </td>
+
+        <td>
+            <div class="value">
+                <tui-doc-copy
+                    class="copy"
+                    [cdkCopyToClipboard]="row.value"
+                >
+                    Copy
+                </tui-doc-copy>
+                {{ row.value }}
+            </div>
+        </td>
     </tr>
 }

--- a/projects/demo/src/pages/markup/colors/examples/table/index.ts
+++ b/projects/demo/src/pages/markup/colors/examples/table/index.ts
@@ -1,10 +1,15 @@
 import {ClipboardModule} from '@angular/cdk/clipboard';
-import {Component, inject, input} from '@angular/core';
+import {Component, computed, inject, input} from '@angular/core';
 import {changeDetection} from '@demo/emulate/change-detection';
 import {WA_WINDOW} from '@ng-web-apis/common';
 import {TuiDocCopy} from '@taiga-ui/addon-doc';
 import {tuiInjectElement, TuiPlatform} from '@taiga-ui/cdk';
 import {TUI_DARK_MODE} from '@taiga-ui/core';
+
+interface ColorRow {
+    readonly color: string;
+    readonly value: string;
+}
 
 @Component({
     selector: 'table[colors]',
@@ -22,7 +27,18 @@ export class TableColors {
 
     public readonly colors = input<readonly string[]>([]);
 
-    protected getValue(variable: string, _p: string, _d: boolean): string {
-        return this.styles.getPropertyValue(variable);
-    }
+    protected readonly rows = computed<readonly ColorRow[]>(
+        (
+            // These reads are intentional:
+            // color values depend on platform and theme.
+            _platform = this.platform.tuiPlatform(),
+            _dark = this.darkMode(),
+        ) =>
+            this.colors()
+                .map((color) => ({
+                    color,
+                    value: this.styles.getPropertyValue(color),
+                }))
+                .filter(({value}) => value),
+    );
 }


### PR DESCRIPTION
Fixes #14265 

```
$ ng serve --prod
```

<img width="832" height="615" alt="image" src="https://github.com/user-attachments/assets/1090a710-9023-4c2d-8da2-6e28bd72dfea" />
<img width="858" height="560" alt="image" src="https://github.com/user-attachments/assets/6eb82673-fe16-412c-bd8a-eb6a04b6f2f1" />
