### PR TITLE
chore(schematics): don't flag `[src]` piped through tuiInitials in avatar migration

### DIFF
--- a/projects/cdk/schematics/ng-update/v5/steps/templates/migrate-avatar.ts
+++ b/projects/cdk/schematics/ng-update/v5/steps/templates/migrate-avatar.ts
@@ -165,7 +165,7 @@ function hasTuiAvatarAttr(attrs: Attribute[]): boolean {
  * string. A `SafeResourceUrl` (or any non-string image) would break at build time, and
  * the bound type cannot be inferred from the template — so flag it with a TODO. Provably
  * string values are skipped: quoted/backtick literals (`[src]="'a.png'"`) and known
- * string flows (`| tuiIcon`, `| tuiFallbackSrc`).
+ * string flows (`| tuiIcon`, `| tuiFallbackSrc`, `| tuiInitials`).
  */
 function maybeInsertSafeResourceUrlTodo(
     recorder: UpdateRecorder,
@@ -192,7 +192,10 @@ function isRawDynamicSrc(attr: Attribute): boolean {
 
     const value = attr.value.trim();
 
-    return !isStringLiteral(value) && !/\|\s*(?:tuiIcon|tuiFallbackSrc)\b/.test(value);
+    return (
+        !isStringLiteral(value) &&
+        !/\|\s*(?:tuiIcon|tuiFallbackSrc|tuiInitials)\b/.test(value)
+    );
 }
 
 /**

--- a/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-avatar-to-directive.spec.ts.snap
+++ b/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-avatar-to-directive.spec.ts.snap
@@ -113,6 +113,13 @@ exports[`ng-update avatar tuiIcon binding is moved to tuiAvatar attribute: test.
 }
 `;
 
+exports[`ng-update avatar tuiInitials binding is moved to tuiAvatar without a SafeResourceUrl TODO: test.html 1`] = `
+{
+  "0. Before": "<tui-avatar [src]="name | tuiInitials" />",
+  "1. After": "<span [tuiAvatar]="name | tuiInitials" ></span>",
+}
+`;
+
 exports[`ng-update avatar unwraps tuiFallbackSrc binding into tuiAvatar with image inside: test.html 1`] = `
 {
   "0. Before": "<a [tuiAvatar]="'https://avatars.githubusercontent.com/u/11832552' | tuiFallbackSrc: '@tui.user' | async"></a>",

--- a/projects/cdk/schematics/ng-update/v5/tests/schematic-migrate-avatar-to-directive.spec.ts
+++ b/projects/cdk/schematics/ng-update/v5/tests/schematic-migrate-avatar-to-directive.spec.ts
@@ -47,6 +47,11 @@ describe('ng-update avatar', () => {
     );
 
     it(
+        'tuiInitials binding is moved to tuiAvatar without a SafeResourceUrl TODO',
+        migrate({template: '<tui-avatar [src]="name | tuiInitials" />'}),
+    );
+
+    it(
         'unwraps tuiFallbackSrc binding into tuiAvatar with image inside',
         migrate({
             template:


### PR DESCRIPTION
## What's changed?

The v5 avatar migration converts a raw dynamic `[src]` into `[tuiAvatar]`, which only accepts a `string`, and leaves a `SafeResourceUrl` TODO when it can't prove the value is a string. It already allowlists provably-string flows (`| tuiIcon`, `| tuiFallbackSrc`).

`tuiInitials` (`TuiInitialsPipe.transform(text: string): string`) also provably returns a string, so `[src]="name | tuiInitials"` was a **false positive** — the migration correctly rewrote it to `[tuiAvatar]="name | tuiInitials"` but also stamped a spurious TODO on it. This adds `tuiInitials` to the allowlist.

This surfaced while checking #13869 (the `tui-avatar-stack` example uses `[src]="name | tuiInitials"`).

## Before / After

```html
<!-- input -->
<tui-avatar [src]="name | tuiInitials" />

<!-- before this PR -->
<!-- TODO: (Taiga UI migration) tuiAvatar accepts only a string ... -->
<span [tuiAvatar]="name | tuiInitials"></span>

<!-- after this PR -->
<span [tuiAvatar]="name | tuiInitials"></span>
```

## Tests

- Added a case to `schematic-migrate-avatar-to-directive.spec.ts` asserting the rewrite happens with **no** TODO comment.
- Full v5 suite green: **107 suites / 655 tests / 747 snapshots**.