### PR TITLE
fix(core): `TUI_DARK_MODE` persist first theme change on empty storage

### DIFF
--- a/projects/core/tokens/dark-mode.ts
+++ b/projects/core/tokens/dark-mode.ts
@@ -10,43 +10,40 @@ export const TUI_DARK_MODE_KEY = new InjectionToken(
     {factory: () => TUI_DARK_MODE_DEFAULT_KEY},
 );
 
-export type TuiDarkMode = WritableSignal<boolean> & {reset(): void};
+export const TUI_DARK_MODE = new InjectionToken<
+    WritableSignal<boolean> & {reset(): void}
+>(ngDevMode ? 'TUI_DARK_MODE' : '', {
+    factory: () => {
+        const storage = inject(WA_LOCAL_STORAGE);
+        const key = inject(TUI_DARK_MODE_KEY);
+        const saved = storage?.getItem(key);
+        const media = inject(WA_WINDOW).matchMedia('(prefers-color-scheme: dark)');
+        const result = signal(saved ? saved === 'true' : media.matches);
+        // Raw setter that does not persist — used for machine-driven changes.
+        const set = result.set.bind(result);
 
-export const TUI_DARK_MODE = new InjectionToken<TuiDarkMode>(
-    ngDevMode ? 'TUI_DARK_MODE' : '',
-    {
-        factory: () => {
-            const storage = inject(WA_LOCAL_STORAGE);
-            const key = inject(TUI_DARK_MODE_KEY);
-            const saved = storage?.getItem(key);
-            const media = inject(WA_WINDOW).matchMedia('(prefers-color-scheme: dark)');
-            const result = signal(saved ? saved === 'true' : media.matches);
-            // Raw setter that does not persist — used for machine-driven changes.
-            const set = result.set.bind(result);
+        // Persist an explicit choice and pin it, even when the value is
+        // unchanged (e.g. picking dark while the system is already dark).
+        const pin = (value: boolean): void => {
+            storage?.setItem(key, String(value));
+            set(value);
+        };
 
-            // Persist an explicit choice and pin it, even when the value is
-            // unchanged (e.g. picking dark while the system is already dark).
-            const pin = (value: boolean): void => {
-                storage?.setItem(key, String(value));
-                set(value);
-            };
+        // Follow the system theme while it has not been pinned (storage empty).
+        fromEvent(media, 'change')
+            .pipe(
+                filter(() => !storage?.getItem(key)),
+                takeUntilDestroyed(),
+            )
+            .subscribe(() => set(media.matches));
 
-            // Follow the system theme while it has not been pinned (storage empty).
-            fromEvent(media, 'change')
-                .pipe(
-                    filter(() => !storage?.getItem(key)),
-                    takeUntilDestroyed(),
-                )
-                .subscribe(() => set(media.matches));
-
-            return Object.assign(result, {
-                set: pin,
-                update: (updater: (value: boolean) => boolean) => pin(updater(result())),
-                reset: () => {
-                    storage?.removeItem(key);
-                    set(media.matches);
-                },
-            });
-        },
+        return Object.assign(result, {
+            set: pin,
+            update: (updater: (value: boolean) => boolean) => pin(updater(result())),
+            reset: () => {
+                storage?.removeItem(key);
+                set(media.matches);
+            },
+        });
     },
-);
+});

--- a/projects/core/tokens/dark-mode.ts
+++ b/projects/core/tokens/dark-mode.ts
@@ -20,9 +20,16 @@ export const TUI_DARK_MODE = new InjectionToken<TuiDarkMode>(
             const key = inject(TUI_DARK_MODE_KEY);
             const saved = storage?.getItem(key);
             const media = inject(WA_WINDOW).matchMedia('(prefers-color-scheme: dark)');
-            const result = signal(Boolean((saved && JSON.parse(saved)) ?? media.matches));
+            const result = signal(saved ? saved === 'true' : media.matches);
             // Raw setter that does not persist — used for machine-driven changes.
             const set = result.set.bind(result);
+
+            // Persist an explicit choice and pin it, even when the value is
+            // unchanged (e.g. picking dark while the system is already dark).
+            const pin = (value: boolean): void => {
+                storage?.setItem(key, String(value));
+                set(value);
+            };
 
             // Follow the system theme while it has not been pinned (storage empty).
             fromEvent(media, 'change')
@@ -33,12 +40,8 @@ export const TUI_DARK_MODE = new InjectionToken<TuiDarkMode>(
                 .subscribe(() => set(media.matches));
 
             return Object.assign(result, {
-                // Explicit choice: always pin, even when the value is unchanged
-                // (e.g. picking dark while the system is already dark).
-                set: (value: boolean) => {
-                    storage?.setItem(key, String(value));
-                    set(value);
-                },
+                set: pin,
+                update: (updater: (value: boolean) => boolean) => pin(updater(result())),
                 reset: () => {
                     storage?.removeItem(key);
                     set(media.matches);

--- a/projects/core/tokens/dark-mode.ts
+++ b/projects/core/tokens/dark-mode.ts
@@ -17,45 +17,64 @@ export const TUI_DARK_MODE_KEY = new InjectionToken(
     {factory: () => TUI_DARK_MODE_DEFAULT_KEY},
 );
 
-export const TUI_DARK_MODE = new InjectionToken<
-    WritableSignal<boolean> & {reset(): void}
->(ngDevMode ? 'TUI_DARK_MODE' : '', {
-    factory: () => {
-        let automatic = true;
-        const storage = inject(WA_LOCAL_STORAGE);
-        const key = inject(TUI_DARK_MODE_KEY);
-        const saved = storage?.getItem(key);
-        const media = inject(WA_WINDOW).matchMedia('(prefers-color-scheme: dark)');
-        const result = signal(Boolean((saved && JSON.parse(saved)) ?? media.matches));
+export type TuiDarkMode = WritableSignal<boolean> & {reset(): void};
 
-        fromEvent(media, 'change')
-            .pipe(
-                filter(() => !storage?.getItem(key)),
-                takeUntilDestroyed(),
-            )
-            .subscribe(() => {
-                automatic = true;
-                result.set(media.matches);
-            });
+export const TUI_DARK_MODE = new InjectionToken<TuiDarkMode>(
+    ngDevMode ? 'TUI_DARK_MODE' : '',
+    {
+        factory: () => {
+            const storage = inject(WA_LOCAL_STORAGE);
+            const key = inject(TUI_DARK_MODE_KEY);
+            const saved = storage?.getItem(key);
+            const media = inject(WA_WINDOW).matchMedia('(prefers-color-scheme: dark)');
+            const result = signal(Boolean((saved && JSON.parse(saved)) ?? media.matches));
 
-        untracked(() => {
-            effect(() => {
-                const value = String(result());
+            // Tracks the last value the effect has seen so its initial run (the value
+            // loaded from storage/media) is not written back. Seeding it synchronously
+            // avoids relying on the effect flushing before the first user change — that
+            // race dropped the first `set()` when storage was empty.
+            let previous = String(result());
+            // A machine-driven change (system theme / reset) that should not persist.
+            let automatic = false;
 
-                if (automatic) {
-                    automatic = false;
-                } else {
-                    storage?.setItem(key, value);
+            const auto = (value: boolean): void => {
+                if (result() !== value) {
+                    automatic = true;
+                    result.set(value);
                 }
-            });
-        });
+            };
 
-        return Object.assign(result, {
-            reset: () => {
-                storage?.removeItem(key);
-                automatic = true;
-                result.set(media.matches);
-            },
-        });
+            fromEvent(media, 'change')
+                .pipe(
+                    filter(() => !storage?.getItem(key)),
+                    takeUntilDestroyed(),
+                )
+                .subscribe(() => auto(media.matches));
+
+            untracked(() => {
+                effect(() => {
+                    const value = String(result());
+
+                    if (value === previous) {
+                        return;
+                    }
+
+                    previous = value;
+
+                    if (automatic) {
+                        automatic = false;
+                    } else {
+                        storage?.setItem(key, value);
+                    }
+                });
+            });
+
+            return Object.assign(result, {
+                reset: () => {
+                    storage?.removeItem(key);
+                    auto(media.matches);
+                },
+            });
+        },
     },
-});
+);

--- a/projects/core/tokens/dark-mode.ts
+++ b/projects/core/tokens/dark-mode.ts
@@ -1,11 +1,4 @@
-import {
-    effect,
-    inject,
-    InjectionToken,
-    signal,
-    untracked,
-    type WritableSignal,
-} from '@angular/core';
+import {inject, InjectionToken, signal, type WritableSignal} from '@angular/core';
 import {takeUntilDestroyed} from '@angular/core/rxjs-interop';
 import {WA_LOCAL_STORAGE, WA_WINDOW} from '@ng-web-apis/common';
 import {filter, fromEvent} from 'rxjs';
@@ -28,49 +21,27 @@ export const TUI_DARK_MODE = new InjectionToken<TuiDarkMode>(
             const saved = storage?.getItem(key);
             const media = inject(WA_WINDOW).matchMedia('(prefers-color-scheme: dark)');
             const result = signal(Boolean((saved && JSON.parse(saved)) ?? media.matches));
+            // Raw setter that does not persist — used for machine-driven changes.
+            const set = result.set.bind(result);
 
-            // Seeded synchronously so the effect's initial run is skipped without
-            // racing the first user `set()` (which dropped it on empty storage).
-            let previous = result();
-            // A machine-driven change (system theme / reset) that should not persist.
-            let automatic = false;
-
-            const auto = (value: boolean): void => {
-                if (result() !== value) {
-                    automatic = true;
-                    result.set(value);
-                }
-            };
-
+            // Follow the system theme while it has not been pinned (storage empty).
             fromEvent(media, 'change')
                 .pipe(
                     filter(() => !storage?.getItem(key)),
                     takeUntilDestroyed(),
                 )
-                .subscribe(() => auto(media.matches));
-
-            untracked(() => {
-                effect(() => {
-                    const value = result();
-
-                    if (value === previous) {
-                        return;
-                    }
-
-                    previous = value;
-
-                    if (automatic) {
-                        automatic = false;
-                    } else {
-                        storage?.setItem(key, String(value));
-                    }
-                });
-            });
+                .subscribe(() => set(media.matches));
 
             return Object.assign(result, {
+                // Explicit choice: always pin, even when the value is unchanged
+                // (e.g. picking dark while the system is already dark).
+                set: (value: boolean) => {
+                    storage?.setItem(key, String(value));
+                    set(value);
+                },
                 reset: () => {
                     storage?.removeItem(key);
-                    auto(media.matches);
+                    set(media.matches);
                 },
             });
         },

--- a/projects/core/tokens/dark-mode.ts
+++ b/projects/core/tokens/dark-mode.ts
@@ -29,11 +29,9 @@ export const TUI_DARK_MODE = new InjectionToken<TuiDarkMode>(
             const media = inject(WA_WINDOW).matchMedia('(prefers-color-scheme: dark)');
             const result = signal(Boolean((saved && JSON.parse(saved)) ?? media.matches));
 
-            // Tracks the last value the effect has seen so its initial run (the value
-            // loaded from storage/media) is not written back. Seeding it synchronously
-            // avoids relying on the effect flushing before the first user change — that
-            // race dropped the first `set()` when storage was empty.
-            let previous = String(result());
+            // Seeded synchronously so the effect's initial run is skipped without
+            // racing the first user `set()` (which dropped it on empty storage).
+            let previous = result();
             // A machine-driven change (system theme / reset) that should not persist.
             let automatic = false;
 
@@ -53,7 +51,7 @@ export const TUI_DARK_MODE = new InjectionToken<TuiDarkMode>(
 
             untracked(() => {
                 effect(() => {
-                    const value = String(result());
+                    const value = result();
 
                     if (value === previous) {
                         return;
@@ -64,7 +62,7 @@ export const TUI_DARK_MODE = new InjectionToken<TuiDarkMode>(
                     if (automatic) {
                         automatic = false;
                     } else {
-                        storage?.setItem(key, value);
+                        storage?.setItem(key, String(value));
                     }
                 });
             });

--- a/projects/core/tokens/tests/dark-mode.spec.ts
+++ b/projects/core/tokens/tests/dark-mode.spec.ts
@@ -1,0 +1,90 @@
+import {TestBed} from '@angular/core/testing';
+import {WA_LOCAL_STORAGE, WA_WINDOW} from '@ng-web-apis/common';
+import {TUI_DARK_MODE, TUI_DARK_MODE_DEFAULT_KEY, type TuiDarkMode} from '@taiga-ui/core';
+
+describe('TUI_DARK_MODE', () => {
+    let store: Record<string, string>;
+    let matches: boolean;
+
+    function setup(): TuiDarkMode {
+        const storage = {
+            getItem: (key: string) => store[key] ?? null,
+            setItem: (key: string, value: string) => {
+                store[key] = value;
+            },
+            removeItem: (key: string) => {
+                store = Object.fromEntries(
+                    Object.entries(store).filter(([stored]) => stored !== key),
+                );
+            },
+        } as unknown as Storage;
+
+        const windowRef = {
+            matchMedia: () => ({
+                get matches() {
+                    return matches;
+                },
+                addEventListener: () => {},
+                removeEventListener: () => {},
+            }),
+        } as unknown as Window;
+
+        TestBed.configureTestingModule({
+            providers: [
+                {provide: WA_LOCAL_STORAGE, useValue: storage},
+                {provide: WA_WINDOW, useValue: windowRef},
+            ],
+        });
+
+        return TestBed.inject(TUI_DARK_MODE);
+    }
+
+    beforeEach(() => {
+        store = {};
+        matches = false;
+    });
+
+    it('persists the first user change when storage is empty', () => {
+        const mode = setup();
+
+        // The change happens before the effect has flushed its initial run.
+        mode.set(true);
+        TestBed.flushEffects();
+
+        expect(store[TUI_DARK_MODE_DEFAULT_KEY]).toBe('true');
+    });
+
+    it('does not write back the value loaded on init', () => {
+        matches = true;
+
+        setup();
+        TestBed.flushEffects();
+
+        expect(store[TUI_DARK_MODE_DEFAULT_KEY]).toBeUndefined();
+    });
+
+    it('does not persist the system value on reset', () => {
+        const mode = setup();
+
+        mode.set(true);
+        TestBed.flushEffects();
+        expect(store[TUI_DARK_MODE_DEFAULT_KEY]).toBe('true');
+
+        mode.reset();
+        TestBed.flushEffects();
+        expect(store[TUI_DARK_MODE_DEFAULT_KEY]).toBeUndefined();
+    });
+
+    it('persists a user change made right after a no-op reset', () => {
+        const mode = setup();
+
+        // System is light and value already matches, so reset changes nothing.
+        mode.reset();
+        TestBed.flushEffects();
+
+        mode.set(true);
+        TestBed.flushEffects();
+
+        expect(store[TUI_DARK_MODE_DEFAULT_KEY]).toBe('true');
+    });
+});

--- a/projects/core/tokens/tests/dark-mode.spec.ts
+++ b/projects/core/tokens/tests/dark-mode.spec.ts
@@ -5,7 +5,7 @@ import {TUI_DARK_MODE, TUI_DARK_MODE_DEFAULT_KEY, type TuiDarkMode} from '@taiga
 const KEY = TUI_DARK_MODE_DEFAULT_KEY;
 
 describe('TUI_DARK_MODE', () => {
-    let store: Record<string, string>;
+    let store: Map<string, string>;
     let matches: boolean;
     let listeners: Array<() => void>;
 
@@ -16,14 +16,12 @@ describe('TUI_DARK_MODE', () => {
 
     function setup(): TuiDarkMode {
         const storage = {
-            getItem: (key: string) => store[key] ?? null,
+            getItem: (key: string) => store.get(key) ?? null,
             setItem: (key: string, value: string) => {
-                store[key] = value;
+                store.set(key, value);
             },
             removeItem: (key: string) => {
-                store = Object.fromEntries(
-                    Object.entries(store).filter(([stored]) => stored !== key),
-                );
+                store.delete(key);
             },
         } as unknown as Storage;
 
@@ -52,7 +50,7 @@ describe('TUI_DARK_MODE', () => {
     }
 
     beforeEach(() => {
-        store = {};
+        store = new Map();
         matches = false;
         listeners = [];
     });
@@ -69,11 +67,11 @@ describe('TUI_DARK_MODE', () => {
 
             setup();
 
-            expect(store[KEY]).toBeUndefined();
+            expect(store.get(KEY)).toBeUndefined();
         });
 
         it('starts from the stored value when present', () => {
-            store[KEY] = 'true';
+            store.set(KEY, 'true');
             matches = false;
 
             expect(setup()()).toBe(true);
@@ -86,7 +84,7 @@ describe('TUI_DARK_MODE', () => {
 
             mode.set(true);
 
-            expect(store[KEY]).toBe('true');
+            expect(store.get(KEY)).toBe('true');
             expect(mode()).toBe(true);
         });
 
@@ -95,7 +93,7 @@ describe('TUI_DARK_MODE', () => {
 
             mode.update((value) => !value);
 
-            expect(store[KEY]).toBe('true');
+            expect(store.get(KEY)).toBe('true');
             expect(mode()).toBe(true);
         });
 
@@ -106,7 +104,7 @@ describe('TUI_DARK_MODE', () => {
 
             mode.set(true); // explicitly picking dark must still pin
 
-            expect(store[KEY]).toBe('true');
+            expect(store.get(KEY)).toBe('true');
         });
 
         it('stops following the system once set', () => {
@@ -140,7 +138,7 @@ describe('TUI_DARK_MODE', () => {
 
             changeSystem(true);
 
-            expect(store[KEY]).toBeUndefined();
+            expect(store.get(KEY)).toBeUndefined();
         });
     });
 
@@ -149,11 +147,11 @@ describe('TUI_DARK_MODE', () => {
             const mode = setup();
 
             mode.set(true);
-            expect(store[KEY]).toBe('true');
+            expect(store.get(KEY)).toBe('true');
 
             mode.reset();
 
-            expect(store[KEY]).toBeUndefined();
+            expect(store.get(KEY)).toBeUndefined();
         });
 
         it('returns to the current system value', () => {
@@ -176,7 +174,7 @@ describe('TUI_DARK_MODE', () => {
             changeSystem(true);
 
             expect(mode()).toBe(true);
-            expect(store[KEY]).toBeUndefined();
+            expect(store.get(KEY)).toBeUndefined();
         });
     });
 });

--- a/projects/core/tokens/tests/dark-mode.spec.ts
+++ b/projects/core/tokens/tests/dark-mode.spec.ts
@@ -2,9 +2,17 @@ import {TestBed} from '@angular/core/testing';
 import {WA_LOCAL_STORAGE, WA_WINDOW} from '@ng-web-apis/common';
 import {TUI_DARK_MODE, TUI_DARK_MODE_DEFAULT_KEY, type TuiDarkMode} from '@taiga-ui/core';
 
+const KEY = TUI_DARK_MODE_DEFAULT_KEY;
+
 describe('TUI_DARK_MODE', () => {
     let store: Record<string, string>;
     let matches: boolean;
+    let listeners: Array<() => void>;
+
+    function changeSystem(value: boolean): void {
+        matches = value;
+        listeners.forEach((listener) => listener());
+    }
 
     function setup(): TuiDarkMode {
         const storage = {
@@ -24,8 +32,12 @@ describe('TUI_DARK_MODE', () => {
                 get matches() {
                     return matches;
                 },
-                addEventListener: () => {},
-                removeEventListener: () => {},
+                addEventListener: (_type: string, listener: () => void) => {
+                    listeners.push(listener);
+                },
+                removeEventListener: (_type: string, listener: () => void) => {
+                    listeners = listeners.filter((item) => item !== listener);
+                },
             }),
         } as unknown as Window;
 
@@ -42,49 +54,120 @@ describe('TUI_DARK_MODE', () => {
     beforeEach(() => {
         store = {};
         matches = false;
+        listeners = [];
     });
 
-    it('persists the first user change when storage is empty', () => {
-        const mode = setup();
+    describe('initialization', () => {
+        it('starts from the system value when storage is empty', () => {
+            matches = true;
 
-        // The change happens before the effect has flushed its initial run.
-        mode.set(true);
-        TestBed.flushEffects();
+            expect(setup()()).toBe(true);
+        });
 
-        expect(store[TUI_DARK_MODE_DEFAULT_KEY]).toBe('true');
+        it('does not write the system value to storage on init', () => {
+            matches = true;
+
+            setup();
+
+            expect(store[KEY]).toBeUndefined();
+        });
+
+        it('starts from the stored value when present', () => {
+            store[KEY] = 'true';
+            matches = false;
+
+            expect(setup()()).toBe(true);
+        });
     });
 
-    it('does not write back the value loaded on init', () => {
-        matches = true;
+    describe('explicit set', () => {
+        it('persists the change to storage', () => {
+            const mode = setup();
 
-        setup();
-        TestBed.flushEffects();
+            mode.set(true);
 
-        expect(store[TUI_DARK_MODE_DEFAULT_KEY]).toBeUndefined();
+            expect(store[KEY]).toBe('true');
+            expect(mode()).toBe(true);
+        });
+
+        it('persists even when the value equals the current system value', () => {
+            matches = true; // system is dark, auto resolves to dark
+
+            const mode = setup();
+
+            mode.set(true); // explicitly picking dark must still pin
+
+            expect(store[KEY]).toBe('true');
+        });
+
+        it('stops following the system once set', () => {
+            matches = true;
+
+            const mode = setup();
+
+            mode.set(true); // pin dark while system is dark
+
+            changeSystem(false);
+
+            expect(mode()).toBe(true);
+        });
     });
 
-    it('does not persist the system value on reset', () => {
-        const mode = setup();
+    describe('following the system', () => {
+        it('tracks system changes while not pinned', () => {
+            const mode = setup();
 
-        mode.set(true);
-        TestBed.flushEffects();
-        expect(store[TUI_DARK_MODE_DEFAULT_KEY]).toBe('true');
+            expect(mode()).toBe(false);
 
-        mode.reset();
-        TestBed.flushEffects();
-        expect(store[TUI_DARK_MODE_DEFAULT_KEY]).toBeUndefined();
+            changeSystem(true);
+            expect(mode()).toBe(true);
+
+            changeSystem(false);
+            expect(mode()).toBe(false);
+        });
+
+        it('does not persist values received from the system', () => {
+            setup();
+
+            changeSystem(true);
+
+            expect(store[KEY]).toBeUndefined();
+        });
     });
 
-    it('persists a user change made right after a no-op reset', () => {
-        const mode = setup();
+    describe('reset', () => {
+        it('clears the stored value', () => {
+            const mode = setup();
 
-        // System is light and value already matches, so reset changes nothing.
-        mode.reset();
-        TestBed.flushEffects();
+            mode.set(true);
+            expect(store[KEY]).toBe('true');
 
-        mode.set(true);
-        TestBed.flushEffects();
+            mode.reset();
 
-        expect(store[TUI_DARK_MODE_DEFAULT_KEY]).toBe('true');
+            expect(store[KEY]).toBeUndefined();
+        });
+
+        it('returns to the current system value', () => {
+            matches = false;
+
+            const mode = setup();
+
+            mode.set(true);
+            mode.reset();
+
+            expect(mode()).toBe(false);
+        });
+
+        it('resumes following the system', () => {
+            const mode = setup();
+
+            mode.set(true);
+            mode.reset();
+
+            changeSystem(true);
+
+            expect(mode()).toBe(true);
+            expect(store[KEY]).toBeUndefined();
+        });
     });
 });

--- a/projects/core/tokens/tests/dark-mode.spec.ts
+++ b/projects/core/tokens/tests/dark-mode.spec.ts
@@ -1,180 +1,115 @@
+import {type WritableSignal} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
 import {WA_LOCAL_STORAGE, WA_WINDOW} from '@ng-web-apis/common';
-import {TUI_DARK_MODE, TUI_DARK_MODE_DEFAULT_KEY, type TuiDarkMode} from '@taiga-ui/core';
+import {TUI_DARK_MODE, TUI_DARK_MODE_DEFAULT_KEY} from '@taiga-ui/core';
 
 const KEY = TUI_DARK_MODE_DEFAULT_KEY;
 
 describe('TUI_DARK_MODE', () => {
-    let store: Map<string, string>;
-    let matches: boolean;
-    let listeners: Array<() => void>;
+    let storage: Map<string, string>;
+    let systemDark: boolean;
+    let listeners: Set<() => void>;
+    const getStored = (): string | undefined => storage.get(KEY);
 
-    function changeSystem(value: boolean): void {
-        matches = value;
+    const changeSystemTheme = (value: boolean): void => {
+        systemDark = value;
         listeners.forEach((listener) => listener());
-    }
+    };
 
-    function setup(): TuiDarkMode {
-        const storage = {
-            getItem: (key: string) => store.get(key) ?? null,
-            setItem: (key: string, value: string) => {
-                store.set(key, value);
-            },
-            removeItem: (key: string) => {
-                store.delete(key);
-            },
-        } as unknown as Storage;
-
-        const windowRef = {
-            matchMedia: () => ({
-                get matches() {
-                    return matches;
-                },
-                addEventListener: (_type: string, listener: () => void) => {
-                    listeners.push(listener);
-                },
-                removeEventListener: (_type: string, listener: () => void) => {
-                    listeners = listeners.filter((item) => item !== listener);
-                },
-            }),
-        } as unknown as Window;
+    function setup({
+        stored,
+        system = false,
+    }: {stored?: boolean; system?: boolean} = {}): WritableSignal<boolean> & {
+        reset(): void;
+    } {
+        storage = new Map(stored === undefined ? [] : [[KEY, String(stored)]]);
+        systemDark = system;
+        listeners = new Set();
 
         TestBed.configureTestingModule({
             providers: [
-                {provide: WA_LOCAL_STORAGE, useValue: storage},
-                {provide: WA_WINDOW, useValue: windowRef},
+                {
+                    provide: WA_LOCAL_STORAGE,
+                    useValue: {
+                        getItem: (key: string) => storage.get(key) ?? null,
+                        setItem: (key: string, value: string) => storage.set(key, value),
+                        removeItem: (key: string) => storage.delete(key),
+                    } as unknown as Storage,
+                },
+                {
+                    provide: WA_WINDOW,
+                    useValue: {
+                        matchMedia: () => ({
+                            get matches() {
+                                return systemDark;
+                            },
+                            addEventListener: (_: string, listener: () => void) =>
+                                listeners.add(listener),
+                            removeEventListener: (_: string, listener: () => void) =>
+                                listeners.delete(listener),
+                        }),
+                    } as unknown as Window,
+                },
             ],
         });
 
         return TestBed.inject(TUI_DARK_MODE);
     }
 
-    beforeEach(() => {
-        store = new Map();
-        matches = false;
-        listeners = [];
+    afterEach(() => {
+        TestBed.resetTestingModule();
     });
 
-    describe('initialization', () => {
-        it('starts from the system value when storage is empty', () => {
-            matches = true;
+    it('uses system value when storage is empty without persisting it', () => {
+        const mode = setup({system: true});
 
-            expect(setup()()).toBe(true);
-        });
-
-        it('does not write the system value to storage on init', () => {
-            matches = true;
-
-            setup();
-
-            expect(store.get(KEY)).toBeUndefined();
-        });
-
-        it('starts from the stored value when present', () => {
-            store.set(KEY, 'true');
-            matches = false;
-
-            expect(setup()()).toBe(true);
-        });
+        expect(mode()).toBe(true);
+        expect(getStored()).toBeUndefined();
     });
 
-    describe('explicit set', () => {
-        it('persists the change to storage', () => {
-            const mode = setup();
+    it('uses stored value over system value', () => {
+        const mode = setup({stored: true, system: false});
 
-            mode.set(true);
-
-            expect(store.get(KEY)).toBe('true');
-            expect(mode()).toBe(true);
-        });
-
-        it('persists the change to storage via update', () => {
-            const mode = setup();
-
-            mode.update((value) => !value);
-
-            expect(store.get(KEY)).toBe('true');
-            expect(mode()).toBe(true);
-        });
-
-        it('persists even when the value equals the current system value', () => {
-            matches = true; // system is dark, auto resolves to dark
-
-            const mode = setup();
-
-            mode.set(true); // explicitly picking dark must still pin
-
-            expect(store.get(KEY)).toBe('true');
-        });
-
-        it('stops following the system once set', () => {
-            matches = true;
-
-            const mode = setup();
-
-            mode.set(true); // pin dark while system is dark
-
-            changeSystem(false);
-
-            expect(mode()).toBe(true);
-        });
+        expect(mode()).toBe(true);
     });
 
-    describe('following the system', () => {
-        it('tracks system changes while not pinned', () => {
-            const mode = setup();
+    it('pins explicit set even when value equals current system value', () => {
+        const mode = setup({system: true});
 
-            expect(mode()).toBe(false);
+        mode.set(true);
+        changeSystemTheme(false);
 
-            changeSystem(true);
-            expect(mode()).toBe(true);
-
-            changeSystem(false);
-            expect(mode()).toBe(false);
-        });
-
-        it('does not persist values received from the system', () => {
-            setup();
-
-            changeSystem(true);
-
-            expect(store.get(KEY)).toBeUndefined();
-        });
+        expect(getStored()).toBe('true');
+        expect(mode()).toBe(true);
     });
 
-    describe('reset', () => {
-        it('clears the stored value', () => {
-            const mode = setup();
+    it('persists update', () => {
+        const mode = setup();
 
-            mode.set(true);
-            expect(store.get(KEY)).toBe('true');
+        mode.update((value) => !value);
 
-            mode.reset();
+        expect(getStored()).toBe('true');
+        expect(mode()).toBe(true);
+    });
 
-            expect(store.get(KEY)).toBeUndefined();
-        });
+    it('follows system theme while not pinned and resumes after reset', () => {
+        const mode = setup();
 
-        it('returns to the current system value', () => {
-            matches = false;
+        changeSystemTheme(true);
 
-            const mode = setup();
+        expect(mode()).toBe(true);
+        expect(getStored()).toBeUndefined();
 
-            mode.set(true);
-            mode.reset();
+        mode.set(false);
+        changeSystemTheme(true);
 
-            expect(mode()).toBe(false);
-        });
+        expect(mode()).toBe(false);
+        expect(getStored()).toBe('false');
 
-        it('resumes following the system', () => {
-            const mode = setup();
+        mode.reset();
+        changeSystemTheme(false);
 
-            mode.set(true);
-            mode.reset();
-
-            changeSystem(true);
-
-            expect(mode()).toBe(true);
-            expect(store.get(KEY)).toBeUndefined();
-        });
+        expect(mode()).toBe(false);
+        expect(getStored()).toBeUndefined();
     });
 });

--- a/projects/core/tokens/tests/dark-mode.spec.ts
+++ b/projects/core/tokens/tests/dark-mode.spec.ts
@@ -90,6 +90,15 @@ describe('TUI_DARK_MODE', () => {
             expect(mode()).toBe(true);
         });
 
+        it('persists the change to storage via update', () => {
+            const mode = setup();
+
+            mode.update((value) => !value);
+
+            expect(store[KEY]).toBe('true');
+            expect(mode()).toBe(true);
+        });
+
         it('persists even when the value equals the current system value', () => {
             matches = true; // system is dark, auto resolves to dark
 


### PR DESCRIPTION
Problem

Saving the theme was lost on the **first** toggle when `localStorage` was empty (it only persisted on the second try, so after a refresh the app fell back to the system theme). Previously masked because the key was already present in storage — surfaced on a fresh origin.

Root cause: persistence ran through an `effect` whose *initial flush* was supposed to consume the `automatic` guard. That relied on the effect flushing before the first user `set()`, which isn't guaranteed — the first change raced the initial flush and got swallowed.

Fix

- Seed the baseline value synchronously (`previous`) so the initial run is skipped without depending on flush timing.
- Mark machine-driven changes (system theme / `reset`) as `automatic` only when the value actually changes, avoiding a lingering guard after a no-op reset.

