### PR TITLE
fix(core): `Carousel` no longer duplicates slides during hydration

### DIFF
--- a/projects/core/components/carousel/carousel.component.ts
+++ b/projects/core/components/carousel/carousel.component.ts
@@ -10,6 +10,7 @@ import {
     model,
     signal,
     TemplateRef,
+    VERSION,
 } from '@angular/core';
 import {WA_WINDOW} from '@ng-web-apis/common';
 import {
@@ -34,6 +35,7 @@ import {debounceTime, filter, fromEvent} from 'rxjs';
     hostDirectives: [WaIntersectionObserverDirective],
     host: {
         waIntersectionThreshold: '0.5',
+        '[attr.ngSkipHydration]': 'skipHydration',
         '[style.max-block-size.px]': 'height()',
     },
 })
@@ -45,6 +47,11 @@ export class TuiCarouselComponent implements AfterViewInit {
     protected readonly math = Math;
     protected readonly template = contentChild.required(TuiItem, {read: TemplateRef});
     protected readonly height = signal(Number.NaN);
+
+    // https://github.com/angular/angular/issues/50543
+    // TODO(v6): delete
+    protected readonly skipHydration =
+        Number.parseInt(VERSION.major, 10) < 20 ? '' : null;
 
     public readonly index = model(0);
     public readonly min = input(-Infinity);

--- a/projects/demo-playwright/tests/kit/carousel/carousel-hydration.pw.spec.ts
+++ b/projects/demo-playwright/tests/kit/carousel/carousel-hydration.pw.spec.ts
@@ -1,0 +1,61 @@
+import {DemoRoute} from '@demo/routes';
+import {TuiDocumentationPagePO, tuiGoto} from '@demo-playwright/utils';
+import {expect, test} from '@playwright/test';
+
+test.describe('Carousel hydration', () => {
+    // https://github.com/taiga-family/taiga-ui/issues/13787
+    test('does not duplicate slides for long pending hydration (caused by long http request)', async ({
+        page,
+    }) => {
+        const ANY_HTTP_REQUEST = /algolia\.net/i;
+
+        /**
+         * Pending HTTP request delays emission of ApplicationRef.isStable()
+         * Hydration waits until `ApplicationRef.isStable() // true`
+         * https://angular.dev/errors/NG0506#zoneless-applications
+         */
+        let releaseHydration = (): void => {};
+
+        const held = new Promise<void>((resolve) => {
+            releaseHydration = resolve;
+        });
+
+        const httpRequest = page.waitForRequest(ANY_HTTP_REQUEST);
+
+        await page.route(ANY_HTTP_REQUEST, async (route) => {
+            await held;
+            await route.fulfill({
+                status: 200,
+                contentType: 'application/json',
+                body: JSON.stringify({results: [{hits: [], nbHits: 0}]}),
+            });
+        });
+
+        await tuiGoto(page, DemoRoute.Carousel);
+
+        // Fail loudly if the "hold a stability-blocking request" assumption ever breaks
+        await expect(httpRequest).resolves.toBeTruthy();
+
+        const example = new TuiDocumentationPagePO(page).getExample('#basic');
+        const slides = example.locator('tui-carousel .t-item');
+
+        // Provide an opportunity to mutate DOM during pending hydration
+        await page.waitForTimeout(2_000);
+
+        await expect(slides).toHaveCount(2);
+        await expect.soft(slides.nth(0)).toHaveText('0', {useInnerText: true});
+        await expect.soft(slides.nth(1)).toHaveText('1', {useInnerText: true});
+
+        releaseHydration();
+
+        await page.waitForLoadState('networkidle');
+        await expect(slides.nth(0)).toHaveText('0', {useInnerText: true});
+
+        // Interactivity proves hydration actually completed
+        const prev = example.locator('button').first();
+
+        await expect(prev).toBeDisabled();
+        await example.locator('button').last().click();
+        await expect(prev).toBeEnabled();
+    });
+});

--- a/projects/demo-playwright/tests/kit/carousel/carousel-hydration.pw.spec.ts
+++ b/projects/demo-playwright/tests/kit/carousel/carousel-hydration.pw.spec.ts
@@ -4,9 +4,7 @@ import {expect, test} from '@playwright/test';
 
 test.describe('Carousel hydration', () => {
     // https://github.com/taiga-family/taiga-ui/issues/13787
-    test('does not duplicate slides for long pending hydration (caused by long http request)', async ({
-        page,
-    }) => {
+    test('does not duplicate slides while hydration is pending', async ({page}) => {
         const ANY_HTTP_REQUEST = /algolia\.net/i;
 
         /**
@@ -14,16 +12,16 @@ test.describe('Carousel hydration', () => {
          * Hydration waits until `ApplicationRef.isStable() // true`
          * https://angular.dev/errors/NG0506#zoneless-applications
          */
-        let releaseHydration = (): void => {};
+        let releaseHydration!: () => void;
 
-        const held = new Promise<void>((resolve) => {
+        const hydrationBlocker = new Promise<void>((resolve) => {
             releaseHydration = resolve;
         });
 
         const httpRequest = page.waitForRequest(ANY_HTTP_REQUEST);
 
         await page.route(ANY_HTTP_REQUEST, async (route) => {
-            await held;
+            await hydrationBlocker;
             await route.fulfill({
                 status: 200,
                 contentType: 'application/json',
@@ -32,9 +30,7 @@ test.describe('Carousel hydration', () => {
         });
 
         await tuiGoto(page, DemoRoute.Carousel);
-
-        // Fail loudly if the "hold a stability-blocking request" assumption ever breaks
-        await expect(httpRequest).resolves.toBeTruthy();
+        await httpRequest;
 
         const example = new TuiDocumentationPagePO(page).getExample('#basic');
         const slides = example.locator('tui-carousel .t-item');
@@ -42,14 +38,12 @@ test.describe('Carousel hydration', () => {
         // Provide an opportunity to mutate DOM during pending hydration
         await page.waitForTimeout(2_000);
 
-        await expect(slides).toHaveCount(2);
-        await expect.soft(slides.nth(0)).toHaveText('0', {useInnerText: true});
-        await expect.soft(slides.nth(1)).toHaveText('1', {useInnerText: true});
+        await expect(slides).toHaveText(['0', '1'], {useInnerText: true});
 
         releaseHydration();
 
         await page.waitForLoadState('networkidle');
-        await expect(slides.nth(0)).toHaveText('0', {useInnerText: true});
+        await expect(slides).toHaveText(['0', '1'], {useInnerText: true});
 
         // Interactivity proves hydration actually completed
         const prev = example.locator('button').first();


### PR DESCRIPTION
Fixes #13787

Relates:
- https://github.com/angular/angular/issues/50543

### Previous behavior

https://github.com/user-attachments/assets/94aa7390-0be1-4231-90de-a62ec3b9eb4a

> [!TIP]
> Pending HTTP request delays emission of `ApplicationRef.isStable()`
> Hydration waits until `ApplicationRef.isStable() // true`
> https://angular.dev/errors/NG0506#zoneless-applications 

### New behavior

https://github.com/user-attachments/assets/1f3a5d03-09f3-4596-b8e8-167742da0cc4

