### PR TITLE
fix(kit): `Textarea` should be resilient to global box-sizing overrides

### DIFF
--- a/projects/demo-playwright/tests/kit/textarea/textarea.pw.spec.ts
+++ b/projects/demo-playwright/tests/kit/textarea/textarea.pw.spec.ts
@@ -45,6 +45,23 @@ test.describe('Textarea', () => {
         });
     });
 
+    ['m', 'l'].forEach((size) => {
+        test(`stays intact with a global border-box reset (size ${size})`, async ({
+            page,
+        }) => {
+            await tuiGoto(page, `${DemoRoute.Textarea}/API?tuiTextfieldSize=${size}`);
+
+            await page.addStyleTag({content: '* { box-sizing: border-box; }'});
+
+            const {demo} = new TuiDocumentationPagePO(page);
+            const textarea = demo.locator('textarea[tuiTextarea]');
+
+            await textarea.fill('1\n2\n3\n4');
+
+            await expect.soft(demo).toHaveScreenshot(`textarea-border-box-${size}.png`);
+        });
+    });
+
     test('overscroll-behavior', async ({page}) => {
         await tuiGoto(page, DemoRoute.Textarea);
 

--- a/projects/kit/components/textarea/textarea.style.less
+++ b/projects/kit/components/textarea/textarea.style.less
@@ -12,6 +12,7 @@ tui-textarea-content:where(*&) {
     padding-inline-end: calc(var(--t-end) + var(--t-side) + var(--t-space));
     overflow: auto;
     pointer-events: none;
+    box-sizing: content-box;
 
     tui-textfield._with-label[data-size='m'] & {
         margin-block-start: calc(-1.25 * var(--tui-font-offset) - 1.375rem);


### PR DESCRIPTION
Fixes #14603 