### PR TITLE
fix(styles): `Skeleton` has visual black flicker artifact during deactivation

### DIFF
--- a/projects/styles/components/appearance.less
+++ b/projects/styles/components/appearance.less
@@ -26,7 +26,7 @@
     appearance: none;
     outline: 0.125rem solid transparent;
     outline-offset: -0.125rem;
-    transition-property: color, background-color, opacity, box-shadow, border-color, border-radius, filter;
+    transition-property: color, background-color, opacity, box-shadow, border-color, border-radius;
 
     &::before,
     &::after {


### PR DESCRIPTION
### Previous behavior

https://github.com/user-attachments/assets/66a1b59f-9e9f-4b09-81d6-6729c54bd2d9

### New behavior

https://github.com/user-attachments/assets/8a16e80b-ee5d-4833-87de-a57371d19c51

