### PR TITLE
chore(schematics): migrate tui-input-card-group exampleText to placeholder in v5 (#11917)

### DIFF
--- a/projects/cdk/schematics/ng-update/v5/steps/constants/attrs-to-replace.ts
+++ b/projects/cdk/schematics/ng-update/v5/steps/constants/attrs-to-replace.ts
@@ -79,6 +79,14 @@ export const ATTRS_TO_REPLACE: readonly ReplacementAttribute[] = [
         to: {attrName: '[loading]'},
     },
     {
+        from: {attrName: 'exampleText', withTagNames: ['tui-input-card-group']},
+        to: {attrName: 'placeholder'},
+    },
+    {
+        from: {attrName: '[exampleText]', withTagNames: ['tui-input-card-group']},
+        to: {attrName: '[placeholder]'},
+    },
+    {
         from: {attrName: 'tuiStepper', withTagNames: ['nav']},
         to: {attrName: ''},
     },

--- a/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-input-card-group.spec.ts.snap
+++ b/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-input-card-group.spec.ts.snap
@@ -1,0 +1,46 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ng-update tui-input-card-group placeholder does not touch exampleText on other elements: test.html 1`] = `
+{
+  "0. Before": "
+                <tui-input-card-group exampleText="Card number"></tui-input-card-group>
+                <div exampleText="unrelated"></div>
+            ",
+  "1. After": "
+                <tui-input-card-group placeholder="Card number"></tui-input-card-group>
+                <div exampleText="unrelated"></div>
+            ",
+}
+`;
+
+exports[`ng-update tui-input-card-group placeholder preserves other attributes while renaming exampleText: test.html 1`] = `
+{
+  "0. Before": "
+                <tui-input-card-group
+                    autocomplete="cc-number"
+                    exampleText="Card number"
+                    [cardValidator]="validator"
+                ></tui-input-card-group>
+            ",
+  "1. After": "
+                <tui-input-card-group
+                    autocomplete="cc-number"
+                    placeholder="Card number"
+                    [cardValidator]="validator"
+                ></tui-input-card-group>
+            ",
+}
+`;
+
+exports[`ng-update tui-input-card-group placeholder renames the deprecated exampleText input to placeholder: test.html 1`] = `
+{
+  "0. Before": "
+                <tui-input-card-group exampleText="Card number"></tui-input-card-group>
+                <tui-input-card-group [exampleText]="text"></tui-input-card-group>
+            ",
+  "1. After": "
+                <tui-input-card-group placeholder="Card number"></tui-input-card-group>
+                <tui-input-card-group [placeholder]="text"></tui-input-card-group>
+            ",
+}
+`;

--- a/projects/cdk/schematics/ng-update/v5/tests/schematic-migrate-input-card-group.spec.ts
+++ b/projects/cdk/schematics/ng-update/v5/tests/schematic-migrate-input-card-group.spec.ts
@@ -1,0 +1,46 @@
+import {join} from 'node:path';
+
+import {resetActiveProject} from 'ng-morph';
+
+import {createMigration} from '../../../utils/run-migration';
+
+describe('ng-update tui-input-card-group placeholder', () => {
+    const migrate = createMigration({
+        collection: join(__dirname, '../../../migration.json'),
+    });
+
+    it(
+        'renames the deprecated exampleText input to placeholder',
+        migrate({
+            template: /* HTML */ `
+                <tui-input-card-group exampleText="Card number"></tui-input-card-group>
+                <tui-input-card-group [exampleText]="text"></tui-input-card-group>
+            `,
+        }),
+    );
+
+    it(
+        'preserves other attributes while renaming exampleText',
+        migrate({
+            template: /* HTML */ `
+                <tui-input-card-group
+                    autocomplete="cc-number"
+                    exampleText="Card number"
+                    [cardValidator]="validator"
+                ></tui-input-card-group>
+            `,
+        }),
+    );
+
+    it(
+        'does not touch exampleText on other elements',
+        migrate({
+            template: /* HTML */ `
+                <tui-input-card-group exampleText="Card number"></tui-input-card-group>
+                <div exampleText="unrelated"></div>
+            `,
+        }),
+    );
+
+    afterEach(() => resetActiveProject());
+});


### PR DESCRIPTION
## Which issue does this PR close?

Addresses **#11917** — `<tui-input-card-group>` `exampleText` → `placeholder` was listed as a remaining gap in the missing-migrations audit.

## Context

In v4 `exampleText` was already marked `@deprecated use 'placeholder' instead` and coexisted with `placeholder` on `<tui-input-card-group>` — both defaulted to the same option (`TUI_INPUT_CARD_GROUP_OPTIONS.exampleText`) and carried identical semantics. In v5 the deprecated `exampleText` input was removed and only `placeholder` remains (now backed by `TUI_INPUT_CARD_GROUP_OPTIONS.placeholder`), so an `[exampleText]` binding silently stops taking effect after `ng update`.

The component tag itself (`tui-input-card-group`) is unchanged, so this is a template attribute rename. It adds two tag-scoped entries to `ATTRS_TO_REPLACE` — the same shape as the existing `showLoader` → `loading` migration on `<tui-loader>`:

- `exampleText` → `placeholder` (static)
- `[exampleText]` → `[placeholder]` (bound)

`exampleTextCVC` is **intentionally not migrated**: in v4 it is a `protected` field driven by the `codeLength` input, not a template-bindable `@Input`, so no consumer `[exampleTextCVC]` binding can exist. Mapping it to `placeholder` would be incorrect (it is the CVC field's placeholder, not the card's).

## Before / After

```html
<!-- Before -->
<tui-input-card-group exampleText="Card number"></tui-input-card-group>
<tui-input-card-group [exampleText]="text"></tui-input-card-group>

<!-- After -->
<tui-input-card-group placeholder="Card number"></tui-input-card-group>
<tui-input-card-group [placeholder]="text"></tui-input-card-group>
```

The rename is scoped to `tui-input-card-group`, so an `exampleText` attribute on any other element is left untouched.

## Tests

- New `schematic-migrate-input-card-group.spec.ts` (static + bound rename; other attributes preserved; tag-scoping negative case).
- Full v5 suite green: **110 suites / 676 tests / 771 snapshots**.
