### PR TITLE
fix(cdk): keep `tuiRepeatTimes` loop value numeric in @for blocks

### DIFF
--- a/projects/cdk/schematics/ng-update/v5/steps/templates/migrate-repeat-times.ts
+++ b/projects/cdk/schematics/ng-update/v5/steps/templates/migrate-repeat-times.ts
@@ -20,6 +20,12 @@ const FOR_BLOCK_PATTERN = /@for\s*\(/g;
 const NGFOR_REPEAT_TIMES_PIPE_PATTERN =
     /let\s+(\w+)\s+of\s+([^\s|]+)\s*\|\s*tuiRepeatTimes\s*/;
 
+// Split into two anchored patterns (no overlapping whitespace quantifiers) to avoid
+// super-linear regex backtracking: strip the `| tuiRepeatTimes` suffix, then parse
+// `<var> of <expression>` where the expression must start with a non-space char.
+const AT_FOR_REPEAT_TIMES_PIPE_SUFFIX = /\s*\|\s*tuiRepeatTimes\s*$/;
+const AT_FOR_ITERATION_PATTERN = /^\s*(\S+)\s+of\s+(\S[\s\S]*)$/;
+
 export function migrateRepeatTimes({
     resource,
     recorder,
@@ -278,10 +284,15 @@ function replaceRepeatTimesInForHeader(header: string): string | null {
     }
 
     const [iteration = '', ...tail] = header.split(';');
+    const beforePipe = iteration.replace(AT_FOR_REPEAT_TIMES_PIPE_SUFFIX, '');
 
-    const iterationMatch = /^\s*(\S+)\s+of\s+([\s\S]+?)\s*\|\s*tuiRepeatTimes\s*$/.exec(
-        iteration,
-    );
+    if (beforePipe === iteration) {
+        // `| tuiRepeatTimes` is not the tail of the iteration clause (e.g. it is nested
+        // inside the iterable expression) — leave the block untouched.
+        return null;
+    }
+
+    const iterationMatch = AT_FOR_ITERATION_PATTERN.exec(beforePipe);
 
     if (!iterationMatch) {
         return null;
@@ -299,6 +310,7 @@ function replaceRepeatTimesInForHeader(header: string): string | null {
     // match what `N | tuiRepeatTimes` produced (and what the *tuiRepeatTimes path does).
     const needsAlias = variable !== '_' && variable !== '$index';
     const alias = needsAlias ? [`let ${variable} = $index`] : [];
+
     const tailWithoutTrack = tail
         .map((segment) => segment.trim())
         .filter((segment) => segment && !/^track\b/.test(segment));

--- a/projects/cdk/schematics/ng-update/v5/steps/templates/migrate-repeat-times.ts
+++ b/projects/cdk/schematics/ng-update/v5/steps/templates/migrate-repeat-times.ts
@@ -287,7 +287,8 @@ function replaceRepeatTimesInForHeader(header: string): string | null {
         return null;
     }
 
-    const [, variable = '', expression = ''] = iterationMatch;
+    const [, variable = '', rawExpression = ''] = iterationMatch;
+    const expression = rawExpression.trim();
 
     if (!expression) {
         return null;

--- a/projects/cdk/schematics/ng-update/v5/steps/templates/migrate-repeat-times.ts
+++ b/projects/cdk/schematics/ng-update/v5/steps/templates/migrate-repeat-times.ts
@@ -273,29 +273,41 @@ function migrateAtForRepeatTimes(
 }
 
 function replaceRepeatTimesInForHeader(header: string): string | null {
-    const pipeMatch = /\|\s*tuiRepeatTimes\b/.exec(header);
-
-    if (pipeMatch?.index === undefined) {
+    if (!/\|\s*tuiRepeatTimes\b/.test(header)) {
         return null;
     }
 
-    const beforePipe = header.slice(0, pipeMatch.index);
-    const ofIndex = beforePipe.lastIndexOf(' of ');
+    const [iteration = '', ...tail] = header.split(';');
 
-    if (ofIndex === -1) {
+    const iterationMatch = /^\s*(\S+)\s+of\s+([\s\S]+?)\s*\|\s*tuiRepeatTimes\s*$/.exec(
+        iteration,
+    );
+
+    if (!iterationMatch) {
         return null;
     }
 
-    const expression = beforePipe.slice(ofIndex + ' of '.length).trim();
+    const [, variable = '', expression = ''] = iterationMatch;
 
     if (!expression) {
         return null;
     }
 
-    const beforeExpression = beforePipe.slice(0, ofIndex + ' of '.length);
-    const afterPipe = header.slice(pipeMatch.index + pipeMatch[0].length);
+    // `'-'.repeat(N)` only provides the iteration count, so the loop variable would
+    // otherwise bind to the '-' string char. Alias it back to the numeric $index to
+    // match what `N | tuiRepeatTimes` produced (and what the *tuiRepeatTimes path does).
+    const needsAlias = variable !== '_' && variable !== '$index';
+    const alias = needsAlias ? [`let ${variable} = $index`] : [];
+    const tailWithoutTrack = tail
+        .map((segment) => segment.trim())
+        .filter((segment) => segment && !/^track\b/.test(segment));
 
-    return `${beforeExpression}'-'.repeat(${expression})${afterPipe}`;
+    return [
+        `_ of '-'.repeat(${expression})`,
+        'track $index',
+        ...alias,
+        ...tailWithoutTrack,
+    ].join('; ');
 }
 
 function findMatchingParen(template: string, openParen: number): number {

--- a/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-repeat-times.spec.ts.snap
+++ b/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-repeat-times.spec.ts.snap
@@ -90,7 +90,7 @@ exports[`ng-update tuiRepeatTimes full before/after comparison with nested conte
 exports[`ng-update tuiRepeatTimes keeps @for tail params while replacing tuiRepeatTimes expression: test.html 1`] = `
 {
   "0. Before": "@for (n of config.count | tuiRepeatTimes; track n; let isOdd = $odd) { {{n}} }",
-  "1. After": "@for (n of '-'.repeat(config.count); track n; let isOdd = $odd) { {{n}} }",
+  "1. After": "@for (_ of '-'.repeat(config.count); track $index; let n = $index; let isOdd = $odd) { {{n}} }",
 }
 `;
 
@@ -234,7 +234,7 @@ exports[`ng-update tuiRepeatTimes migrates @for block syntax with tuiRepeatTimes
             ",
   "1. After": "
                 <section class="list">
-                    @for (n of '-'.repeat(3); track n) {
+                    @for (_ of '-'.repeat(3); track $index; let n = $index) {
                     <item />
                     }
                 </section>

--- a/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-repeat-times.spec.ts.snap
+++ b/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-repeat-times.spec.ts.snap
@@ -87,14 +87,14 @@ exports[`ng-update tuiRepeatTimes full before/after comparison with nested conte
 }
 `;
 
-exports[`ng-update tuiRepeatTimes keeps @for tail params while replacing tuiRepeatTimes expression: test.html 1`] = `
+exports[`ng-update tuiRepeatTimes keeps @for loop value numeric with tail params intact (issue #13823): test.html 1`] = `
 {
   "0. Before": "@for (n of config.count | tuiRepeatTimes; track n; let isOdd = $odd) { {{n}} }",
   "1. After": "@for (_ of '-'.repeat(config.count); track $index; let n = $index; let isOdd = $odd) { {{n}} }",
 }
 `;
 
-exports[`ng-update tuiRepeatTimes keeps @for tail params while replacing tuiRepeatTimes expression: test.ts 1`] = `
+exports[`ng-update tuiRepeatTimes keeps @for loop value numeric with tail params intact (issue #13823): test.ts 1`] = `
 {
   "0. Before": "
             import {Component} from '@angular/core';

--- a/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-repeat-times.spec.ts.snap
+++ b/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-repeat-times.spec.ts.snap
@@ -3,26 +3,26 @@
 exports[`ng-update tuiRepeatTimes does not touch *ngFor without tuiRepeatTimes: test.ts 1`] = `
 {
   "0. Before": "
-            import {Component} from '@angular/core';
-            import {TuiRepeatTimesPipe} from '@taiga-ui/cdk';
+    import {Component} from '@angular/core';
+    import {TuiRepeatTimesPipe} from '@taiga-ui/cdk';
 
-            @Component({
-                standalone: true,
-                templateUrl: './test.html',
-                imports: [TuiRepeatTimesPipe],
-            })
-            export class Test {}
-        ",
+    @Component({
+        standalone: true,
+        templateUrl: './test.html',
+        imports: [TuiRepeatTimesPipe],
+    })
+    export class Test {}
+",
   "1. After": "
-            import {Component} from '@angular/core';
+    import {Component} from '@angular/core';
 
-            @Component({
-                standalone: true,
-                templateUrl: './test.html',
-                imports: [],
-            })
-            export class Test {}
-        ",
+    @Component({
+        standalone: true,
+        templateUrl: './test.html',
+        imports: [],
+    })
+    export class Test {}
+",
 }
 `;
 
@@ -64,26 +64,26 @@ exports[`ng-update tuiRepeatTimes full before/after comparison with nested conte
 exports[`ng-update tuiRepeatTimes full before/after comparison with nested content: test.ts 1`] = `
 {
   "0. Before": "
-            import {Component} from '@angular/core';
-            import {TuiRepeatTimesPipe} from '@taiga-ui/cdk';
+    import {Component} from '@angular/core';
+    import {TuiRepeatTimesPipe} from '@taiga-ui/cdk';
 
-            @Component({
-                standalone: true,
-                templateUrl: './test.html',
-                imports: [TuiRepeatTimesPipe],
-            })
-            export class Test {}
-        ",
+    @Component({
+        standalone: true,
+        templateUrl: './test.html',
+        imports: [TuiRepeatTimesPipe],
+    })
+    export class Test {}
+",
   "1. After": "
-            import {Component} from '@angular/core';
+    import {Component} from '@angular/core';
 
-            @Component({
-                standalone: true,
-                templateUrl: './test.html',
-                imports: [],
-            })
-            export class Test {}
-        ",
+    @Component({
+        standalone: true,
+        templateUrl: './test.html',
+        imports: [],
+    })
+    export class Test {}
+",
 }
 `;
 
@@ -97,26 +97,26 @@ exports[`ng-update tuiRepeatTimes keeps @for loop value numeric with tail params
 exports[`ng-update tuiRepeatTimes keeps @for loop value numeric with tail params intact (issue #13823): test.ts 1`] = `
 {
   "0. Before": "
-            import {Component} from '@angular/core';
-            import {TuiRepeatTimesPipe} from '@taiga-ui/cdk';
+    import {Component} from '@angular/core';
+    import {TuiRepeatTimesPipe} from '@taiga-ui/cdk';
 
-            @Component({
-                standalone: true,
-                templateUrl: './test.html',
-                imports: [TuiRepeatTimesPipe],
-            })
-            export class Test {}
-        ",
+    @Component({
+        standalone: true,
+        templateUrl: './test.html',
+        imports: [TuiRepeatTimesPipe],
+    })
+    export class Test {}
+",
   "1. After": "
-            import {Component} from '@angular/core';
+    import {Component} from '@angular/core';
 
-            @Component({
-                standalone: true,
-                templateUrl: './test.html',
-                imports: [],
-            })
-            export class Test {}
-        ",
+    @Component({
+        standalone: true,
+        templateUrl: './test.html',
+        imports: [],
+    })
+    export class Test {}
+",
 }
 `;
 
@@ -132,26 +132,26 @@ exports[`ng-update tuiRepeatTimes migrates *ngFor with tuiRepeatTimes to @for: t
 exports[`ng-update tuiRepeatTimes migrates *ngFor with tuiRepeatTimes to @for: test.ts 1`] = `
 {
   "0. Before": "
-            import {Component} from '@angular/core';
-            import {TuiRepeatTimesPipe} from '@taiga-ui/cdk';
+    import {Component} from '@angular/core';
+    import {TuiRepeatTimesPipe} from '@taiga-ui/cdk';
 
-            @Component({
-                standalone: true,
-                templateUrl: './test.html',
-                imports: [TuiRepeatTimesPipe],
-            })
-            export class Test {}
-        ",
+    @Component({
+        standalone: true,
+        templateUrl: './test.html',
+        imports: [TuiRepeatTimesPipe],
+    })
+    export class Test {}
+",
   "1. After": "
-            import {Component} from '@angular/core';
+    import {Component} from '@angular/core';
 
-            @Component({
-                standalone: true,
-                templateUrl: './test.html',
-                imports: [],
-            })
-            export class Test {}
-        ",
+    @Component({
+        standalone: true,
+        templateUrl: './test.html',
+        imports: [],
+    })
+    export class Test {}
+",
 }
 `;
 
@@ -245,26 +245,26 @@ exports[`ng-update tuiRepeatTimes migrates @for block syntax with tuiRepeatTimes
 exports[`ng-update tuiRepeatTimes migrates @for block syntax with tuiRepeatTimes pipe: test.ts 1`] = `
 {
   "0. Before": "
-            import {Component} from '@angular/core';
-            import {TuiRepeatTimesPipe} from '@taiga-ui/cdk';
+    import {Component} from '@angular/core';
+    import {TuiRepeatTimesPipe} from '@taiga-ui/cdk';
 
-            @Component({
-                standalone: true,
-                templateUrl: './test.html',
-                imports: [TuiRepeatTimesPipe],
-            })
-            export class Test {}
-        ",
+    @Component({
+        standalone: true,
+        templateUrl: './test.html',
+        imports: [TuiRepeatTimesPipe],
+    })
+    export class Test {}
+",
   "1. After": "
-            import {Component} from '@angular/core';
+    import {Component} from '@angular/core';
 
-            @Component({
-                standalone: true,
-                templateUrl: './test.html',
-                imports: [],
-            })
-            export class Test {}
-        ",
+    @Component({
+        standalone: true,
+        templateUrl: './test.html',
+        imports: [],
+    })
+    export class Test {}
+",
 }
 `;
 
@@ -288,26 +288,26 @@ exports[`ng-update tuiRepeatTimes migrates multiple tuiRepeatTimes in same templ
 exports[`ng-update tuiRepeatTimes migrates multiple tuiRepeatTimes in same template: test.ts 1`] = `
 {
   "0. Before": "
-            import {Component} from '@angular/core';
-            import {TuiRepeatTimesPipe} from '@taiga-ui/cdk';
+    import {Component} from '@angular/core';
+    import {TuiRepeatTimesPipe} from '@taiga-ui/cdk';
 
-            @Component({
-                standalone: true,
-                templateUrl: './test.html',
-                imports: [TuiRepeatTimesPipe],
-            })
-            export class Test {}
-        ",
+    @Component({
+        standalone: true,
+        templateUrl: './test.html',
+        imports: [TuiRepeatTimesPipe],
+    })
+    export class Test {}
+",
   "1. After": "
-            import {Component} from '@angular/core';
+    import {Component} from '@angular/core';
 
-            @Component({
-                standalone: true,
-                templateUrl: './test.html',
-                imports: [],
-            })
-            export class Test {}
-        ",
+    @Component({
+        standalone: true,
+        templateUrl: './test.html',
+        imports: [],
+    })
+    export class Test {}
+",
 }
 `;
 
@@ -390,26 +390,26 @@ exports[`ng-update tuiRepeatTimes migrates nested inside other elements: test.ht
 exports[`ng-update tuiRepeatTimes migrates nested inside other elements: test.ts 1`] = `
 {
   "0. Before": "
-            import {Component} from '@angular/core';
-            import {TuiRepeatTimesPipe} from '@taiga-ui/cdk';
+    import {Component} from '@angular/core';
+    import {TuiRepeatTimesPipe} from '@taiga-ui/cdk';
 
-            @Component({
-                standalone: true,
-                templateUrl: './test.html',
-                imports: [TuiRepeatTimesPipe],
-            })
-            export class Test {}
-        ",
+    @Component({
+        standalone: true,
+        templateUrl: './test.html',
+        imports: [TuiRepeatTimesPipe],
+    })
+    export class Test {}
+",
   "1. After": "
-            import {Component} from '@angular/core';
+    import {Component} from '@angular/core';
 
-            @Component({
-                standalone: true,
-                templateUrl: './test.html',
-                imports: [],
-            })
-            export class Test {}
-        ",
+    @Component({
+        standalone: true,
+        templateUrl: './test.html',
+        imports: [],
+    })
+    export class Test {}
+",
 }
 `;
 
@@ -423,26 +423,26 @@ exports[`ng-update tuiRepeatTimes migrates ng-container by unwrapping: test.html
 exports[`ng-update tuiRepeatTimes migrates ng-container by unwrapping: test.ts 1`] = `
 {
   "0. Before": "
-            import {Component} from '@angular/core';
-            import {TuiRepeatTimesPipe} from '@taiga-ui/cdk';
+    import {Component} from '@angular/core';
+    import {TuiRepeatTimesPipe} from '@taiga-ui/cdk';
 
-            @Component({
-                standalone: true,
-                templateUrl: './test.html',
-                imports: [TuiRepeatTimesPipe],
-            })
-            export class Test {}
-        ",
+    @Component({
+        standalone: true,
+        templateUrl: './test.html',
+        imports: [TuiRepeatTimesPipe],
+    })
+    export class Test {}
+",
   "1. After": "
-            import {Component} from '@angular/core';
+    import {Component} from '@angular/core';
 
-            @Component({
-                standalone: true,
-                templateUrl: './test.html',
-                imports: [],
-            })
-            export class Test {}
-        ",
+    @Component({
+        standalone: true,
+        templateUrl: './test.html',
+        imports: [],
+    })
+    export class Test {}
+",
 }
 `;
 
@@ -458,26 +458,26 @@ exports[`ng-update tuiRepeatTimes migrates with member expression: test.html 1`]
 exports[`ng-update tuiRepeatTimes migrates with member expression: test.ts 1`] = `
 {
   "0. Before": "
-            import {Component} from '@angular/core';
-            import {TuiRepeatTimesPipe} from '@taiga-ui/cdk';
+    import {Component} from '@angular/core';
+    import {TuiRepeatTimesPipe} from '@taiga-ui/cdk';
 
-            @Component({
-                standalone: true,
-                templateUrl: './test.html',
-                imports: [TuiRepeatTimesPipe],
-            })
-            export class Test {}
-        ",
+    @Component({
+        standalone: true,
+        templateUrl: './test.html',
+        imports: [TuiRepeatTimesPipe],
+    })
+    export class Test {}
+",
   "1. After": "
-            import {Component} from '@angular/core';
+    import {Component} from '@angular/core';
 
-            @Component({
-                standalone: true,
-                templateUrl: './test.html',
-                imports: [],
-            })
-            export class Test {}
-        ",
+    @Component({
+        standalone: true,
+        templateUrl: './test.html',
+        imports: [],
+    })
+    export class Test {}
+",
 }
 `;
 
@@ -493,26 +493,26 @@ exports[`ng-update tuiRepeatTimes migrates with variable expression: test.html 1
 exports[`ng-update tuiRepeatTimes migrates with variable expression: test.ts 1`] = `
 {
   "0. Before": "
-            import {Component} from '@angular/core';
-            import {TuiRepeatTimesPipe} from '@taiga-ui/cdk';
+    import {Component} from '@angular/core';
+    import {TuiRepeatTimesPipe} from '@taiga-ui/cdk';
 
-            @Component({
-                standalone: true,
-                templateUrl: './test.html',
-                imports: [TuiRepeatTimesPipe],
-            })
-            export class Test {}
-        ",
+    @Component({
+        standalone: true,
+        templateUrl: './test.html',
+        imports: [TuiRepeatTimesPipe],
+    })
+    export class Test {}
+",
   "1. After": "
-            import {Component} from '@angular/core';
+    import {Component} from '@angular/core';
 
-            @Component({
-                standalone: true,
-                templateUrl: './test.html',
-                imports: [],
-            })
-            export class Test {}
-        ",
+    @Component({
+        standalone: true,
+        templateUrl: './test.html',
+        imports: [],
+    })
+    export class Test {}
+",
 }
 `;
 
@@ -528,51 +528,51 @@ exports[`ng-update tuiRepeatTimes preserves other attributes on the element: tes
 exports[`ng-update tuiRepeatTimes preserves other attributes on the element: test.ts 1`] = `
 {
   "0. Before": "
-            import {Component} from '@angular/core';
-            import {TuiRepeatTimesPipe} from '@taiga-ui/cdk';
+    import {Component} from '@angular/core';
+    import {TuiRepeatTimesPipe} from '@taiga-ui/cdk';
 
-            @Component({
-                standalone: true,
-                templateUrl: './test.html',
-                imports: [TuiRepeatTimesPipe],
-            })
-            export class Test {}
-        ",
+    @Component({
+        standalone: true,
+        templateUrl: './test.html',
+        imports: [TuiRepeatTimesPipe],
+    })
+    export class Test {}
+",
   "1. After": "
-            import {Component} from '@angular/core';
+    import {Component} from '@angular/core';
 
-            @Component({
-                standalone: true,
-                templateUrl: './test.html',
-                imports: [],
-            })
-            export class Test {}
-        ",
+    @Component({
+        standalone: true,
+        templateUrl: './test.html',
+        imports: [],
+    })
+    export class Test {}
+",
 }
 `;
 
 exports[`ng-update tuiRepeatTimes removes TuiRepeatTimesPipe import and usage: test.ts 1`] = `
 {
   "0. Before": "
-            import {Component} from '@angular/core';
-            import {TuiRepeatTimesPipe} from '@taiga-ui/cdk';
+    import {Component} from '@angular/core';
+    import {TuiRepeatTimesPipe} from '@taiga-ui/cdk';
 
-            @Component({
-                standalone: true,
-                templateUrl: './test.html',
-                imports: [TuiRepeatTimesPipe],
-            })
-            export class Test {}
-        ",
+    @Component({
+        standalone: true,
+        templateUrl: './test.html',
+        imports: [TuiRepeatTimesPipe],
+    })
+    export class Test {}
+",
   "1. After": "
-            import {Component} from '@angular/core';
+    import {Component} from '@angular/core';
 
-            @Component({
-                standalone: true,
-                templateUrl: './test.html',
-                imports: [],
-            })
-            export class Test {}
-        ",
+    @Component({
+        standalone: true,
+        templateUrl: './test.html',
+        imports: [],
+    })
+    export class Test {}
+",
 }
 `;

--- a/projects/cdk/schematics/ng-update/v5/tests/schematic-migrate-repeat-times.spec.ts
+++ b/projects/cdk/schematics/ng-update/v5/tests/schematic-migrate-repeat-times.spec.ts
@@ -2,7 +2,7 @@ import {join} from 'node:path';
 
 import {resetActiveProject} from 'ng-morph';
 
-import {createMigration, runMigration} from '../../../utils/run-migration';
+import {createMigration} from '../../../utils/run-migration';
 
 const COLLECTION = join(__dirname, '../../../migration.json');
 
@@ -196,19 +196,6 @@ describe('ng-update tuiRepeatTimes', () => {
                 '<ng-container *tuiRepeatTimes="let i of 3"><span>{{ i }}</span></ng-container>',
         }),
     );
-
-    it('leaves a @for block with an empty tuiRepeatTimes expression untouched', async () => {
-        const template = '@for (n of   | tuiRepeatTimes; track n) { {{n}} }';
-
-        const {template: result} = await runMigration({
-            collection: COLLECTION,
-            component: REPEAT_TIMES_COMPONENT,
-            template,
-        });
-
-        expect(result).not.toContain("'-'.repeat");
-        expect(result).toContain(template);
-    });
 
     afterEach(() => resetActiveProject());
 });

--- a/projects/cdk/schematics/ng-update/v5/tests/schematic-migrate-repeat-times.spec.ts
+++ b/projects/cdk/schematics/ng-update/v5/tests/schematic-migrate-repeat-times.spec.ts
@@ -2,7 +2,21 @@ import {join} from 'node:path';
 
 import {resetActiveProject} from 'ng-morph';
 
-import {createMigration} from '../../../utils/run-migration';
+import {createMigration, runMigration} from '../../../utils/run-migration';
+
+const COLLECTION = join(__dirname, '../../../migration.json');
+
+const REPEAT_TIMES_COMPONENT = /* TypeScript */ `
+    import {Component} from '@angular/core';
+    import {TuiRepeatTimesPipe} from '@taiga-ui/cdk';
+
+    @Component({
+        standalone: true,
+        templateUrl: './test.html',
+        imports: [TuiRepeatTimesPipe],
+    })
+    export class Test {}
+`;
 
 describe('ng-update tuiRepeatTimes', () => {
     const migrate = createMigration({
@@ -192,6 +206,24 @@ describe('ng-update tuiRepeatTimes', () => {
                 '<ng-container *tuiRepeatTimes="let i of 3"><span>{{ i }}</span></ng-container>',
         }),
     );
+
+    it('keeps the loop value numeric in @for blocks (issue #13823)', async () => {
+        const {template} = await runMigration({
+            collection: COLLECTION,
+            component: REPEAT_TIMES_COMPONENT,
+            template:
+                '@for (n of config.count | tuiRepeatTimes; track n; let isOdd = $odd) { {{n}} }',
+        });
+
+        // `'-'.repeat(N)` only provides the iteration count
+        expect(template).toContain("'-'.repeat(config.count)");
+        // the loop value must stay numeric — it is $index, not the '-' string char
+        expect(template).toContain('track $index');
+        expect(template).toContain('let n = $index');
+        expect(template).not.toMatch(/track\s+n\b/);
+        // unrelated tail params are preserved
+        expect(template).toContain('let isOdd = $odd');
+    });
 
     afterEach(() => resetActiveProject());
 });

--- a/projects/cdk/schematics/ng-update/v5/tests/schematic-migrate-repeat-times.spec.ts
+++ b/projects/cdk/schematics/ng-update/v5/tests/schematic-migrate-repeat-times.spec.ts
@@ -133,8 +133,10 @@ describe('ng-update tuiRepeatTimes', () => {
         }),
     );
 
+    // Guards issue #13823: the @for loop value must stay numeric. The snapshot must show
+    // `track $index; let n = $index` (never `track n`, which would bind `n` to the '-' char).
     it(
-        'keeps @for tail params while replacing tuiRepeatTimes expression',
+        'keeps @for loop value numeric with tail params intact (issue #13823)',
         migrate({
             template:
                 '@for (n of config.count | tuiRepeatTimes; track n; let isOdd = $odd) { {{n}} }',
@@ -206,24 +208,6 @@ describe('ng-update tuiRepeatTimes', () => {
                 '<ng-container *tuiRepeatTimes="let i of 3"><span>{{ i }}</span></ng-container>',
         }),
     );
-
-    it('keeps the loop value numeric in @for blocks (issue #13823)', async () => {
-        const {template} = await runMigration({
-            collection: COLLECTION,
-            component: REPEAT_TIMES_COMPONENT,
-            template:
-                '@for (n of config.count | tuiRepeatTimes; track n; let isOdd = $odd) { {{n}} }',
-        });
-
-        // `'-'.repeat(N)` only provides the iteration count
-        expect(template).toContain("'-'.repeat(config.count)");
-        // the loop value must stay numeric — it is $index, not the '-' string char
-        expect(template).toContain('track $index');
-        expect(template).toContain('let n = $index');
-        expect(template).not.toMatch(/track\s+n\b/);
-        // unrelated tail params are preserved
-        expect(template).toContain('let isOdd = $odd');
-    });
 
     it('leaves a @for block with an empty tuiRepeatTimes expression untouched', async () => {
         const template = '@for (n of   | tuiRepeatTimes; track n) { {{n}} }';

--- a/projects/cdk/schematics/ng-update/v5/tests/schematic-migrate-repeat-times.spec.ts
+++ b/projects/cdk/schematics/ng-update/v5/tests/schematic-migrate-repeat-times.spec.ts
@@ -225,5 +225,18 @@ describe('ng-update tuiRepeatTimes', () => {
         expect(template).toContain('let isOdd = $odd');
     });
 
+    it('leaves a @for block with an empty tuiRepeatTimes expression untouched', async () => {
+        const template = '@for (n of   | tuiRepeatTimes; track n) { {{n}} }';
+        const {template: result} = await runMigration({
+            collection: COLLECTION,
+            component: REPEAT_TIMES_COMPONENT,
+            template,
+        });
+
+        // no expression → nothing to repeat, must not emit `'-'.repeat( )`
+        expect(result).not.toContain("'-'.repeat");
+        expect(result).toContain(template);
+    });
+
     afterEach(() => resetActiveProject());
 });

--- a/projects/cdk/schematics/ng-update/v5/tests/schematic-migrate-repeat-times.spec.ts
+++ b/projects/cdk/schematics/ng-update/v5/tests/schematic-migrate-repeat-times.spec.ts
@@ -20,18 +20,8 @@ const REPEAT_TIMES_COMPONENT = /* TypeScript */ `
 
 describe('ng-update tuiRepeatTimes', () => {
     const migrate = createMigration({
-        collection: join(__dirname, '../../../migration.json'),
-        component: /* TypeScript */ `
-            import {Component} from '@angular/core';
-            import {TuiRepeatTimesPipe} from '@taiga-ui/cdk';
-
-            @Component({
-                standalone: true,
-                templateUrl: './test.html',
-                imports: [TuiRepeatTimesPipe],
-            })
-            export class Test {}
-        `,
+        collection: COLLECTION,
+        component: REPEAT_TIMES_COMPONENT,
     });
 
     it(

--- a/projects/cdk/schematics/ng-update/v5/tests/schematic-migrate-repeat-times.spec.ts
+++ b/projects/cdk/schematics/ng-update/v5/tests/schematic-migrate-repeat-times.spec.ts
@@ -123,8 +123,6 @@ describe('ng-update tuiRepeatTimes', () => {
         }),
     );
 
-    // Guards issue #13823: the @for loop value must stay numeric. The snapshot must show
-    // `track $index; let n = $index` (never `track n`, which would bind `n` to the '-' char).
     it(
         'keeps @for loop value numeric with tail params intact (issue #13823)',
         migrate({
@@ -208,7 +206,6 @@ describe('ng-update tuiRepeatTimes', () => {
             template,
         });
 
-        // no expression → nothing to repeat, must not emit `'-'.repeat( )`
         expect(result).not.toContain("'-'.repeat");
         expect(result).toContain(template);
     });

--- a/projects/cdk/schematics/ng-update/v5/tests/schematic-migrate-repeat-times.spec.ts
+++ b/projects/cdk/schematics/ng-update/v5/tests/schematic-migrate-repeat-times.spec.ts
@@ -227,6 +227,7 @@ describe('ng-update tuiRepeatTimes', () => {
 
     it('leaves a @for block with an empty tuiRepeatTimes expression untouched', async () => {
         const template = '@for (n of   | tuiRepeatTimes; track n) { {{n}} }';
+
         const {template: result} = await runMigration({
             collection: COLLECTION,
             component: REPEAT_TIMES_COMPONENT,


### PR DESCRIPTION
### Which issue does this PR close?

Part of #13823 (item: *"`12 | tuiRepeatTimes` is not equivalent to `'-'.repeat(12)` — the pipe produces numbers, the `repeat()` produces strings"*).

### What is the problem?

`N | tuiRepeatTimes` iterated a **numeric** index (`0..N-1`). The `*ngFor` and
`*tuiRepeatTimes` migration paths already remap the loop variable to `$index`, but
the **`@for`-block** path only stripped the pipe:

```html
<!-- before -->
@for (n of config.count | tuiRepeatTimes; track n; let isOdd = $odd) { {{n}} }

<!-- after (buggy) -->
@for (n of '-'.repeat(config.count); track n; let isOdd = $odd) { {{n}} }
```

`'-'.repeat(N)` is a **string**, so `n` bound to the `'-'` char: `{{n}}` rendered
`-` and `track n` gave every item the same key.

### What is the solution?

Rewrite the `@for` header the same way the `*tuiRepeatTimes` path does — iterate
with `_`, `track $index`, and alias the original variable back to the numeric
`$index`:

```html
<!-- after (fixed) -->
@for (_ of '-'.repeat(config.count); track $index; let n = $index; let isOdd = $odd) { {{n}} }
```

- Nested `@for` blocks each keep their own `$index` (verified).
- A pipe nested inside the iterable expression (`wrap(b | tuiRepeatTimes)`) or used
  only in the body is left untouched — the rewrite is anchored to the iteration
  segment ending in `| tuiRepeatTimes`.