### PR TITLE
fix(addon-doc): show explicit null option in API table selects

### DIFF
--- a/projects/addon-doc/components/api/api-item.component.ts
+++ b/projects/addon-doc/components/api/api-item.component.ts
@@ -66,7 +66,10 @@ export class TuiDocAPIItem<T> implements OnInit {
     public readonly items = input([], {transform: (v?: readonly T[]) => v || []});
 
     protected readonly hasCleaner = computed(
-        () => this.type().includes('null') || this.type().includes('PolymorpheusContent'),
+        () =>
+            (this.type().includes('null') ||
+                this.type().includes('PolymorpheusContent')) &&
+            (this.value() ?? 'null') !== 'null',
     );
 
     public ngOnInit(): void {

--- a/projects/addon-doc/components/api/api-item.component.ts
+++ b/projects/addon-doc/components/api/api-item.component.ts
@@ -26,6 +26,7 @@ import {TuiInspectPipe} from './inspect.pipe';
 import {TuiTypeReferencePipe} from './type-reference.pipe';
 
 const SERIALIZED_SUFFIX = '$';
+const SERIALIZED_NULL = 'null';
 
 @Component({
     selector: 'tr[tuiDocAPIItem]',
@@ -66,10 +67,9 @@ export class TuiDocAPIItem<T> implements OnInit {
     public readonly items = input([], {transform: (v?: readonly T[]) => v || []});
 
     protected readonly hasCleaner = computed(
-        () =>
-            (this.type().includes('null') ||
-                this.type().includes('PolymorpheusContent')) &&
-            (this.value() ?? 'null') !== 'null',
+        (type = this.type(), value = this.value()) =>
+            (type.includes(SERIALIZED_NULL) || type.includes('PolymorpheusContent')) &&
+            (value ?? SERIALIZED_NULL) !== SERIALIZED_NULL,
     );
 
     public ngOnInit(): void {

--- a/projects/addon-doc/components/api/api-item.template.html
+++ b/projects/addon-doc/components/api/api-item.template.html
@@ -43,8 +43,8 @@
         >
             <input
                 tuiSelect
-                [ngModel]="value() ?? null"
-                (ngModelChange)="onValueChange($event)"
+                [ngModel]="value() ?? 'null'"
+                (ngModelChange)="onValueChange($event === 'null' ? null : $event)"
             />
             <tui-data-list-wrapper
                 *tuiDropdown
@@ -94,6 +94,6 @@
         #content
         let-data
     >
-        <code [style.margin]="0">{{ data | tuiInspect }}</code>
+        <code [style.margin]="0">{{ data === 'null' ? 'null' : (data | tuiInspect) }}</code>
     </ng-template>
 </td>


### PR DESCRIPTION
[valueEffect](https://github.com/taiga-family/taiga-ui/blob/main/projects/kit/components/select/select.directive.ts#L42) bypasses stringify when value is null and undefined, so null no longer rendered in the textfield. Restore it via a 'null' sentinel mapped back to actual null on change.
