### PR TITLE
fix(addon-mobile): `DropdownMobile` / `DropdownSheet` should enforce `l`-size for `DataList` regardless of textfield size

### DIFF
--- a/projects/addon-mobile/components/sheet-dialog/sheet-dialog.style.less
+++ b/projects/addon-mobile/components/sheet-dialog/sheet-dialog.style.less
@@ -63,6 +63,7 @@
         padding: 0;
 
         [tuiOption][data-size] {
+            box-sizing: content-box;
             margin-inline: -0.5rem;
             padding-inline: 0.5rem;
         }

--- a/projects/addon-mobile/directives/dropdown-mobile/dropdown-mobile.directive.ts
+++ b/projects/addon-mobile/directives/dropdown-mobile/dropdown-mobile.directive.ts
@@ -1,6 +1,7 @@
 import {Directive, inject} from '@angular/core';
 import {WA_IS_MOBILE} from '@ng-web-apis/platform';
 import {tuiIsHTMLElement} from '@taiga-ui/cdk/utils/dom';
+import {tuiDataListOptionsProvider} from '@taiga-ui/core/components/data-list';
 import {
     TUI_DROPDOWN_COMPONENT,
     TuiDropdownDirective,
@@ -18,6 +19,7 @@ import {TuiDropdownMobileComponent} from './dropdown-mobile.component';
                     ? TuiDropdownMobileComponent
                     : inject(TUI_DROPDOWN_COMPONENT, {skipSelf: true}),
         },
+        tuiDataListOptionsProvider(() => ({size: inject(WA_IS_MOBILE) ? 'l' : ''})),
     ],
     host: {
         '[style.visibility]': 'dropdown.ref() ? "visible" : ""',

--- a/projects/addon-mobile/directives/dropdown-mobile/dropdown-mobile.directive.ts
+++ b/projects/addon-mobile/directives/dropdown-mobile/dropdown-mobile.directive.ts
@@ -1,7 +1,7 @@
 import {Directive, inject} from '@angular/core';
 import {WA_IS_MOBILE} from '@ng-web-apis/platform';
 import {tuiIsHTMLElement} from '@taiga-ui/cdk/utils/dom';
-import {tuiDataListOptionsProvider} from '@taiga-ui/core/components/data-list';
+import {TUI_DATA_LIST_SIZE} from '@taiga-ui/core/components/data-list';
 import {
     TUI_DROPDOWN_COMPONENT,
     TuiDropdownDirective,
@@ -19,7 +19,10 @@ import {TuiDropdownMobileComponent} from './dropdown-mobile.component';
                     ? TuiDropdownMobileComponent
                     : inject(TUI_DROPDOWN_COMPONENT, {skipSelf: true}),
         },
-        tuiDataListOptionsProvider(() => ({size: inject(WA_IS_MOBILE) ? 'l' : ''})),
+        {
+            provide: TUI_DATA_LIST_SIZE,
+            useFactory: () => (inject(WA_IS_MOBILE) ? 'l' : ''),
+        },
     ],
     host: {
         '[style.visibility]': 'dropdown.ref() ? "visible" : ""',

--- a/projects/addon-mobile/directives/dropdown-mobile/dropdown-mobile.style.less
+++ b/projects/addon-mobile/directives/dropdown-mobile/dropdown-mobile.style.less
@@ -50,6 +50,10 @@ tui-dropdown-mobile:where(*&) {
         inset-inline-end: 1rem;
         inset-block-end: ~'max(1rem, env(safe-area-inset-bottom))';
     }
+
+    tui-data-list [tuiOption] {
+        box-sizing: content-box;
+    }
 }
 
 .t-dropdown-mobile:where(*&) {

--- a/projects/addon-mobile/directives/dropdown-sheet/dropdown-sheet.directive.ts
+++ b/projects/addon-mobile/directives/dropdown-sheet/dropdown-sheet.directive.ts
@@ -1,5 +1,6 @@
 import {Directive, inject, input} from '@angular/core';
 import {WA_IS_MOBILE} from '@ng-web-apis/platform';
+import {tuiDataListOptionsProvider} from '@taiga-ui/core/components/data-list';
 import {TUI_DROPDOWN_COMPONENT} from '@taiga-ui/core/portals/dropdown';
 
 import {TuiDropdownSheetComponent} from './dropdown-sheet.component';
@@ -14,6 +15,7 @@ import {TuiDropdownSheetComponent} from './dropdown-sheet.component';
                     ? TuiDropdownSheetComponent
                     : inject(TUI_DROPDOWN_COMPONENT, {skipSelf: true}),
         },
+        tuiDataListOptionsProvider(() => ({size: inject(WA_IS_MOBILE) ? 'l' : ''})),
     ],
 })
 export class TuiDropdownSheet {

--- a/projects/addon-mobile/directives/dropdown-sheet/dropdown-sheet.directive.ts
+++ b/projects/addon-mobile/directives/dropdown-sheet/dropdown-sheet.directive.ts
@@ -1,6 +1,6 @@
 import {Directive, inject, input} from '@angular/core';
 import {WA_IS_MOBILE} from '@ng-web-apis/platform';
-import {tuiDataListOptionsProvider} from '@taiga-ui/core/components/data-list';
+import {TUI_DATA_LIST_SIZE} from '@taiga-ui/core/components/data-list';
 import {TUI_DROPDOWN_COMPONENT} from '@taiga-ui/core/portals/dropdown';
 
 import {TuiDropdownSheetComponent} from './dropdown-sheet.component';
@@ -15,7 +15,10 @@ import {TuiDropdownSheetComponent} from './dropdown-sheet.component';
                     ? TuiDropdownSheetComponent
                     : inject(TUI_DROPDOWN_COMPONENT, {skipSelf: true}),
         },
-        tuiDataListOptionsProvider(() => ({size: inject(WA_IS_MOBILE) ? 'l' : ''})),
+        {
+            provide: TUI_DATA_LIST_SIZE,
+            useFactory: () => (inject(WA_IS_MOBILE) ? 'l' : ''),
+        },
     ],
 })
 export class TuiDropdownSheet {

--- a/projects/core/components/data-list/data-list.component.ts
+++ b/projects/core/components/data-list/data-list.component.ts
@@ -20,20 +20,12 @@ import {tuiIsFocusedIn, tuiMoveFocus} from '@taiga-ui/cdk/utils/focus';
 import {tuiIsPresent} from '@taiga-ui/cdk/utils/miscellaneous';
 import {TuiCell, tuiCellOptionsProvider} from '@taiga-ui/core/components/cell';
 import {TUI_NOTHING_FOUND_MESSAGE, tuiAsAuxiliary} from '@taiga-ui/core/tokens';
-import {type TuiSizeL, type TuiSizeS} from '@taiga-ui/core/types';
 import {type PolymorpheusContent, PolymorpheusOutlet} from '@taiga-ui/polymorpheus';
 import {timer} from 'rxjs';
 
-import {TUI_DATA_LIST_HOST, type TuiDataListAccessor} from './data-list.tokens';
+import {type TuiDataListAccessor, tuiInjectDataListSize} from './data-list.tokens';
 import {TUI_OPTION_CONTENT, TuiWithOptionContent} from './option-content.directive';
 import {TuiOptionWithValue} from './option-with-value.directive';
-
-export function tuiInjectDataListSize(): TuiSizeL | TuiSizeS {
-    const sizes = ['s', 'm', 'l'] as const;
-    const size = inject(TUI_DATA_LIST_HOST, {optional: true})?.size;
-
-    return size && sizes.includes(size) ? size : 'l';
-}
 
 // TODO: Consider aria-activedescendant for proper accessibility implementation
 @Component({

--- a/projects/core/components/data-list/data-list.tokens.ts
+++ b/projects/core/components/data-list/data-list.tokens.ts
@@ -1,5 +1,11 @@
-import {InjectionToken, type Provider, type Signal, type Type} from '@angular/core';
-import {tuiProvide} from '@taiga-ui/cdk/utils/di';
+import {
+    inject,
+    InjectionToken,
+    type Provider,
+    type Signal,
+    type Type,
+} from '@angular/core';
+import {tuiCreateOptions, tuiProvide} from '@taiga-ui/cdk/utils/di';
 import {type TuiSizeL, type TuiSizeS} from '@taiga-ui/core/types';
 
 export interface TuiDataListAccessor<T = unknown> {
@@ -17,4 +23,18 @@ export const TUI_DATA_LIST_HOST = new InjectionToken<TuiDataListHost<unknown>>(
 
 export function tuiAsDataListHost<T>(host: Type<TuiDataListHost<T>>): Provider {
     return tuiProvide(TUI_DATA_LIST_HOST, host);
+}
+
+export const [TUI_DATA_LIST_OPTIONS, tuiDataListOptionsProvider] = tuiCreateOptions<{
+    size: TuiSizeL | TuiSizeS | '';
+}>({size: ''});
+
+export function tuiInjectDataListSize(): TuiSizeL | TuiSizeS {
+    const sizes = ['s', 'm', 'l'] as const;
+
+    const size =
+        inject(TUI_DATA_LIST_OPTIONS).size ||
+        inject(TUI_DATA_LIST_HOST, {optional: true})?.size;
+
+    return size && sizes.includes(size) ? size : 'l';
 }

--- a/projects/core/components/data-list/data-list.tokens.ts
+++ b/projects/core/components/data-list/data-list.tokens.ts
@@ -5,7 +5,7 @@ import {
     type Signal,
     type Type,
 } from '@angular/core';
-import {tuiCreateOptions, tuiProvide} from '@taiga-ui/cdk/utils/di';
+import {tuiProvide} from '@taiga-ui/cdk/utils/di';
 import {type TuiSizeL, type TuiSizeS} from '@taiga-ui/core/types';
 
 export interface TuiDataListAccessor<T = unknown> {
@@ -25,15 +25,15 @@ export function tuiAsDataListHost<T>(host: Type<TuiDataListHost<T>>): Provider {
     return tuiProvide(TUI_DATA_LIST_HOST, host);
 }
 
-export const [TUI_DATA_LIST_OPTIONS, tuiDataListOptionsProvider] = tuiCreateOptions<{
-    size: TuiSizeL | TuiSizeS | '';
-}>({size: ''});
+export const TUI_DATA_LIST_SIZE = new InjectionToken<TuiSizeL | TuiSizeS | ''>(
+    ngDevMode ? 'TUI_DATA_LIST_SIZE' : '',
+);
 
 export function tuiInjectDataListSize(): TuiSizeL | TuiSizeS {
     const sizes = ['s', 'm', 'l'] as const;
 
     const size =
-        inject(TUI_DATA_LIST_OPTIONS).size ||
+        inject(TUI_DATA_LIST_SIZE, {optional: true}) ||
         inject(TUI_DATA_LIST_HOST, {optional: true})?.size;
 
     return size && sizes.includes(size) ? size : 'l';

--- a/projects/demo-cypress/src/tests/combo-box/combo-box-dropdown-mobile.cy.ts
+++ b/projects/demo-cypress/src/tests/combo-box/combo-box-dropdown-mobile.cy.ts
@@ -1,0 +1,88 @@
+import {ChangeDetectionStrategy, Component, inject, input} from '@angular/core';
+import {FormsModule} from '@angular/forms';
+import {WA_IS_MOBILE} from '@ng-web-apis/platform';
+import {TuiDropdownMobile} from '@taiga-ui/addon-mobile';
+import {TuiRoot, type TuiSizeL, type TuiSizeS} from '@taiga-ui/core';
+import {TUI_COUNTRIES, TuiChevron, TuiComboBox, TuiDataListWrapper} from '@taiga-ui/kit';
+
+@Component({
+    imports: [
+        FormsModule,
+        TuiChevron,
+        TuiComboBox,
+        TuiDataListWrapper,
+        TuiDropdownMobile,
+        TuiRoot,
+    ],
+    template: `
+        <tui-root>
+            <tui-textfield
+                tuiChevron
+                tuiDropdownMobile
+                [tuiTextfieldSize]="textfieldSize()"
+            >
+                <input
+                    placeholder="Select destination"
+                    tuiComboBox
+                    [(ngModel)]="value"
+                />
+
+                <tui-data-list-wrapper
+                    *tuiDropdown
+                    [items]="countries"
+                />
+            </tui-textfield>
+        </tui-root>
+    `,
+    changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class Sandbox {
+    protected readonly countries = Object.values(inject(TUI_COUNTRIES)());
+    protected value: string | null = null;
+
+    public readonly textfieldSize = input<TuiSizeL | TuiSizeS>('l');
+}
+
+describe('ComboBox + DropdownMobile', () => {
+    beforeEach(() => cy.viewport(300, 350));
+
+    describe('enforces L-size for Datalist regardless of textfield size on mobile devices', () => {
+        (['l', 'm', 's'] as const).forEach((size) => {
+            it(`textfieldSize=${size}`, () => {
+                cy.mount(Sandbox, {
+                    componentProperties: {textfieldSize: size},
+                    providers: [{provide: WA_IS_MOBILE, useValue: true}],
+                });
+
+                cy.get('input').click();
+                cy.get('[tuiOption][data-size="l"]').should(
+                    'have.length.greaterThan',
+                    100,
+                );
+                cy.compareSnapshot(
+                    `combo-box-with-dropdown-mobile--mobile--size-${size}`,
+                );
+            });
+        });
+    });
+
+    describe('still regards textfield size on desktop', () => {
+        (['l', 'm', 's'] as const).forEach((size) => {
+            it(`textfieldSize=${size}`, () => {
+                cy.mount(Sandbox, {
+                    componentProperties: {textfieldSize: size},
+                    providers: [{provide: WA_IS_MOBILE, useValue: false}],
+                });
+
+                cy.get('input').click();
+                cy.get(`[tuiOption][data-size="${size}"]`).should(
+                    'have.length.greaterThan',
+                    100,
+                );
+                cy.compareSnapshot(
+                    `combo-box-with-dropdown-mobile--desktop--size-${size}`,
+                );
+            });
+        });
+    });
+});

--- a/projects/demo-cypress/src/tests/select/select-dropdown-sheet.cy.ts
+++ b/projects/demo-cypress/src/tests/select/select-dropdown-sheet.cy.ts
@@ -21,10 +21,9 @@ import {TuiChevron, TuiDataListWrapper, TuiSelect} from '@taiga-ui/kit';
                 tuiDropdownSheet="Select platform"
                 [tuiTextfieldSize]="textfieldSize()"
             >
-                <label tuiLabel>Platform</label>
-
                 <input
                     tuiSelect
+                    placeholder="Platform"
                     [(ngModel)]="value"
                 />
 

--- a/projects/demo-cypress/src/tests/select/select-dropdown-sheet.cy.ts
+++ b/projects/demo-cypress/src/tests/select/select-dropdown-sheet.cy.ts
@@ -1,0 +1,79 @@
+import {ChangeDetectionStrategy, Component, input} from '@angular/core';
+import {FormsModule} from '@angular/forms';
+import {WA_IS_MOBILE} from '@ng-web-apis/platform';
+import {TuiDropdownSheet} from '@taiga-ui/addon-mobile';
+import {TuiRoot, type TuiSizeL, type TuiSizeS} from '@taiga-ui/core';
+import {TuiChevron, TuiDataListWrapper, TuiSelect} from '@taiga-ui/kit';
+
+@Component({
+    imports: [
+        FormsModule,
+        TuiChevron,
+        TuiDataListWrapper,
+        TuiDropdownSheet,
+        TuiRoot,
+        TuiSelect,
+    ],
+    template: `
+        <tui-root>
+            <tui-textfield
+                tuiChevron
+                tuiDropdownSheet="Select platform"
+                [tuiTextfieldSize]="textfieldSize()"
+            >
+                <label tuiLabel>Platform</label>
+
+                <input
+                    tuiSelect
+                    [(ngModel)]="value"
+                />
+
+                <tui-data-list-wrapper
+                    *tuiDropdown
+                    [items]="platforms"
+                />
+            </tui-textfield>
+        </tui-root>
+    `,
+    changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class Sandbox {
+    protected readonly platforms = ['web', 'ios', 'android'] as const;
+    protected value: 'android' | 'ios' | 'web' | null = 'ios';
+
+    public readonly textfieldSize = input<TuiSizeL | TuiSizeS>('l');
+}
+
+describe('Select + DropdownSheet', () => {
+    beforeEach(() => cy.viewport(300, 350));
+
+    describe('enforces L-size for Datalist regardless of textfield size on mobile devices', () => {
+        (['l', 'm', 's'] as const).forEach((size) => {
+            it(`textfieldSize=${size}`, () => {
+                cy.mount(Sandbox, {
+                    componentProperties: {textfieldSize: size},
+                    providers: [{provide: WA_IS_MOBILE, useValue: true}],
+                });
+
+                cy.get('input').click();
+                cy.get('[tuiOption][data-size="l"]').should('have.length', 3);
+                cy.compareSnapshot(`select-with-dropdown-sheet--mobile--size-${size}`);
+            });
+        });
+    });
+
+    describe('still regards textfield size on desktop', () => {
+        (['l', 'm', 's'] as const).forEach((size) => {
+            it(`textfieldSize=${size}`, () => {
+                cy.mount(Sandbox, {
+                    componentProperties: {textfieldSize: size},
+                    providers: [{provide: WA_IS_MOBILE, useValue: false}],
+                });
+
+                cy.get('input').click();
+                cy.get(`[tuiOption][data-size="${size}"]`).should('have.length', 3);
+                cy.compareSnapshot(`select-with-dropdown-sheet--desktop--size-${size}`);
+            });
+        });
+    });
+});


### PR DESCRIPTION
Fixes #14382

### New behavior

<img height="300" alt="combo-box-dropdown-mobile cy ts-combo-box-with-dropdown-mobile--mobile--size-s" src="https://github.com/user-attachments/assets/6de20447-57aa-43da-a930-9d99282bef23" />

<img height="300" alt="select-dropdown-sheet cy ts-select-with-dropdown-sheet--mobile--size-s" src="https://github.com/user-attachments/assets/a268eb98-7e98-4dc0-9631-f519f5b14ccb" />

<img width="2250" height="960" alt="image" src="https://github.com/user-attachments/assets/e491fa8b-a2b7-4cb3-ad6d-4f0c9a36abfd" />


