### PR TITLE
fix(cdk): flag removed dialog `header` option during v5 migration

### DIFF
--- a/projects/cdk/schematics/ng-update/v5/index.ts
+++ b/projects/cdk/schematics/ng-update/v5/index.ts
@@ -36,6 +36,7 @@ import {MODULES_TO_REMOVE} from './steps/constants/modules-to-remove';
 import {migrateBreakpointService} from './steps/migrate-breakpoint-service';
 import {migrateCloseable} from './steps/migrate-closeable';
 import {migrateCssVariables} from './steps/migrate-css-variables';
+import {migrateDialogHeader} from './steps/migrate-dialog-header';
 import {migrateDialogLegacySizes} from './steps/migrate-dialog-legacy-sizes';
 import {migrateDocI18nTokens} from './steps/migrate-doc-i18n-tokens';
 import {migrateDropdownOpen} from './steps/migrate-dropdown-open';
@@ -89,6 +90,10 @@ function main(options: TuiSchema, timings: MigrationStepTiming[]): Rule {
                 {
                     name: 'migrateDialogLegacySizes',
                     step: () => migrateDialogLegacySizes(tree, options),
+                },
+                {
+                    name: 'migrateDialogHeader',
+                    step: () => migrateDialogHeader(tree, options),
                 },
                 {
                     name: 'migrateDropdownOpen',

--- a/projects/cdk/schematics/ng-update/v5/steps/migrate-dialog-header.ts
+++ b/projects/cdk/schematics/ng-update/v5/steps/migrate-dialog-header.ts
@@ -7,7 +7,6 @@ import {TODO_MARK} from '../../../utils/insert-todo';
 import {getDialogOptions} from './utils/get-dialog-options';
 
 const DOCS_LINK = 'https://taiga-ui.dev/components/dialog';
-
 const TODO_MESSAGE = `dialog \`header\` option (content shown above the title) was removed from \`TuiDialogOptions\` in v5. Place that content in the dialog template with \`tuiHeader\` instead. See: ${DOCS_LINK}`;
 
 export function migrateDialogHeader(_tree: Tree, _options: TuiSchema): void {

--- a/projects/cdk/schematics/ng-update/v5/steps/migrate-dialog-header.ts
+++ b/projects/cdk/schematics/ng-update/v5/steps/migrate-dialog-header.ts
@@ -8,12 +8,7 @@ import {getDialogOptions} from './utils/get-dialog-options';
 
 const DOCS_LINK = 'https://taiga-ui.dev/components/dialog';
 
-const TODO_MESSAGE = [
-    'dialog `header` (content shown above the title) was removed from `TuiDialogOptions` in v5.',
-    '// - If it was rich content above the title: place `tuiHeader` in the dialog template (clear `label` if you had one).',
-    '// - If it was just a string title: move that string into `label`.',
-    `// See: ${DOCS_LINK}`,
-].join('\n');
+const TODO_MESSAGE = `dialog \`header\` option (content shown above the title) was removed from \`TuiDialogOptions\` in v5. To keep content above the title, pass an empty \`label\` and place \`tuiHeader\` in the dialog template where you need it. See: ${DOCS_LINK}`;
 
 export function migrateDialogHeader(_tree: Tree, _options: TuiSchema): void {
     getSourceFiles(ALL_TS_FILES).forEach((sourceFile) => {

--- a/projects/cdk/schematics/ng-update/v5/steps/migrate-dialog-header.ts
+++ b/projects/cdk/schematics/ng-update/v5/steps/migrate-dialog-header.ts
@@ -7,6 +7,7 @@ import {TODO_MARK} from '../../../utils/insert-todo';
 import {getDialogOptions} from './utils/get-dialog-options';
 
 const DOCS_LINK = 'https://taiga-ui.dev/components/dialog';
+
 const TODO_MESSAGE = [
     'dialog `header` (content shown above the title) was removed from `TuiDialogOptions` in v5.',
     '// - If it was rich content above the title: place `tuiHeader` in the dialog template (clear `label` if you had one).',

--- a/projects/cdk/schematics/ng-update/v5/steps/migrate-dialog-header.ts
+++ b/projects/cdk/schematics/ng-update/v5/steps/migrate-dialog-header.ts
@@ -3,7 +3,7 @@ import {getSourceFiles, type SourceFile, SyntaxKind} from 'ng-morph';
 
 import {ALL_TS_FILES} from '../../../constants';
 import {type TuiSchema} from '../../../ng-add/schema';
-import {insertTodo} from '../../../utils/insert-todo';
+import {TODO_MARK} from '../../../utils/insert-todo';
 import {getDialogOptions} from './utils/get-dialog-options';
 
 const DOCS_LINK = 'https://taiga-ui.dev/components/dialog';
@@ -16,15 +16,18 @@ export function migrateDialogHeader(_tree: Tree, _options: TuiSchema): void {
 }
 
 function migrateSourceFile(sourceFile: SourceFile): void {
-    sourceFile.getDescendantsOfKind(SyntaxKind.CallExpression).forEach((call) => {
-        if (call.wasForgotten()) {
-            return;
-        }
+    // Collect every insertion position up front: `insertText` forgets the whole ts-morph
+    // node tree, so we cannot re-read `header` nodes after the first insert.
+    const linePositions = sourceFile
+        .getDescendantsOfKind(SyntaxKind.CallExpression)
+        .map((call) => getDialogOptions(call)?.getProperty('header')?.getStartLinePos())
+        .filter((position): position is number => position !== undefined);
 
-        const headerProperty = getDialogOptions(call)?.getProperty('header');
-
-        if (headerProperty) {
-            insertTodo(headerProperty, TODO_MESSAGE);
-        }
-    });
+    // Insert bottom-to-top so each insertion only shifts offsets after it, keeping the
+    // remaining (earlier) positions valid.
+    [...new Set(linePositions)]
+        .sort((a, b) => b - a)
+        .forEach((position) => {
+            sourceFile.insertText(position, `// ${TODO_MARK} ${TODO_MESSAGE}\n`);
+        });
 }

--- a/projects/cdk/schematics/ng-update/v5/steps/migrate-dialog-header.ts
+++ b/projects/cdk/schematics/ng-update/v5/steps/migrate-dialog-header.ts
@@ -8,7 +8,7 @@ import {getDialogOptions} from './utils/get-dialog-options';
 
 const DOCS_LINK = 'https://taiga-ui.dev/components/dialog';
 
-const TODO_MESSAGE = `dialog \`header\` option (content shown above the title) was removed from \`TuiDialogOptions\` in v5. To keep content above the title, pass an empty \`label\` and place \`tuiHeader\` in the dialog template where you need it. See: ${DOCS_LINK}`;
+const TODO_MESSAGE = `dialog \`header\` option (content shown above the title) was removed from \`TuiDialogOptions\` in v5. Place that content in the dialog template with \`tuiHeader\` instead. See: ${DOCS_LINK}`;
 
 export function migrateDialogHeader(_tree: Tree, _options: TuiSchema): void {
     getSourceFiles(ALL_TS_FILES).forEach((sourceFile) => {

--- a/projects/cdk/schematics/ng-update/v5/steps/migrate-dialog-header.ts
+++ b/projects/cdk/schematics/ng-update/v5/steps/migrate-dialog-header.ts
@@ -7,7 +7,12 @@ import {TODO_MARK} from '../../../utils/insert-todo';
 import {getDialogOptions} from './utils/get-dialog-options';
 
 const DOCS_LINK = 'https://taiga-ui.dev/components/dialog';
-const TODO_MESSAGE = `dialog \`header\` option (content shown above the title) was removed from \`TuiDialogOptions\` in v5. To keep content above the title, pass an empty \`label\` and place \`tuiHeader\` in the dialog template where you need it. For a plain string title, use \`label\` instead. See: ${DOCS_LINK}`;
+const TODO_MESSAGE = [
+    'dialog `header` (content shown above the title) was removed from `TuiDialogOptions` in v5.',
+    '// - If it was rich content above the title: place `tuiHeader` in the dialog template (clear `label` if you had one).',
+    '// - If it was just a string title: move that string into `label`.',
+    `// See: ${DOCS_LINK}`,
+].join('\n');
 
 export function migrateDialogHeader(_tree: Tree, _options: TuiSchema): void {
     getSourceFiles(ALL_TS_FILES).forEach((sourceFile) => {

--- a/projects/cdk/schematics/ng-update/v5/steps/migrate-dialog-header.ts
+++ b/projects/cdk/schematics/ng-update/v5/steps/migrate-dialog-header.ts
@@ -1,0 +1,30 @@
+import {type Tree} from '@angular-devkit/schematics';
+import {getSourceFiles, type SourceFile, SyntaxKind} from 'ng-morph';
+
+import {ALL_TS_FILES} from '../../../constants';
+import {type TuiSchema} from '../../../ng-add/schema';
+import {insertTodo} from '../../../utils/insert-todo';
+import {getDialogOptions} from './utils/get-dialog-options';
+
+const DOCS_LINK = 'https://taiga-ui.dev/components/dialog';
+const TODO_MESSAGE = `dialog \`header\` option (content shown above the title) was removed from \`TuiDialogOptions\` in v5. To keep content above the title, pass an empty \`label\` and place \`tuiHeader\` in the dialog template where you need it. For a plain string title, use \`label\` instead. See: ${DOCS_LINK}`;
+
+export function migrateDialogHeader(_tree: Tree, _options: TuiSchema): void {
+    getSourceFiles(ALL_TS_FILES).forEach((sourceFile) => {
+        migrateSourceFile(sourceFile);
+    });
+}
+
+function migrateSourceFile(sourceFile: SourceFile): void {
+    sourceFile.getDescendantsOfKind(SyntaxKind.CallExpression).forEach((call) => {
+        if (call.wasForgotten()) {
+            return;
+        }
+
+        const headerProperty = getDialogOptions(call)?.getProperty('header');
+
+        if (headerProperty) {
+            insertTodo(headerProperty, TODO_MESSAGE);
+        }
+    });
+}

--- a/projects/cdk/schematics/ng-update/v5/steps/migrate-dialog-legacy-sizes.ts
+++ b/projects/cdk/schematics/ng-update/v5/steps/migrate-dialog-legacy-sizes.ts
@@ -13,11 +13,13 @@ import {
 
 const TAIGA_CORE = '@taiga-ui/core';
 const TAIGA_LEGACY = '@taiga-ui/legacy';
+
 const MIGRATE_TOKENS = [
     TUI_DIALOG_FACTORY,
     TUI_DIALOG_SERVICE,
     TUI_DIALOG_OPTIONS_PROVIDER,
 ];
+
 const LEGACY_SIZE_FULLSCREEN = 'fullscreen';
 const LEGACY_SIZES = ['auto', LEGACY_SIZE_FULLSCREEN, 'page'];
 const TODO_MESSAGE = `legacy dialog size detected (deprecated size: ${LEGACY_SIZES.map((size) => `'${size}'`).join(', ')}); migration only moved imports. Review this call.`;

--- a/projects/cdk/schematics/ng-update/v5/steps/migrate-dialog-legacy-sizes.ts
+++ b/projects/cdk/schematics/ng-update/v5/steps/migrate-dialog-legacy-sizes.ts
@@ -4,15 +4,20 @@ import {getSourceFiles, Node, type SourceFile, SyntaxKind} from 'ng-morph';
 import {ALL_TS_FILES} from '../../../constants';
 import {type TuiSchema} from '../../../ng-add/schema';
 import {insertTodo} from '../../../utils/insert-todo';
-import {isServiceMethodCall} from '../../../utils/is-service-method-call';
+import {
+    getDialogOptions,
+    TUI_DIALOG_FACTORY,
+    TUI_DIALOG_OPTIONS_PROVIDER,
+    TUI_DIALOG_SERVICE,
+} from './utils/get-dialog-options';
 
 const TAIGA_CORE = '@taiga-ui/core';
 const TAIGA_LEGACY = '@taiga-ui/legacy';
-const FACTORY_NAME = 'tuiDialog';
-const SERVICE_NAME = 'TuiDialogService';
-const METHOD_NAME = 'open';
-const PROVIDER_NAME = 'tuiDialogOptionsProvider';
-const MIGRATE_TOKENS = [FACTORY_NAME, SERVICE_NAME, PROVIDER_NAME];
+const MIGRATE_TOKENS = [
+    TUI_DIALOG_FACTORY,
+    TUI_DIALOG_SERVICE,
+    TUI_DIALOG_OPTIONS_PROVIDER,
+];
 const LEGACY_SIZE_FULLSCREEN = 'fullscreen';
 const LEGACY_SIZES = ['auto', LEGACY_SIZE_FULLSCREEN, 'page'];
 const TODO_MESSAGE = `legacy dialog size detected (deprecated size: ${LEGACY_SIZES.map((size) => `'${size}'`).join(', ')}); migration only moved imports. Review this call.`;
@@ -32,17 +37,9 @@ function migrateSourceFile(sourceFile: SourceFile): void {
             return;
         }
 
-        const isFactory = call.getExpression().getText() === FACTORY_NAME;
-        const isProvider = call.getExpression().getText() === PROVIDER_NAME;
-        const isMethod = isServiceMethodCall(call, SERVICE_NAME, METHOD_NAME);
+        const options = getDialogOptions(call);
 
-        if (!isFactory && !isProvider && !isMethod) {
-            return;
-        }
-
-        const options = isProvider ? call.getArguments()[0] : call.getArguments()[1];
-
-        if (!options || !Node.isObjectLiteralExpression(options)) {
+        if (!options) {
             return;
         }
 

--- a/projects/cdk/schematics/ng-update/v5/steps/utils/get-dialog-options.ts
+++ b/projects/cdk/schematics/ng-update/v5/steps/utils/get-dialog-options.ts
@@ -17,6 +17,7 @@ export function getDialogOptions(
 ): ObjectLiteralExpression | undefined {
     const isFactory = call.getExpression().getText() === TUI_DIALOG_FACTORY;
     const isProvider = call.getExpression().getText() === TUI_DIALOG_OPTIONS_PROVIDER;
+
     const isMethod = isServiceMethodCall(
         call,
         TUI_DIALOG_SERVICE,

--- a/projects/cdk/schematics/ng-update/v5/steps/utils/get-dialog-options.ts
+++ b/projects/cdk/schematics/ng-update/v5/steps/utils/get-dialog-options.ts
@@ -2,10 +2,13 @@ import {type CallExpression, Node, type ObjectLiteralExpression} from 'ng-morph'
 
 import {isServiceMethodCall} from '../../../../utils/is-service-method-call';
 
+// Exported: reused by migrate-dialog-legacy-sizes to move these imports to legacy.
 export const TUI_DIALOG_FACTORY = 'tuiDialog';
 export const TUI_DIALOG_SERVICE = 'TuiDialogService';
-export const TUI_DIALOG_OPEN_METHOD = 'open';
 export const TUI_DIALOG_OPTIONS_PROVIDER = 'tuiDialogOptionsProvider';
+
+// Internal — only the method name checked on TuiDialogService.
+const TUI_DIALOG_OPEN_METHOD = 'open';
 
 /**
  * Returns the dialog options object literal for a call, or `undefined` when the call is

--- a/projects/cdk/schematics/ng-update/v5/steps/utils/get-dialog-options.ts
+++ b/projects/cdk/schematics/ng-update/v5/steps/utils/get-dialog-options.ts
@@ -1,0 +1,33 @@
+import {type CallExpression, Node, type ObjectLiteralExpression} from 'ng-morph';
+
+import {isServiceMethodCall} from '../../../../utils/is-service-method-call';
+
+export const TUI_DIALOG_FACTORY = 'tuiDialog';
+export const TUI_DIALOG_SERVICE = 'TuiDialogService';
+export const TUI_DIALOG_OPEN_METHOD = 'open';
+export const TUI_DIALOG_OPTIONS_PROVIDER = 'tuiDialogOptionsProvider';
+
+/**
+ * Returns the dialog options object literal for a call, or `undefined` when the call is
+ * not a recognized dialog entry point. Covers `tuiDialog(component, options)`,
+ * `TuiDialogService.open(content, options)` and `tuiDialogOptionsProvider(options)`.
+ */
+export function getDialogOptions(
+    call: CallExpression,
+): ObjectLiteralExpression | undefined {
+    const isFactory = call.getExpression().getText() === TUI_DIALOG_FACTORY;
+    const isProvider = call.getExpression().getText() === TUI_DIALOG_OPTIONS_PROVIDER;
+    const isMethod = isServiceMethodCall(
+        call,
+        TUI_DIALOG_SERVICE,
+        TUI_DIALOG_OPEN_METHOD,
+    );
+
+    if (!isFactory && !isProvider && !isMethod) {
+        return undefined;
+    }
+
+    const options = isProvider ? call.getArguments()[0] : call.getArguments()[1];
+
+    return options && Node.isObjectLiteralExpression(options) ? options : undefined;
+}

--- a/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-dialog-header.spec.ts.snap
+++ b/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-dialog-header.spec.ts.snap
@@ -1,0 +1,127 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ng-update tuiDialog header option adds a TODO for every dialog call with \`header\` in the same file: test.ts 1`] = `
+{
+  "0. Before": "
+                import {Component} from '@angular/core';
+                import {tuiDialog} from '@taiga-ui/core';
+
+                @Component({standalone: true})
+                export class TestComponent {
+                    private readonly dialog1 = tuiDialog('content', {header: 'Title 1'});
+                    private readonly dialog2 = tuiDialog('content', {header: 'Title 2'});
+                }
+            ",
+  "1. After": "
+                import {Component} from '@angular/core';
+                import {tuiDialog} from '@taiga-ui/core';
+
+                @Component({standalone: true})
+                export class TestComponent {
+// TODO: (Taiga UI migration) dialog \`header\` (content shown above the title) was removed from \`TuiDialogOptions\` in v5.
+// - If it was rich content above the title: place \`tuiHeader\` in the dialog template (clear \`label\` if you had one).
+// - If it was just a string title: move that string into \`label\`.
+// See: https://taiga-ui.dev/components/dialog
+                    private readonly dialog1 = tuiDialog('content', {header: 'Title 1'});
+// TODO: (Taiga UI migration) dialog \`header\` (content shown above the title) was removed from \`TuiDialogOptions\` in v5.
+// - If it was rich content above the title: place \`tuiHeader\` in the dialog template (clear \`label\` if you had one).
+// - If it was just a string title: move that string into \`label\`.
+// See: https://taiga-ui.dev/components/dialog
+                    private readonly dialog2 = tuiDialog('content', {header: 'Title 2'});
+                }
+            ",
+}
+`;
+
+exports[`ng-update tuiDialog header option adds a TODO near \`header\` in a TuiDialogService.open call: test.ts 1`] = `
+{
+  "0. Before": "
+                import {Component, inject} from '@angular/core';
+                import {TuiDialogService} from '@taiga-ui/core';
+
+                @Component({standalone: true})
+                export class TestComponent {
+                    constructor() {
+                        inject(TuiDialogService).open('content', {header: someTemplate});
+                    }
+                }
+            ",
+  "1. After": "
+                import {Component, inject} from '@angular/core';
+                import {TuiDialogService} from '@taiga-ui/core';
+
+                @Component({standalone: true})
+                export class TestComponent {
+                    constructor() {
+// TODO: (Taiga UI migration) dialog \`header\` (content shown above the title) was removed from \`TuiDialogOptions\` in v5.
+// - If it was rich content above the title: place \`tuiHeader\` in the dialog template (clear \`label\` if you had one).
+// - If it was just a string title: move that string into \`label\`.
+// See: https://taiga-ui.dev/components/dialog
+                        inject(TuiDialogService).open('content', {header: someTemplate});
+                    }
+                }
+            ",
+}
+`;
+
+exports[`ng-update tuiDialog header option adds a TODO near \`header\` in a tuiDialog factory call: test.ts 1`] = `
+{
+  "0. Before": "
+                import {Component} from '@angular/core';
+                import {tuiDialog} from '@taiga-ui/core';
+
+                @Component({standalone: true})
+                export class TestComponent {
+                    private readonly dialog = tuiDialog('content', {
+                        header: 'Title',
+                        size: 'm',
+                    });
+                }
+            ",
+  "1. After": "
+                import {Component} from '@angular/core';
+                import {tuiDialog} from '@taiga-ui/core';
+
+                @Component({standalone: true})
+                export class TestComponent {
+                    private readonly dialog = tuiDialog('content', {
+// TODO: (Taiga UI migration) dialog \`header\` (content shown above the title) was removed from \`TuiDialogOptions\` in v5.
+// - If it was rich content above the title: place \`tuiHeader\` in the dialog template (clear \`label\` if you had one).
+// - If it was just a string title: move that string into \`label\`.
+// See: https://taiga-ui.dev/components/dialog
+                        header: 'Title',
+                        size: 'm',
+                    });
+                }
+            ",
+}
+`;
+
+exports[`ng-update tuiDialog header option adds a TODO near \`header\` in a tuiDialogOptionsProvider call: test.ts 1`] = `
+{
+  "0. Before": "
+                import {Component} from '@angular/core';
+                import {tuiDialogOptionsProvider} from '@taiga-ui/core';
+
+                @Component({
+                    standalone: true,
+                    providers: [tuiDialogOptionsProvider({header: 'Title'})],
+                })
+                export class TestComponent {}
+            ",
+  "1. After": "
+                import {Component} from '@angular/core';
+                import {tuiDialogOptionsProvider} from '@taiga-ui/core';
+
+                @Component({
+                    standalone: true,
+// TODO: (Taiga UI migration) dialog \`header\` (content shown above the title) was removed from \`TuiDialogOptions\` in v5.
+// - If it was rich content above the title: place \`tuiHeader\` in the dialog template (clear \`label\` if you had one).
+// - If it was just a string title: move that string into \`label\`.
+// See: https://taiga-ui.dev/components/dialog
+                    providers: [tuiDialogOptionsProvider({header: 'Title'})],
+                })
+                export class TestComponent {}
+            ",
+}
+`;

--- a/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-dialog-header.spec.ts.snap
+++ b/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-dialog-header.spec.ts.snap
@@ -18,15 +18,9 @@ exports[`ng-update tuiDialog header option adds a TODO for every dialog call wit
 
                 @Component({standalone: true})
                 export class TestComponent {
-// TODO: (Taiga UI migration) dialog \`header\` (content shown above the title) was removed from \`TuiDialogOptions\` in v5.
-// - If it was rich content above the title: place \`tuiHeader\` in the dialog template (clear \`label\` if you had one).
-// - If it was just a string title: move that string into \`label\`.
-// See: https://taiga-ui.dev/components/dialog
+// TODO: (Taiga UI migration) dialog \`header\` option (content shown above the title) was removed from \`TuiDialogOptions\` in v5. To keep content above the title, pass an empty \`label\` and place \`tuiHeader\` in the dialog template where you need it. See: https://taiga-ui.dev/components/dialog
                     private readonly dialog1 = tuiDialog('content', {header: 'Title 1'});
-// TODO: (Taiga UI migration) dialog \`header\` (content shown above the title) was removed from \`TuiDialogOptions\` in v5.
-// - If it was rich content above the title: place \`tuiHeader\` in the dialog template (clear \`label\` if you had one).
-// - If it was just a string title: move that string into \`label\`.
-// See: https://taiga-ui.dev/components/dialog
+// TODO: (Taiga UI migration) dialog \`header\` option (content shown above the title) was removed from \`TuiDialogOptions\` in v5. To keep content above the title, pass an empty \`label\` and place \`tuiHeader\` in the dialog template where you need it. See: https://taiga-ui.dev/components/dialog
                     private readonly dialog2 = tuiDialog('content', {header: 'Title 2'});
                 }
             ",
@@ -53,10 +47,7 @@ exports[`ng-update tuiDialog header option adds a TODO near \`header\` in a TuiD
                 @Component({standalone: true})
                 export class TestComponent {
                     constructor() {
-// TODO: (Taiga UI migration) dialog \`header\` (content shown above the title) was removed from \`TuiDialogOptions\` in v5.
-// - If it was rich content above the title: place \`tuiHeader\` in the dialog template (clear \`label\` if you had one).
-// - If it was just a string title: move that string into \`label\`.
-// See: https://taiga-ui.dev/components/dialog
+// TODO: (Taiga UI migration) dialog \`header\` option (content shown above the title) was removed from \`TuiDialogOptions\` in v5. To keep content above the title, pass an empty \`label\` and place \`tuiHeader\` in the dialog template where you need it. See: https://taiga-ui.dev/components/dialog
                         inject(TuiDialogService).open('content', {header: someTemplate});
                     }
                 }
@@ -85,10 +76,7 @@ exports[`ng-update tuiDialog header option adds a TODO near \`header\` in a tuiD
                 @Component({standalone: true})
                 export class TestComponent {
                     private readonly dialog = tuiDialog('content', {
-// TODO: (Taiga UI migration) dialog \`header\` (content shown above the title) was removed from \`TuiDialogOptions\` in v5.
-// - If it was rich content above the title: place \`tuiHeader\` in the dialog template (clear \`label\` if you had one).
-// - If it was just a string title: move that string into \`label\`.
-// See: https://taiga-ui.dev/components/dialog
+// TODO: (Taiga UI migration) dialog \`header\` option (content shown above the title) was removed from \`TuiDialogOptions\` in v5. To keep content above the title, pass an empty \`label\` and place \`tuiHeader\` in the dialog template where you need it. See: https://taiga-ui.dev/components/dialog
                         header: 'Title',
                         size: 'm',
                     });
@@ -115,10 +103,7 @@ exports[`ng-update tuiDialog header option adds a TODO near \`header\` in a tuiD
 
                 @Component({
                     standalone: true,
-// TODO: (Taiga UI migration) dialog \`header\` (content shown above the title) was removed from \`TuiDialogOptions\` in v5.
-// - If it was rich content above the title: place \`tuiHeader\` in the dialog template (clear \`label\` if you had one).
-// - If it was just a string title: move that string into \`label\`.
-// See: https://taiga-ui.dev/components/dialog
+// TODO: (Taiga UI migration) dialog \`header\` option (content shown above the title) was removed from \`TuiDialogOptions\` in v5. To keep content above the title, pass an empty \`label\` and place \`tuiHeader\` in the dialog template where you need it. See: https://taiga-ui.dev/components/dialog
                     providers: [tuiDialogOptionsProvider({header: 'Title'})],
                 })
                 export class TestComponent {}

--- a/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-dialog-header.spec.ts.snap
+++ b/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-dialog-header.spec.ts.snap
@@ -18,9 +18,9 @@ exports[`ng-update tuiDialog header option adds a TODO for every dialog call wit
 
                 @Component({standalone: true})
                 export class TestComponent {
-// TODO: (Taiga UI migration) dialog \`header\` option (content shown above the title) was removed from \`TuiDialogOptions\` in v5. To keep content above the title, pass an empty \`label\` and place \`tuiHeader\` in the dialog template where you need it. See: https://taiga-ui.dev/components/dialog
+// TODO: (Taiga UI migration) dialog \`header\` option (content shown above the title) was removed from \`TuiDialogOptions\` in v5. Place that content in the dialog template with \`tuiHeader\` instead. See: https://taiga-ui.dev/components/dialog
                     private readonly dialog1 = tuiDialog('content', {header: 'Title 1'});
-// TODO: (Taiga UI migration) dialog \`header\` option (content shown above the title) was removed from \`TuiDialogOptions\` in v5. To keep content above the title, pass an empty \`label\` and place \`tuiHeader\` in the dialog template where you need it. See: https://taiga-ui.dev/components/dialog
+// TODO: (Taiga UI migration) dialog \`header\` option (content shown above the title) was removed from \`TuiDialogOptions\` in v5. Place that content in the dialog template with \`tuiHeader\` instead. See: https://taiga-ui.dev/components/dialog
                     private readonly dialog2 = tuiDialog('content', {header: 'Title 2'});
                 }
             ",
@@ -47,7 +47,7 @@ exports[`ng-update tuiDialog header option adds a TODO near \`header\` in a TuiD
                 @Component({standalone: true})
                 export class TestComponent {
                     constructor() {
-// TODO: (Taiga UI migration) dialog \`header\` option (content shown above the title) was removed from \`TuiDialogOptions\` in v5. To keep content above the title, pass an empty \`label\` and place \`tuiHeader\` in the dialog template where you need it. See: https://taiga-ui.dev/components/dialog
+// TODO: (Taiga UI migration) dialog \`header\` option (content shown above the title) was removed from \`TuiDialogOptions\` in v5. Place that content in the dialog template with \`tuiHeader\` instead. See: https://taiga-ui.dev/components/dialog
                         inject(TuiDialogService).open('content', {header: someTemplate});
                     }
                 }
@@ -76,7 +76,7 @@ exports[`ng-update tuiDialog header option adds a TODO near \`header\` in a tuiD
                 @Component({standalone: true})
                 export class TestComponent {
                     private readonly dialog = tuiDialog('content', {
-// TODO: (Taiga UI migration) dialog \`header\` option (content shown above the title) was removed from \`TuiDialogOptions\` in v5. To keep content above the title, pass an empty \`label\` and place \`tuiHeader\` in the dialog template where you need it. See: https://taiga-ui.dev/components/dialog
+// TODO: (Taiga UI migration) dialog \`header\` option (content shown above the title) was removed from \`TuiDialogOptions\` in v5. Place that content in the dialog template with \`tuiHeader\` instead. See: https://taiga-ui.dev/components/dialog
                         header: 'Title',
                         size: 'm',
                     });
@@ -103,7 +103,7 @@ exports[`ng-update tuiDialog header option adds a TODO near \`header\` in a tuiD
 
                 @Component({
                     standalone: true,
-// TODO: (Taiga UI migration) dialog \`header\` option (content shown above the title) was removed from \`TuiDialogOptions\` in v5. To keep content above the title, pass an empty \`label\` and place \`tuiHeader\` in the dialog template where you need it. See: https://taiga-ui.dev/components/dialog
+// TODO: (Taiga UI migration) dialog \`header\` option (content shown above the title) was removed from \`TuiDialogOptions\` in v5. Place that content in the dialog template with \`tuiHeader\` instead. See: https://taiga-ui.dev/components/dialog
                     providers: [tuiDialogOptionsProvider({header: 'Title'})],
                 })
                 export class TestComponent {}

--- a/projects/cdk/schematics/ng-update/v5/tests/schematic-migrate-dialog-header.spec.ts
+++ b/projects/cdk/schematics/ng-update/v5/tests/schematic-migrate-dialog-header.spec.ts
@@ -1,0 +1,98 @@
+import {join} from 'node:path';
+
+import {resetActiveProject} from 'ng-morph';
+
+import {runMigration} from '../../../utils/run-migration';
+
+const collection = join(__dirname, '../../../migration.json');
+
+const TODO = `// TODO: (Taiga UI migration) dialog \`header\` option (content shown above the title) was removed from \`TuiDialogOptions\` in v5. To keep content above the title, pass an empty \`label\` and place \`tuiHeader\` in the dialog template where you need it. For a plain string title, use \`label\` instead. See: https://taiga-ui.dev/components/dialog`;
+
+describe('ng-update tuiDialog header option', () => {
+    const migrateComponent = async (component: string): Promise<string> => {
+        const {component: result} = await runMigration({component, collection});
+
+        return result;
+    };
+
+    it('adds a TODO near `header` in a tuiDialog factory call', async () => {
+        const result = await migrateComponent(`
+            import {Component} from '@angular/core';
+            import {tuiDialog} from '@taiga-ui/core';
+
+            @Component({standalone: true})
+            export class TestComponent {
+                private readonly dialog = tuiDialog('content', {
+                    header: 'Title',
+                    size: 'm',
+                });
+            }
+        `);
+
+        expect(result).toContain(TODO);
+        expect(result).toContain("header: 'Title'");
+    });
+
+    it('adds a TODO near `header` in a TuiDialogService.open call', async () => {
+        const result = await migrateComponent(`
+            import {Component, inject} from '@angular/core';
+            import {TuiDialogService} from '@taiga-ui/core';
+
+            @Component({standalone: true})
+            export class TestComponent {
+                constructor() {
+                    inject(TuiDialogService).open('content', {header: someTemplate});
+                }
+            }
+        `);
+
+        expect(result).toContain(TODO);
+    });
+
+    it('adds a TODO near `header` in a tuiDialogOptionsProvider call', async () => {
+        const result = await migrateComponent(`
+            import {Component} from '@angular/core';
+            import {tuiDialogOptionsProvider} from '@taiga-ui/core';
+
+            @Component({
+                standalone: true,
+                providers: [tuiDialogOptionsProvider({header: 'Title'})],
+            })
+            export class TestComponent {}
+        `);
+
+        expect(result).toContain(TODO);
+    });
+
+    it('does not add a TODO when there is no `header` option', async () => {
+        const result = await migrateComponent(`
+            import {Component} from '@angular/core';
+            import {tuiDialog} from '@taiga-ui/core';
+
+            @Component({standalone: true})
+            export class TestComponent {
+                private readonly dialog = tuiDialog('content', {
+                    label: 'Title',
+                    size: 'm',
+                });
+            }
+        `);
+
+        expect(result).not.toContain('TODO: (Taiga UI migration)');
+    });
+
+    it('does not touch a `header` property on an unrelated call', async () => {
+        const result = await migrateComponent(`
+            import {Component} from '@angular/core';
+
+            @Component({standalone: true})
+            export class TestComponent {
+                private readonly config = somethingElse({header: 'Title'});
+            }
+        `);
+
+        expect(result).not.toContain('TODO: (Taiga UI migration)');
+    });
+
+    afterEach(() => resetActiveProject());
+});

--- a/projects/cdk/schematics/ng-update/v5/tests/schematic-migrate-dialog-header.spec.ts
+++ b/projects/cdk/schematics/ng-update/v5/tests/schematic-migrate-dialog-header.spec.ts
@@ -2,115 +2,111 @@ import {join} from 'node:path';
 
 import {resetActiveProject} from 'ng-morph';
 
-import {runMigration} from '../../../utils/run-migration';
-
-const collection = join(__dirname, '../../../migration.json');
-
-const TODO =
-    '// TODO: (Taiga UI migration) dialog `header` option (content shown above the title) was removed from `TuiDialogOptions` in v5. To keep content above the title, pass an empty `label` and place `tuiHeader` in the dialog template where you need it. For a plain string title, use `label` instead. See: https://taiga-ui.dev/components/dialog';
+import {createMigration} from '../../../utils/run-migration';
 
 describe('ng-update tuiDialog header option', () => {
-    const migrateComponent = async (component: string): Promise<string> => {
-        const {component: result} = await runMigration({component, collection});
-
-        return result;
-    };
-
-    it('adds a TODO near `header` in a tuiDialog factory call', async () => {
-        const result = await migrateComponent(`
-            import {Component} from '@angular/core';
-            import {tuiDialog} from '@taiga-ui/core';
-
-            @Component({standalone: true})
-            export class TestComponent {
-                private readonly dialog = tuiDialog('content', {
-                    header: 'Title',
-                    size: 'm',
-                });
-            }
-        `);
-
-        expect(result).toContain(TODO);
-        expect(result).toContain("header: 'Title'");
+    const migrate = createMigration({
+        collection: join(__dirname, '../../../migration.json'),
     });
 
-    it('adds a TODO near `header` in a TuiDialogService.open call', async () => {
-        const result = await migrateComponent(`
-            import {Component, inject} from '@angular/core';
-            import {TuiDialogService} from '@taiga-ui/core';
+    it(
+        'adds a TODO near `header` in a tuiDialog factory call',
+        migrate({
+            component: /* TypeScript */ `
+                import {Component} from '@angular/core';
+                import {tuiDialog} from '@taiga-ui/core';
 
-            @Component({standalone: true})
-            export class TestComponent {
-                constructor() {
-                    inject(TuiDialogService).open('content', {header: someTemplate});
+                @Component({standalone: true})
+                export class TestComponent {
+                    private readonly dialog = tuiDialog('content', {
+                        header: 'Title',
+                        size: 'm',
+                    });
                 }
-            }
-        `);
+            `,
+        }),
+    );
 
-        expect(result).toContain(TODO);
-    });
+    it(
+        'adds a TODO near `header` in a TuiDialogService.open call',
+        migrate({
+            component: /* TypeScript */ `
+                import {Component, inject} from '@angular/core';
+                import {TuiDialogService} from '@taiga-ui/core';
 
-    it('adds a TODO near `header` in a tuiDialogOptionsProvider call', async () => {
-        const result = await migrateComponent(`
-            import {Component} from '@angular/core';
-            import {tuiDialogOptionsProvider} from '@taiga-ui/core';
+                @Component({standalone: true})
+                export class TestComponent {
+                    constructor() {
+                        inject(TuiDialogService).open('content', {header: someTemplate});
+                    }
+                }
+            `,
+        }),
+    );
 
-            @Component({
-                standalone: true,
-                providers: [tuiDialogOptionsProvider({header: 'Title'})],
-            })
-            export class TestComponent {}
-        `);
+    it(
+        'adds a TODO near `header` in a tuiDialogOptionsProvider call',
+        migrate({
+            component: /* TypeScript */ `
+                import {Component} from '@angular/core';
+                import {tuiDialogOptionsProvider} from '@taiga-ui/core';
 
-        expect(result).toContain(TODO);
-    });
+                @Component({
+                    standalone: true,
+                    providers: [tuiDialogOptionsProvider({header: 'Title'})],
+                })
+                export class TestComponent {}
+            `,
+        }),
+    );
 
-    it('does not add a TODO when there is no `header` option', async () => {
-        const result = await migrateComponent(`
-            import {Component} from '@angular/core';
-            import {tuiDialog} from '@taiga-ui/core';
+    it(
+        'adds a TODO for every dialog call with `header` in the same file',
+        migrate({
+            component: /* TypeScript */ `
+                import {Component} from '@angular/core';
+                import {tuiDialog} from '@taiga-ui/core';
 
-            @Component({standalone: true})
-            export class TestComponent {
-                private readonly dialog = tuiDialog('content', {
-                    label: 'Title',
-                    size: 'm',
-                });
-            }
-        `);
+                @Component({standalone: true})
+                export class TestComponent {
+                    private readonly dialog1 = tuiDialog('content', {header: 'Title 1'});
+                    private readonly dialog2 = tuiDialog('content', {header: 'Title 2'});
+                }
+            `,
+        }),
+    );
 
-        expect(result).not.toContain('TODO: (Taiga UI migration)');
-    });
+    it(
+        'does not add a TODO when there is no `header` option',
+        migrate({
+            component: /* TypeScript */ `
+                import {Component} from '@angular/core';
+                import {tuiDialog} from '@taiga-ui/core';
 
-    it('does not touch a `header` property on an unrelated call', async () => {
-        const result = await migrateComponent(`
-            import {Component} from '@angular/core';
+                @Component({standalone: true})
+                export class TestComponent {
+                    private readonly dialog = tuiDialog('content', {
+                        label: 'Title',
+                        size: 'm',
+                    });
+                }
+            `,
+        }),
+    );
 
-            @Component({standalone: true})
-            export class TestComponent {
-                private readonly config = somethingElse({header: 'Title'});
-            }
-        `);
+    it(
+        'does not touch a `header` property on an unrelated call',
+        migrate({
+            component: /* TypeScript */ `
+                import {Component} from '@angular/core';
 
-        expect(result).not.toContain('TODO: (Taiga UI migration)');
-    });
-
-    it('adds a TODO for every dialog call with `header` in the same file', async () => {
-        const result = await migrateComponent(`
-            import {Component} from '@angular/core';
-            import {tuiDialog} from '@taiga-ui/core';
-
-            @Component({standalone: true})
-            export class TestComponent {
-                private readonly dialog1 = tuiDialog('content', {header: 'Title 1'});
-                private readonly dialog2 = tuiDialog('content', {header: 'Title 2'});
-            }
-        `);
-
-        const occurrences = result.split('TODO: (Taiga UI migration)').length - 1;
-
-        expect(occurrences).toBe(2);
-    });
+                @Component({standalone: true})
+                export class TestComponent {
+                    private readonly config = somethingElse({header: 'Title'});
+                }
+            `,
+        }),
+    );
 
     afterEach(() => resetActiveProject());
 });

--- a/projects/cdk/schematics/ng-update/v5/tests/schematic-migrate-dialog-header.spec.ts
+++ b/projects/cdk/schematics/ng-update/v5/tests/schematic-migrate-dialog-header.spec.ts
@@ -95,5 +95,22 @@ describe('ng-update tuiDialog header option', () => {
         expect(result).not.toContain('TODO: (Taiga UI migration)');
     });
 
+    it('adds a TODO for every dialog call with `header` in the same file', async () => {
+        const result = await migrateComponent(`
+            import {Component} from '@angular/core';
+            import {tuiDialog} from '@taiga-ui/core';
+
+            @Component({standalone: true})
+            export class TestComponent {
+                private readonly dialog1 = tuiDialog('content', {header: 'Title 1'});
+                private readonly dialog2 = tuiDialog('content', {header: 'Title 2'});
+            }
+        `);
+
+        const occurrences = result.split('TODO: (Taiga UI migration)').length - 1;
+
+        expect(occurrences).toBe(2);
+    });
+
     afterEach(() => resetActiveProject());
 });

--- a/projects/cdk/schematics/ng-update/v5/tests/schematic-migrate-dialog-header.spec.ts
+++ b/projects/cdk/schematics/ng-update/v5/tests/schematic-migrate-dialog-header.spec.ts
@@ -6,7 +6,8 @@ import {runMigration} from '../../../utils/run-migration';
 
 const collection = join(__dirname, '../../../migration.json');
 
-const TODO = `// TODO: (Taiga UI migration) dialog \`header\` option (content shown above the title) was removed from \`TuiDialogOptions\` in v5. To keep content above the title, pass an empty \`label\` and place \`tuiHeader\` in the dialog template where you need it. For a plain string title, use \`label\` instead. See: https://taiga-ui.dev/components/dialog`;
+const TODO =
+    '// TODO: (Taiga UI migration) dialog `header` option (content shown above the title) was removed from `TuiDialogOptions` in v5. To keep content above the title, pass an empty `label` and place `tuiHeader` in the dialog template where you need it. For a plain string title, use `label` instead. See: https://taiga-ui.dev/components/dialog';
 
 describe('ng-update tuiDialog header option', () => {
     const migrateComponent = async (component: string): Promise<string> => {


### PR DESCRIPTION
### Which issue does this PR close?

Part of #13823 (item: *"Dialog `header` option is not migrated to anything"*).

### What is the problem?

In v4 `TuiDialogOptions` had two distinct fields:

- `label: string` — the dialog title;
- `header: PolymorpheusContent` — content rendered **above** the title.

In v5 `header` was removed entirely (it is **not** an alias of `label`). Any
`header` left in dialog options silently produces a type error after `ng update`,
with no guidance.

### What is the solution?

There is no faithful automatic transform: `header` was positioned *above* the
title, so mapping it to `label` would relocate content, and rich
`PolymorpheusContent` cannot be expressed as a `string` label at all. The v5
pattern (per maintainer guidance) is manual: pass an empty `label` and place
`tuiHeader` in the dialog template.

So this migration **flags** each `header` usage with a `TODO` comment pointing to
that pattern and the docs, instead of guessing:

```ts
tuiDialog('content', {
    // TODO: (Taiga UI migration) dialog `header` option (content shown above the title)
    // was removed from `TuiDialogOptions` in v5. To keep content above the title, pass an
    // empty `label` and place `tuiHeader` in the dialog template where you need it. For a
    // plain string title, use `label` instead. See: https://taiga-ui.dev/components/dialog
    header: 'Title',
    size: 'm',
})
```

Detection is scoped to dialog options objects only — `tuiDialog(...)`,
`TuiDialogService.open(...)` and `tuiDialogOptionsProvider(...)` — mirroring
`migrateDialogLegacySizes`, so unrelated `header` keys are never touched.