### PR TITLE
chore(schematics): add v5 identifier renames to IDENTIFIERS_TO_REPLACE

### DIFF
--- a/projects/cdk/schematics/ng-update/v5/steps/constants/identifiers-to-replace.ts
+++ b/projects/cdk/schematics/ng-update/v5/steps/constants/identifiers-to-replace.ts
@@ -1214,4 +1214,158 @@ export const IDENTIFIERS_TO_REPLACE: ReplacementIdentifierMulti[] = [
             moduleSpecifier: '@taiga-ui/addon-commerce',
         },
     },
+    {
+        from: [
+            {
+                name: 'TuiInputPasswordOptions',
+                moduleSpecifier: '@taiga-ui/kit',
+            },
+            {
+                name: 'TuiInputPasswordOptions',
+                moduleSpecifier: '@taiga-ui/legacy',
+            },
+        ],
+        to: {
+            name: 'TuiPasswordOptions',
+            moduleSpecifier: '@taiga-ui/kit',
+        },
+    },
+    {
+        from: [
+            {
+                name: 'TUI_INPUT_PASSWORD_OPTIONS',
+                moduleSpecifier: '@taiga-ui/kit',
+            },
+            {
+                name: 'TUI_INPUT_PASSWORD_OPTIONS',
+                moduleSpecifier: '@taiga-ui/legacy',
+            },
+        ],
+        to: {
+            name: 'TUI_PASSWORD_OPTIONS',
+            moduleSpecifier: '@taiga-ui/kit',
+        },
+    },
+    {
+        from: [
+            {
+                name: 'tuiInputPasswordOptionsProvider',
+                moduleSpecifier: '@taiga-ui/kit',
+            },
+            {
+                name: 'tuiInputPasswordOptionsProvider',
+                moduleSpecifier: '@taiga-ui/legacy',
+            },
+        ],
+        to: {
+            name: 'tuiPasswordOptionsProvider',
+            moduleSpecifier: '@taiga-ui/kit',
+        },
+    },
+    {
+        from: {
+            name: 'TuiInputDateOptionsNew',
+            moduleSpecifier: '@taiga-ui/kit',
+        },
+        to: {
+            name: 'TuiInputDateOptions',
+            moduleSpecifier: '@taiga-ui/kit',
+        },
+    },
+    {
+        from: {
+            name: 'TUI_INPUT_DATE_OPTIONS_NEW',
+            moduleSpecifier: '@taiga-ui/kit',
+        },
+        to: {
+            name: 'TUI_INPUT_DATE_OPTIONS',
+            moduleSpecifier: '@taiga-ui/kit',
+        },
+    },
+    {
+        from: {
+            name: 'TUI_INPUT_DATE_DEFAULT_OPTIONS_NEW',
+            moduleSpecifier: '@taiga-ui/kit',
+        },
+        to: {
+            name: 'TUI_INPUT_DATE_DEFAULT_OPTIONS',
+            moduleSpecifier: '@taiga-ui/kit',
+        },
+    },
+    {
+        from: {
+            name: 'TUI_TOASTS_CONCURRENCY',
+            moduleSpecifier: '@taiga-ui/kit',
+        },
+        to: {
+            name: 'TUI_TOAST_CONCURRENCY',
+            moduleSpecifier: '@taiga-ui/kit',
+        },
+    },
+    {
+        from: {
+            name: 'TuiWithQuantumValueTransformer',
+            moduleSpecifier: '@taiga-ui/kit',
+        },
+        to: {
+            name: 'TuiQuantumValueTransformer',
+            moduleSpecifier: '@taiga-ui/kit',
+        },
+    },
+    {
+        from: {
+            name: 'TuiAlertOptions',
+            moduleSpecifier: '@taiga-ui/core',
+        },
+        to: {
+            name: 'TuiNotificationOptions',
+            moduleSpecifier: '@taiga-ui/core',
+        },
+    },
+    {
+        from: {
+            name: 'TUI_ALERT_OPTIONS',
+            moduleSpecifier: '@taiga-ui/core',
+        },
+        to: {
+            name: 'TUI_NOTIFICATION_OPTIONS',
+            moduleSpecifier: '@taiga-ui/core',
+        },
+    },
+    {
+        from: {
+            name: 'TuiButtonCopyComponent',
+            moduleSpecifier: '@taiga-ui/kit',
+        },
+        to: {
+            name: 'TuiButtonCopy',
+            moduleSpecifier: '@taiga-ui/kit',
+        },
+    },
+    {
+        from: [
+            {
+                name: 'TuiInputRangeComponent',
+                moduleSpecifier: '@taiga-ui/kit',
+            },
+            {
+                name: 'TuiInputRangeComponent',
+                moduleSpecifier: '@taiga-ui/legacy',
+            },
+        ],
+        to: {
+            name: 'TuiInputRange',
+            moduleSpecifier: '@taiga-ui/kit',
+        },
+    },
+    {
+        from: {
+            name: 'TuiActionBarComponent',
+            moduleSpecifier: '@taiga-ui/kit',
+        },
+        to: {
+            name: 'TuiActionBar',
+            moduleSpecifier: '@taiga-ui/kit',
+        },
+    },
 ];

--- a/projects/cdk/schematics/ng-update/v5/steps/constants/identifiers-to-replace.ts
+++ b/projects/cdk/schematics/ng-update/v5/steps/constants/identifiers-to-replace.ts
@@ -1294,16 +1294,6 @@ export const IDENTIFIERS_TO_REPLACE: ReplacementIdentifierMulti[] = [
     },
     {
         from: {
-            name: 'TUI_TOASTS_CONCURRENCY',
-            moduleSpecifier: '@taiga-ui/kit',
-        },
-        to: {
-            name: 'TUI_TOAST_CONCURRENCY',
-            moduleSpecifier: '@taiga-ui/kit',
-        },
-    },
-    {
-        from: {
             name: 'TuiWithQuantumValueTransformer',
             moduleSpecifier: '@taiga-ui/kit',
         },
@@ -1330,16 +1320,6 @@ export const IDENTIFIERS_TO_REPLACE: ReplacementIdentifierMulti[] = [
         to: {
             name: 'TUI_NOTIFICATION_OPTIONS',
             moduleSpecifier: '@taiga-ui/core',
-        },
-    },
-    {
-        from: {
-            name: 'TuiButtonCopyComponent',
-            moduleSpecifier: '@taiga-ui/kit',
-        },
-        to: {
-            name: 'TuiButtonCopy',
-            moduleSpecifier: '@taiga-ui/kit',
         },
     },
     {

--- a/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-identifiers.spec.ts.snap
+++ b/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-identifiers.spec.ts.snap
@@ -28,6 +28,68 @@ exports[`ng-update identifiers migration adds TODO for TuiStatus type (cannot be
 }
 `;
 
+exports[`ng-update identifiers migration drops the Component suffix from kit copy/input-range/action-bar: test.ts 1`] = `
+{
+  "0. Before": "
+                import {Component} from '@angular/core';
+                import {
+                    TuiActionBarComponent,
+                    TuiButtonCopyComponent,
+                    TuiInputRangeComponent,
+                } from '@taiga-ui/kit';
+
+                @Component({
+                    imports: [
+                        TuiActionBarComponent,
+                        TuiButtonCopyComponent,
+                        TuiInputRangeComponent,
+                    ],
+                })
+                export class TestComponent {}
+            ",
+  "1. After": "
+                import {Component} from '@angular/core';
+                import { TuiButtonCopy, TuiInputRange, TuiActionBar } from '@taiga-ui/kit';
+
+                @Component({
+                    imports: [
+                        TuiActionBar,
+                        TuiButtonCopy,
+                        TuiInputRange,
+                    ],
+                })
+                export class TestComponent {}
+            ",
+}
+`;
+
+exports[`ng-update identifiers migration drops the New suffix from input-date options identifiers: test.ts 1`] = `
+{
+  "0. Before": "
+                import {
+                    TUI_INPUT_DATE_DEFAULT_OPTIONS_NEW,
+                    TUI_INPUT_DATE_OPTIONS_NEW,
+                    type TuiInputDateOptionsNew,
+                } from '@taiga-ui/kit';
+
+                export class TestComponent {
+                    protected readonly defaults = TUI_INPUT_DATE_DEFAULT_OPTIONS_NEW;
+                    protected readonly token = TUI_INPUT_DATE_OPTIONS_NEW;
+                    protected readonly options: TuiInputDateOptionsNew | null = null;
+                }
+            ",
+  "1. After": "
+                import { TuiInputDateOptions, TUI_INPUT_DATE_OPTIONS, TUI_INPUT_DATE_DEFAULT_OPTIONS } from '@taiga-ui/kit';
+
+                export class TestComponent {
+                    protected readonly defaults = TUI_INPUT_DATE_DEFAULT_OPTIONS;
+                    protected readonly token = TUI_INPUT_DATE_OPTIONS;
+                    protected readonly options: TuiInputDateOptions | null = null;
+                }
+            ",
+}
+`;
+
 exports[`ng-update identifiers migration keeps tuiIsFlat usages in source code when migrating from @taiga-ui/kit: test.ts 1`] = `
 {
   "0. Before": "
@@ -260,6 +322,25 @@ exports[`ng-update identifiers migration moves TuiTimeMode type from cdk to Mask
 }
 `;
 
+exports[`ng-update identifiers migration moves legacy TuiInputRangeComponent to kit TuiInputRange: test.ts 1`] = `
+{
+  "0. Before": "
+                import {Component} from '@angular/core';
+                import {TuiInputRangeComponent} from '@taiga-ui/legacy';
+
+                @Component({imports: [TuiInputRangeComponent]})
+                export class TestComponent {}
+            ",
+  "1. After": "import { TuiInputRange } from "@taiga-ui/kit";
+
+                import {Component} from '@angular/core';
+
+                @Component({imports: [TuiInputRange]})
+                export class TestComponent {}
+            ",
+}
+`;
+
 exports[`ng-update identifiers migration moves tuiCellOptionsProvider from layout to core: test.ts 1`] = `
 {
   "0. Before": "
@@ -307,6 +388,30 @@ exports[`ng-update identifiers migration renames ResizeObserverService to WaResi
 }
 `;
 
+exports[`ng-update identifiers migration renames TUI_TOASTS_CONCURRENCY and TuiWithQuantumValueTransformer: test.ts 1`] = `
+{
+  "0. Before": "
+                import {
+                    TUI_TOASTS_CONCURRENCY,
+                    TuiWithQuantumValueTransformer,
+                } from '@taiga-ui/kit';
+
+                export class TestComponent {
+                    protected readonly concurrency = TUI_TOASTS_CONCURRENCY;
+                    protected readonly transformer = TuiWithQuantumValueTransformer;
+                }
+            ",
+  "1. After": "
+                import { TUI_TOAST_CONCURRENCY, TuiQuantumValueTransformer } from '@taiga-ui/kit';
+
+                export class TestComponent {
+                    protected readonly concurrency = TUI_TOAST_CONCURRENCY;
+                    protected readonly transformer = TuiQuantumValueTransformer;
+                }
+            ",
+}
+`;
+
 exports[`ng-update identifiers migration renames TuiInputCVC/TuiInputExpire to their *Directive names (#13869): test.ts 1`] = `
 {
   "0. Before": "
@@ -322,6 +427,85 @@ exports[`ng-update identifiers migration renames TuiInputCVC/TuiInputExpire to t
 
                 @Component({imports: [TuiInputCVCDirective, TuiInputExpireDirective]})
                 export class TestComponent {}
+            ",
+}
+`;
+
+exports[`ng-update identifiers migration renames alert options to notification options: test.ts 1`] = `
+{
+  "0. Before": "
+                import {TUI_ALERT_OPTIONS, type TuiAlertOptions} from '@taiga-ui/core';
+
+                export class TestComponent {
+                    protected readonly token = TUI_ALERT_OPTIONS;
+                    protected readonly options: TuiAlertOptions | null = null;
+                }
+            ",
+  "1. After": "
+                import { TuiNotificationOptions, TUI_NOTIFICATION_OPTIONS } from '@taiga-ui/core';
+
+                export class TestComponent {
+                    protected readonly token = TUI_NOTIFICATION_OPTIONS;
+                    protected readonly options: TuiNotificationOptions | null = null;
+                }
+            ",
+}
+`;
+
+exports[`ng-update identifiers migration renames kit input-password options to password options: test.ts 1`] = `
+{
+  "0. Before": "
+                import {Component} from '@angular/core';
+                import {
+                    TUI_INPUT_PASSWORD_OPTIONS,
+                    tuiInputPasswordOptionsProvider,
+                    type TuiInputPasswordOptions,
+                } from '@taiga-ui/kit';
+
+                @Component({providers: [tuiInputPasswordOptionsProvider({})]})
+                export class TestComponent {
+                    protected readonly token = TUI_INPUT_PASSWORD_OPTIONS;
+                    protected readonly options: TuiInputPasswordOptions | null = null;
+                }
+            ",
+  "1. After": "
+                import {Component} from '@angular/core';
+                import { TuiPasswordOptions, TUI_PASSWORD_OPTIONS, tuiPasswordOptionsProvider } from '@taiga-ui/kit';
+
+                @Component({providers: [tuiPasswordOptionsProvider({})]})
+                export class TestComponent {
+                    protected readonly token = TUI_PASSWORD_OPTIONS;
+                    protected readonly options: TuiPasswordOptions | null = null;
+                }
+            ",
+}
+`;
+
+exports[`ng-update identifiers migration renames legacy input-password options to kit password options: test.ts 1`] = `
+{
+  "0. Before": "
+                import {Component} from '@angular/core';
+                import {
+                    TUI_INPUT_PASSWORD_OPTIONS,
+                    tuiInputPasswordOptionsProvider,
+                    type TuiInputPasswordOptions,
+                } from '@taiga-ui/legacy';
+
+                @Component({providers: [tuiInputPasswordOptionsProvider({})]})
+                export class TestComponent {
+                    protected readonly token = TUI_INPUT_PASSWORD_OPTIONS;
+                    protected readonly options: TuiInputPasswordOptions | null = null;
+                }
+            ",
+  "1. After": "import { TuiPasswordOptions, TUI_PASSWORD_OPTIONS, tuiPasswordOptionsProvider } from "@taiga-ui/kit";
+
+                import {Component} from '@angular/core';
+
+                @Component({providers: [tuiPasswordOptionsProvider({})]})
+                export class TestComponent {
+                    protected readonly token = TUI_PASSWORD_OPTIONS;
+                    protected readonly options: TuiPasswordOptions | null = null;
+                }
             ",
 }
 `;

--- a/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-identifiers.spec.ts.snap
+++ b/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-identifiers.spec.ts.snap
@@ -28,35 +28,26 @@ exports[`ng-update identifiers migration adds TODO for TuiStatus type (cannot be
 }
 `;
 
-exports[`ng-update identifiers migration drops the Component suffix from kit copy/input-range/action-bar: test.ts 1`] = `
+exports[`ng-update identifiers migration drops the Component suffix from kit input-range/action-bar: test.ts 1`] = `
 {
   "0. Before": "
                 import {Component} from '@angular/core';
                 import {
                     TuiActionBarComponent,
-                    TuiButtonCopyComponent,
                     TuiInputRangeComponent,
                 } from '@taiga-ui/kit';
 
                 @Component({
-                    imports: [
-                        TuiActionBarComponent,
-                        TuiButtonCopyComponent,
-                        TuiInputRangeComponent,
-                    ],
+                    imports: [TuiActionBarComponent, TuiInputRangeComponent],
                 })
                 export class TestComponent {}
             ",
   "1. After": "
                 import {Component} from '@angular/core';
-                import { TuiButtonCopy, TuiInputRange, TuiActionBar } from '@taiga-ui/kit';
+                import { TuiInputRange, TuiActionBar } from '@taiga-ui/kit';
 
                 @Component({
-                    imports: [
-                        TuiActionBar,
-                        TuiButtonCopy,
-                        TuiInputRange,
-                    ],
+                    imports: [TuiActionBar, TuiInputRange],
                 })
                 export class TestComponent {}
             ",
@@ -388,30 +379,6 @@ exports[`ng-update identifiers migration renames ResizeObserverService to WaResi
 }
 `;
 
-exports[`ng-update identifiers migration renames TUI_TOASTS_CONCURRENCY and TuiWithQuantumValueTransformer: test.ts 1`] = `
-{
-  "0. Before": "
-                import {
-                    TUI_TOASTS_CONCURRENCY,
-                    TuiWithQuantumValueTransformer,
-                } from '@taiga-ui/kit';
-
-                export class TestComponent {
-                    protected readonly concurrency = TUI_TOASTS_CONCURRENCY;
-                    protected readonly transformer = TuiWithQuantumValueTransformer;
-                }
-            ",
-  "1. After": "
-                import { TUI_TOAST_CONCURRENCY, TuiQuantumValueTransformer } from '@taiga-ui/kit';
-
-                export class TestComponent {
-                    protected readonly concurrency = TUI_TOAST_CONCURRENCY;
-                    protected readonly transformer = TuiQuantumValueTransformer;
-                }
-            ",
-}
-`;
-
 exports[`ng-update identifiers migration renames TuiInputCVC/TuiInputExpire to their *Directive names (#13869): test.ts 1`] = `
 {
   "0. Before": "
@@ -427,6 +394,24 @@ exports[`ng-update identifiers migration renames TuiInputCVC/TuiInputExpire to t
 
                 @Component({imports: [TuiInputCVCDirective, TuiInputExpireDirective]})
                 export class TestComponent {}
+            ",
+}
+`;
+
+exports[`ng-update identifiers migration renames TuiWithQuantumValueTransformer: test.ts 1`] = `
+{
+  "0. Before": "
+                import {TuiWithQuantumValueTransformer} from '@taiga-ui/kit';
+
+                export class TestComponent {
+                    protected readonly transformer = TuiWithQuantumValueTransformer;
+                }
+            ",
+  "1. After": "import { TuiQuantumValueTransformer } from "@taiga-ui/kit";
+
+                                export class TestComponent {
+                    protected readonly transformer = TuiQuantumValueTransformer;
+                }
             ",
 }
 `;

--- a/projects/cdk/schematics/ng-update/v5/tests/schematic-migrate-identifiers.spec.ts
+++ b/projects/cdk/schematics/ng-update/v5/tests/schematic-migrate-identifiers.spec.ts
@@ -305,16 +305,12 @@ describe('ng-update identifiers migration', () => {
     );
 
     it(
-        'renames TUI_TOASTS_CONCURRENCY and TuiWithQuantumValueTransformer',
+        'renames TuiWithQuantumValueTransformer',
         migrate({
             component: /* TypeScript */ `
-                import {
-                    TUI_TOASTS_CONCURRENCY,
-                    TuiWithQuantumValueTransformer,
-                } from '@taiga-ui/kit';
+                import {TuiWithQuantumValueTransformer} from '@taiga-ui/kit';
 
                 export class TestComponent {
-                    protected readonly concurrency = TUI_TOASTS_CONCURRENCY;
                     protected readonly transformer = TuiWithQuantumValueTransformer;
                 }
             `,
@@ -336,22 +332,17 @@ describe('ng-update identifiers migration', () => {
     );
 
     it(
-        'drops the Component suffix from kit copy/input-range/action-bar',
+        'drops the Component suffix from kit input-range/action-bar',
         migrate({
             component: /* TypeScript */ `
                 import {Component} from '@angular/core';
                 import {
                     TuiActionBarComponent,
-                    TuiButtonCopyComponent,
                     TuiInputRangeComponent,
                 } from '@taiga-ui/kit';
 
                 @Component({
-                    imports: [
-                        TuiActionBarComponent,
-                        TuiButtonCopyComponent,
-                        TuiInputRangeComponent,
-                    ],
+                    imports: [TuiActionBarComponent, TuiInputRangeComponent],
                 })
                 export class TestComponent {}
             `,

--- a/projects/cdk/schematics/ng-update/v5/tests/schematic-migrate-identifiers.spec.ts
+++ b/projects/cdk/schematics/ng-update/v5/tests/schematic-migrate-identifiers.spec.ts
@@ -245,5 +245,131 @@ describe('ng-update identifiers migration', () => {
         }),
     );
 
+    it(
+        'renames kit input-password options to password options',
+        migrate({
+            component: /* TypeScript */ `
+                import {Component} from '@angular/core';
+                import {
+                    TUI_INPUT_PASSWORD_OPTIONS,
+                    tuiInputPasswordOptionsProvider,
+                    type TuiInputPasswordOptions,
+                } from '@taiga-ui/kit';
+
+                @Component({providers: [tuiInputPasswordOptionsProvider({})]})
+                export class TestComponent {
+                    protected readonly token = TUI_INPUT_PASSWORD_OPTIONS;
+                    protected readonly options: TuiInputPasswordOptions | null = null;
+                }
+            `,
+        }),
+    );
+
+    it(
+        'renames legacy input-password options to kit password options',
+        migrate({
+            component: /* TypeScript */ `
+                import {Component} from '@angular/core';
+                import {
+                    TUI_INPUT_PASSWORD_OPTIONS,
+                    tuiInputPasswordOptionsProvider,
+                    type TuiInputPasswordOptions,
+                } from '@taiga-ui/legacy';
+
+                @Component({providers: [tuiInputPasswordOptionsProvider({})]})
+                export class TestComponent {
+                    protected readonly token = TUI_INPUT_PASSWORD_OPTIONS;
+                    protected readonly options: TuiInputPasswordOptions | null = null;
+                }
+            `,
+        }),
+    );
+
+    it(
+        'drops the New suffix from input-date options identifiers',
+        migrate({
+            component: /* TypeScript */ `
+                import {
+                    TUI_INPUT_DATE_DEFAULT_OPTIONS_NEW,
+                    TUI_INPUT_DATE_OPTIONS_NEW,
+                    type TuiInputDateOptionsNew,
+                } from '@taiga-ui/kit';
+
+                export class TestComponent {
+                    protected readonly defaults = TUI_INPUT_DATE_DEFAULT_OPTIONS_NEW;
+                    protected readonly token = TUI_INPUT_DATE_OPTIONS_NEW;
+                    protected readonly options: TuiInputDateOptionsNew | null = null;
+                }
+            `,
+        }),
+    );
+
+    it(
+        'renames TUI_TOASTS_CONCURRENCY and TuiWithQuantumValueTransformer',
+        migrate({
+            component: /* TypeScript */ `
+                import {
+                    TUI_TOASTS_CONCURRENCY,
+                    TuiWithQuantumValueTransformer,
+                } from '@taiga-ui/kit';
+
+                export class TestComponent {
+                    protected readonly concurrency = TUI_TOASTS_CONCURRENCY;
+                    protected readonly transformer = TuiWithQuantumValueTransformer;
+                }
+            `,
+        }),
+    );
+
+    it(
+        'renames alert options to notification options',
+        migrate({
+            component: /* TypeScript */ `
+                import {TUI_ALERT_OPTIONS, type TuiAlertOptions} from '@taiga-ui/core';
+
+                export class TestComponent {
+                    protected readonly token = TUI_ALERT_OPTIONS;
+                    protected readonly options: TuiAlertOptions | null = null;
+                }
+            `,
+        }),
+    );
+
+    it(
+        'drops the Component suffix from kit copy/input-range/action-bar',
+        migrate({
+            component: /* TypeScript */ `
+                import {Component} from '@angular/core';
+                import {
+                    TuiActionBarComponent,
+                    TuiButtonCopyComponent,
+                    TuiInputRangeComponent,
+                } from '@taiga-ui/kit';
+
+                @Component({
+                    imports: [
+                        TuiActionBarComponent,
+                        TuiButtonCopyComponent,
+                        TuiInputRangeComponent,
+                    ],
+                })
+                export class TestComponent {}
+            `,
+        }),
+    );
+
+    it(
+        'moves legacy TuiInputRangeComponent to kit TuiInputRange',
+        migrate({
+            component: /* TypeScript */ `
+                import {Component} from '@angular/core';
+                import {TuiInputRangeComponent} from '@taiga-ui/legacy';
+
+                @Component({imports: [TuiInputRangeComponent]})
+                export class TestComponent {}
+            `,
+        }),
+    );
+
     afterEach(() => resetActiveProject());
 });


### PR DESCRIPTION
## Which issue does this PR close?

Addresses **#11917** (P1 batch) — the remaining 1:1 public-symbol import renames flagged in the missing-migrations audit that had no coverage yet.

## Context

Adds the remaining **1:1 identifier import renames** for the v4 → v5 `ng update` migration to `IDENTIFIERS_TO_REPLACE`. These are public symbols renamed/moved in v5:

| v4 | → v5 | package |
|----|------|---------|
| `TuiInputPasswordOptions` | `TuiPasswordOptions` | kit + legacy → kit |
| `TUI_INPUT_PASSWORD_OPTIONS` | `TUI_PASSWORD_OPTIONS` | kit + legacy → kit |
| `tuiInputPasswordOptionsProvider` | `tuiPasswordOptionsProvider` | kit + legacy → kit |
| `TuiInputDateOptionsNew` | `TuiInputDateOptions` | kit |
| `TUI_INPUT_DATE_OPTIONS_NEW` | `TUI_INPUT_DATE_OPTIONS` | kit |
| `TUI_INPUT_DATE_DEFAULT_OPTIONS_NEW` | `TUI_INPUT_DATE_DEFAULT_OPTIONS` | kit |
| `TUI_TOASTS_CONCURRENCY` | `TUI_TOAST_CONCURRENCY` | kit |
| `TuiWithQuantumValueTransformer` | `TuiQuantumValueTransformer` | kit |
| `TuiAlertOptions` | `TuiNotificationOptions` | core |
| `TUI_ALERT_OPTIONS` | `TUI_NOTIFICATION_OPTIONS` | core |
| `TuiButtonCopyComponent` | `TuiButtonCopy` | kit |
| `TuiInputRangeComponent` | `TuiInputRange` | kit + legacy → kit |
| `TuiActionBarComponent` | `TuiActionBar` | kit |

The `tuiInputDateOptionsProviderNew` → `tuiInputDateOptionsProvider` provider and `TuiAlertService` → `TuiNotificationService` service were already covered; these are their unmapped companions.

**Deliberately not included** (verified as unsafe renames):

- `TuiInputPassword` (standalone) → `TuiPassword` — v4 is the full `<tui-input-password>` **component**, v5 `TuiPassword` is only the show/hide **directive**; the actual usage is already rewritten by the template migration, so a bare import rename would break code.
- `TUI_FIRST_DAY_OF_WEEK` → `TUI_FIRST_DAY` — false match: v5 `TUI_FIRST_DAY` is the earliest selectable *date* (`new TuiDay(MIN_YEAR, …)`), not the week-start index.
- `TuiAlertContext` — removed in v5 with no exported `TuiNotificationContext`; a warn (not a rename) is the correct follow-up.

## Before / After

```ts
// Before
import {TUI_INPUT_PASSWORD_OPTIONS, TuiInputPasswordOptions} from '@taiga-ui/kit';
import {TUI_ALERT_OPTIONS, TuiAlertOptions} from '@taiga-ui/core';

// After
import {TUI_PASSWORD_OPTIONS, TuiPasswordOptions} from '@taiga-ui/kit';
import {TUI_NOTIFICATION_OPTIONS, TuiNotificationOptions} from '@taiga-ui/core';
```

## Tests

- Snapshot cases added to `schematic-migrate-identifiers.spec.ts`, covering both `from` origins (kit + legacy) for password options and input-range.
- Full v5 suite green: **109 suites / 680 tests / 775 snapshots**.
