### PR TITLE
chore(schematics): wrap `$event` with `$any` when migrating `documentationPropertyValueChange` to `valueChange`

### DIFF
--- a/projects/cdk/schematics/ng-update/v5/steps/templates/migrate-doc-documentation.ts
+++ b/projects/cdk/schematics/ng-update/v5/steps/templates/migrate-doc-documentation.ts
@@ -176,9 +176,9 @@ function buildInnerReplacement(template: string, element: Element): Replacement[
     }
 
     const valueChangeTodo =
-        valueChange !== undefined
-            ? `<!-- ${TODO_MARK} $any($event) used because model<T>() emits T | undefined; consider using [(value)] two-way binding or replace $any($event) with $event ?? <default> -->\n`
-            : '';
+        valueChange === undefined
+            ? ''
+            : `<!-- ${TODO_MARK} $any($event) used because model<T>() emits T | undefined; consider using [(value)] two-way binding or replace $any($event) with $event ?? <default> -->\n`;
 
     if (valueChange !== undefined) {
         orderedAttrs.push(

--- a/projects/cdk/schematics/ng-update/v5/steps/templates/migrate-doc-documentation.ts
+++ b/projects/cdk/schematics/ng-update/v5/steps/templates/migrate-doc-documentation.ts
@@ -175,7 +175,9 @@ function buildInnerReplacement(template: string, element: Element): Replacement[
     }
 
     if (valueChange !== undefined) {
-        orderedAttrs.push(`(valueChange)="${valueChange}"`);
+        orderedAttrs.push(
+            `(valueChange)="${valueChange.replaceAll('$event', '$any($event)')}"`,
+        );
     }
 
     const isMultiline = startTagStr.includes('\n');

--- a/projects/cdk/schematics/ng-update/v5/steps/templates/migrate-doc-documentation.ts
+++ b/projects/cdk/schematics/ng-update/v5/steps/templates/migrate-doc-documentation.ts
@@ -2,6 +2,7 @@ import {type UpdateRecorder} from '@angular-devkit/schematics';
 import {type DevkitFileSystem} from 'ng-morph';
 import {type DefaultTreeAdapterTypes} from 'parse5';
 
+import {TODO_MARK} from '../../../../utils/insert-todo';
 import {findElementsByTagName} from '../../../../utils/templates/elements';
 import {
     getTemplateFromTemplateResource,
@@ -174,6 +175,11 @@ function buildInnerReplacement(template: string, element: Element): Replacement[
         orderedAttrs.push(`[value]="${oneWayValue}"`);
     }
 
+    const valueChangeTodo =
+        valueChange !== undefined
+            ? `<!-- ${TODO_MARK} $any($event) used because model<T>() emits T | undefined; consider using [(value)] two-way binding or replace $any($event) with $event ?? <default> -->\n`
+            : '';
+
     if (valueChange !== undefined) {
         orderedAttrs.push(
             `(valueChange)="${valueChange.replaceAll('$event', '$any($event)')}"`,
@@ -190,11 +196,11 @@ function buildInnerReplacement(template: string, element: Element): Replacement[
 
         orderedAttrs.forEach((attr) => lines.push(`${attrIndent}${attr}`));
         lines.push(isSelfClosing ? `${elementIndent}/>` : `${elementIndent}>`);
-        newStartTag = lines.join('\n');
+        newStartTag = `${valueChangeTodo}${lines.join('\n')}`;
     } else {
         const close = isSelfClosing ? ' />' : '>';
 
-        newStartTag = `<tr ${orderedAttrs.join(' ')}${close}`;
+        newStartTag = `${valueChangeTodo}<tr ${orderedAttrs.join(' ')}${close}`;
     }
 
     replacements.push({

--- a/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-doc-documentation.spec.ts.snap
+++ b/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-doc-documentation.spec.ts.snap
@@ -167,13 +167,6 @@ exports[`ng-update tui-doc-documentation to table[tuiDocAPI] renames [documentat
 }
 `;
 
-exports[`ng-update tui-doc-documentation to table[tuiDocAPI] replaces tui-doc-documentation tag with table and adds tuiDocAPI attribute: test.html 1`] = `
-{
-  "0. Before": "<tui-doc-documentation></tui-doc-documentation>",
-  "1. After": "<table tuiDocAPI></table>",
-}
-`;
-
 exports[`ng-update tui-doc-documentation to table[tuiDocAPI] renames one-way [documentationPropertyValue] + (documentationPropertyValueChange) to [value] + (valueChange): test.html 1`] = `
 {
   "0. Before": "
@@ -196,9 +189,47 @@ exports[`ng-update tui-doc-documentation to table[tuiDocAPI] renames one-way [do
                         tuiDocAPIItem
                         type="boolean"
                         [value]="multiple"
-                        (valueChange)="multipleChange($event)"
+                        (valueChange)="multipleChange($any($event))"
                     >
                         Allows to upload several files
+                    </tr>
+                </table>
+            ",
+}
+`;
+
+exports[`ng-update tui-doc-documentation to table[tuiDocAPI] replaces tui-doc-documentation tag with table and adds tuiDocAPI attribute: test.html 1`] = `
+{
+  "0. Before": "<tui-doc-documentation></tui-doc-documentation>",
+  "1. After": "<table tuiDocAPI></table>",
+}
+`;
+
+exports[`ng-update tui-doc-documentation to table[tuiDocAPI] wraps $event with $any() in (valueChange) to handle model<T>() emitting T | undefined: test.html 1`] = `
+{
+  "0. Before": "
+                <tui-doc-documentation>
+                    <ng-template
+                        documentationPropertyMode="input"
+                        documentationPropertyName="ngModel"
+                        documentationPropertyType="string"
+                        [documentationPropertyValue]="control.value"
+                        (documentationPropertyValueChange)="control.setValue($event)"
+                    >
+                        Example pass HTML code
+                    </ng-template>
+                </tui-doc-documentation>
+            ",
+  "1. After": "
+                <table tuiDocAPI>
+                    <tr
+                        name="[ngModel]"
+                        tuiDocAPIItem
+                        type="string"
+                        [value]="control.value"
+                        (valueChange)="control.setValue($any($event))"
+                    >
+                        Example pass HTML code
                     </tr>
                 </table>
             ",

--- a/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-doc-documentation.spec.ts.snap
+++ b/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-doc-documentation.spec.ts.snap
@@ -184,7 +184,8 @@ exports[`ng-update tui-doc-documentation to table[tuiDocAPI] renames one-way [do
             ",
   "1. After": "
                 <table tuiDocAPI>
-                    <tr
+                    <!-- TODO: (Taiga UI migration) $any($event) used because model<T>() emits T | undefined; consider using [(value)] two-way binding or replace $any($event) with $event ?? <default> -->
+<tr
                         name="[multiple]"
                         tuiDocAPIItem
                         type="boolean"
@@ -222,7 +223,8 @@ exports[`ng-update tui-doc-documentation to table[tuiDocAPI] wraps $event with $
             ",
   "1. After": "
                 <table tuiDocAPI>
-                    <tr
+                    <!-- TODO: (Taiga UI migration) $any($event) used because model<T>() emits T | undefined; consider using [(value)] two-way binding or replace $any($event) with $event ?? <default> -->
+<tr
                         name="[ngModel]"
                         tuiDocAPIItem
                         type="string"

--- a/projects/cdk/schematics/ng-update/v5/tests/schematic-migrate-doc-documentation.spec.ts
+++ b/projects/cdk/schematics/ng-update/v5/tests/schematic-migrate-doc-documentation.spec.ts
@@ -128,6 +128,25 @@ describe('ng-update tui-doc-documentation to table[tuiDocAPI]', () => {
     );
 
     it(
+        'wraps $event with $any() in (valueChange) to handle model<T>() emitting T | undefined',
+        migrate({
+            template: /* HTML */ `
+                <tui-doc-documentation>
+                    <ng-template
+                        documentationPropertyMode="input"
+                        documentationPropertyName="ngModel"
+                        documentationPropertyType="string"
+                        [documentationPropertyValue]="control.value"
+                        (documentationPropertyValueChange)="control.setValue($event)"
+                    >
+                        Example pass HTML code
+                    </ng-template>
+                </tui-doc-documentation>
+            `,
+        }),
+    );
+
+    it(
         'renames one-way [documentationPropertyValue] + (documentationPropertyValueChange) to [value] + (valueChange)',
         migrate({
             template: /* HTML */ `


### PR DESCRIPTION
Part of #13950 