### PR TITLE
fix(cdk): remove @taiga-ui/editor from ng-update packageGroup

### DIFF
--- a/projects/cdk/package.json
+++ b/projects/cdk/package.json
@@ -83,8 +83,7 @@
             "@taiga-ui/layout",
             "@taiga-ui/experimental",
             "@taiga-ui/proprietary",
-            "@taiga-ui/legacy",
-            "@taiga-ui/editor"
+            "@taiga-ui/legacy"
         ]
     },
     "schematics": "./schematics/collection.json"


### PR DESCRIPTION
`nx migrate @taiga-ui/core` (and `ng update @taiga-ui/core`) fails when a project has `@taiga-ui/editor` installed, because `ng-update.packageGroup` in `projects/cdk/package.json` lists `@taiga-ui/editor` alongside all the lock-step packages. Both `ng update` and `nx migrate` resolve every package in `packageGroup` to the *same target version* as the package being updated (e.g. `5.13.0`), but `@taiga-ui/editor` is released independently and has never published a `5.13.0` — its latest is `5.4.0`. The migration aborts trying to fetch a version that doesn't exist.