### PR TITLE
fix(core): loader fix content height overflow inside grid layout

### DIFF
--- a/projects/core/components/loader/loader.style.less
+++ b/projects/core/components/loader/loader.style.less
@@ -54,6 +54,7 @@
     border: none;
     isolation: inherit;
     min-inline-size: 0;
+    min-block-size: 0;
 }
 
 .t-loader {


### PR DESCRIPTION
`TuiLoader`'s content wrapper (`.t-content`, a `<fieldset>`) is a CSS grid item without an explicit `min-block-size`, so the browser's automatic minimum size algorithm lets it grow to the height of its projected content instead of respecting the loader's own height. This breaks any `tui-scrollbar` (or other height-constrained content) nested inside `tui-loader`, since the scrollbar's `block-size: 100%` resolves against an already-inflated parent and never clips/scrolls. Fix mirrors the existing `min-inline-size: 0` rule (added in #14273 for width) by adding the equivalent `min-block-size: 0` for height.