### PR TITLE
chore: enable animations in cypress

### DIFF
--- a/projects/demo-cypress/cypress-image-diff.config.js
+++ b/projects/demo-cypress/cypress-image-diff.config.js
@@ -6,4 +6,7 @@ module.exports = {
         FILENAME: 'report-summary',
         OVERWRITE: true,
     },
+    CYPRESS_SCREENSHOT_OPTIONS: {
+        disableTimersAndAnimations: false,
+    },
 };


### PR DESCRIPTION
Enabling animations in e2e so that scroll-driven animations work. All the actual animations are disabled in tests either through `--tui-duration` or with `WA_IS_E2E` dedicated token.