### PR TITLE
fix(kit): `Textarea` fix scroll on ios

### DIFF
--- a/projects/demo-playwright/tests/kit/dropdown-selection/dropdown-selection.pw.spec.ts
+++ b/projects/demo-playwright/tests/kit/dropdown-selection/dropdown-selection.pw.spec.ts
@@ -54,7 +54,8 @@ test.describe('DropdownSelection', () => {
 
         await example.locator('textarea').focus();
 
-        await example.locator('textarea').fill('\n@');
+        await example.locator('textarea').fill('\n');
+        await example.locator('textarea').fill('@');
 
         await expect(page.locator('tui-dropdown')).toBeVisible();
     });

--- a/projects/kit/components/textarea/textarea.style.less
+++ b/projects/kit/components/textarea/textarea.style.less
@@ -11,6 +11,7 @@ tui-textarea-content:where(*&) {
     padding-inline-start: var(--t-start);
     padding-inline-end: calc(var(--t-end) + var(--t-side) + var(--t-space));
     overflow: auto;
+    pointer-events: none;
 
     tui-textfield._with-label[data-size='m'] & {
         margin-block-start: calc(-1.25 * var(--tui-font-offset) - 1.375rem);


### PR DESCRIPTION
On iOS Safari, tapping a textarea  with label inside failed to focus the textarea. Additionally, it caused an unexpected template scroll. (See attached video.)

Introduced by the attached refactoring PR #14542


https://github.com/user-attachments/assets/8e515aaf-4e01-49e1-8167-32dbd7ba3ec1

