### PR TITLE
fix(kit): add fallback for dropdown calendar inside tui-drawer

### DIFF
--- a/projects/kit/components/input-date/input-date.directive.ts
+++ b/projects/kit/components/input-date/input-date.directive.ts
@@ -135,7 +135,7 @@ export abstract class TuiInputDateBase<
         this.onChange(value as T);
         this.open.set(false);
 
-        if (!this.el.closest('tui-dropdown')) {
+        if (!this.el.closest('tui-dropdown,tui-drawer')) {
             this.el.blur();
         }
     }


### PR DESCRIPTION
simple fallback for tuiActiveZone

releates to https://github.com/taiga-family/taiga-ui/issues/13422