### PR TITLE
chore(demo): fix demo versions select (#UIKIT-7949)

### DIFF
--- a/projects/demo/src/pages/app/version-manager/version-manager.providers.ts
+++ b/projects/demo/src/pages/app/version-manager/version-manager.providers.ts
@@ -1,7 +1,7 @@
 import {DOCUMENT} from '@angular/common';
 import {inject, InjectionToken, type Provider} from '@angular/core';
 
-import {TUI_VERSIONS_META_MAP, type TuiVersionMeta} from './versions.constants';
+import {TUI_VERSIONS_META_OPTIONS, type TuiVersionMeta} from './versions.constants';
 
 export const TUI_SELECTED_VERSION_META = new InjectionToken<TuiVersionMeta | null>(
     ngDevMode ? 'TUI_SELECTED_VERSION_META' : '',
@@ -14,10 +14,14 @@ export const TUI_VERSION_MANAGER_PROVIDERS: Provider[] = [
             const document = inject(DOCUMENT);
             const baseHref = document.querySelector('base')?.href ?? '';
             const base = baseHref.replace(document.location.origin, '');
+            const versions = inject(TUI_VERSIONS_META_OPTIONS);
 
-            return (
-                TUI_VERSIONS_META_MAP.get(base) ?? TUI_VERSIONS_META_MAP.get('/') ?? null
+            const versionMap = versions.reduce(
+                (map, item) => map.set(item.baseHref, item),
+                new Map<string, TuiVersionMeta>(),
             );
+
+            return versionMap.get(base) ?? versionMap.get('/') ?? null;
         },
     },
 ];

--- a/projects/demo/src/pages/app/version-manager/versions.constants.ts
+++ b/projects/demo/src/pages/app/version-manager/versions.constants.ts
@@ -30,11 +30,6 @@ export const TUI_VERSIONS_META: readonly TuiVersionMeta[] = [
         })),
 ];
 
-export const TUI_VERSIONS_META_MAP = TUI_VERSIONS_META.reduce(
-    (map, item) => map.set(item.baseHref, item),
-    new Map<string, TuiVersionMeta>(),
-);
-
 export const TUI_VERSIONS_META_OPTIONS = new InjectionToken<readonly TuiVersionMeta[]>(
     ngDevMode ? 'TUI_VERSIONS_META_OPTIONS' : '',
     {factory: () => TUI_VERSIONS_META},


### PR DESCRIPTION
Fixes #UIKIT-7949

<img width="297" height="366" alt="image" src="https://github.com/user-attachments/assets/9236308a-5a31-4d55-b4d5-2299d138fc39" />


## Description

Fix incorrect version display in proprietary deployments by using the `TUI_VERSIONS_META_OPTIONS` DI token instead of the hardcoded `TUI_VERSIONS_META_MAP` constant.

## Problem

The version manager was reading the selected version from a hardcoded constant, which caused incorrect version display in proprietary deployments where each major version runs on a separate domain.

**Affected:**
- Proprietary v4 was showing "v5" instead of "v4.91.0" as the current version

## Solution

Changed the provider to inject and use `TUI_VERSIONS_META_OPTIONS` token instead of the constant. This allows each deployment to define its own version list via DI token override.

## Testing

- ✅ Public v5: works correctly
- ✅ Public v4: works correctly  
- ✅ Proprietary v5: works correctly
- ✅ Proprietary v4: **fixed** (was showing v5, now shows v4)
