### PR TITLE
fix(kit): `Pincode` ios animation

### DIFF
--- a/projects/kit/components/pincode/pincode.style.less
+++ b/projects/kit/components/pincode/pincode.style.less
@@ -232,6 +232,13 @@ input[tuiPincode] {
                 background-color calc(var(--t-duration) * 4 / 3) var(--tui-curve-productive-standard);
         }
 
+        .t-item_filled .t-value,
+        .t-item_filled .t-dot_value {
+            transition:
+                color calc(var(--t-duration) * 4 / 3) var(--tui-curve-productive-standard),
+                background-color calc(var(--t-duration) * 4 / 3) var(--tui-curve-productive-standard);
+        }
+
         .t-value {
             font-size: 1.75rem;
             font-weight: bold;


### PR DESCRIPTION
Fixes flaky digit scale-in animation in `Pincode` on iOS Safari

A filled digit had both a `scale` transition and the `tuiPincodeInput` bounce
animation on the same property. WebKit intermittently drops the animation
restart and falls back to the slow transition

Fix: remove `scale` from the
transition on `.t-item_filled` so input relies on the bounce only - delete-shrink
(not-filled rule) and the pending/invalid/success keyframes stay untouched

Before:

https://github.com/user-attachments/assets/c2164cb9-7ad7-4b49-b416-37b3d8a3ff32

After:

https://github.com/user-attachments/assets/98e071b0-ee8b-4de7-bcca-bb3411e9c148


