### PR TITLE
fix: improve tree shaking of `TuiDay` class for unused `InputDate*` components

### DIFF
--- a/projects/kit/components/input-date-multi/input-date-multi.directive.ts
+++ b/projects/kit/components/input-date-multi/input-date-multi.directive.ts
@@ -95,13 +95,11 @@ export class TuiInputDateMultiDirective extends TuiInputChipDirective<TuiDay> {
     });
 
     public readonly min = input(this.dateMultiOptions.min ?? TUI_FIRST_DAY, {
-        transform: (min: TuiDay | null): TuiDay =>
-            min instanceof TuiDay ? min : TUI_FIRST_DAY,
+        transform: (min: TuiDay | null): TuiDay => min ?? TUI_FIRST_DAY,
     });
 
     public readonly max = input(this.dateMultiOptions.max ?? TUI_LAST_DAY, {
-        transform: (max: TuiDay | null): TuiDay =>
-            max instanceof TuiDay ? max : TUI_LAST_DAY,
+        transform: (max: TuiDay | null): TuiDay => max ?? TUI_LAST_DAY,
     });
 
     protected processCalendar(calendar: AbstractTuiCalendar): void {

--- a/projects/kit/components/input-date-multi/input-date-multi.directive.ts
+++ b/projects/kit/components/input-date-multi/input-date-multi.directive.ts
@@ -2,7 +2,12 @@ import {computed, Directive, effect, inject, input} from '@angular/core';
 import {MaskitoDirective} from '@maskito/angular';
 import {maskitoDate} from '@maskito/kit';
 import {tuiAsControl, tuiValueTransformerFrom} from '@taiga-ui/cdk/classes';
-import {DATE_FILLER_LENGTH, TuiDay} from '@taiga-ui/cdk/date-time';
+import {
+    DATE_FILLER_LENGTH,
+    TUI_FIRST_DAY,
+    TUI_LAST_DAY,
+    TuiDay,
+} from '@taiga-ui/cdk/date-time';
 import {tuiFallbackValueProvider} from '@taiga-ui/cdk/tokens';
 import {tuiDirectiveBinding} from '@taiga-ui/cdk/utils/di';
 import {tuiArrayToggle, tuiSetSignal} from '@taiga-ui/cdk/utils/miscellaneous';
@@ -89,8 +94,15 @@ export class TuiInputDateMultiDirective extends TuiInputChipDirective<TuiDay> {
         }
     });
 
-    public readonly min = input<TuiDay | null>(this.dateMultiOptions.min);
-    public readonly max = input<TuiDay | null>(this.dateMultiOptions.max);
+    public readonly min = input(this.dateMultiOptions.min ?? TUI_FIRST_DAY, {
+        transform: (min: TuiDay | null): TuiDay =>
+            min instanceof TuiDay ? min : TUI_FIRST_DAY,
+    });
+
+    public readonly max = input(this.dateMultiOptions.max ?? TUI_LAST_DAY, {
+        transform: (max: TuiDay | null): TuiDay =>
+            max instanceof TuiDay ? max : TUI_LAST_DAY,
+    });
 
     protected processCalendar(calendar: AbstractTuiCalendar): void {
         tuiSetSignal(calendar.value, this.value());

--- a/projects/kit/components/input-date-range/input-date-range.directive.ts
+++ b/projects/kit/components/input-date-range/input-date-range.directive.ts
@@ -37,12 +37,12 @@ import {TUI_INPUT_DATE_RANGE_OPTIONS} from './input-date-range.options';
     hostDirectives: [TuiWithInput, TuiDropdownAuto, MaskitoDirective],
 })
 export class TuiInputDateRangeDirective extends TuiInputDateBase<TuiDayRange> {
-    public override readonly max = input(this.options.max, {
+    public override readonly max = input(this.options.max ?? TUI_LAST_DAY, {
         transform: (max: TuiDay | null): TuiDay =>
             max instanceof TuiDay ? max : TUI_LAST_DAY,
     });
 
-    public override readonly min = input(this.options.min, {
+    public override readonly min = input(this.options.min ?? TUI_FIRST_DAY, {
         transform: (min: TuiDay | null): TuiDay =>
             min instanceof TuiDay ? min : TUI_FIRST_DAY,
     });

--- a/projects/kit/components/input-date-range/input-date-range.directive.ts
+++ b/projects/kit/components/input-date-range/input-date-range.directive.ts
@@ -7,7 +7,7 @@ import {
     RANGE_SEPARATOR_CHAR,
     TUI_FIRST_DAY,
     TUI_LAST_DAY,
-    TuiDay,
+    type TuiDay,
     type TuiDayLike,
     TuiDayRange,
 } from '@taiga-ui/cdk/date-time';
@@ -38,13 +38,11 @@ import {TUI_INPUT_DATE_RANGE_OPTIONS} from './input-date-range.options';
 })
 export class TuiInputDateRangeDirective extends TuiInputDateBase<TuiDayRange> {
     public override readonly max = input(this.options.max ?? TUI_LAST_DAY, {
-        transform: (max: TuiDay | null): TuiDay =>
-            max instanceof TuiDay ? max : TUI_LAST_DAY,
+        transform: (max: TuiDay | null): TuiDay => max ?? TUI_LAST_DAY,
     });
 
     public override readonly min = input(this.options.min ?? TUI_FIRST_DAY, {
-        transform: (min: TuiDay | null): TuiDay =>
-            min instanceof TuiDay ? min : TUI_FIRST_DAY,
+        transform: (min: TuiDay | null): TuiDay => min ?? TUI_FIRST_DAY,
     });
 
     protected override readonly filler = tuiWithDateFiller(

--- a/projects/kit/components/input-date-time/input-date-time.directive.ts
+++ b/projects/kit/components/input-date-time/input-date-time.directive.ts
@@ -11,6 +11,8 @@ import {tuiAsControl, tuiValueTransformerFrom} from '@taiga-ui/cdk/classes';
 import {
     DATE_FILLER_LENGTH,
     MILLISECONDS_IN_DAY,
+    TUI_FIRST_DAY,
+    TUI_LAST_DAY,
     TuiDay,
     TuiTime,
 } from '@taiga-ui/cdk/date-time';
@@ -104,11 +106,11 @@ export class TuiInputDateTimeDirective
     );
 
     public override readonly min = computed<TuiDay>((min = this.minInput()) =>
-        Array.isArray(min) ? min[0] : (min ?? this.options.min),
+        Array.isArray(min) ? min[0] : (min ?? this.options.min ?? TUI_FIRST_DAY),
     );
 
     public override readonly max = computed<TuiDay>((max = this.maxInput()) =>
-        Array.isArray(max) ? max[0] : (max ?? this.options.max),
+        Array.isArray(max) ? max[0] : (max ?? this.options.max ?? TUI_LAST_DAY),
     );
 
     public readonly minTime = computed((min = this.minInput()) =>

--- a/projects/kit/components/input-date/input-date.directive.ts
+++ b/projects/kit/components/input-date/input-date.directive.ts
@@ -186,13 +186,11 @@ export abstract class TuiInputDateBase<
 })
 export class TuiInputDateDirective extends TuiInputDateBase<TuiDay> {
     public override readonly max = input(this.options.max ?? TUI_LAST_DAY, {
-        transform: (max: TuiDay | null): TuiDay =>
-            max instanceof TuiDay ? max : TUI_LAST_DAY,
+        transform: (max: TuiDay | null): TuiDay => max ?? TUI_LAST_DAY,
     });
 
     public override readonly min = input(this.options.min ?? TUI_FIRST_DAY, {
-        transform: (min: TuiDay | null): TuiDay =>
-            min instanceof TuiDay ? min : TUI_FIRST_DAY,
+        transform: (min: TuiDay | null): TuiDay => min ?? TUI_FIRST_DAY,
     });
 
     protected readonly mask = tuiMaskito(

--- a/projects/kit/components/input-date/input-date.directive.ts
+++ b/projects/kit/components/input-date/input-date.directive.ts
@@ -185,12 +185,12 @@ export abstract class TuiInputDateBase<
     ],
 })
 export class TuiInputDateDirective extends TuiInputDateBase<TuiDay> {
-    public override readonly max = input(this.options.max, {
+    public override readonly max = input(this.options.max ?? TUI_LAST_DAY, {
         transform: (max: TuiDay | null): TuiDay =>
             max instanceof TuiDay ? max : TUI_LAST_DAY,
     });
 
-    public override readonly min = input(this.options.min, {
+    public override readonly min = input(this.options.min ?? TUI_FIRST_DAY, {
         transform: (min: TuiDay | null): TuiDay =>
             min instanceof TuiDay ? min : TUI_FIRST_DAY,
     });

--- a/projects/kit/components/input-date/input-date.options.ts
+++ b/projects/kit/components/input-date/input-date.options.ts
@@ -2,20 +2,20 @@ import {
     TUI_IDENTITY_VALUE_TRANSFORMER,
     type TuiValueTransformer,
 } from '@taiga-ui/cdk/classes';
-import {TUI_FIRST_DAY, TUI_LAST_DAY, type TuiDay} from '@taiga-ui/cdk/date-time';
+import {type TuiDay} from '@taiga-ui/cdk/date-time';
 import {tuiCreateOptions} from '@taiga-ui/cdk/utils/di';
 
 export interface TuiInputDateOptions {
     readonly icon: string;
-    readonly max: TuiDay;
-    readonly min: TuiDay;
+    readonly max: TuiDay | null;
+    readonly min: TuiDay | null;
     readonly valueTransformer: TuiValueTransformer<TuiDay | null, any>;
 }
 
 export const TUI_INPUT_DATE_DEFAULT_OPTIONS = {
     icon: '@tui.calendar',
-    min: TUI_FIRST_DAY,
-    max: TUI_LAST_DAY,
+    min: null,
+    max: null,
     valueTransformer: TUI_IDENTITY_VALUE_TRANSFORMER,
 } as const;
 

--- a/projects/kit/components/input-year/input-year.directive.ts
+++ b/projects/kit/components/input-year/input-year.directive.ts
@@ -2,6 +2,7 @@ import {computed, Directive, effect, inject, input} from '@angular/core';
 import {MaskitoDirective} from '@maskito/angular';
 import {maskitoNumber} from '@maskito/kit';
 import {tuiAsControl, TuiControl, tuiValueTransformerFrom} from '@taiga-ui/cdk/classes';
+import {TUI_FIRST_DAY, TUI_LAST_DAY} from '@taiga-ui/cdk/date-time';
 import {tuiSetSignal} from '@taiga-ui/cdk/utils/miscellaneous';
 import {TuiCalendarYear} from '@taiga-ui/core/components/calendar';
 import {TuiInputDirective, TuiWithInput} from '@taiga-ui/core/components/input';
@@ -85,8 +86,8 @@ export class TuiInputYearDirective extends TuiControl<number | null> {
         onCleanup(() => subscription?.unsubscribe());
     });
 
-    public readonly min = input(this.options.min.year);
-    public readonly max = input(this.options.max.year);
+    public readonly min = input((this.options.min ?? TUI_FIRST_DAY).year);
+    public readonly max = input((this.options.max ?? TUI_LAST_DAY).year);
 
     protected toggle(): void {
         if (this.interactive()) {


### PR DESCRIPTION
## Problem
Create empty angular application.

Create `src/app/provide-proprietary.ts`:
```ts
export function provideProprietary(): Array<EnvironmentProviders | Provider> {
    return [
        // [...]
        tuiInputDateOptionsProvider({icon: '@custom-icon-pack.calendar'}),
        // [...]
    ]
}
```

Add it to `src/app/app.config.ts`:
```ts
import {provideProprietary} from './provide-proprietary';

export const appConfig: ApplicationConfig = {
  providers: [
    // [...]
    provideProprietary(),
  ]
};
```
<img height="400" alt="previous" src="https://github.com/user-attachments/assets/45383e74-d406-40ac-b994-bdc1681b6c6b" />

### New behavior
<img height="400" alt="new" src="https://github.com/user-attachments/assets/5e12ae6c-299b-46e0-9bc5-9c77c93c6dcd" />


