### PR TITLE
fix(cdk): expose "./schematics" subpath in package "exports"

### DIFF
--- a/projects/cdk/package.json
+++ b/projects/cdk/package.json
@@ -32,6 +32,7 @@
         }
     ],
     "exports": {
+        "./schematics": "./schematics/index.js",
         "./schematics/*": "./schematics/*"
     },
     "dependencies": {

--- a/projects/cdk/schematics/tests/subpath-export.spec.ts
+++ b/projects/cdk/schematics/tests/subpath-export.spec.ts
@@ -1,0 +1,39 @@
+import {execFileSync} from 'node:child_process';
+import {mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync} from 'node:fs';
+import {tmpdir} from 'node:os';
+import {join} from 'node:path';
+
+describe('@taiga-ui/cdk exposes the schematics entry point via "exports"', () => {
+    let root = '';
+
+    beforeAll(() => {
+        root = mkdtempSync(join(tmpdir(), 'tui-cdk-exports-'));
+
+        const manifest = readFileSync(
+            join(__dirname, '..', '..', 'package.json'),
+            'utf8',
+        );
+
+        const packageDir = join(root, 'node_modules', '@taiga-ui', 'cdk');
+
+        mkdirSync(join(packageDir, 'schematics'), {recursive: true});
+        writeFileSync(join(packageDir, 'package.json'), manifest);
+        writeFileSync(join(packageDir, 'schematics', 'index.js'), '');
+    });
+
+    afterAll(() => {
+        if (root) {
+            rmSync(root, {recursive: true, force: true});
+        }
+    });
+
+    it('resolves the bare "@taiga-ui/cdk/schematics" subpath', () => {
+        expect(() =>
+            execFileSync(
+                process.execPath,
+                ['-e', 'require.resolve("@taiga-ui/cdk/schematics")'],
+                {cwd: root, stdio: 'pipe'},
+            ),
+        ).not.toThrow();
+    });
+});


### PR DESCRIPTION
## What

Add `"./schematics": "./schematics/index.js"` to `@taiga-ui/cdk`'s `exports`.

## Why

`exports` currently declares only `"./schematics/*"`. That wildcard covers deep imports (`@taiga-ui/cdk/schematics/utils/…`, `@taiga-ui/cdk/schematics/ng-update/…`) but **not** the bare barrel import `@taiga-ui/cdk/schematics` — the wildcard needs something after `schematics/` to match. So importing the bare subpath fails at runtime:

```
ERR_PACKAGE_PATH_NOT_EXPORTED: Package subpath './schematics' is not defined by "exports" in @taiga-ui/cdk
```

This breaks downstream packages whose schematics import the barrel, e.g. an `ng-add` doing `import {...} from '@taiga-ui/cdk/schematics'`. `tsconfig` `paths` / jest `moduleNameMapper` hide it in-repo because they bypass `exports`; it only surfaces for a real consumer.

## Change

Purely additive — `"./schematics/*"` is untouched, so every existing deep import keeps resolving to its own file. Only the exact bare `./schematics` gains a mapping, to the barrel `index.js`.
