### PR TITLE
fix(core): fix `tuiSelectLike` on ios safari

### DIFF
--- a/projects/core/components/textfield/select-like.directive.ts
+++ b/projects/core/components/textfield/select-like.directive.ts
@@ -1,5 +1,5 @@
 import {Directive, inject} from '@angular/core';
-import {WA_IS_ANDROID} from '@ng-web-apis/platform';
+import {WA_IS_ANDROID, WA_IS_MOBILE} from '@ng-web-apis/platform';
 import {tuiInjectElement} from '@taiga-ui/cdk/utils/dom';
 
 import {TUI_TEXTFIELD_OPTIONS} from './textfield.options';
@@ -13,7 +13,7 @@ import {TUI_TEXTFIELD_OPTIONS} from './textfield.options';
         tuiSelectLike: '',
         // Click on cleaner icon does not trigger `beforeinput` event --> handle all kind of deletion in input event
         '(beforeinput)':
-            'options.cleaner() && $event.inputType.includes("delete") || $event.preventDefault()',
+            'isMobile || options.cleaner() && $event.inputType.includes("delete") || $event.preventDefault()',
         '(input.capture)': '$event.inputType?.includes("delete") && clear()',
         '(keydown.backspace)': 'options.cleaner() && clear()', // No (input) event if caret is at the beginning
         '(keydown.delete)': 'options.cleaner() && clear()', // No (input) event if caret is at the end
@@ -25,6 +25,7 @@ export class TuiSelectLike {
     private readonly el = tuiInjectElement<HTMLInputElement>();
     private readonly isAndroid = inject(WA_IS_ANDROID);
 
+    protected readonly isMobile = inject(WA_IS_MOBILE);
     protected readonly options = inject(TUI_TEXTFIELD_OPTIONS);
 
     protected clear(): void {

--- a/projects/core/components/textfield/select-like.directive.ts
+++ b/projects/core/components/textfield/select-like.directive.ts
@@ -13,7 +13,7 @@ import {TUI_TEXTFIELD_OPTIONS} from './textfield.options';
         tuiSelectLike: '',
         // Click on cleaner icon does not trigger `beforeinput` event --> handle all kind of deletion in input event
         '(beforeinput)':
-            '(isMobile && $event.inputType.includes("insert")) || options.cleaner() && $event.inputType.includes("delete") || $event.preventDefault()',
+            '(isMobile && !$event.inputType.includes("deleteBy")) || options.cleaner() && $event.inputType.includes("delete") || $event.preventDefault()',
         '(input.capture)': '$event.inputType?.includes("delete") && clear()',
         '(keydown.backspace)': 'options.cleaner() && clear()', // No (input) event if caret is at the beginning
         '(keydown.delete)': 'options.cleaner() && clear()', // No (input) event if caret is at the end

--- a/projects/core/components/textfield/select-like.directive.ts
+++ b/projects/core/components/textfield/select-like.directive.ts
@@ -13,7 +13,7 @@ import {TUI_TEXTFIELD_OPTIONS} from './textfield.options';
         tuiSelectLike: '',
         // Click on cleaner icon does not trigger `beforeinput` event --> handle all kind of deletion in input event
         '(beforeinput)':
-            '(isMobile && !$event.inputType.includes("deleteBy")) || options.cleaner() && $event.inputType.includes("delete") || $event.preventDefault()',
+            '(isMobile && $event.inputType.includes("insertText")) || options.cleaner() && $event.inputType.includes("delete") || $event.preventDefault()',
         '(input.capture)': '$event.inputType?.includes("delete") && clear()',
         '(keydown.backspace)': 'options.cleaner() && clear()', // No (input) event if caret is at the beginning
         '(keydown.delete)': 'options.cleaner() && clear()', // No (input) event if caret is at the end

--- a/projects/core/components/textfield/select-like.directive.ts
+++ b/projects/core/components/textfield/select-like.directive.ts
@@ -13,7 +13,7 @@ import {TUI_TEXTFIELD_OPTIONS} from './textfield.options';
         tuiSelectLike: '',
         // Click on cleaner icon does not trigger `beforeinput` event --> handle all kind of deletion in input event
         '(beforeinput)':
-            'isMobile || options.cleaner() && $event.inputType.includes("delete") || $event.preventDefault()',
+            '(isMobile && $event.inputType.includes("insert")) || options.cleaner() && $event.inputType.includes("delete") || $event.preventDefault()',
         '(input.capture)': '$event.inputType?.includes("delete") && clear()',
         '(keydown.backspace)': 'options.cleaner() && clear()', // No (input) event if caret is at the beginning
         '(keydown.delete)': 'options.cleaner() && clear()', // No (input) event if caret is at the end


### PR DESCRIPTION
On every engine except WebKit, execCommand ignores that cancellation and inserts the text anyway — so it worked. But iOS Safari honors preventDefault() on the beforeinput triggered by execCommand, so the programmatic insert got cancelled and the field stayed empty. 

What's the fix? 🛠️

Skip the preventDefault() guard on mobile (WA_IS_MOBILE):

This is safe because on mobile inputmode="none" already prevents the soft keyboard from appearing — the user can't type manually, so the only source of insertText is our own execCommand. The blocking is still fully in place on desktop, where hardware keyboards make it necessary.
