### PR TITLE
chore(schematics): add `tui-input-chip` when migrating `tui-input-tag` with `[tuiTextfieldLabelOutside]="true"`

### DIFF
--- a/projects/cdk/schematics/ng-update/v5/steps/templates/migrate-input-tag.ts
+++ b/projects/cdk/schematics/ng-update/v5/steps/templates/migrate-input-tag.ts
@@ -250,10 +250,11 @@ export function migrateInputTag({
         }, '');
 
         const migrationAttrs = `${baseAttrs}${stringifyControlStateAttrs(controlStateAttrs)}`;
+        const itemChip = isLabelOutsideTrue ? '<tui-input-chip *tuiItem />\n' : '';
 
         recorder.insertRight(
             insertOffset,
-            `\n<input tuiInputChip${migrationAttrs}${placeholderAttr} />\n`,
+            `\n<input tuiInputChip${migrationAttrs}${placeholderAttr} />\n${itemChip}`,
         );
     });
 }
@@ -298,6 +299,7 @@ function migrateSelfClosingInputTag({
     const todoAttrs: Attribute[] = [];
     let hasHintContent = false;
     let labelOutsideIsDynamic = false;
+    let labelOutsideIsTrue = false;
 
     for (const attr of element.attrs) {
         const nameLower = attr.name.toLowerCase();
@@ -317,6 +319,7 @@ function migrateSelfClosingInputTag({
             const isBinding = nameLower.startsWith('[');
             const isLabelOutsideTrue = value === 'true' || (!isBinding && value === '');
 
+            labelOutsideIsTrue = isLabelOutsideTrue;
             labelOutsideIsDynamic =
                 !isLabelOutsideTrue && value !== 'false' && value !== '';
             continue;
@@ -381,10 +384,14 @@ function migrateSelfClosingInputTag({
     const iconLine = iconStr ? `${indent}${iconStr}\n` : '';
     const todoComment = buildSelfClosingTodo(todoAttrs, labelOutsideIsDynamic, indent);
 
+    const itemChipLine = labelOutsideIsTrue
+        ? `${indent}<tui-input-chip *tuiItem />\n`
+        : '';
+
     const replacement =
         `${todoComment}<tui-textfield multi${wrapperStr}>\n` +
         `${indent}<input tuiInputChip${inputStr}${controlStateStr} />\n` +
-        `${iconLine}${indent}</tui-textfield>`;
+        `${itemChipLine}${iconLine}${indent}</tui-textfield>`;
 
     recorder.remove(
         templateOffset + loc.startOffset,

--- a/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-full-page-template.spec.ts.snap
+++ b/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-full-page-template.spec.ts.snap
@@ -218,6 +218,7 @@ exports[`ng-update full page template migrates a realistic page with legacy cont
                 </h2>
                 <tui-textfield multi class="input-tag tui-space_vertical-10">
                 <input tuiInputChip [(ngModel)]="tags" />
+                <tui-input-chip *tuiItem />
                 <tui-icon [tuiTooltip]="hint" />
                 </tui-textfield>
 

--- a/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-input-tag.spec.ts.snap
+++ b/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-input-tag.spec.ts.snap
@@ -148,6 +148,7 @@ exports[`ng-update migrates self-closing <tui-input-tag ... /> with hint to tui-
   "1. After": "
                 <tui-textfield multi class="input-tag">
                 <input tuiInputChip [(ngModel)]="tags" />
+                <tui-input-chip *tuiItem />
                 <tui-icon [tuiTooltip]="hint" />
                 </tui-textfield>
             ",
@@ -284,6 +285,7 @@ exports[`ng-update removes [tuiTextfieldLabelOutside] from tui-input-tag: test.h
                     
                  multi>
 <input tuiInputChip [formControl]="control" placeholder="Enter tags" />
+<tui-input-chip *tuiItem />
 </tui-textfield>
             ",
 }


### PR DESCRIPTION
Part of https://github.com/taiga-family/taiga-ui/issues/11917