### PR TITLE
feat(layout): add custom color for tuiList markers

### DIFF
--- a/projects/demo/src/pages/components/list/examples/5/index.html
+++ b/projects/demo/src/pages/components/list/examples/5/index.html
@@ -1,0 +1,15 @@
+<ul
+    style="--tui-list-marker: var(--tui-status-negative)"
+    tuiList
+>
+    <li>All bullets in this list share the same custom color</li>
+    <!-- prettier-ignore -->
+    <li>Set the<code>--tui-list-marker</code>variable on the list itself</li>
+    <li>No need to override the bullet background manually</li>
+</ul>
+
+<ul tuiList>
+    <li>Bullets can also be recolored individually</li>
+    <li style="--tui-list-marker: var(--tui-status-warning)">This one is a warning</li>
+    <li style="--tui-list-marker: var(--tui-status-positive)">This one is positive</li>
+</ul>

--- a/projects/demo/src/pages/components/list/examples/5/index.ts
+++ b/projects/demo/src/pages/components/list/examples/5/index.ts
@@ -1,0 +1,12 @@
+import {Component} from '@angular/core';
+import {changeDetection} from '@demo/emulate/change-detection';
+import {encapsulation} from '@demo/emulate/encapsulation';
+import {TuiList} from '@taiga-ui/layout';
+
+@Component({
+    imports: [TuiList],
+    templateUrl: './index.html',
+    encapsulation,
+    changeDetection,
+})
+export default class Example {}

--- a/projects/demo/src/pages/components/list/index.ts
+++ b/projects/demo/src/pages/components/list/index.ts
@@ -8,5 +8,11 @@ import {TuiDemo} from '@demo/utils';
     changeDetection,
 })
 export default class Page {
-    protected readonly examples = ['Bulleted', 'Numbered', 'Nested', 'Long text'];
+    protected readonly examples = [
+        'Bulleted',
+        'Numbered',
+        'Nested',
+        'Long text',
+        'Custom color',
+    ];
 }

--- a/projects/layout/components/list/list.style.less
+++ b/projects/layout/components/list/list.style.less
@@ -23,7 +23,11 @@
 
     &:is(ul) > li::before {
         color: transparent;
-        background: radial-gradient(circle 0.1875rem, var(--tui-status-info) 100%, transparent 101%);
+        background: radial-gradient(
+            circle 0.1875rem,
+            var(--tui-list-marker, var(--tui-status-info)) 100%,
+            transparent 101%
+        );
         inline-size: 0.75rem;
         margin-inline-end: 0.75rem;
     }


### PR DESCRIPTION
ul[tuiList] bullet color was hardcoded via var(--tui-status-info) inside the radial-gradient, forcing consumers to override the entire gradient just to recolor markers. Exposed a --tui-list-marker CSS variable (default unchanged) so the color can be overridden with a single declaration, on the list or per <li>
