### PR TITLE
chore(demo): improve example `Options with long text` on documentation page `Datalist`

### DIFF
--- a/projects/demo/src/pages/components/data-list/examples/6/index.html
+++ b/projects/demo/src/pages/components/data-list/examples/6/index.html
@@ -2,17 +2,16 @@
     appearance="flat"
     tuiButton
     tuiChevron
+    tuiDropdownLimitWidth="min"
     type="button"
     [tuiDropdown]="content"
-    [tuiDropdownLimitWidth]="isMobile ? 'fixed' : 'min'"
-    [tuiDropdownMaxHeight]="700"
     [(tuiDropdownOpen)]="open"
 >
     Why Taiga UI?
 </button>
 
 <ng-template #content>
-    <tui-data-list>
+    <tui-data-list [style.max-inline-size.rem]="35">
         @for (group of groups; track group) {
             <tui-opt-group [label]="group.label">
                 @for (item of group.items; track item) {

--- a/projects/demo/src/pages/components/data-list/examples/6/index.html
+++ b/projects/demo/src/pages/components/data-list/examples/6/index.html
@@ -18,7 +18,6 @@
                     <button
                         tuiOption
                         type="button"
-                        class="option"
                         (click)="open = false"
                     >
                         {{ item }}

--- a/projects/demo/src/pages/components/data-list/examples/6/index.ts
+++ b/projects/demo/src/pages/components/data-list/examples/6/index.ts
@@ -1,19 +1,12 @@
-import {Component, inject} from '@angular/core';
-import {FormControl, ReactiveFormsModule} from '@angular/forms';
+import {Component} from '@angular/core';
 import {changeDetection} from '@demo/emulate/change-detection';
 import {encapsulation} from '@demo/emulate/encapsulation';
-import {WA_IS_MOBILE} from '@ng-web-apis/platform';
 import {TuiButton, TuiDataList, TuiDropdown} from '@taiga-ui/core';
 import {TuiChevron} from '@taiga-ui/kit';
 
 @Component({
-    imports: [ReactiveFormsModule, TuiButton, TuiChevron, TuiDataList, TuiDropdown],
+    imports: [TuiButton, TuiChevron, TuiDataList, TuiDropdown],
     templateUrl: './index.html',
-    styles: `
-        .option {
-            white-space: normal;
-        }
-    `,
     encapsulation,
     changeDetection,
 })
@@ -37,8 +30,4 @@ export default class Example {
             items: ['Calendar', 'Dialog', 'ComboBox', 'Select'],
         },
     ];
-
-    protected readonly isMobile = inject(WA_IS_MOBILE);
-
-    public control = new FormControl('');
 }


### PR DESCRIPTION
## Previous behavior
https://taiga-ui.dev/components/data-list#options-with-long-text
<img width="1495" height="804" alt="previous" src="https://github.com/user-attachments/assets/f4032f0d-aa19-4046-b85a-6fee1e2ad8c1" />

## New behavior
Return to original behavior as it was in `v2` documentation
https://taiga-ui.dev/v2/components/data-list#long-text-options
<img width="1495" height="804" alt="new" src="https://github.com/user-attachments/assets/52ed619d-1d3d-4e69-b321-d118dd8059c6" />
