### PR TITLE
fix(addon-doc): correct tab order in `Example` after language switch

### DIFF
--- a/projects/addon-doc/components/example/example.component.ts
+++ b/projects/addon-doc/components/example/example.component.ts
@@ -44,7 +44,12 @@ import {BehaviorSubject, map, switchMap} from 'rxjs';
 
 import {TuiDocCode} from '../code';
 import {TUI_DOC_EXAMPLE_OPTIONS} from './example.options';
-import {TuiDocExampleGetTabsPipe} from './example-get-tabs.pipe';
+
+interface TuiDocExampleTab {
+    readonly code: string;
+    readonly key: string;
+    readonly title: PolymorpheusContent;
+}
 
 @Component({
     selector: 'tui-doc-example',
@@ -55,7 +60,6 @@ import {TuiDocExampleGetTabsPipe} from './example-get-tabs.pipe';
         RouterLink,
         TuiButton,
         TuiDocCode,
-        TuiDocExampleGetTabsPipe,
         TuiFullscreen,
         TuiHeader,
         TuiLink,
@@ -107,6 +111,7 @@ export class TuiDocExample implements OnChanges {
         );
 
     protected readonly route = inject(ActivatedRoute);
+    protected readonly previewTab = 'tui-doc-example-preview';
     protected activeItemIndex = 0;
     protected fullscreen = false;
     protected readonly copy = computed(() => this.copyTexts()[0]);
@@ -123,6 +128,25 @@ export class TuiDocExample implements OnChanges {
         ),
         {initialValue: {}},
     );
+
+    protected readonly tabs = computed<readonly TuiDocExampleTab[]>(() => [
+        ...(this.preview()
+            ? [
+                  {
+                      code: '',
+                      key: 'tui-doc-example-preview',
+                      title: this.defaultTab(),
+                  },
+              ]
+            : []),
+        ...Object.entries(this.processor())
+            .filter(([, code]) => code)
+            .map(([key, code]) => ({
+                code,
+                key,
+                title: this.getTabTitle(key),
+            })),
+    ]);
 
     protected readonly lazyComponent = resource({
         request: async () => this.component(),

--- a/projects/addon-doc/components/example/example.component.ts
+++ b/projects/addon-doc/components/example/example.component.ts
@@ -43,8 +43,8 @@ import {type PolymorpheusContent, PolymorpheusOutlet} from '@taiga-ui/polymorphe
 import {BehaviorSubject, map, switchMap} from 'rxjs';
 
 import {TuiDocCode} from '../code';
-import {TuiDocExampleGetTabsPipe} from './example-get-tabs.pipe';
 import {TUI_DOC_EXAMPLE_OPTIONS} from './example.options';
+import {TuiDocExampleGetTabsPipe} from './example-get-tabs.pipe';
 
 @Component({
     selector: 'tui-doc-example',

--- a/projects/addon-doc/components/example/example.component.ts
+++ b/projects/addon-doc/components/example/example.component.ts
@@ -43,13 +43,8 @@ import {type PolymorpheusContent, PolymorpheusOutlet} from '@taiga-ui/polymorphe
 import {BehaviorSubject, map, switchMap} from 'rxjs';
 
 import {TuiDocCode} from '../code';
+import {TuiDocExampleGetTabsPipe} from './example-get-tabs.pipe';
 import {TUI_DOC_EXAMPLE_OPTIONS} from './example.options';
-
-interface TuiDocExampleTab {
-    readonly code: string;
-    readonly key: string;
-    readonly title: PolymorpheusContent;
-}
 
 @Component({
     selector: 'tui-doc-example',
@@ -60,6 +55,7 @@ interface TuiDocExampleTab {
         RouterLink,
         TuiButton,
         TuiDocCode,
+        TuiDocExampleGetTabsPipe,
         TuiFullscreen,
         TuiHeader,
         TuiLink,
@@ -111,7 +107,6 @@ export class TuiDocExample implements OnChanges {
         );
 
     protected readonly route = inject(ActivatedRoute);
-    protected readonly previewTab = 'tui-doc-example-preview';
     protected activeItemIndex = 0;
     protected fullscreen = false;
     protected readonly copy = computed(() => this.copyTexts()[0]);
@@ -128,25 +123,6 @@ export class TuiDocExample implements OnChanges {
         ),
         {initialValue: {}},
     );
-
-    protected readonly tabs = computed<readonly TuiDocExampleTab[]>(() => [
-        ...(this.preview()
-            ? [
-                  {
-                      code: '',
-                      key: this.previewTab,
-                      title: this.defaultTab(),
-                  },
-              ]
-            : []),
-        ...Object.entries(this.processor())
-            .filter(([, code]) => code)
-            .map(([key, code]) => ({
-                code,
-                key,
-                title: this.getTabTitle(key),
-            })),
-    ]);
 
     protected readonly lazyComponent = resource({
         request: async () => this.component(),

--- a/projects/addon-doc/components/example/example.component.ts
+++ b/projects/addon-doc/components/example/example.component.ts
@@ -134,7 +134,7 @@ export class TuiDocExample implements OnChanges {
             ? [
                   {
                       code: '',
-                      key: 'tui-doc-example-preview',
+                      key: this.previewTab,
                       title: this.defaultTab(),
                   },
               ]

--- a/projects/addon-doc/components/example/example.template.html
+++ b/projects/addon-doc/components/example/example.template.html
@@ -31,16 +31,17 @@
     class="t-example"
     [(tuiFullscreen)]="fullscreen"
 >
-    @if (tabs(); as tabs) {
+    @if (processor() | tuiDocExampleGetTabs: defaultTab(); as all) {
+        @let tabs = preview() ? all : all.slice(1);
         @if (tabs.length) {
             <div class="t-header">
                 <tui-segmented
                     class="t-tabs"
                     [(activeItemIndex)]="activeItemIndex"
                 >
-                    @for (tab of tabs; track tab.key) {
+                    @for (tab of tabs; track $index) {
                         <button type="button">
-                            <ng-container *polymorpheusOutlet="tab.title as text">
+                            <ng-container *polymorpheusOutlet="getTabTitle(tab) as text">
                                 {{ text }}
                             </ng-container>
                         </button>
@@ -84,9 +85,9 @@
                 }
             </div>
         }
-        @for (tab of tabs; track tab.key) {
+        @for (tab of tabs; track $index) {
             <div class="t-content">
-                @if (tab.key === previewTab) {
+                @if (!$index && preview()) {
                     <section
                         automation-id="tui-doc-example"
                         class="t-demo"
@@ -96,12 +97,13 @@
                         <ng-container *ngComponentOutlet="lazyComponent.value() ?? null" />
                     </section>
                 }
+                @let code = processor()[tab] || '';
                 <tui-doc-code
-                    [code]="tab.code"
-                    [style.display]="activeItemIndex === $index && tab.key !== previewTab ? 'block' : 'none'"
+                    [code]="code"
+                    [style.display]="activeItemIndex === $index && ($index || !preview()) ? 'block' : 'none'"
                 >
                     @for (action of codeActions; track action) {
-                        <ng-container *polymorpheusOutlet="action as text; context: {$implicit: tab.code}">
+                        <ng-container *polymorpheusOutlet="action as text; context: {$implicit: code}">
                             {{ text }}
                         </ng-container>
                     }

--- a/projects/addon-doc/components/example/example.template.html
+++ b/projects/addon-doc/components/example/example.template.html
@@ -31,17 +31,16 @@
     class="t-example"
     [(tuiFullscreen)]="fullscreen"
 >
-    @if (processor() | tuiDocExampleGetTabs: defaultTab(); as all) {
-        @let tabs = preview() ? all : all.slice(1);
+    @if (tabs(); as tabs) {
         @if (tabs.length) {
             <div class="t-header">
                 <tui-segmented
                     class="t-tabs"
                     [(activeItemIndex)]="activeItemIndex"
                 >
-                    @for (tab of tabs; track tab) {
+                    @for (tab of tabs; track tab.key) {
                         <button type="button">
-                            <ng-container *polymorpheusOutlet="getTabTitle(tab) as text">
+                            <ng-container *polymorpheusOutlet="tab.title as text">
                                 {{ text }}
                             </ng-container>
                         </button>
@@ -85,9 +84,9 @@
                 }
             </div>
         }
-        @for (tab of tabs; track tab) {
+        @for (tab of tabs; track tab.key) {
             <div class="t-content">
-                @if (!$index && preview()) {
+                @if (tab.key === previewTab) {
                     <section
                         automation-id="tui-doc-example"
                         class="t-demo"
@@ -97,13 +96,12 @@
                         <ng-container *ngComponentOutlet="lazyComponent.value() ?? null" />
                     </section>
                 }
-                @let code = processor()[tab] || '';
                 <tui-doc-code
-                    [code]="code"
-                    [style.display]="activeItemIndex === $index && ($index || !preview()) ? 'block' : 'none'"
+                    [code]="tab.code"
+                    [style.display]="activeItemIndex === $index && tab.key !== previewTab ? 'block' : 'none'"
                 >
                     @for (action of codeActions; track action) {
-                        <ng-container *polymorpheusOutlet="action as text; context: {$implicit: code}">
+                        <ng-container *polymorpheusOutlet="action as text; context: {$implicit: tab.code}">
                             {{ text }}
                         </ng-container>
                     }

--- a/projects/addon-doc/components/example/test/example.component.spec.ts
+++ b/projects/addon-doc/components/example/test/example.component.spec.ts
@@ -78,7 +78,7 @@ describe('TuiDocExample', () => {
         });
     });
 
-    it('keep preview place when changing language', async () => {
+    it('keep preview place when changing language', () => {
         const preview = fixture.nativeElement.querySelector(
             '[automation-id="tui-doc-example"]',
         );

--- a/projects/addon-doc/components/example/test/example.component.spec.ts
+++ b/projects/addon-doc/components/example/test/example.component.spec.ts
@@ -3,7 +3,7 @@ import {type ComponentFixture, TestBed} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
 import {provideRouter} from '@angular/router';
 import {WA_LOCATION} from '@ng-web-apis/common';
-import {TuiDocExample} from '@taiga-ui/addon-doc';
+import {TUI_DOC_PREVIEW_TEXT, TuiDocExample} from '@taiga-ui/addon-doc';
 import {tuiToKebab} from '@taiga-ui/addon-doc/utils';
 import {provideTaiga} from '@taiga-ui/core';
 import {provideHighlightOptions} from 'ngx-highlightjs';
@@ -26,8 +26,11 @@ describe('TuiDocExample', () => {
 
     let fixture: ComponentFixture<Test>;
     let testComponent: Test;
+    const previewText = signal('Preview');
 
     beforeEach(async () => {
+        previewText.set('Preview');
+
         TestBed.configureTestingModule({
             imports: [Test],
             providers: [
@@ -35,6 +38,7 @@ describe('TuiDocExample', () => {
                 provideRouter([]),
                 provideHighlightOptions({}),
                 {provide: WA_LOCATION, useValue: {pathname: '/test'}},
+                {provide: TUI_DOC_PREVIEW_TEXT, useFactory: () => previewText},
             ],
         });
 
@@ -72,5 +76,19 @@ describe('TuiDocExample', () => {
 
             expect(hostId()).toBe('external-id');
         });
+    });
+
+    it('keep preview place when changing language', async () => {
+        const preview = fixture.nativeElement.querySelector(
+            '[automation-id="tui-doc-example"]',
+        );
+
+        // cspell:ignore Voorbeeld
+        previewText.set('Voorbeeld');
+        fixture.detectChanges();
+
+        expect(
+            fixture.nativeElement.querySelector('[automation-id="tui-doc-example"]'),
+        ).toBe(preview);
     });
 });


### PR DESCRIPTION
Fixes #14241
