### PR TITLE
fix(core): `Textfield` fix multi-select clear button close event  (#1…

### DIFF
--- a/projects/core/components/textfield/textfield-multi/textfield-multi.template.html
+++ b/projects/core/components/textfield/textfield-multi/textfield-multi.template.html
@@ -55,7 +55,7 @@
         type="button"
         class="t-clear"
         [iconStart]="icons.close"
-        (click)="accessor?.setValue([])"
+        (click.stop)="accessor?.setValue([]); interactiveInput?.nativeElement?.focus()"
     >
         {{ clear() }}
     </button>

--- a/projects/core/components/textfield/textfield.template.html
+++ b/projects/core/components/textfield/textfield.template.html
@@ -19,7 +19,7 @@
         type="button"
         class="t-clear"
         [iconStart]="icons.close"
-        (click)="accessor?.setValue(null)"
+        (click.stop)="accessor?.setValue(null); interactiveInput?.nativeElement?.focus()"
     >
         {{ clear() }}
     </button>


### PR DESCRIPTION
Fixes #13572 

<img width="448" height="389" alt="image" src="https://github.com/user-attachments/assets/ffcbc54f-a738-499e-b4f4-19b396bd2fec" />
<img width="424" height="387" alt="image" src="https://github.com/user-attachments/assets/fac84776-a20d-4f56-a1cb-f6f6ddf7043f" />

# Fix: Dropdown closes when clicking cleaner button in MultiSelect

## Problem

When clicking the clear button (✕) in a `tui-textfield[multi]` (MultiSelect) with an open dropdown, the dropdown would close unexpectedly. This behavior was inconsistent with other textfield components like ComboBox and Select.

## Root Cause

The click event on the clear button was bubbling up to the parent dropdown host, which interpreted it as an external click and closed the dropdown.

## Solution

Added `(click.stop)` event handler to the clear button to prevent event bubbling, and explicitly focus the input to preserve the original behavior. Now the dropdown remains open when clearing the value, matching the behavior of other textfield components.

```html
<button
    *ngIf="options.cleaner()"
    ...
    (click.stop)="accessor?.setValue(null); interactiveInput?.nativeElement.focus()"
>
```

## Impact

- ✅ **MultiSelect**: Dropdown now stays open when clearing value
- ✅ **Consistent behavior**: All textfield components with dropdown now work the same way
- ✅ **No breaking changes**: Existing functionality is preserved (input still receives focus)
- ✅ **No visual flickering**: Smooth dropdown state transitions

## Testing

Tested with `tui-textfield[multi]` components with dropdown functionality. The dropdown now remains open when the clear button is clicked, and the input correctly receives focus.


