### PR TITLE
fix(core): persist first `TUI_DARK_MODE` change and pin explicit choice

### DIFF
--- a/projects/core/tokens/dark-mode.ts
+++ b/projects/core/tokens/dark-mode.ts
@@ -1,11 +1,4 @@
-import {
-    effect,
-    inject,
-    InjectionToken,
-    signal,
-    untracked,
-    type WritableSignal,
-} from '@angular/core';
+import {inject, InjectionToken, signal, type WritableSignal} from '@angular/core';
 import {takeUntilDestroyed} from '@angular/core/rxjs-interop';
 import {WA_LOCAL_STORAGE, WA_WINDOW} from '@ng-web-apis/common';
 import {filter, fromEvent} from 'rxjs';
@@ -21,41 +14,35 @@ export const TUI_DARK_MODE = new InjectionToken<
     WritableSignal<boolean> & {reset(): void}
 >(ngDevMode ? 'TUI_DARK_MODE' : '', {
     factory: () => {
-        let automatic = true;
-
         const storage = inject(WA_LOCAL_STORAGE);
         const key = inject(TUI_DARK_MODE_KEY);
         const saved = storage?.getItem(key);
         const media = inject(WA_WINDOW).matchMedia('(prefers-color-scheme: dark)');
-        const result = signal(Boolean((saved && JSON.parse(saved)) ?? media.matches));
+        const result = signal(saved ? saved === 'true' : media.matches);
+        // Raw setter that does not persist — used for machine-driven changes.
+        const set = result.set.bind(result);
 
+        // Persist an explicit choice and pin it, even when the value is
+        // unchanged (e.g. picking dark while the system is already dark).
+        const pin = (value: boolean): void => {
+            storage?.setItem(key, String(value));
+            set(value);
+        };
+
+        // Follow the system theme while it has not been pinned (storage empty).
         fromEvent(media, 'change')
             .pipe(
                 filter(() => !storage?.getItem(key)),
                 takeUntilDestroyed(),
             )
-            .subscribe(() => {
-                automatic = true;
-                result.set(media.matches);
-            });
-
-        untracked(() => {
-            effect(() => {
-                const value = String(result());
-
-                if (automatic) {
-                    automatic = false;
-                } else {
-                    storage?.setItem(key, value);
-                }
-            });
-        });
+            .subscribe(() => set(media.matches));
 
         return Object.assign(result, {
+            set: pin,
+            update: (updater: (value: boolean) => boolean) => pin(updater(result())),
             reset: () => {
                 storage?.removeItem(key);
-                automatic = true;
-                result.set(media.matches);
+                set(media.matches);
             },
         });
     },

--- a/projects/core/tokens/test/dark-mode.spec.ts
+++ b/projects/core/tokens/test/dark-mode.spec.ts
@@ -1,0 +1,116 @@
+import {type WritableSignal} from '@angular/core';
+import {TestBed} from '@angular/core/testing';
+import {WA_LOCAL_STORAGE, WA_WINDOW} from '@ng-web-apis/common';
+
+import {TUI_DARK_MODE, TUI_DARK_MODE_DEFAULT_KEY} from '../dark-mode';
+
+const KEY = TUI_DARK_MODE_DEFAULT_KEY;
+
+describe('TUI_DARK_MODE', () => {
+    let storage: Map<string, string>;
+    let systemDark: boolean;
+    let listeners: Set<() => void>;
+    const getStored = (): string | undefined => storage.get(KEY);
+
+    const changeSystemTheme = (value: boolean): void => {
+        systemDark = value;
+        listeners.forEach((listener) => listener());
+    };
+
+    function setup({
+        stored,
+        system = false,
+    }: {stored?: boolean; system?: boolean} = {}): WritableSignal<boolean> & {
+        reset(): void;
+    } {
+        storage = new Map(stored === undefined ? [] : [[KEY, String(stored)]]);
+        systemDark = system;
+        listeners = new Set();
+
+        TestBed.configureTestingModule({
+            providers: [
+                {
+                    provide: WA_LOCAL_STORAGE,
+                    useValue: {
+                        getItem: (key: string) => storage.get(key) ?? null,
+                        setItem: (key: string, value: string) => storage.set(key, value),
+                        removeItem: (key: string) => storage.delete(key),
+                    } as unknown as Storage,
+                },
+                {
+                    provide: WA_WINDOW,
+                    useValue: {
+                        matchMedia: () => ({
+                            get matches() {
+                                return systemDark;
+                            },
+                            addEventListener: (_: string, listener: () => void) =>
+                                listeners.add(listener),
+                            removeEventListener: (_: string, listener: () => void) =>
+                                listeners.delete(listener),
+                        }),
+                    } as unknown as Window,
+                },
+            ],
+        });
+
+        return TestBed.inject(TUI_DARK_MODE);
+    }
+
+    afterEach(() => {
+        TestBed.resetTestingModule();
+    });
+
+    it('uses system value when storage is empty without persisting it', () => {
+        const mode = setup({system: true});
+
+        expect(mode()).toBe(true);
+        expect(getStored()).toBeUndefined();
+    });
+
+    it('uses stored value over system value', () => {
+        const mode = setup({stored: true, system: false});
+
+        expect(mode()).toBe(true);
+    });
+
+    it('pins explicit set even when value equals current system value', () => {
+        const mode = setup({system: true});
+
+        mode.set(true);
+        changeSystemTheme(false);
+
+        expect(getStored()).toBe('true');
+        expect(mode()).toBe(true);
+    });
+
+    it('persists update', () => {
+        const mode = setup();
+
+        mode.update((value) => !value);
+
+        expect(getStored()).toBe('true');
+        expect(mode()).toBe(true);
+    });
+
+    it('follows system theme while not pinned and resumes after reset', () => {
+        const mode = setup();
+
+        changeSystemTheme(true);
+
+        expect(mode()).toBe(true);
+        expect(getStored()).toBeUndefined();
+
+        mode.set(false);
+        changeSystemTheme(true);
+
+        expect(mode()).toBe(false);
+        expect(getStored()).toBe('false');
+
+        mode.reset();
+        changeSystemTheme(false);
+
+        expect(mode()).toBe(false);
+        expect(getStored()).toBeUndefined();
+    });
+});


### PR DESCRIPTION
Backport of #14501 to `v4.x`.

## Problem

`TUI_DARK_MODE` persistence ran through an `effect` that relied on signal change detection, which caused two bugs on `v4.x`:

1. **First change lost on empty storage.** The `automatic` guard was meant to be consumed by the effect's initial flush, but that flush is async — the first user `set()` could race it and get swallowed, so the theme only persisted on the *second* toggle. After a refresh the app fell back to the system theme. (Masked whenever `localStorage` already held a value.)
2. **Explicit choice equal to the system value never pinned.** Picking e.g. "dark" while the system is already dark produced no signal change → effect didn't run → nothing was written → the app kept following the OS.

Plus `JSON.parse(saved)` throws a `SyntaxError` on a corrupted stored value, breaking token creation.

## Fix

Persist in the overridden `set()`/`update()` instead of an effect:
- an explicit `set`/`update` always writes to storage and pins (stops following the OS), even when the value is unchanged;
- machine-driven changes (system theme, `reset`) use the raw setter and don't persist;
- read the stored flag with `saved === 'true'` (we only ever write `String(boolean)`), avoiding the `JSON.parse` throw.

Drops the `effect`, `untracked` and the `automatic` flag entirely.

## Tests

Adds `projects/core/tokens/test/dark-mode.spec.ts` (5 cases: init from system/stored, pin-on-equal, `update`, follow-system + reset). Verified the behavioral cases fail on the old implementation and pass on the fix.