### PR TITLE
chore(schematics): drop redundant TuiTextfield from TuiInputYearModule migration

### DIFF
--- a/projects/cdk/schematics/ng-update/v5/steps/constants/identifiers-to-replace.ts
+++ b/projects/cdk/schematics/ng-update/v5/steps/constants/identifiers-to-replace.ts
@@ -26,16 +26,10 @@ export const IDENTIFIERS_TO_REPLACE: ReplacementIdentifierMulti[] = [
             name: 'TuiInputYearModule',
             moduleSpecifier: '@taiga-ui/legacy',
         },
-        to: [
-            {
-                name: 'TuiInputYear',
-                moduleSpecifier: '@taiga-ui/kit',
-            },
-            {
-                name: 'TuiTextfield',
-                moduleSpecifier: '@taiga-ui/core',
-            },
-        ],
+        to: {
+            name: 'TuiInputYear',
+            moduleSpecifier: '@taiga-ui/kit',
+        },
     },
     {
         from: {

--- a/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-input-year.spec.ts.snap
+++ b/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-input-year.spec.ts.snap
@@ -141,13 +141,12 @@ exports[`ng-update migrate TuiInputYearModule to TuiInputYear: test.ts 1`] = `
                 })
                 export class MyComponent {}
             ",
-  "1. After": "import { TuiInput } from "@taiga-ui/core";
-import { TuiInputYear } from "@taiga-ui/kit";
+  "1. After": "import { TuiInputYear } from "@taiga-ui/kit";
 
                                 @NgModule({
                     imports: [
                         // ...
-                        TuiInputYear, TuiInput,
+                        TuiInputYear,
                     ],
                     // ...
                 })
@@ -157,7 +156,7 @@ import { TuiInputYear } from "@taiga-ui/kit";
                     standalone: true,
                     imports: [
                         // ...
-                        TuiInputYear, TuiInput,
+                        TuiInputYear,
                     ],
                     templateUrl: './test.html',
                     // ...


### PR DESCRIPTION
## What / Why

`TuiInputYearModule` was migrated to **both** `TuiInputYear` (`@taiga-ui/kit`) **and** `TuiTextfield` (`@taiga-ui/core`).

The `TuiTextfield` import is redundant: the `TuiInputYear` barrel already re-exports `TuiTextfieldComponent` + `TuiTextfieldOptionsDirective`, so `<tui-textfield>` works with just `TuiInputYear` imported.

Worse, the extra import was **chain-renamed** by the existing `TuiTextfield → TuiInput` rule into a non-existent `TuiInput` from `@taiga-ui/core`, producing a broken import in migrated code.

## Change
- Map `TuiInputYearModule` → `TuiInputYear` only.
- Updated snapshot.

Same reasoning as the `InputNumber` cleanup requested by @nsbarsukov in #14475.

## Verification
`schematic-migrate-input-year.spec.ts` — 2/2 green; `tsc` (pre-commit) green; ESLint clean.