### PR TITLE
feat(addon-mobile): `DropdownSheet` add `tuiDropdownSheetOptions` input to customize sheet dialog

### DIFF
--- a/projects/addon-mobile/directives/dropdown-sheet/dropdown-sheet.component.ts
+++ b/projects/addon-mobile/directives/dropdown-sheet/dropdown-sheet.component.ts
@@ -37,10 +37,7 @@ export class TuiDropdownSheetComponent {
     protected readonly sub = toObservable(this.content)
         .pipe(
             tuiIfMap((content) =>
-                this.dialogs.open(content, {
-                    label: this.directive.tuiDropdownSheet(),
-                    ...this.directive.tuiDropdownSheetOptions(),
-                }),
+                this.dialogs.open(content, this.directive.tuiDropdownSheet()),
             ),
             takeUntilDestroyed(),
         )

--- a/projects/addon-mobile/directives/dropdown-sheet/dropdown-sheet.component.ts
+++ b/projects/addon-mobile/directives/dropdown-sheet/dropdown-sheet.component.ts
@@ -37,7 +37,10 @@ export class TuiDropdownSheetComponent {
     protected readonly sub = toObservable(this.content)
         .pipe(
             tuiIfMap((content) =>
-                this.dialogs.open(content, {label: this.directive.tuiDropdownSheet()}),
+                this.dialogs.open(content, {
+                    label: this.directive.tuiDropdownSheet(),
+                    ...this.directive.tuiDropdownSheetOptions(),
+                }),
             ),
             takeUntilDestroyed(),
         )

--- a/projects/addon-mobile/directives/dropdown-sheet/dropdown-sheet.directive.ts
+++ b/projects/addon-mobile/directives/dropdown-sheet/dropdown-sheet.directive.ts
@@ -1,5 +1,6 @@
 import {Directive, inject, input} from '@angular/core';
 import {WA_IS_MOBILE} from '@ng-web-apis/platform';
+import {type TuiSheetDialogOptions} from '@taiga-ui/addon-mobile/components/sheet-dialog';
 import {TUI_DATA_LIST_SIZE} from '@taiga-ui/core/components/data-list';
 import {TUI_DROPDOWN_COMPONENT} from '@taiga-ui/core/portals/dropdown';
 
@@ -23,4 +24,5 @@ import {TuiDropdownSheetComponent} from './dropdown-sheet.component';
 })
 export class TuiDropdownSheet {
     public readonly tuiDropdownSheet = input('');
+    public readonly tuiDropdownSheetOptions = input<Partial<TuiSheetDialogOptions>>({});
 }

--- a/projects/addon-mobile/directives/dropdown-sheet/dropdown-sheet.directive.ts
+++ b/projects/addon-mobile/directives/dropdown-sheet/dropdown-sheet.directive.ts
@@ -1,6 +1,7 @@
 import {Directive, inject, input} from '@angular/core';
 import {WA_IS_MOBILE} from '@ng-web-apis/platform';
 import {type TuiSheetDialogOptions} from '@taiga-ui/addon-mobile/components/sheet-dialog';
+import {tuiIsString} from '@taiga-ui/cdk/utils/miscellaneous';
 import {TUI_DATA_LIST_SIZE} from '@taiga-ui/core/components/data-list';
 import {TUI_DROPDOWN_COMPONENT} from '@taiga-ui/core/portals/dropdown';
 
@@ -23,6 +24,13 @@ import {TuiDropdownSheetComponent} from './dropdown-sheet.component';
     ],
 })
 export class TuiDropdownSheet {
-    public readonly tuiDropdownSheet = input('');
-    public readonly tuiDropdownSheetOptions = input<Partial<TuiSheetDialogOptions>>({});
+    public readonly tuiDropdownSheet = input(
+        {},
+        {
+            transform: (
+                options: Partial<TuiSheetDialogOptions> | string,
+            ): Partial<TuiSheetDialogOptions> =>
+                tuiIsString(options) ? {label: options} : options,
+        },
+    );
 }

--- a/projects/demo-cypress/src/tests/dropdown-sheet.cy.ts
+++ b/projects/demo-cypress/src/tests/dropdown-sheet.cy.ts
@@ -18,8 +18,7 @@ import {TuiChevron, TuiDataListWrapper, TuiSelect} from '@taiga-ui/kit';
         <tui-root>
             <tui-textfield
                 tuiChevron
-                tuiDropdownSheet="Select platform"
-                [tuiDropdownSheetOptions]="options()"
+                [tuiDropdownSheet]="options()"
             >
                 <input
                     tuiSelect
@@ -40,11 +39,27 @@ export class Sandbox {
     protected readonly items = Array.from({length: 20}, (_, i) => `Item ${i}`);
     protected value: string | null = null;
 
-    public readonly options = input<Partial<TuiSheetDialogOptions>>({});
+    public readonly options = input<Partial<TuiSheetDialogOptions> | string>(
+        'Select platform',
+    );
 }
 
-describe('DropdownSheet with sheet dialog options', () => {
+describe('DropdownSheet', () => {
     beforeEach(() => cy.viewport(300, 350));
+
+    describe('accepts either a string shorthand or an options object as label', () => {
+        (['Select platform', {label: 'Select platform'}] as const).forEach((options) => {
+            it(JSON.stringify(options), () => {
+                cy.mount(Sandbox, {
+                    componentProperties: {options},
+                    providers: [{provide: WA_IS_MOBILE, useValue: true}],
+                });
+
+                cy.get('input').click();
+                cy.get('tui-sheet-dialog header').should('have.text', 'Select platform');
+            });
+        });
+    });
 
     it('closes sheet when swipe ends at the top by default', () => {
         cy.mount(Sandbox, {providers: [{provide: WA_IS_MOBILE, useValue: true}]});
@@ -63,7 +78,7 @@ describe('DropdownSheet with sheet dialog options', () => {
 
     it('keeps sheet open when closable is false', () => {
         cy.mount(Sandbox, {
-            componentProperties: {options: {closable: false}},
+            componentProperties: {options: {label: 'Select platform', closable: false}},
             providers: [{provide: WA_IS_MOBILE, useValue: true}],
         });
 

--- a/projects/demo-cypress/src/tests/dropdown-sheet.cy.ts
+++ b/projects/demo-cypress/src/tests/dropdown-sheet.cy.ts
@@ -29,7 +29,7 @@ import {TuiChevron, TuiDataListWrapper, TuiSelect} from '@taiga-ui/kit';
 
                 <tui-data-list-wrapper
                     *tuiDropdown
-                    [items]="platforms"
+                    [items]="items"
                 />
             </tui-textfield>
         </tui-root>
@@ -37,8 +37,8 @@ import {TuiChevron, TuiDataListWrapper, TuiSelect} from '@taiga-ui/kit';
     changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class Sandbox {
-    protected readonly platforms = ['web', 'ios', 'android'] as const;
-    protected value: 'android' | 'ios' | 'web' | null = 'ios';
+    protected readonly items = Array.from({length: 20}, (_, i) => `Item ${i}`);
+    protected value: string | null = null;
 
     public readonly options = input<Partial<TuiSheetDialogOptions>>({});
 }
@@ -73,10 +73,11 @@ describe('DropdownSheet with sheet dialog options', () => {
             .should('not.have.class', '_closeable');
 
         cy.get('tui-sheet-dialog').trigger('touchstart');
-        cy.get('tui-sheet-dialog').scrollTo('top', {ensureScrollable: false});
+        cy.get('tui-sheet-dialog').scrollTo('bottom');
+        cy.get('tui-sheet-dialog').scrollTo('top');
         cy.get('tui-sheet-dialog').trigger('touchend');
 
         cy.get('tui-sheet-dialog').should('be.visible');
-        cy.get('[tuiOption]').should('have.length', 3);
+        cy.get('[tuiOption]').should('have.length', 20);
     });
 });

--- a/projects/demo-cypress/src/tests/dropdown-sheet.cy.ts
+++ b/projects/demo-cypress/src/tests/dropdown-sheet.cy.ts
@@ -1,0 +1,82 @@
+import {ChangeDetectionStrategy, Component, input} from '@angular/core';
+import {FormsModule} from '@angular/forms';
+import {WA_IS_MOBILE} from '@ng-web-apis/platform';
+import {TuiDropdownSheet, type TuiSheetDialogOptions} from '@taiga-ui/addon-mobile';
+import {TuiRoot} from '@taiga-ui/core';
+import {TuiChevron, TuiDataListWrapper, TuiSelect} from '@taiga-ui/kit';
+
+@Component({
+    imports: [
+        FormsModule,
+        TuiChevron,
+        TuiDataListWrapper,
+        TuiDropdownSheet,
+        TuiRoot,
+        TuiSelect,
+    ],
+    template: `
+        <tui-root>
+            <tui-textfield
+                tuiChevron
+                tuiDropdownSheet="Select platform"
+                [tuiDropdownSheetOptions]="options()"
+            >
+                <input
+                    tuiSelect
+                    placeholder="Platform"
+                    [(ngModel)]="value"
+                />
+
+                <tui-data-list-wrapper
+                    *tuiDropdown
+                    [items]="platforms"
+                />
+            </tui-textfield>
+        </tui-root>
+    `,
+    changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class Sandbox {
+    protected readonly platforms = ['web', 'ios', 'android'] as const;
+    protected value: 'android' | 'ios' | 'web' | null = 'ios';
+
+    public readonly options = input<Partial<TuiSheetDialogOptions>>({});
+}
+
+describe('DropdownSheet with sheet dialog options', () => {
+    beforeEach(() => cy.viewport(300, 350));
+
+    it('closes sheet when swipe ends at the top by default', () => {
+        cy.mount(Sandbox, {providers: [{provide: WA_IS_MOBILE, useValue: true}]});
+
+        cy.get('input').click();
+        cy.get('tui-sheet-dialog')
+            .should('be.visible')
+            .should('have.class', '_closeable');
+
+        cy.get('tui-sheet-dialog').trigger('touchstart');
+        cy.get('tui-sheet-dialog').scrollTo('top');
+        cy.get('tui-sheet-dialog').trigger('touchend');
+
+        cy.get('tui-sheet-dialog').should('not.exist');
+    });
+
+    it('keeps sheet open when closable is false', () => {
+        cy.mount(Sandbox, {
+            componentProperties: {options: {closable: false}},
+            providers: [{provide: WA_IS_MOBILE, useValue: true}],
+        });
+
+        cy.get('input').click();
+        cy.get('tui-sheet-dialog')
+            .should('be.visible')
+            .should('not.have.class', '_closeable');
+
+        cy.get('tui-sheet-dialog').trigger('touchstart');
+        cy.get('tui-sheet-dialog').scrollTo('top', {ensureScrollable: false});
+        cy.get('tui-sheet-dialog').trigger('touchend');
+
+        cy.get('tui-sheet-dialog').should('be.visible');
+        cy.get('[tuiOption]').should('have.length', 3);
+    });
+});


### PR DESCRIPTION
Closes #13167

## Problem

The `SheetDialog`-based dropdown (`tuiDropdownSheet`) closes when a swipe/scroll gesture ends at the top of the sheet. With long scrollable lists this triggers accidentally while scrolling, dismissing the dropdown unexpectedly. There was no way to opt out: `TuiDropdownSheetComponent` opened the sheet with a hardcoded `{label}`, so `TuiSheetDialogOptions.closable` never reached the dialog. A scoped DI override doesn't work either, since `TuiSheetDialogService` is root-provided.

As suggested in https://github.com/taiga-family/taiga-ui/issues/13167#issuecomment-4039927638, this adds sheet dialog options as a separate input.

## Solution

- New `tuiDropdownSheetOptions` input on `TuiDropdownSheet` accepting `Partial<TuiSheetDialogOptions>`, mirroring the existing `tuiSheetDialogOptions` input on `TuiSheetDialog`
- `TuiDropdownSheetComponent` spreads these options into `TuiSheetDialogService.open()` (after `label`, so a label passed via options wins)

```html
<tui-textfield
    tuiDropdownSheet="Select platform"
    [tuiDropdownSheetOptions]="{closable: false}"
>
```

Since `closable` also accepts `Observable<boolean>`, confirm-before-close flows are possible too, and the rest of the sheet options (`stops`, `initial`, `offset`, `bar`, …) become configurable per dropdown as a bonus.

## Testing

Added a Cypress component test reproducing the gesture from the issue (`touchstart` → scroll to top → `touchend`):

- by default the sheet still closes when the swipe ends at the top (existing behavior preserved)
- with `closable: false` the sheet stays open

Verified the test fails without the fix (`expected '<tui-sheet-dialog._closeable>' not to have class '_closeable'`) and passes with it.
