### PR TITLE
chore(schematics): migrate accordion `size` onto `tui-accordion` instead of the button

### DIFF
--- a/projects/cdk/schematics/ng-update/v5/steps/templates/migrate-accordion.ts
+++ b/projects/cdk/schematics/ng-update/v5/steps/templates/migrate-accordion.ts
@@ -2,6 +2,7 @@ import {type UpdateRecorder} from '@angular-devkit/schematics';
 import {type DevkitFileSystem} from 'ng-morph';
 import {type DefaultTreeAdapterTypes} from 'parse5';
 
+import {TODO_MARK} from '../../../../utils/insert-todo';
 import {
     findElementsByFn,
     findElementsByTagName,
@@ -15,6 +16,9 @@ import {type TemplateResource} from '../../../interfaces';
 import {hasAncestor} from '../../../utils/templates';
 
 type Element = DefaultTreeAdapterTypes.Element;
+
+const SIZE_TODO =
+    '`size` was removed from individual accordion items; set it on the parent <tui-accordion size="..."> instead. See https://taiga-ui.dev/components/accordion';
 
 export function migrateAccordionItem({
     resource,
@@ -98,12 +102,18 @@ function buildReplacement(
     const isLazy = options.isStandalone && contentElement.tagName === 'ng-template';
     const lineIndent = options.isStandalone ? `${indent}    ` : indent;
 
+    const sizeAttr = element.attrs.find(
+        (attr) => attr.name === 'size' || attr.name === '[size]',
+    );
+
     const ATTRS_TO_REMOVE = [
         'borders',
         'disableHover',
         'showArrow',
         'async',
         'rounded',
+        'size',
+        '[size]',
         'tuiaccordionitemcontent',
     ];
 
@@ -126,11 +136,25 @@ function buildReplacement(
     const button = buildButton(header, `${buttonAttr}${otherAttrs}`, lineIndent);
     const expand = buildExpand(content, isLazy, lineIndent, forceBlock, classAttrStr);
 
+    // In v5 `size` lives on `<tui-accordion>`, not the item/button. A standalone item
+    // gets its own generated wrapper, so the value moves there losslessly; inside an
+    // existing accordion only one size can win, so drop it and flag it for review.
+    const sizeAttrStr = sizeAttr
+        ? ` ${sizeAttr.name}${sizeAttr.value ? `="${sizeAttr.value}"` : ''}`
+        : '';
+
     const replacement = options.isStandalone
-        ? [`${indent}<tui-accordion>`, button, expand, `${indent}</tui-accordion>`].join(
-              '\n',
-          )
-        : [button, expand].join('\n');
+        ? [
+              `${indent}<tui-accordion${sizeAttrStr}>`,
+              button,
+              expand,
+              `${indent}</tui-accordion>`,
+          ].join('\n')
+        : [
+              ...(sizeAttr ? [`${indent}<!-- ${TODO_MARK} ${SIZE_TODO} -->`] : []),
+              button,
+              expand,
+          ].join('\n');
 
     return {
         startOffset,

--- a/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-accordion.spec.ts.snap
+++ b/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-accordion.spec.ts.snap
@@ -1,5 +1,55 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`ng-update accordion item drops size from nested items and leaves a TODO comment (#13823): test.html 1`] = `
+{
+  "0. Before": "
+                <tui-accordion>
+                    <tui-accordion-item size="s">
+                        First
+                        <ng-template tuiAccordionItemContent>One</ng-template>
+                    </tui-accordion-item>
+                    <tui-accordion-item [size]="size">
+                        Second
+                        <ng-template tuiAccordionItemContent>Two</ng-template>
+                    </tui-accordion-item>
+                </tui-accordion>
+            ",
+  "1. After": "
+                <!-- TODO: (Taiga UI migration) tui-accordion-item has been removed. Use new tuiAccordion instead. See example https://taiga-ui.dev/components/accordion -->
+<tui-accordion>
+                    <!-- TODO: (Taiga UI migration) \`size\` was removed from individual accordion items; set it on the parent <tui-accordion size="..."> instead. See https://taiga-ui.dev/components/accordion -->
+                    <button tuiAccordion>First</button>
+                    <tui-expand>One</tui-expand>
+                    <!-- TODO: (Taiga UI migration) \`size\` was removed from individual accordion items; set it on the parent <tui-accordion size="..."> instead. See https://taiga-ui.dev/components/accordion -->
+                    <button tuiAccordion>Second</button>
+                    <tui-expand>Two</tui-expand>
+                </tui-accordion>
+            ",
+}
+`;
+
+exports[`ng-update accordion item drops size from nested items and leaves a TODO comment (#13823): test.ts 1`] = `
+{
+  "0. Before": "
+            import {TuiAccordion} from '@taiga-ui/experimental';
+
+            @Component({
+                templateUrl: './test.html',
+                imports: [TuiAccordion],
+            })
+            export class TestComponent {}
+        ",
+  "1. After": "import { TuiAccordion } from "@taiga-ui/kit";
+
+                        @Component({
+                templateUrl: './test.html',
+                imports: [TuiAccordion],
+            })
+            export class TestComponent {}
+        ",
+}
+`;
+
 exports[`ng-update accordion item migrates nested accordion items: test.html 1`] = `
 {
   "0. Before": "
@@ -108,6 +158,88 @@ exports[`ng-update accordion item migrates standalone tui-expand content templat
 `;
 
 exports[`ng-update accordion item migrates standalone tui-expand content template: test.ts 1`] = `
+{
+  "0. Before": "
+            import {TuiAccordion} from '@taiga-ui/experimental';
+
+            @Component({
+                templateUrl: './test.html',
+                imports: [TuiAccordion],
+            })
+            export class TestComponent {}
+        ",
+  "1. After": "import { TuiAccordion } from "@taiga-ui/kit";
+
+                        @Component({
+                templateUrl: './test.html',
+                imports: [TuiAccordion],
+            })
+            export class TestComponent {}
+        ",
+}
+`;
+
+exports[`ng-update accordion item moves bound [size] from a standalone item onto the generated tui-accordion (#13823): test.html 1`] = `
+{
+  "0. Before": "
+                <tui-accordion-item [size]="size">
+                    Header
+                    <ng-template tuiAccordionItemContent>Content</ng-template>
+                </tui-accordion-item>
+            ",
+  "1. After": "
+                <tui-accordion [size]="size">
+                    <button tuiAccordion>Header</button>
+                    <tui-expand>
+                        <ng-container *tuiItem>Content</ng-container>
+                    </tui-expand>
+                </tui-accordion>
+            ",
+}
+`;
+
+exports[`ng-update accordion item moves bound [size] from a standalone item onto the generated tui-accordion (#13823): test.ts 1`] = `
+{
+  "0. Before": "
+            import {TuiAccordion} from '@taiga-ui/experimental';
+
+            @Component({
+                templateUrl: './test.html',
+                imports: [TuiAccordion],
+            })
+            export class TestComponent {}
+        ",
+  "1. After": "import { TuiAccordion } from "@taiga-ui/kit";
+
+                        @Component({
+                templateUrl: './test.html',
+                imports: [TuiAccordion],
+            })
+            export class TestComponent {}
+        ",
+}
+`;
+
+exports[`ng-update accordion item moves size from a standalone item onto the generated tui-accordion (#13823): test.html 1`] = `
+{
+  "0. Before": "
+                <tui-accordion-item size="s">
+                    Header
+                    <ng-template tuiAccordionItemContent>Content</ng-template>
+                </tui-accordion-item>
+            ",
+  "1. After": "
+                <tui-accordion size="s">
+                    <button tuiAccordion>Header</button>
+                    <tui-expand>
+                        <ng-container *tuiItem>Content</ng-container>
+                    </tui-expand>
+                </tui-accordion>
+            ",
+}
+`;
+
+exports[`ng-update accordion item moves size from a standalone item onto the generated tui-accordion (#13823): test.ts 1`] = `
 {
   "0. Before": "
             import {TuiAccordion} from '@taiga-ui/experimental';

--- a/projects/cdk/schematics/ng-update/v5/tests/schematic-migrate-accordion.spec.ts
+++ b/projects/cdk/schematics/ng-update/v5/tests/schematic-migrate-accordion.spec.ts
@@ -114,5 +114,47 @@ describe('ng-update accordion item', () => {
         }),
     );
 
+    it(
+        'moves size from a standalone item onto the generated tui-accordion (#13823)',
+        migrate({
+            template: /* HTML */ `
+                <tui-accordion-item size="s">
+                    Header
+                    <ng-template tuiAccordionItemContent>Content</ng-template>
+                </tui-accordion-item>
+            `,
+        }),
+    );
+
+    it(
+        'moves bound [size] from a standalone item onto the generated tui-accordion (#13823)',
+        migrate({
+            template: /* HTML */ `
+                <tui-accordion-item [size]="size">
+                    Header
+                    <ng-template tuiAccordionItemContent>Content</ng-template>
+                </tui-accordion-item>
+            `,
+        }),
+    );
+
+    it(
+        'drops size from nested items and leaves a TODO comment (#13823)',
+        migrate({
+            template: /* HTML */ `
+                <tui-accordion>
+                    <tui-accordion-item size="s">
+                        First
+                        <ng-template tuiAccordionItemContent>One</ng-template>
+                    </tui-accordion-item>
+                    <tui-accordion-item [size]="size">
+                        Second
+                        <ng-template tuiAccordionItemContent>Two</ng-template>
+                    </tui-accordion-item>
+                </tui-accordion>
+            `,
+        }),
+    );
+
     afterEach(() => resetActiveProject());
 });


### PR DESCRIPTION
## Which issue does this PR close?

Addresses the accordion `size` item from #13823.

## Problem

In v4 `size` was set per item: `<tui-accordion-item size="m">`.

In v5 `size` lives on `<tui-accordion>` — the `tuiAccordion` button reads it from the parent via `tuiDirectiveBinding`, so a `size` placed on the button is **silently ignored**. The migration used to copy `size` from `tui-accordion-item` onto the generated `<button tuiAccordion>`, leaving users with a no-op attribute (the exact symptom reported in #13823).

## Fix

- `size` / `[size]` is no longer carried onto the `<button tuiAccordion>`.
- **Standalone item** (migration generates the `<tui-accordion>` wrapper) → the value is moved onto it losslessly. Works for both `size="s"` and `[size]="expr"`.
- **Nested item** (already inside a user `<tui-accordion>`, where one size applies to all items) → `size` is dropped and a `TODO` comment with a docs link is inserted, per the maintainer discussion in the issue.

## Before / After

**Standalone**

| Before | After |
| --- | --- |
| `<tui-accordion-item size="s">…</tui-accordion-item>` | `<tui-accordion size="s"><button tuiAccordion>…</button><tui-expand>…</tui-expand></tui-accordion>` |

**Nested**

```html
<!-- After -->
<tui-accordion>
    <!-- TODO: (Taiga UI migration) `size` was removed from individual accordion items; set it on the parent <tui-accordion size="..."> instead. See https://taiga-ui.dev/components/accordion -->
    <button tuiAccordion>First</button>
    <tui-expand>One</tui-expand>
</tui-accordion>
```

## Tests

- Added 3 cases to `schematic-migrate-accordion.spec.ts` (standalone `size`, standalone `[size]`, nested drop + comment).
- Full `ng-update/v5` suite green: **107 suites / 657 tests / 752 snapshots**, no existing snapshot changed.