### PR TITLE
fix(core): improve tree shaking of `Hint` entrypoint

### DIFF
--- a/projects/core/portals/hint/hint.component.ts
+++ b/projects/core/portals/hint/hint.component.ts
@@ -3,6 +3,7 @@ import {
     Component,
     forwardRef,
     inject,
+    type Provider,
     signal,
 } from '@angular/core';
 import {takeUntilDestroyed} from '@angular/core/rxjs-interop';
@@ -33,15 +34,18 @@ import {TuiHintPointer} from './hint-pointer.directive';
 import {TuiHintPosition} from './hint-position.directive';
 import {TuiHintUnstyledComponent} from './hint-unstyled.component';
 
-export const TUI_HINT_PROVIDERS = [
-    TuiPositionService,
-    TuiHoveredService,
-    tuiPositionAccessorFor('hint', TuiHintPosition),
-    tuiRectAccessorFor(
-        'hint',
-        forwardRef(() => TuiHintDirective),
-    ),
-];
+/** @internal */
+export function tuiGetHintProviders(): Provider[] {
+    return [
+        TuiPositionService,
+        TuiHoveredService,
+        tuiPositionAccessorFor('hint', TuiHintPosition),
+        tuiRectAccessorFor(
+            'hint',
+            forwardRef(() => TuiHintDirective),
+        ),
+    ];
+}
 
 const GAP = 8;
 
@@ -57,7 +61,7 @@ const GAP = 8;
     `,
     styleUrl: './hint.style.less',
     changeDetection: ChangeDetectionStrategy.OnPush,
-    providers: [TUI_HINT_PROVIDERS, tuiButtonOptionsProvider({size: 's'})],
+    providers: [tuiGetHintProviders(), tuiButtonOptionsProvider({size: 's'})],
     hostDirectives: [TuiAppearance, TuiAnimated, TuiActiveZone],
     host: {
         role: 'tooltip',

--- a/projects/kit/components/line-clamp/line-clamp-box.component.ts
+++ b/projects/kit/components/line-clamp/line-clamp-box.component.ts
@@ -1,5 +1,5 @@
 import {ChangeDetectionStrategy, Component, inject} from '@angular/core';
-import {TUI_HINT_PROVIDERS, TuiHintComponent} from '@taiga-ui/core/portals/hint';
+import {tuiGetHintProviders, TuiHintComponent} from '@taiga-ui/core/portals/hint';
 import {PolymorpheusOutlet} from '@taiga-ui/polymorpheus';
 
 import {TuiLineClamp} from './line-clamp.component';
@@ -11,7 +11,7 @@ import {TuiLineClamp} from './line-clamp.component';
         '<ng-container *polymorpheusOutlet="content() as text">{{ text }}</ng-container>',
     styleUrl: './line-clamp-box.style.less',
     changeDetection: ChangeDetectionStrategy.OnPush,
-    providers: TUI_HINT_PROVIDERS,
+    providers: tuiGetHintProviders(),
     host: {'[style.line-height.px]': 'host.line()', '[style.min-width.px]': 'width'},
 })
 export class TuiLineClampBox extends TuiHintComponent {


### PR DESCRIPTION
## Problem
Create empty angular application.

Create `src/app/provide-proprietary.ts`:
```ts
import {tuiHintOptionsProvider} from '@taiga-ui/core/portals/hint';

export function provideProprietary(): Array<EnvironmentProviders | Provider> {
    return [
        // [...]
        tuiHintOptionsProvider({icon: '@custom-icon-pack.question'}),
        // [...]
    ]
}
```

Add it to `src/app/app.config.ts`:
```ts
import {provideProprietary} from './provide-proprietary';

export const appConfig: ApplicationConfig = {
  providers: [
    // [...]
    provideProprietary(),
  ]
};
```
<img width="1272" height="617" alt="previous" src="https://github.com/user-attachments/assets/40119f7f-e868-4c2a-b40d-c9c2e5618043" />


### Impact of new changes
Measured on production build (`ng build`) of an app that only calls `tuiHintOptionsProvider({...})`:
<img width="1272" height="617" alt="new" src="https://github.com/user-attachments/assets/ea951d0b-494e-4ebd-b267-efb402d0372d" />

- `taiga-ui-core-portals-hint.mjs`: **13.2 KB → 114 bytes**
- `taiga-ui-polymorpheus.mjs`: **2,31 KB → 0 bytes**

The single change cascades — removing the hint component family also frees its entire transitive subtree:

| Category | Δ |
|---|---:|
| **@taiga-ui/core/portals/hint** | −13 KB |
| **@taiga-ui/cdk** (directives/utils: `active-zone`, `animated`, `hovered`, `portals`, …) | −7.4 KB |
| **@taiga-ui/core** (`appearance`, `classes`, `services`, `popup`, `button`) | −4.8 KB |
| **rxjs** (`share`, `repeat`, `withLatestFrom`, `timer`, schedulers, …) | −4.7 KB |
| **@taiga-ui/polymorpheus** | −2.3 KB |


