### PR TITLE
fix(kit): preview does not reset zoom/rotation on nested content changes

### DIFF
--- a/projects/demo-cypress/src/tests/preview.cy.ts
+++ b/projects/demo-cypress/src/tests/preview.cy.ts
@@ -63,7 +63,6 @@ describe('TuiPreview content mutations', () => {
                 .componentInstance as {onResize(): void};
 
             cy.get('#page').should('exist');
-            cy.wait(300);
             cy.then(() => cy.spy(preview, 'onResize').as('onResize'));
         });
     });

--- a/projects/demo-cypress/src/tests/preview.cy.ts
+++ b/projects/demo-cypress/src/tests/preview.cy.ts
@@ -1,0 +1,87 @@
+import {ChangeDetectionStrategy, Component, signal} from '@angular/core';
+import {By} from '@angular/platform-browser';
+import {TuiRoot} from '@taiga-ui/core';
+import {TuiPreview} from '@taiga-ui/kit';
+
+describe('TuiPreview content mutations', () => {
+    @Component({
+        imports: [TuiPreview, TuiRoot],
+        template: `
+            <tui-root>
+                <div style="inline-size: 400px; block-size: 400px">
+                    <tui-preview [rotatable]="true">
+                        <div
+                            id="page"
+                            style="inline-size: 200px; block-size: 200px"
+                        >
+                            <div
+                                id="content"
+                                style="inline-size: 100px; block-size: 100px; overflow: hidden"
+                            >
+                                {{ text() }}
+                            </div>
+                        </div>
+                        @if (pageTwo()) {
+                            <div id="page-2">second page</div>
+                        }
+                    </tui-preview>
+                </div>
+                <button
+                    id="change-deep"
+                    type="button"
+                    (click)="changeDeep()"
+                >
+                    Change deep
+                </button>
+                <button
+                    id="flip"
+                    type="button"
+                    (click)="flip()"
+                >
+                    Flip
+                </button>
+            </tui-root>
+        `,
+        changeDetection: ChangeDetectionStrategy.OnPush,
+    })
+    class Test {
+        protected readonly text = signal('test1');
+        protected readonly pageTwo = signal(false);
+
+        protected changeDeep(): void {
+            this.text.update((value) => (value === 'test1' ? 'test2' : 'test1'));
+        }
+
+        protected flip(): void {
+            this.pageTwo.update((value) => !value);
+        }
+    }
+
+    beforeEach(() => {
+        cy.mount(Test).then((wrapper) => {
+            const preview = wrapper.fixture.debugElement.query(By.css('tui-preview'))
+                .componentInstance as {onResize(): void};
+
+            cy.get('#page').should('exist');
+            cy.wait(300);
+            cy.then(() => cy.spy(preview, 'onResize').as('onResize'));
+        });
+    });
+
+    it('does not reset when nested content changes deep inside a page', () => {
+        cy.get('#change-deep').click({force: true});
+        cy.get('#content').should('contain.text', 'test2');
+
+        // Give the mutation observer time to (wrongly) fire before asserting.
+        cy.wait(300);
+
+        cy.get('@onResize').should('not.have.been.called');
+    });
+
+    it('resets when a direct child changes (page flip)', () => {
+        cy.get('#flip').click({force: true});
+        cy.get('#page-2').should('exist');
+
+        cy.get('@onResize').should('have.been.called');
+    });
+});

--- a/projects/demo/src/pages/components/preview/examples/2/index.html
+++ b/projects/demo/src/pages/components/preview/examples/2/index.html
@@ -27,9 +27,8 @@
         </button>
 
         <img
-            *polymorpheusOutlet="content[index] as src"
             alt="preview"
-            [src]="src"
+            [src]="content[index]"
         />
     </tui-preview>
 </ng-template>

--- a/projects/demo/src/pages/components/preview/examples/2/index.ts
+++ b/projects/demo/src/pages/components/preview/examples/2/index.ts
@@ -3,10 +3,9 @@ import {changeDetection} from '@demo/emulate/change-detection';
 import {encapsulation} from '@demo/emulate/encapsulation';
 import {TuiButton} from '@taiga-ui/core';
 import {TuiPreview} from '@taiga-ui/kit';
-import {PolymorpheusOutlet} from '@taiga-ui/polymorpheus';
 
 @Component({
-    imports: [PolymorpheusOutlet, TuiButton, TuiPreview],
+    imports: [TuiButton, TuiPreview],
     templateUrl: './index.html',
     encapsulation,
     changeDetection,

--- a/projects/kit/components/preview/preview.component.ts
+++ b/projects/kit/components/preview/preview.component.ts
@@ -102,6 +102,15 @@ export class TuiPreviewComponent {
         }
     }
 
+    protected onMutation(target: HTMLElement, [event]: MutationRecord[]): void {
+        if (
+            event?.target.isSameNode(target) ||
+            (event?.target.parentNode?.isSameNode(target) && event.type === 'attributes')
+        ) {
+            this.onResize(target);
+        }
+    }
+
     protected onResize({clientWidth, clientHeight}: HTMLElement): void {
         this.width = clientWidth;
         this.height = clientHeight;

--- a/projects/kit/components/preview/preview.template.html
+++ b/projects/kit/components/preview/preview.template.html
@@ -1,9 +1,7 @@
 <section
     #contentWrapper
     attributeFilter="src"
-    characterData
     childList
-    subtree
     class="t-wrapper"
     [class.t-not-interactive-content]="zoomable()"
     [class.t-transitive]="transitioned$ | async"

--- a/projects/kit/components/preview/preview.template.html
+++ b/projects/kit/components/preview/preview.template.html
@@ -2,6 +2,7 @@
     #contentWrapper
     attributeFilter="src"
     childList
+    subtree
     class="t-wrapper"
     [class.t-not-interactive-content]="zoomable()"
     [class.t-transitive]="transitioned$ | async"
@@ -10,7 +11,7 @@
     (resize)="onResize(contentWrapper)"
     (tuiPan)="onPan($event)"
     (tuiZoom)="onZoom($event)"
-    (waMutationObserver)="onResize(contentWrapper)"
+    (waMutationObserver)="onMutation(contentWrapper, $event)"
 >
     <ng-content />
 </section>


### PR DESCRIPTION
Fixes #13622


Updated the MutationObserver logic to only track changes on direct children.

Now the observer reacts only to:

- Addition/removal of direct child nodes
- Changes to the src attribute of direct child nodes

Any DOM mutations deeper in the tree (grandchildren and beyond) are now ignored.
