### PR TITLE
refactor: use `maskitoPhone` instead of deprecated `maskitoPhoneOptionsGenerator`

### DIFF
--- a/projects/cdk/schematics/ng-update/v5/steps/templates/migrate-format-phone-pipe.ts
+++ b/projects/cdk/schematics/ng-update/v5/steps/templates/migrate-format-phone-pipe.ts
@@ -9,8 +9,8 @@ import {
 import {type TemplateResource} from '../../../interfaces';
 
 const PIPE_RENAME_REGEX = /(\|\s*)tuiFormatPhone\b/g;
-const TODO_COMMENT_WITH_ARGS = `<!-- ${TODO_MARK} \`tuiFormatPhone\` pipe was replaced by \`maskito\` pipe. Replace its arguments with \`maskitoPhoneOptionsGenerator({countryIsoCode, metadata})\` from '@maskito/phone' (note: countryIsoCode is ISO format e.g. 'US', not '+1'). See: https://taiga-ui.dev/components/input-phone-international#phone-format-helpers -->`;
-const TODO_COMMENT_NO_ARGS = `<!-- ${TODO_MARK} \`tuiFormatPhone\` pipe was replaced by \`maskito\` pipe. Add \`maskitoPhoneOptionsGenerator({countryIsoCode, metadata})\` from '@maskito/phone' as argument. See: https://taiga-ui.dev/components/input-phone-international#phone-format-helpers -->`;
+const TODO_COMMENT_WITH_ARGS = `<!-- ${TODO_MARK} \`tuiFormatPhone\` pipe was replaced by \`maskito\` pipe. Replace its arguments with \`maskitoPhone({countryIsoCode, metadata})\` from '@maskito/phone' (note: countryIsoCode is ISO format e.g. 'US', not '+1'). See: https://taiga-ui.dev/components/input-phone-international#phone-format-helpers -->`;
+const TODO_COMMENT_NO_ARGS = `<!-- ${TODO_MARK} \`tuiFormatPhone\` pipe was replaced by \`maskito\` pipe. Add \`maskitoPhone({countryIsoCode, metadata})\` from '@maskito/phone' as argument. See: https://taiga-ui.dev/components/input-phone-international#phone-format-helpers -->`;
 
 export function migrateFormatPhonePipe({
     resource,

--- a/projects/cdk/schematics/ng-update/v5/steps/templates/migrate-input-phone.ts
+++ b/projects/cdk/schematics/ng-update/v5/steps/templates/migrate-input-phone.ts
@@ -156,7 +156,7 @@ export function migrateInputPhone({
                 `     - ${names} have no direct v5 equivalent.`,
                 '       In v5 both are replaced by a single [mask] input of type MaskitoOptions.',
                 '       Replace with: <input tuiInputPhone [mask]="phoneOptions" /> where',
-                "       phoneOptions = maskitoPhoneOptionsGenerator({countryIsoCode: 'RU', metadata}) from @maskito/phone. -->",
+                "       phoneOptions = maskitoPhone({countryIsoCode: 'RU', metadata}) from @maskito/phone. -->",
             ].join('\n');
 
             const insertAt = (sourceCodeLocation?.startOffset ?? 0) + templateOffset;

--- a/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-format-phone-pipe.spec.ts.snap
+++ b/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-format-phone-pipe.spec.ts.snap
@@ -17,7 +17,7 @@ exports[`ng-update migrate TuiFormatPhonePipe to MaskitoPipe adds TODO inside ba
                                 @Component({
                     standalone: true,
                     imports: [MaskitoPipe],
-                    template: \`<!-- TODO: (Taiga UI migration) \`tuiFormatPhone\` pipe was replaced by \`maskito\` pipe. Add \`maskitoPhoneOptionsGenerator({countryIsoCode, metadata})\` from '@maskito/phone' as argument. See: https://taiga-ui.dev/components/input-phone-international#phone-format-helpers --> {{ phone | maskito }}\`
+                    template: \`<!-- TODO: (Taiga UI migration) \`tuiFormatPhone\` pipe was replaced by \`maskito\` pipe. Add \`maskitoPhone({countryIsoCode, metadata})\` from '@maskito/phone' as argument. See: https://taiga-ui.dev/components/input-phone-international#phone-format-helpers --> {{ phone | maskito }}\`
                 })
                 export class TestComponent {}
             ",
@@ -27,7 +27,7 @@ exports[`ng-update migrate TuiFormatPhonePipe to MaskitoPipe adds TODO inside ba
 exports[`ng-update migrate TuiFormatPhonePipe to MaskitoPipe renames tuiFormatPhone inside element binding and adds TODO for no-arg usage: test.html 1`] = `
 {
   "0. Before": "<span [title]="phone | tuiFormatPhone">{{ phone | tuiFormatPhone }}</span>",
-  "1. After": "<!-- TODO: (Taiga UI migration) \`tuiFormatPhone\` pipe was replaced by \`maskito\` pipe. Add \`maskitoPhoneOptionsGenerator({countryIsoCode, metadata})\` from '@maskito/phone' as argument. See: https://taiga-ui.dev/components/input-phone-international#phone-format-helpers -->
+  "1. After": "<!-- TODO: (Taiga UI migration) \`tuiFormatPhone\` pipe was replaced by \`maskito\` pipe. Add \`maskitoPhone({countryIsoCode, metadata})\` from '@maskito/phone' as argument. See: https://taiga-ui.dev/components/input-phone-international#phone-format-helpers -->
 <span [title]="phone | maskito">{{ phone | maskito }}</span>",
 }
 `;
@@ -35,7 +35,7 @@ exports[`ng-update migrate TuiFormatPhonePipe to MaskitoPipe renames tuiFormatPh
 exports[`ng-update migrate TuiFormatPhonePipe to MaskitoPipe renames tuiFormatPhone pipe to maskito in template and adds TODO: test.html 1`] = `
 {
   "0. Before": "{{ phone | tuiFormatPhone }}",
-  "1. After": "<!-- TODO: (Taiga UI migration) \`tuiFormatPhone\` pipe was replaced by \`maskito\` pipe. Add \`maskitoPhoneOptionsGenerator({countryIsoCode, metadata})\` from '@maskito/phone' as argument. See: https://taiga-ui.dev/components/input-phone-international#phone-format-helpers -->
+  "1. After": "<!-- TODO: (Taiga UI migration) \`tuiFormatPhone\` pipe was replaced by \`maskito\` pipe. Add \`maskitoPhone({countryIsoCode, metadata})\` from '@maskito/phone' as argument. See: https://taiga-ui.dev/components/input-phone-international#phone-format-helpers -->
 {{ phone | maskito }}",
 }
 `;
@@ -43,7 +43,7 @@ exports[`ng-update migrate TuiFormatPhonePipe to MaskitoPipe renames tuiFormatPh
 exports[`ng-update migrate TuiFormatPhonePipe to MaskitoPipe renames tuiFormatPhone pipe with country code and mask arguments and adds TODO: test.html 1`] = `
 {
   "0. Before": "{{ phone | tuiFormatPhone:'+1':'(###) ###-####' }}",
-  "1. After": "<!-- TODO: (Taiga UI migration) \`tuiFormatPhone\` pipe was replaced by \`maskito\` pipe. Replace its arguments with \`maskitoPhoneOptionsGenerator({countryIsoCode, metadata})\` from '@maskito/phone' (note: countryIsoCode is ISO format e.g. 'US', not '+1'). See: https://taiga-ui.dev/components/input-phone-international#phone-format-helpers -->
+  "1. After": "<!-- TODO: (Taiga UI migration) \`tuiFormatPhone\` pipe was replaced by \`maskito\` pipe. Replace its arguments with \`maskitoPhone({countryIsoCode, metadata})\` from '@maskito/phone' (note: countryIsoCode is ISO format e.g. 'US', not '+1'). See: https://taiga-ui.dev/components/input-phone-international#phone-format-helpers -->
 {{ phone | maskito:'+1':'(###) ###-####' }}",
 }
 `;
@@ -51,7 +51,7 @@ exports[`ng-update migrate TuiFormatPhonePipe to MaskitoPipe renames tuiFormatPh
 exports[`ng-update migrate TuiFormatPhonePipe to MaskitoPipe renames tuiFormatPhone pipe with country code argument and adds TODO: test.html 1`] = `
 {
   "0. Before": "{{ phone | tuiFormatPhone:'+1' }}",
-  "1. After": "<!-- TODO: (Taiga UI migration) \`tuiFormatPhone\` pipe was replaced by \`maskito\` pipe. Replace its arguments with \`maskitoPhoneOptionsGenerator({countryIsoCode, metadata})\` from '@maskito/phone' (note: countryIsoCode is ISO format e.g. 'US', not '+1'). See: https://taiga-ui.dev/components/input-phone-international#phone-format-helpers -->
+  "1. After": "<!-- TODO: (Taiga UI migration) \`tuiFormatPhone\` pipe was replaced by \`maskito\` pipe. Replace its arguments with \`maskitoPhone({countryIsoCode, metadata})\` from '@maskito/phone' (note: countryIsoCode is ISO format e.g. 'US', not '+1'). See: https://taiga-ui.dev/components/input-phone-international#phone-format-helpers -->
 {{ phone | maskito:'+1' }}",
 }
 `;
@@ -73,7 +73,7 @@ exports[`ng-update migrate TuiFormatPhonePipe to MaskitoPipe replaces TuiFormatP
                                 @Component({
                     standalone: true,
                     imports: [MaskitoPipe],
-                    template: '<!-- TODO: (Taiga UI migration) \`tuiFormatPhone\` pipe was replaced by \`maskito\` pipe. Add \`maskitoPhoneOptionsGenerator({countryIsoCode, metadata})\` from '@maskito/phone' as argument. See: https://taiga-ui.dev/components/input-phone-international#phone-format-helpers --> {{ phone | maskito }}',
+                    template: '<!-- TODO: (Taiga UI migration) \`tuiFormatPhone\` pipe was replaced by \`maskito\` pipe. Add \`maskitoPhone({countryIsoCode, metadata})\` from '@maskito/phone' as argument. See: https://taiga-ui.dev/components/input-phone-international#phone-format-helpers --> {{ phone | maskito }}',
                 })
                 export class TestComponent {}
             ",

--- a/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-input-phone.spec.ts.snap
+++ b/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-input-phone.spec.ts.snap
@@ -7,7 +7,7 @@ exports[`ng-update adds TODO for countryCode and removes it from wrapper: test.h
      - countrycode have no direct v5 equivalent.
        In v5 both are replaced by a single [mask] input of type MaskitoOptions.
        Replace with: <input tuiInputPhone [mask]="phoneOptions" /> where
-       phoneOptions = maskitoPhoneOptionsGenerator({countryIsoCode: 'RU', metadata}) from @maskito/phone. -->
+       phoneOptions = maskitoPhone({countryIsoCode: 'RU', metadata}) from @maskito/phone. -->
 <tui-textfield  >
 <label tuiLabel>Phone</label>
 
@@ -23,7 +23,7 @@ exports[`ng-update adds TODO for phoneMaskAfterCountryCode and removes it from w
      - phonemaskaftercountrycode have no direct v5 equivalent.
        In v5 both are replaced by a single [mask] input of type MaskitoOptions.
        Replace with: <input tuiInputPhone [mask]="phoneOptions" /> where
-       phoneOptions = maskitoPhoneOptionsGenerator({countryIsoCode: 'RU', metadata}) from @maskito/phone. -->
+       phoneOptions = maskitoPhone({countryIsoCode: 'RU', metadata}) from @maskito/phone. -->
 <tui-textfield  >
 <label tuiLabel>Phone</label>
 
@@ -48,7 +48,7 @@ exports[`ng-update adds single TODO when both countryCode and phoneMaskAfterCoun
      - countrycode, phonemaskaftercountrycode have no direct v5 equivalent.
        In v5 both are replaced by a single [mask] input of type MaskitoOptions.
        Replace with: <input tuiInputPhone [mask]="phoneOptions" /> where
-       phoneOptions = maskitoPhoneOptionsGenerator({countryIsoCode: 'RU', metadata}) from @maskito/phone. -->
+       phoneOptions = maskitoPhone({countryIsoCode: 'RU', metadata}) from @maskito/phone. -->
 <tui-textfield
                     
                     

--- a/projects/demo/src/pages/components/input-phone-international/examples/6/index.ts
+++ b/projects/demo/src/pages/components/input-phone-international/examples/6/index.ts
@@ -3,7 +3,7 @@ import {changeDetection} from '@demo/emulate/change-detection';
 import {encapsulation} from '@demo/emulate/encapsulation';
 import {MaskitoPipe} from '@maskito/angular';
 import {maskitoTransform} from '@maskito/core';
-import {maskitoPhoneOptionsGenerator} from '@maskito/phone';
+import {maskitoPhone} from '@maskito/phone';
 import metadata from 'libphonenumber-js/max/metadata';
 
 @Component({
@@ -16,7 +16,7 @@ import metadata from 'libphonenumber-js/max/metadata';
 export default class Example {
     protected rawValue = '12125552368';
 
-    protected readonly mask = maskitoPhoneOptionsGenerator({
+    protected readonly mask = maskitoPhone({
         metadata,
         countryIsoCode: 'US',
     });

--- a/projects/kit/components/input-phone-international/input-phone-international.component.ts
+++ b/projects/kit/components/input-phone-international/input-phone-international.component.ts
@@ -7,7 +7,7 @@ import {
     type MaskitoOptions,
     maskitoTransform,
 } from '@maskito/core';
-import {maskitoGetCountryFromNumber, maskitoPhoneOptionsGenerator} from '@maskito/phone';
+import {maskitoGetCountryFromNumber, maskitoPhone} from '@maskito/phone';
 import {WA_IS_IOS} from '@ng-web-apis/platform';
 import {tuiAsControl, TuiControl} from '@taiga-ui/cdk/classes';
 import {CHAR_PLUS} from '@taiga-ui/cdk/constants';
@@ -137,7 +137,7 @@ export class TuiInputPhoneInternationalComponent extends TuiControl<string> {
             return MASKITO_DEFAULT_OPTIONS;
         }
 
-        const {plugins, ...options} = maskitoPhoneOptionsGenerator({
+        const {plugins, ...options} = maskitoPhone({
             countryIsoCode,
             metadata,
             separator: this.options.separator,


### PR DESCRIPTION
Relates:
* https://github.com/taiga-family/maskito/issues/2645