### PR TITLE
fix(cdk): flag SafeResourceUrl avatar `src` during v5 migration

### DIFF
--- a/projects/cdk/schematics/ng-update/v5/steps/templates/migrate-avatar.ts
+++ b/projects/cdk/schematics/ng-update/v5/steps/templates/migrate-avatar.ts
@@ -163,8 +163,9 @@ function hasTuiAvatarAttr(attrs: Attribute[]): boolean {
 /**
  * A raw dynamic `[src]`/`[(src)]` becomes `[tuiAvatar]="..."`, which only accepts a
  * string. A `SafeResourceUrl` (or any non-string image) would break at build time, and
- * the bound type cannot be inferred from the template — so flag it with a TODO. Icon and
- * fallback bindings (`| tuiIcon`, `| tuiFallbackSrc`) are known-string flows and skipped.
+ * the bound type cannot be inferred from the template — so flag it with a TODO. Provably
+ * string values are skipped: quoted/backtick literals (`[src]="'a.png'"`) and known
+ * string flows (`| tuiIcon`, `| tuiFallbackSrc`).
  */
 function maybeInsertSafeResourceUrlTodo(
     recorder: UpdateRecorder,
@@ -185,7 +186,26 @@ function maybeInsertSafeResourceUrlTodo(
 function isRawDynamicSrc(attr: Attribute): boolean {
     const isBinding = attr.name === '[src]' || attr.name === '[(src)]';
 
-    return isBinding && !/\|\s*(?:tuiIcon|tuiFallbackSrc)\b/.test(attr.value);
+    if (!isBinding) {
+        return false;
+    }
+
+    const value = attr.value.trim();
+
+    return !isStringLiteral(value) && !/\|\s*(?:tuiIcon|tuiFallbackSrc)\b/.test(value);
+}
+
+/**
+ * A quoted or backtick-delimited value is provably a `string`, so it can never be a
+ * `SafeResourceUrl` and does not need a TODO.
+ */
+function isStringLiteral(value: string): boolean {
+    return (
+        value.length >= 2 &&
+        ((value.startsWith("'") && value.endsWith("'")) ||
+            (value.startsWith('"') && value.endsWith('"')) ||
+            (value.startsWith('`') && value.endsWith('`')))
+    );
 }
 
 function getSrcAttr(attrs: Attribute[]): Attribute | undefined {

--- a/projects/cdk/schematics/ng-update/v5/steps/templates/migrate-avatar.ts
+++ b/projects/cdk/schematics/ng-update/v5/steps/templates/migrate-avatar.ts
@@ -2,11 +2,11 @@ import {type UpdateRecorder} from '@angular-devkit/schematics';
 import {type DevkitFileSystem} from 'ng-morph';
 import {type DefaultTreeAdapterTypes, type Token} from 'parse5';
 
+import {TODO_MARK} from '../../../../utils/insert-todo';
 import {
     findElementsByTagName,
     findElementsWithAttribute,
 } from '../../../../utils/templates/elements';
-import {TODO_MARK} from '../../../../utils/insert-todo';
 import {findAttr} from '../../../../utils/templates/inputs';
 import {
     getTemplateFromTemplateResource,

--- a/projects/cdk/schematics/ng-update/v5/steps/templates/migrate-avatar.ts
+++ b/projects/cdk/schematics/ng-update/v5/steps/templates/migrate-avatar.ts
@@ -6,6 +6,7 @@ import {
     findElementsByTagName,
     findElementsWithAttribute,
 } from '../../../../utils/templates/elements';
+import {TODO_MARK} from '../../../../utils/insert-todo';
 import {findAttr} from '../../../../utils/templates/inputs';
 import {
     getTemplateFromTemplateResource,
@@ -20,6 +21,9 @@ type Attribute = Token.Attribute;
 type Element = DefaultTreeAdapterTypes.Element;
 
 type ElementLocation = Token.ElementLocation;
+
+const SAFE_RESOURCE_URL_TODO =
+    'tuiAvatar accepts only a string (icon name or URL). If this value is a SafeResourceUrl or another non-string image source, render it via an inner <img> instead: <span tuiAvatar><img [src]="..." alt="" /></span>.';
 
 export function migrateAvatarToDirective({
     resource,
@@ -85,6 +89,8 @@ export function migrateAvatarToDirective({
             return;
         }
 
+        maybeInsertSafeResourceUrlTodo(recorder, loc, templateOffset, srcAttr);
+
         replaceAttribute(
             recorder,
             tuiAvatarAttr?.name ?? 'tuiAvatar',
@@ -106,6 +112,10 @@ export function migrateAvatarToDirective({
         const srcAttr = getSrcAttr(element.attrs);
         const hasAvatarAttr = hasTuiAvatarAttr(element.attrs);
         const attrToAdd = hasAvatarAttr ? null : getAvatarAttr(srcAttr);
+
+        if (!hasAvatarAttr) {
+            maybeInsertSafeResourceUrlTodo(recorder, loc, templateOffset, srcAttr);
+        }
 
         replaceTag(
             recorder,
@@ -148,6 +158,34 @@ function hasTuiAvatarAttr(attrs: Attribute[]): boolean {
             .map((attr) => attr.toLowerCase())
             .includes(name),
     );
+}
+
+/**
+ * A raw dynamic `[src]`/`[(src)]` becomes `[tuiAvatar]="..."`, which only accepts a
+ * string. A `SafeResourceUrl` (or any non-string image) would break at build time, and
+ * the bound type cannot be inferred from the template — so flag it with a TODO. Icon and
+ * fallback bindings (`| tuiIcon`, `| tuiFallbackSrc`) are known-string flows and skipped.
+ */
+function maybeInsertSafeResourceUrlTodo(
+    recorder: UpdateRecorder,
+    loc: ElementLocation,
+    templateOffset: number,
+    srcAttr?: Attribute,
+): void {
+    if (!srcAttr || !isRawDynamicSrc(srcAttr)) {
+        return;
+    }
+
+    recorder.insertLeft(
+        templateOffset + loc.startOffset,
+        `<!-- ${TODO_MARK} ${SAFE_RESOURCE_URL_TODO} -->\n`,
+    );
+}
+
+function isRawDynamicSrc(attr: Attribute): boolean {
+    const isBinding = attr.name === '[src]' || attr.name === '[(src)]';
+
+    return isBinding && !/\|\s*(?:tuiIcon|tuiFallbackSrc)\b/.test(attr.value);
 }
 
 function getSrcAttr(attrs: Attribute[]): Attribute | undefined {

--- a/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-avatar-to-directive.spec.ts.snap
+++ b/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-avatar-to-directive.spec.ts.snap
@@ -30,6 +30,13 @@ exports[`ng-update avatar complex templates: test.html 1`] = `
 }
 `;
 
+exports[`ng-update avatar keeps a bound string literal [src] without a SafeResourceUrl TODO: test.html 1`] = `
+{
+  "0. Before": "<tui-avatar [src]="'assets/avatar.png'"></tui-avatar>",
+  "1. After": "<span [tuiAvatar]="'assets/avatar.png'"></span>",
+}
+`;
+
 exports[`ng-update avatar moves src value to tuiAvatar attribute on host element: test.html 1`] = `
 {
   "0. Before": "<a tuiAvatar src="avatar.png"></a>",

--- a/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-avatar-to-directive.spec.ts.snap
+++ b/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-avatar-to-directive.spec.ts.snap
@@ -73,7 +73,8 @@ exports[`ng-update avatar picture inside tui-avatar: test.html 1`] = `
 exports[`ng-update avatar replaces bound src attribute with bound tuiAvatar: test.html 1`] = `
 {
   "0. Before": "<tui-avatar [src]="avatarUrl" size="m"></tui-avatar>",
-  "1. After": "<span [tuiAvatar]="avatarUrl" size="m"></span>",
+  "1. After": "<!-- TODO: (Taiga UI migration) tuiAvatar accepts only a string (icon name or URL). If this value is a SafeResourceUrl or another non-string image source, render it via an inner <img> instead: <span tuiAvatar><img [src]="..." alt="" /></span>. -->
+<span [tuiAvatar]="avatarUrl" size="m"></span>",
 }
 `;
 

--- a/projects/cdk/schematics/ng-update/v5/tests/schematic-migrate-avatar-to-directive.spec.ts
+++ b/projects/cdk/schematics/ng-update/v5/tests/schematic-migrate-avatar-to-directive.spec.ts
@@ -14,8 +14,6 @@ describe('ng-update avatar', () => {
         migrate({template: '<tui-avatar src="tuiIconUser"></tui-avatar>'}),
     );
 
-    // Also guards issue #13823: a raw dynamic [src] binding gets the SafeResourceUrl TODO —
-    // the snapshot's "After" shows the inserted comment above the migrated element.
     it(
         'replaces bound src attribute with bound tuiAvatar',
         migrate({template: '<tui-avatar [src]="avatarUrl" size="m"></tui-avatar>'}),
@@ -91,8 +89,6 @@ describe('ng-update avatar', () => {
         }),
     );
 
-    // Guards Gemini's fix: a bound string literal is not a SafeResourceUrl, so it is migrated
-    // to [tuiAvatar] without a TODO (the snapshot's "After" has no inserted comment).
     it(
         'keeps a bound string literal [src] without a SafeResourceUrl TODO',
         migrate({template: '<tui-avatar [src]="\'assets/avatar.png\'"></tui-avatar>'}),

--- a/projects/cdk/schematics/ng-update/v5/tests/schematic-migrate-avatar-to-directive.spec.ts
+++ b/projects/cdk/schematics/ng-update/v5/tests/schematic-migrate-avatar-to-directive.spec.ts
@@ -2,7 +2,7 @@ import {join} from 'node:path';
 
 import {resetActiveProject} from 'ng-morph';
 
-import {createMigration, runMigration} from '../../../utils/run-migration';
+import {createMigration} from '../../../utils/run-migration';
 
 const COLLECTION = join(__dirname, '../../../migration.json');
 
@@ -14,6 +14,8 @@ describe('ng-update avatar', () => {
         migrate({template: '<tui-avatar src="tuiIconUser"></tui-avatar>'}),
     );
 
+    // Also guards issue #13823: a raw dynamic [src] binding gets the SafeResourceUrl TODO —
+    // the snapshot's "After" shows the inserted comment above the migrated element.
     it(
         'replaces bound src attribute with bound tuiAvatar',
         migrate({template: '<tui-avatar [src]="avatarUrl" size="m"></tui-avatar>'}),
@@ -89,44 +91,12 @@ describe('ng-update avatar', () => {
         }),
     );
 
-    it('adds a SafeResourceUrl TODO for a raw dynamic [src] binding (issue #13823)', async () => {
-        const {template} = await runMigration({
-            collection: COLLECTION,
-            template: '<tui-avatar [src]="safeUrl"></tui-avatar>',
-        });
-
-        expect(template).toContain('[tuiAvatar]="safeUrl"');
-        expect(template).toContain('TODO: (Taiga UI migration)');
-        expect(template).toContain('SafeResourceUrl');
-    });
-
-    it('does not add a SafeResourceUrl TODO for an icon binding', async () => {
-        const {template} = await runMigration({
-            collection: COLLECTION,
-            template: '<tui-avatar [src]="\'@tui.mastercard\' | tuiIcon" />',
-        });
-
-        expect(template).not.toContain('SafeResourceUrl');
-    });
-
-    it('does not add a SafeResourceUrl TODO for a static string src', async () => {
-        const {template} = await runMigration({
-            collection: COLLECTION,
-            template: '<tui-avatar src="@tui.user"></tui-avatar>',
-        });
-
-        expect(template).not.toContain('SafeResourceUrl');
-    });
-
-    it('does not add a SafeResourceUrl TODO for a bound string literal', async () => {
-        const {template} = await runMigration({
-            collection: COLLECTION,
-            template: '<tui-avatar [src]="\'assets/avatar.png\'"></tui-avatar>',
-        });
-
-        expect(template).toContain('[tuiAvatar]="\'assets/avatar.png\'"');
-        expect(template).not.toContain('SafeResourceUrl');
-    });
+    // Guards Gemini's fix: a bound string literal is not a SafeResourceUrl, so it is migrated
+    // to [tuiAvatar] without a TODO (the snapshot's "After" has no inserted comment).
+    it(
+        'keeps a bound string literal [src] without a SafeResourceUrl TODO',
+        migrate({template: '<tui-avatar [src]="\'assets/avatar.png\'"></tui-avatar>'}),
+    );
 
     afterEach(() => resetActiveProject());
 });

--- a/projects/cdk/schematics/ng-update/v5/tests/schematic-migrate-avatar-to-directive.spec.ts
+++ b/projects/cdk/schematics/ng-update/v5/tests/schematic-migrate-avatar-to-directive.spec.ts
@@ -118,5 +118,15 @@ describe('ng-update avatar', () => {
         expect(template).not.toContain('SafeResourceUrl');
     });
 
+    it('does not add a SafeResourceUrl TODO for a bound string literal', async () => {
+        const {template} = await runMigration({
+            collection: COLLECTION,
+            template: '<tui-avatar [src]="\'assets/avatar.png\'"></tui-avatar>',
+        });
+
+        expect(template).toContain('[tuiAvatar]="\'assets/avatar.png\'"');
+        expect(template).not.toContain('SafeResourceUrl');
+    });
+
     afterEach(() => resetActiveProject());
 });

--- a/projects/cdk/schematics/ng-update/v5/tests/schematic-migrate-avatar-to-directive.spec.ts
+++ b/projects/cdk/schematics/ng-update/v5/tests/schematic-migrate-avatar-to-directive.spec.ts
@@ -2,12 +2,12 @@ import {join} from 'node:path';
 
 import {resetActiveProject} from 'ng-morph';
 
-import {createMigration} from '../../../utils/run-migration';
+import {createMigration, runMigration} from '../../../utils/run-migration';
+
+const COLLECTION = join(__dirname, '../../../migration.json');
 
 describe('ng-update avatar', () => {
-    const migrate = createMigration({
-        collection: join(__dirname, '../../../migration.json'),
-    });
+    const migrate = createMigration({collection: COLLECTION});
 
     it(
         'replaces src attribute with tuiAvatar',
@@ -88,6 +88,35 @@ describe('ng-update avatar', () => {
             `,
         }),
     );
+
+    it('adds a SafeResourceUrl TODO for a raw dynamic [src] binding (issue #13823)', async () => {
+        const {template} = await runMigration({
+            collection: COLLECTION,
+            template: '<tui-avatar [src]="safeUrl"></tui-avatar>',
+        });
+
+        expect(template).toContain('[tuiAvatar]="safeUrl"');
+        expect(template).toContain('TODO: (Taiga UI migration)');
+        expect(template).toContain('SafeResourceUrl');
+    });
+
+    it('does not add a SafeResourceUrl TODO for an icon binding', async () => {
+        const {template} = await runMigration({
+            collection: COLLECTION,
+            template: '<tui-avatar [src]="\'@tui.mastercard\' | tuiIcon" />',
+        });
+
+        expect(template).not.toContain('SafeResourceUrl');
+    });
+
+    it('does not add a SafeResourceUrl TODO for a static string src', async () => {
+        const {template} = await runMigration({
+            collection: COLLECTION,
+            template: '<tui-avatar src="@tui.user"></tui-avatar>',
+        });
+
+        expect(template).not.toContain('SafeResourceUrl');
+    });
 
     afterEach(() => resetActiveProject());
 });

--- a/projects/cdk/schematics/ng-update/v5/tests/schematic-migrate-avatar-to-directive.spec.ts
+++ b/projects/cdk/schematics/ng-update/v5/tests/schematic-migrate-avatar-to-directive.spec.ts
@@ -4,10 +4,10 @@ import {resetActiveProject} from 'ng-morph';
 
 import {createMigration} from '../../../utils/run-migration';
 
-const COLLECTION = join(__dirname, '../../../migration.json');
-
 describe('ng-update avatar', () => {
-    const migrate = createMigration({collection: COLLECTION});
+    const migrate = createMigration({
+        collection: join(__dirname, '../../../migration.json'),
+    });
 
     it(
         'replaces src attribute with tuiAvatar',


### PR DESCRIPTION
### Which issue does this PR close?

Part of #13823 (item: *"`tui-avatar` migration results in an error when `src` is `SafeResourceUrl`"*).

### What is the problem?

`<tui-avatar [src]="x">` migrates to `<span [tuiAvatar]="x">`. In v5 `tuiAvatar`
is proxied to the `iconStart` input, which only accepts a **string** (icon name or
URL). When the bound value is a `SafeResourceUrl` (or any non-string image source)
the migrated template breaks at build time — and the type cannot be inferred from
the template alone.

### What is the solution?

Per maintainer guidance in the issue (drop a comment for bindings, pointing at the
`img`-inside pattern), insert a `TODO` on **raw dynamic** `[src]`/`[(src)]`
bindings:

```html
<!-- TODO: (Taiga UI migration) tuiAvatar accepts only a string (icon name or URL).
     If this value is a SafeResourceUrl or another non-string image source, render it
     via an inner <img> instead: <span tuiAvatar><img [src]="..." alt="" /></span>. -->
<span [tuiAvatar]="avatarUrl"></span>
```

Known-string flows are intentionally skipped, so the comment only appears where the
type is genuinely ambiguous:

- `| tuiIcon` bindings (icon string) — skipped;
- `| tuiFallbackSrc` bindings (already unwrapped into an inner `<img>`) — skipped;
- static string `src="..."` — skipped.

Since the bound type is invisible to the migration, the comment is advisory rather
than a code transform.