### PR TITLE
feat(addon-mobile): show top bar in sheet dialog despite appearance

### DIFF
--- a/projects/addon-mobile/components/sheet-dialog/sheet-dialog.template.html
+++ b/projects/addon-mobile/components/sheet-dialog/sheet-dialog.template.html
@@ -8,7 +8,7 @@
 </div>
 <div class="t-sheet">
     <div
-        *ngIf="context.bar && !context.appearance.includes('fullscreen')"
+        *ngIf="context.bar"
         class="t-top"
     ></div>
     <h2


### PR DESCRIPTION
adds top bar visibility for fullscreen sheet dialog (like in 5.x)