### PR TITLE
(WIP, idea) feat: unify storage key generation

### DIFF
--- a/projects/core/utils/miscellaneous/index.ts
+++ b/projects/core/utils/miscellaneous/index.ts
@@ -6,3 +6,4 @@ export * from './liquid-glass';
 export * from './override-options';
 export * from './provide-taiga';
 export * from './size-bigger';
+export * from './storage-key-factory';

--- a/projects/core/utils/miscellaneous/storage-key-factory.ts
+++ b/projects/core/utils/miscellaneous/storage-key-factory.ts
@@ -1,0 +1,7 @@
+export const TUI_STORAGE_KEY_PREFIX = '@tui';
+
+export type TuiStorageKey = `${typeof TUI_STORAGE_KEY_PREFIX}[${string}]`;
+
+export function tuiStorageKeyFactory(key: string): TuiStorageKey {
+    return `${TUI_STORAGE_KEY_PREFIX}[${key}]`;
+}

--- a/projects/demo-playwright/tests/core/hint/hint.pw.spec.ts
+++ b/projects/demo-playwright/tests/core/hint/hint.pw.spec.ts
@@ -165,7 +165,7 @@ test.describe('TuiHint', () => {
             const example = new TuiDocumentationPagePO(page).getExample('#basic');
 
             await page.addInitScript(() =>
-                globalThis.localStorage.setItem('tuiPlatform', 'ios'),
+                globalThis.localStorage.setItem('@tui[platform]', 'ios'),
             );
 
             await tuiGoto(page, DemoRoute.Hint);

--- a/projects/demo-playwright/tests/layout/app-bar.pw.spec.ts
+++ b/projects/demo-playwright/tests/layout/app-bar.pw.spec.ts
@@ -21,7 +21,7 @@ test.describe('AppBar', () => {
 
         test('mobile appbar inside dialog', async ({page}) => {
             await page.addInitScript(() =>
-                globalThis.localStorage.setItem('tuiPlatform', 'ios'),
+                globalThis.localStorage.setItem('@tui[platform]', 'ios'),
             );
 
             await tuiGoto(page, DemoRoute.AppBar);

--- a/projects/demo-playwright/utils/goto.ts
+++ b/projects/demo-playwright/utils/goto.ts
@@ -39,13 +39,13 @@ export async function tuiGoto(
 
     if (enableNightMode) {
         await page.addInitScript(() =>
-            globalThis.localStorage.setItem('tuiDark', 'true'),
+            globalThis.localStorage.setItem('@tui[is-dark]', 'true'),
         );
     }
 
     if (language) {
         await page.addInitScript(
-            (lang) => globalThis.localStorage.setItem('tuiLanguage', lang),
+            (lang) => globalThis.localStorage.setItem('@tui[language]', lang),
             language,
         );
     }

--- a/projects/demo/src/components/settings/platform-key.ts
+++ b/projects/demo/src/components/settings/platform-key.ts
@@ -1,1 +1,3 @@
-export const TUI_PLATFORM_KEY = 'tuiPlatform';
+import {tuiStorageKeyFactory} from '@taiga-ui/core';
+
+export const TUI_PLATFORM_KEY = tuiStorageKeyFactory('platform');

--- a/projects/demo/src/index.html
+++ b/projects/demo/src/index.html
@@ -154,7 +154,7 @@
     </body>
     <script>
         // Or whatever key you provided to TUI_DARK_MODE_KEY
-        const theme = localStorage?.getItem('tuiDark');
+        const theme = localStorage?.getItem('@tui[is-dark]');
 
         if (theme === 'true' || (!theme && matchMedia('(prefers-color-scheme: dark)').matches)) {
             document.body.setAttribute('tuiTheme', 'dark');

--- a/projects/demo/src/pages/app/getting-started/examples/index.md
+++ b/projects/demo/src/pages/app/getting-started/examples/index.md
@@ -9,7 +9,7 @@
   </body>
   <script>
     // Or whatever key you provided to TUI_DARK_MODE_KEY
-    const theme = localStorage?.getItem('tuiDark');
+    const theme = localStorage?.getItem('@tui[is-dark]');
 
     if (theme === 'true' || (!theme && matchMedia('(prefers-color-scheme: dark)').matches)) {
       document.body.setAttribute('tuiTheme', 'dark');

--- a/projects/demo/src/pages/customization/dark-mode/index.html
+++ b/projects/demo/src/pages/customization/dark-mode/index.html
@@ -36,7 +36,7 @@
     <h2 class="tui-text_h4 tui-space_top-8">Custom localStorage key</h2>
     <p>
         By default the preference is stored under the
-        <code>tuiDark</code>
+        <code>&#64;tui[is-dark]</code>
         key (
         <code>TUI_DARK_MODE_DEFAULT_KEY</code>
         ). Provide

--- a/projects/demo/src/pages/customization/dark-mode/setup.md
+++ b/projects/demo/src/pages/customization/dark-mode/setup.md
@@ -5,8 +5,8 @@ bootstrapApplication(AppComponent, {
   providers: [
     {
       provide: TUI_DARK_MODE_KEY,
-      // Override the default 'tuiDark' localStorage key
-      useValue: 'myAppTheme',
+      // Override the default '@tui[is-dark]' localStorage key
+      useValue: 'my-app-theme-key',
     },
   ],
 });

--- a/projects/experimental/components/search-results/search-results.options.ts
+++ b/projects/experimental/components/search-results/search-results.options.ts
@@ -1,8 +1,9 @@
 import {tuiCreateOptions} from '@taiga-ui/cdk/utils/di';
+import {tuiStorageKeyFactory} from '@taiga-ui/core';
 
 export const [TUI_SEARCH_RESULTS_OPTIONS, tuiSearchResultsOptionsProvider] =
     tuiCreateOptions({
-        key: 'taiga-search-history',
+        key: tuiStorageKeyFactory('search-history'),
         history: '@tui.clock',
         popular: '@tui.search',
         empty: '@tui.search',

--- a/projects/experimental/components/search-results/search-results.options.ts
+++ b/projects/experimental/components/search-results/search-results.options.ts
@@ -1,5 +1,5 @@
 import {tuiCreateOptions} from '@taiga-ui/cdk/utils/di';
-import {tuiStorageKeyFactory} from '@taiga-ui/core';
+import {tuiStorageKeyFactory} from '@taiga-ui/core/utils/miscellaneous';
 
 export const [TUI_SEARCH_RESULTS_OPTIONS, tuiSearchResultsOptionsProvider] =
     tuiCreateOptions({


### PR DESCRIPTION
This is the general concept of the unification of a storage key generation.

In some cases taiga uses `tuiKeyName`-like keys, but in `<tui-search-history />` somehow `taiga-search-history` is used.

I suggest the unified way of a storage key generation.