### PR TITLE
fix: remove extra top margin on tuiTitle inside tuiLabel

### DIFF
--- a/projects/styles/components/label.less
+++ b/projects/styles/components/label.less
@@ -44,10 +44,6 @@
         font: var(--tui-typography-body-s);
     }
 
-    [tuiTitle] {
-        margin-block-start: 0.125rem;
-    }
-
     [tuiSubtitle] {
         color: var(--tui-text-secondary);
     }


### PR DESCRIPTION
## Problem

When using `tui-avatar` inside a `tuiLabel`-wrapped textfield, the avatar is shifted down by about 2px.

Reproduction: https://stackblitz.com/edit/angular-7hmwjtyf

## Root cause

The `[tuiLabel] [tuiTitle]` rule in `label.less` adds `margin-block-start: 0.125rem`, which pushes the title (and any inline avatar) down inside the label.

## Fix

Remove the `[tuiTitle]` margin rule. The label's flex layout with `gap: 0.25rem` already handles spacing correctly.
