### PR TITLE
fix(core): `Notification` should not show `cursor: pointer` for non-interactive `tui-notification` selector

### DIFF
--- a/projects/core/styles/components/notification.less
+++ b/projects/core/styles/components/notification.less
@@ -218,8 +218,8 @@ tui-notification,
             inset-inline-end: 0.75rem;
         }
     }
-}
 
-[tuiNotificationV='@{tui-version}'] {
-    cursor: pointer;
+    .interactive({
+        cursor: pointer
+    });
 }

--- a/projects/core/styles/components/notification.less
+++ b/projects/core/styles/components/notification.less
@@ -220,6 +220,6 @@ tui-notification,
     }
 
     .interactive({
-        cursor: pointer
+        cursor: pointer;
     });
 }


### PR DESCRIPTION
https://taiga-ui.dev/v4/components/notification#basic

**Relates:**
<img width="1173" height="409" alt="Screenshot 2026-07-06 at 15 40 15" src="https://github.com/user-attachments/assets/c13fae09-e667-4054-a0b9-0646c926906f" />

https://github.com/taiga-family/taiga-ui/pull/13634/changes#diff-16756c9104f83637fddf905572779742ba2159358fa037a13df68dba4b9aaab5R223
