### PR TITLE
chore(schematics): keep non-legacy `@taiga-ui/styles` imports out of `@taiga-ui/legacy`

### DIFF
--- a/projects/cdk/schematics/ng-update/v5/steps/styles/migrate-imports.ts
+++ b/projects/cdk/schematics/ng-update/v5/steps/styles/migrate-imports.ts
@@ -1,7 +1,3 @@
-// Only `basic`, `markup` and `taiga-ui-global` were dropped from `@taiga-ui/styles`
-// and now live in `@taiga-ui/legacy/styles`. Everything else (`taiga-ui-theme`,
-// `taiga-ui-fonts`, `utils`, `components`, `mixins`, `variables`, `theme`) stays in
-// `@taiga-ui/styles`, so redirect only the moved paths instead of the whole package.
 export function migrateImports(fileContent: string): string {
     return fileContent
         .replaceAll('@taiga-ui/styles/basic', '@taiga-ui/legacy/styles/basic')

--- a/projects/cdk/schematics/ng-update/v5/steps/styles/migrate-imports.ts
+++ b/projects/cdk/schematics/ng-update/v5/steps/styles/migrate-imports.ts
@@ -1,6 +1,15 @@
+// Only `basic`, `markup` and `taiga-ui-global` were dropped from `@taiga-ui/styles`
+// and now live in `@taiga-ui/legacy/styles`. Everything else (`taiga-ui-theme`,
+// `taiga-ui-fonts`, `utils`, `components`, `mixins`, `variables`, `theme`) stays in
+// `@taiga-ui/styles`, so redirect only the moved paths instead of the whole package.
 export function migrateImports(fileContent: string): string {
     return fileContent
-        .replaceAll('@taiga-ui/styles', '@taiga-ui/legacy/styles')
+        .replaceAll('@taiga-ui/styles/basic', '@taiga-ui/legacy/styles/basic')
+        .replaceAll('@taiga-ui/styles/markup', '@taiga-ui/legacy/styles/markup')
+        .replaceAll(
+            '@taiga-ui/styles/taiga-ui-global',
+            '@taiga-ui/legacy/styles/taiga-ui-global',
+        )
         .replaceAll('@taiga-ui/core/styles/taiga-ui-local', '@taiga-ui/styles/utils')
         .replaceAll('@taiga-ui/core/styles/', '@taiga-ui/styles/')
         .replaceAll('@taiga-ui/kit/styles/', '@taiga-ui/styles/');

--- a/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-style-imports.spec.ts.snap
+++ b/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-style-imports.spec.ts.snap
@@ -1,5 +1,33 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`ng-update migrate style imports keeps already migrated @taiga-ui/styles theme/fonts in project.json (#13823): project.json 1`] = `
+{
+  "0. Before": "{"name":"test-project","targets":{"build":{"options":{"styles":["@taiga-ui/styles/taiga-ui-theme.less","@taiga-ui/styles/taiga-ui-fonts.less","@taiga-ui/styles/taiga-ui-global.less"]}}}}",
+  "1. After": "// TODO: (Taiga UI migration) Global styles will be removed in next major release. Include their source code in your project if you still require them: https://github.com/taiga-family/taiga-ui/blob/main/projects/legacy/styles/taiga-ui-global.less
+{"name":"test-project","targets":{"build":{"options":{"styles":["@taiga-ui/styles/taiga-ui-theme.less","@taiga-ui/styles/taiga-ui-fonts.less","@taiga-ui/legacy/styles/taiga-ui-global.less"]}}}}",
+}
+`;
+
+exports[`ng-update migrate style imports keeps v5 @taiga-ui/styles theme/fonts/utils in place while still moving legacy markup (#13823): test.less 1`] = `
+{
+  "0. Before": "
+                @import '@taiga-ui/styles/taiga-ui-theme.less';
+                @import '@taiga-ui/styles/taiga-ui-fonts.less';
+                @import '@taiga-ui/styles/utils';
+                @import '@taiga-ui/styles/mixins/button.less';
+                @import '@taiga-ui/styles/markup/tui-space.less';
+            ",
+  "1. After": "
+                @import '@taiga-ui/styles/taiga-ui-theme.less';
+                @import '@taiga-ui/styles/taiga-ui-fonts.less';
+                @import '@taiga-ui/styles/utils';
+                @import '@taiga-ui/styles/mixins/button.less';
+// TODO: (Taiga UI migration) Global styles will be removed in next major release. Include their source code in your project if you still require them: https://github.com/taiga-family/taiga-ui/blob/main/projects/legacy/styles/markup/tui-space.less
+                @import '@taiga-ui/legacy/styles/markup/tui-space.less';
+            ",
+}
+`;
+
 exports[`ng-update migrate style imports should handle multiple replacements in the same file: test.less 1`] = `
 {
   "0. Before": "

--- a/projects/cdk/schematics/ng-update/v5/tests/schematic-migrate-style-imports.spec.ts
+++ b/projects/cdk/schematics/ng-update/v5/tests/schematic-migrate-style-imports.spec.ts
@@ -40,6 +40,39 @@ describe('ng-update migrate style imports', () => {
     );
 
     it(
+        'keeps v5 @taiga-ui/styles theme/fonts/utils in place while still moving legacy markup (#13823)',
+        migrate({
+            styles: `
+                @import '@taiga-ui/styles/taiga-ui-theme.less';
+                @import '@taiga-ui/styles/taiga-ui-fonts.less';
+                @import '@taiga-ui/styles/utils';
+                @import '@taiga-ui/styles/mixins/button.less';
+                @import '@taiga-ui/styles/markup/tui-space.less';
+            `,
+        }),
+    );
+
+    it(
+        'keeps already migrated @taiga-ui/styles theme/fonts in project.json (#13823)',
+        migrate({
+            projectJson: JSON.stringify({
+                name: 'test-project',
+                targets: {
+                    build: {
+                        options: {
+                            styles: [
+                                '@taiga-ui/styles/taiga-ui-theme.less',
+                                '@taiga-ui/styles/taiga-ui-fonts.less',
+                                '@taiga-ui/styles/taiga-ui-global.less',
+                            ],
+                        },
+                    },
+                },
+            }),
+        }),
+    );
+
+    it(
         'should migrate style imports in project.json',
         migrate({
             projectJson: JSON.stringify({


### PR DESCRIPTION
## Which issue does this PR close?

Addresses the style-imports item reported by @hakimio in #13823.

## Problem

The style import migration blanket-replaced `@taiga-ui/styles` → `@taiga-ui/legacy/styles`:

```ts
fileContent.replaceAll('@taiga-ui/styles', '@taiga-ui/legacy/styles')
```

That relied on the input only ever containing v4 paths. In v4 `@taiga-ui/styles` held exactly `basic`, `markup` and `taiga-ui-global`, all of which moved to `@taiga-ui/legacy/styles` in v5 — so the blanket replace happened to be correct for a clean v4 project.

But the paths that **stay** in `@taiga-ui/styles` in v5 (`taiga-ui-theme`, `taiga-ui-fonts`, `utils`, `components`, `mixins`, `variables`, `theme`) were also rerouted to `@taiga-ui/legacy/styles` whenever they were already present — e.g. when re-running the migration or on partially-updated configs. The step was not idempotent.

## Fix

Redirect only the three prefixes that actually moved to the legacy package and leave everything else in `@taiga-ui/styles` alone:

```ts
fileContent
    .replaceAll('@taiga-ui/styles/basic', '@taiga-ui/legacy/styles/basic')
    .replaceAll('@taiga-ui/styles/markup', '@taiga-ui/legacy/styles/markup')
    .replaceAll('@taiga-ui/styles/taiga-ui-global', '@taiga-ui/legacy/styles/taiga-ui-global')
    // ...unchanged core/kit → styles conversions
```

`@taiga-ui/core/styles` and `@taiga-ui/kit/styles` never contained `basic`/`markup`/`taiga-ui-global` in v4, so there is no collision with the core/kit → styles conversions.

## Before / After

Input already on v5 paths:

| Import | Before (buggy) | After |
| --- | --- | --- |
| `@taiga-ui/styles/taiga-ui-theme.less` | `@taiga-ui/legacy/styles/taiga-ui-theme.less` | unchanged ✅ |
| `@taiga-ui/styles/taiga-ui-fonts.less` | `@taiga-ui/legacy/styles/taiga-ui-fonts.less` | unchanged ✅ |
| `@taiga-ui/styles/utils` | `@taiga-ui/legacy/styles/utils` | unchanged ✅ |
| `@taiga-ui/styles/markup/tui-space.less` | `@taiga-ui/legacy/styles/markup/tui-space.less` | `@taiga-ui/legacy/styles/markup/tui-space.less` (+ TODO) |
| `@taiga-ui/styles/taiga-ui-global.less` | `@taiga-ui/legacy/styles/taiga-ui-global.less` | `@taiga-ui/legacy/styles/taiga-ui-global.less` (+ TODO) |

## Tests

- Added 2 cases (one `.less`, one `project.json`) proving v5 `@taiga-ui/styles` theme/fonts/utils are left in place while `markup`/`taiga-ui-global` still move to legacy with their TODO comments.
- Full `ng-update/v5` suite green: **107 suites / 659 tests / 754 snapshots**, no existing snapshot changed.