### PR TITLE
chore(schematics): migrate nav[tuiTabsWithMore] to tui-tabs-with-more in v5 (#11917)

### DIFF
--- a/projects/cdk/schematics/ng-update/v5/steps/constants/attrs-to-replace.ts
+++ b/projects/cdk/schematics/ng-update/v5/steps/constants/attrs-to-replace.ts
@@ -87,6 +87,10 @@ export const ATTRS_TO_REPLACE: readonly ReplacementAttribute[] = [
         to: {attrName: ''},
     },
     {
+        from: {attrName: 'tuiTabsWithMore', withTagNames: ['nav']},
+        to: {attrName: ''},
+    },
+    {
         from: {attrName: 'tuiExpandContent', withTagNames: ['ng-template']},
         to: {attrName: 'tuiItem'},
     },

--- a/projects/cdk/schematics/ng-update/v5/steps/constants/tags-to-replace.ts
+++ b/projects/cdk/schematics/ng-update/v5/steps/constants/tags-to-replace.ts
@@ -36,4 +36,9 @@ export const TAGS_TO_REPLACE: readonly ReplacementTag[] = [
         to: 'tui-tabs',
         filterFn: (element) => hasElementAttribute(element, 'tuiTabs'),
     },
+    {
+        from: 'nav',
+        to: 'tui-tabs-with-more',
+        filterFn: (element) => hasElementAttribute(element, 'tuiTabsWithMore'),
+    },
 ];

--- a/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-chip-and-badge.spec.ts.snap
+++ b/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-chip-and-badge.spec.ts.snap
@@ -57,6 +57,13 @@ exports[`ng-update chip and badge selectors replaces nav[tuiStepper] with tui-st
 }
 `;
 
+exports[`ng-update chip and badge selectors replaces nav[tuiTabsWithMore] with tui-tabs-with-more: test.html 1`] = `
+{
+  "0. Before": "<nav tuiTabsWithMore></nav>",
+  "1. After": "<tui-tabs-with-more ></tui-tabs-with-more>",
+}
+`;
+
 exports[`ng-update chip and badge selectors replaces tui-badge with span and tuiBadge directive: test.html 1`] = `
 {
   "0. Before": "<tui-badge></tui-badge>",

--- a/projects/cdk/schematics/ng-update/v5/tests/schematic-migrate-chip-and-badge.spec.ts
+++ b/projects/cdk/schematics/ng-update/v5/tests/schematic-migrate-chip-and-badge.spec.ts
@@ -30,6 +30,11 @@ describe('ng-update chip and badge selectors', () => {
     );
 
     it(
+        'replaces nav[tuiTabsWithMore] with tui-tabs-with-more',
+        migrate({template: '<nav tuiTabsWithMore></nav>'}),
+    );
+
+    it(
         'preserves attributes and content on tui-badge',
         migrate({
             template:


### PR DESCRIPTION
## Which issue does this PR close?

Addresses **#11917** — `nav[tuiTabsWithMore]` → `<tui-tabs-with-more>` was listed as a remaining gap in the missing-migrations audit.

## Context

In v4 the tabs-with-more component was declared with a dual selector — `selector: 'tui-tabs-with-more, nav[tuiTabsWithMore]'` — so both the element form and the `nav[tuiTabsWithMore]` attribute form worked. In v5 the selector was narrowed to `selector: 'tui-tabs-with-more'`, dropping the `nav[...]` attribute form, so `<nav tuiTabsWithMore>` silently stops rendering as tabs-with-more after `ng update`.

The base `nav[tuiTabs]` → `<tui-tabs>` and `nav[tuiStepper]` → `<tui-stepper>` rewrites were already covered by the same declarative mechanism; the "with more" variant was the one gap. This mirrors those siblings with two constant entries:

- `TAGS_TO_REPLACE`: rewrite `nav` → `tui-tabs-with-more` when the element carries the `tuiTabsWithMore` attribute.
- `ATTRS_TO_REPLACE`: strip the now-redundant `tuiTabsWithMore` attribute from `nav`.

All public inputs/outputs are unchanged between v4 and v5 (`size`, `underline`, `moreContent`, `dropdownContent`, `itemsLimit`, and the two-way `activeItemIndex`), so no attribute/input rename is needed — renaming the tag and stripping the marker attribute preserves every other binding. `hasElementAttribute` matches exactly (not substring), so there is no collision with the base `tuiTabs` entry.

## Before / After

```html
<!-- Before -->
<nav tuiTabsWithMore></nav>

<!-- After -->
<tui-tabs-with-more></tui-tabs-with-more>
```

## Tests

- New case in `schematic-migrate-chip-and-badge.spec.ts` (alongside the existing `nav[tuiStepper]` / `nav[tuiTabs]` cases).
- Full v5 suite green: **110 suites / 676 tests / 771 snapshots**.
