### PR TITLE
ci: group failed screenshots by exact snapshot name

### DIFF
--- a/projects/demo/src/pages/components/floating-container/examples/5/index.html
+++ b/projects/demo/src/pages/components/floating-container/examples/5/index.html
@@ -30,7 +30,7 @@
 </p>
 
 <p>
-    <tui-textfield [iconStart]="'@tui.paintbrush'">
+    <tui-textfield iconStart="@tui.paintbrush">
         <label tuiLabel>Background color</label>
         <input
             placeholder="#00000000"

--- a/projects/testing/visual-testing/combine-playwright-failed-screenshots.ts
+++ b/projects/testing/visual-testing/combine-playwright-failed-screenshots.ts
@@ -6,6 +6,7 @@ const FAILED_SCREENSHOTS_PATH =
     process.env.FAILED_SCREENSHOTS_PATH ?? 'projects/demo-playwright/tests-results';
 
 const DIFF_IMAGE_POSTFIX = process.env.DIFF_IMAGE_POSTFIX ?? '-diff.png';
+const SNAPSHOT_IMAGE_POSTFIXES = ['-actual.png', DIFF_IMAGE_POSTFIX, '-expected.png'];
 const OUTPUT_DIFF_IMAGE_POSTFIX = process.env.OUTPUT_DIFF_IMAGE_POSTFIX ?? '.diff.png';
 const RETRY_COUNT = Number(process.env.RETRY_COUNT ?? 2);
 const REG_EXP = new RegExp(`retry${RETRY_COUNT}$|retry${RETRY_COUNT}/`);
@@ -33,18 +34,45 @@ export async function tuiCombinePlaywrightFailedScreenshots(
         )
         .map(({name}) => `${rootPath}/${name}`);
 
+    const images = new Set(imagesPaths);
     const diffs = imagesPaths.filter((path) => path.endsWith(DIFF_IMAGE_POSTFIX));
 
     for (const diffImage of diffs) {
-        const diffImageName = diffImage.split('/').pop()!.replace(DIFF_IMAGE_POSTFIX, '');
+        const diffImageName = getSnapshotPath(diffImage).split('/').pop() ?? '';
         const output = `${rootPath}/${diffImageName}${OUTPUT_DIFF_IMAGE_POSTFIX}`;
-
-        const inputs = imagesPaths.filter((path) =>
-            path.startsWith(diffImage.replace(DIFF_IMAGE_POSTFIX, '')),
-        );
+        const inputs = getSnapshotInputs(images, diffImage);
 
         tuiCombineSnapshots(inputs, output).then(() =>
             console.info(` ✅ Async saved merged image: ${output}`),
         );
     }
+}
+
+/**
+ * Returns screenshots that belong to the same Playwright snapshot.
+ *
+ * We intentionally build exact file names instead of matching by prefix.
+ * Snapshot names can share the same prefix:
+ *
+ * @example
+ * // For "5.desktop-diff.png" include only:
+ * // - "5.desktop-actual.png"
+ * // - "5.desktop-diff.png"
+ * // - "5.desktop-expected.png"
+ * //
+ * // Do not include:
+ * // - "5.desktop-rtl-actual.png"
+ * // - "5.desktop-rtl-diff.png"
+ * // - "5.desktop-rtl-expected.png"
+ */
+function getSnapshotInputs(images: ReadonlySet<string>, diffImage: string): string[] {
+    const snapshotPath = getSnapshotPath(diffImage);
+
+    return SNAPSHOT_IMAGE_POSTFIXES.map((postfix) => `${snapshotPath}${postfix}`).filter(
+        (path) => images.has(path),
+    );
+}
+
+function getSnapshotPath(diffImage: string): string {
+    return diffImage.slice(0, -DIFF_IMAGE_POSTFIX.length);
 }


### PR DESCRIPTION
### Before

<img width="1360" height="904" alt="image" src="https://github.com/user-attachments/assets/14a54f23-655e-49af-90fb-fe4de8a7f490" />
