### PR TITLE
chore: enable animations in playwright

### DIFF
--- a/projects/core/components/loader/loader.component.ts
+++ b/projects/core/components/loader/loader.component.ts
@@ -1,5 +1,5 @@
 import {ChangeDetectionStrategy, Component, inject, input} from '@angular/core';
-import {isSafari, WA_IS_E2E, WA_IS_IOS} from '@ng-web-apis/platform';
+import {isSafari, WA_IS_IOS} from '@ng-web-apis/platform';
 import {tuiInjectElement} from '@taiga-ui/cdk/utils/dom';
 import {type PolymorpheusContent, PolymorpheusOutlet} from '@taiga-ui/polymorpheus';
 
@@ -11,17 +11,12 @@ import {TUI_LOADER_OPTIONS} from './loader.options';
     templateUrl: './loader.template.html',
     styleUrl: './loader.style.less',
     changeDetection: ChangeDetectionStrategy.OnPush,
-    host: {
-        '[attr.data-size]': 'size()',
-        '[class._e2e]': 'e2e',
-        '[class._loading]': 'loading()',
-    },
+    host: {'[attr.data-size]': 'size()', '[class._loading]': 'loading()'},
 })
 export class TuiLoader {
     private readonly options = inject(TUI_LOADER_OPTIONS);
 
     protected readonly isApple = isSafari(tuiInjectElement()) || inject(WA_IS_IOS);
-    protected readonly e2e = inject(WA_IS_E2E);
 
     public readonly size = input(this.options.size);
     public readonly inheritColor = input(this.options.inheritColor);

--- a/projects/core/components/loader/loader.component.ts
+++ b/projects/core/components/loader/loader.component.ts
@@ -1,5 +1,5 @@
 import {ChangeDetectionStrategy, Component, inject, input} from '@angular/core';
-import {isSafari, WA_IS_IOS} from '@ng-web-apis/platform';
+import {isSafari, WA_IS_E2E, WA_IS_IOS} from '@ng-web-apis/platform';
 import {tuiInjectElement} from '@taiga-ui/cdk/utils/dom';
 import {type PolymorpheusContent, PolymorpheusOutlet} from '@taiga-ui/polymorpheus';
 
@@ -11,12 +11,17 @@ import {TUI_LOADER_OPTIONS} from './loader.options';
     templateUrl: './loader.template.html',
     styleUrl: './loader.style.less',
     changeDetection: ChangeDetectionStrategy.OnPush,
-    host: {'[attr.data-size]': 'size()', '[class._loading]': 'loading()'},
+    host: {
+        '[attr.data-size]': 'size()',
+        '[class._e2e]': 'e2e',
+        '[class._loading]': 'loading()',
+    },
 })
 export class TuiLoader {
     private readonly options = inject(TUI_LOADER_OPTIONS);
 
     protected readonly isApple = isSafari(tuiInjectElement()) || inject(WA_IS_IOS);
+    protected readonly e2e = inject(WA_IS_E2E);
 
     public readonly size = input(this.options.size);
     public readonly inheritColor = input(this.options.inheritColor);

--- a/projects/core/components/loader/loader.style.less
+++ b/projects/core/components/loader/loader.style.less
@@ -45,13 +45,6 @@
     &[data-size='xxl'] {
         --t-diameter: @circle-diameter[xxl];
     }
-
-    &._e2e {
-        .t-icon,
-        .t-circle {
-            animation: none;
-        }
-    }
 }
 
 .t-content {

--- a/projects/core/components/loader/loader.style.less
+++ b/projects/core/components/loader/loader.style.less
@@ -45,6 +45,13 @@
     &[data-size='xxl'] {
         --t-diameter: @circle-diameter[xxl];
     }
+
+    &._e2e {
+        .t-icon,
+        .t-circle {
+            animation: none;
+        }
+    }
 }
 
 .t-content {
@@ -137,5 +144,6 @@
     stroke: inherit;
     // Use native CSS max function instead LESS one
     stroke-width: ~'max(var(--tui-thickness), 1.5px)';
+    stroke-linecap: round;
     animation: tuiLoaderDashOffset 4s linear infinite;
 }

--- a/projects/demo-playwright/animations.css
+++ b/projects/demo-playwright/animations.css
@@ -1,0 +1,4 @@
+tui-loader > .t-loader .t-icon,
+tui-loader > .t-loader .t-circle {
+    animation: none !important;
+}

--- a/projects/demo-playwright/playwright.config.ts
+++ b/projects/demo-playwright/playwright.config.ts
@@ -90,6 +90,7 @@ export default defineConfig({
         : [chromium],
     expect: {
         toHaveScreenshot: {
+            animations: 'allow',
             caret: 'hide',
             scale: 'device',
             ...options,

--- a/projects/demo-playwright/playwright.config.ts
+++ b/projects/demo-playwright/playwright.config.ts
@@ -1,10 +1,11 @@
+import path from 'node:path';
+
 import {defineConfig, devices} from '@playwright/test';
 import {type configureAxe} from 'axe-playwright';
 import {type ViewportSize} from 'playwright-core';
 
 import {pages as PUBLIC_PAGES} from '../demo/src/pages/app/pages';
 import {tuiGetDemoPathsForE2E} from './utils/get-demo-paths';
-import path from 'node:path';
 
 const DEFAULT_VIEWPORT: ViewportSize = {width: 750, height: 700};
 const THRESHOLD = Number.parseFloat(process.env.PW_THRESHOLD ?? '') || 0.02;
@@ -92,9 +93,9 @@ export default defineConfig({
     expect: {
         toHaveScreenshot: {
             animations: 'allow',
+            stylePath: [path.resolve(__dirname, 'animations.css')],
             caret: 'hide',
             scale: 'device',
-            stylePath: [path.join(__dirname, 'animations.css')],
             ...options,
         },
         toMatchSnapshot: {...options},

--- a/projects/demo-playwright/playwright.config.ts
+++ b/projects/demo-playwright/playwright.config.ts
@@ -90,7 +90,6 @@ export default defineConfig({
         : [chromium],
     expect: {
         toHaveScreenshot: {
-            animations: 'disabled',
             caret: 'hide',
             scale: 'device',
             ...options,

--- a/projects/demo-playwright/playwright.config.ts
+++ b/projects/demo-playwright/playwright.config.ts
@@ -4,6 +4,7 @@ import {type ViewportSize} from 'playwright-core';
 
 import {pages as PUBLIC_PAGES} from '../demo/src/pages/app/pages';
 import {tuiGetDemoPathsForE2E} from './utils/get-demo-paths';
+import path from 'node:path';
 
 const DEFAULT_VIEWPORT: ViewportSize = {width: 750, height: 700};
 const THRESHOLD = Number.parseFloat(process.env.PW_THRESHOLD ?? '') || 0.02;
@@ -93,6 +94,7 @@ export default defineConfig({
             animations: 'allow',
             caret: 'hide',
             scale: 'device',
+            stylePath: [path.join(__dirname, 'animations.css')],
             ...options,
         },
         toMatchSnapshot: {...options},

--- a/projects/demo/src/pages/app/landing/index.less
+++ b/projects/demo/src/pages/app/landing/index.less
@@ -35,6 +35,14 @@
     &._hide {
         display: none;
     }
+
+    &._e2e {
+        .scroll,
+        .scroll::before,
+        .scroll::after {
+            animation: none;
+        }
+    }
 }
 
 .footer {

--- a/projects/demo/src/pages/app/landing/index.ts
+++ b/projects/demo/src/pages/app/landing/index.ts
@@ -25,8 +25,8 @@ import {TuiButton} from '@taiga-ui/core';
     providers: [tuiProvide(WA_INTERSECTION_ROOT, ElementRef)],
     host: {
         tuiTheme: 'light',
-        '[class._hide]': 'hidden',
         '[class._e2e]': 'e2e',
+        '[class._hide]': 'hidden',
         '[style.background]': 'background',
     },
 })

--- a/projects/demo/src/pages/app/landing/index.ts
+++ b/projects/demo/src/pages/app/landing/index.ts
@@ -13,6 +13,7 @@ import {
     WA_INTERSECTION_ROOT,
     WaIntersectionObserver,
 } from '@ng-web-apis/intersection-observer';
+import {WA_IS_E2E} from '@ng-web-apis/platform';
 import {TuiAnimated, TuiAutoFocus, tuiProvide} from '@taiga-ui/cdk';
 import {TuiButton} from '@taiga-ui/core';
 
@@ -25,6 +26,7 @@ import {TuiButton} from '@taiga-ui/core';
     host: {
         tuiTheme: 'light',
         '[class._hide]': 'hidden',
+        '[class._e2e]': 'e2e',
         '[style.background]': 'background',
     },
 })
@@ -34,6 +36,7 @@ export default class Page implements OnInit {
     private readonly activatedRoute = inject(ActivatedRoute);
 
     protected readonly storage = inject(WA_LOCAL_STORAGE);
+    protected readonly e2e = inject(WA_IS_E2E);
     protected readonly routes = DemoRoute;
     protected current = 0;
     protected intersected = false;

--- a/projects/demo/src/pages/components/thumbnail-card/examples/2/index.less
+++ b/projects/demo/src/pages/components/thumbnail-card/examples/2/index.less
@@ -43,5 +43,5 @@
     background-color: #7c48c3;
     background-image: linear-gradient(45deg, #c86dd7 0%, #3023ae 100%);
     overflow: visible;
-    animation: spinCard 5s infinite;
+    animation: spinCard calc(var(--tui-duration) * 20) infinite;
 }

--- a/projects/styles/components/progress-bar.less
+++ b/projects/styles/components/progress-bar.less
@@ -97,7 +97,7 @@
 
         background: linear-gradient(to right, @track-color 0 45%, @progress-color 45% 55%, @track-color 55% 100%) right;
         background-size: 225%;
-        animation: tuiIndeterminateAnimation 3s infinite ease-in-out;
+        animation: tuiIndeterminateAnimation calc(var(--tui-duration) * 10) infinite ease-in-out;
     }
 
     &::-webkit-progress-inner-element {


### PR DESCRIPTION
Enabling animations in e2e so that scroll-driven animations work. All the actual animations are disabled in tests either through `--tui-duration` or with `WA_IS_E2E` dedicated token.