### PR TITLE
fix(layout): `CardCollapsed` fix transition on Safari and Firefox

### DIFF
--- a/projects/layout/components/card/collapsed.style.less
+++ b/projects/layout/components/card/collapsed.style.less
@@ -1,9 +1,8 @@
 @import '@taiga-ui/styles/utils';
 
 [tuiCardCollapsed]:where(*&) {
-    .transition(~'clip-path, margin');
-
-    border-image: radial-gradient(at center, var(--tui-background-neutral-2) 26.5%, transparent 27%) 50% 49% / 0 2rem
+    transition-property: clip-path, margin !important;
+    border-image: radial-gradient(at top, var(--tui-background-neutral-2) 26.5%, transparent 27%) 100% 49% / 0 2rem
         2rem / 0 0 2rem;
 
     > tui-expand {


### PR DESCRIPTION
Fixes #12349