### PR TITLE
fix(core): `Textfield` fix items displaying over border

### DIFF
--- a/projects/core/components/textfield/textfield-multi/textfield-multi.style.less
+++ b/projects/core/components/textfield/textfield-multi/textfield-multi.style.less
@@ -36,6 +36,7 @@ tui-textfield[multi][multi]:where(*&) {
 
     > .t-items {
         position: sticky;
+        z-index: -1;
         display: flex;
         inset-inline-start: var(--t-start);
         min-inline-size: 0;


### PR DESCRIPTION
Fixes #11489
