### PR TITLE
chore(schematics): migrate *tuiActionBar to *tuiPopup in v5 templates

### DIFF
--- a/projects/cdk/schematics/ng-update/v5/steps/constants/attrs-to-replace.ts
+++ b/projects/cdk/schematics/ng-update/v5/steps/constants/attrs-to-replace.ts
@@ -51,6 +51,10 @@ export const ATTRS_TO_REPLACE: readonly ReplacementAttribute[] = [
         to: {attrName: '*tuiDropdown'},
     },
     {
+        from: {attrName: '*tuiActionBar', withTagNames: ['*']},
+        to: {attrName: '*tuiPopup'},
+    },
+    {
         from: {attrName: 'tuiTextfield', withTagNames: ['*']},
         to: {attrName: 'tuiInput'},
     },

--- a/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-action-bar.spec.ts.snap
+++ b/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-action-bar.spec.ts.snap
@@ -1,0 +1,39 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ng-update tui-action-bar migrates *tuiActionBar to *tuiPopup: test.html 1`] = `
+{
+  "0. Before": "
+                <tui-action-bar *tuiActionBar="open()">
+                    <span>Action bar opened</span>
+                </tui-action-bar>
+            ",
+  "1. After": "
+                <tui-action-bar *tuiPopup="open()">
+                    <span>Action bar opened</span>
+                </tui-action-bar>
+            ",
+}
+`;
+
+exports[`ng-update tui-action-bar preserves other attributes on the element: test.html 1`] = `
+{
+  "0. Before": "
+                <tui-action-bar
+                    *tuiActionBar="open"
+                    size="s"
+                    [expanded]="expanded"
+                >
+                    <span>Action bar opened</span>
+                </tui-action-bar>
+            ",
+  "1. After": "
+                <tui-action-bar
+                    *tuiPopup="open"
+                    size="s"
+                    [expanded]="expanded"
+                >
+                    <span>Action bar opened</span>
+                </tui-action-bar>
+            ",
+}
+`;

--- a/projects/cdk/schematics/ng-update/v5/tests/schematic-migrate-action-bar.spec.ts
+++ b/projects/cdk/schematics/ng-update/v5/tests/schematic-migrate-action-bar.spec.ts
@@ -1,0 +1,48 @@
+import {join} from 'node:path';
+
+import {resetActiveProject} from 'ng-morph';
+
+import {createMigration} from '../../../utils/run-migration';
+
+describe('ng-update tui-action-bar', () => {
+    const migrate = createMigration({
+        collection: join(__dirname, '../../../migration.json'),
+        component: /* TypeScript */ `
+            import {TuiActionBar} from '@taiga-ui/kit';
+
+            @Component({
+                templateUrl: './test.html',
+                imports: [TuiActionBar],
+            })
+            export class TestComponent {}
+        `,
+    });
+
+    it(
+        'migrates *tuiActionBar to *tuiPopup',
+        migrate({
+            template: /* HTML */ `
+                <tui-action-bar *tuiActionBar="open()">
+                    <span>Action bar opened</span>
+                </tui-action-bar>
+            `,
+        }),
+    );
+
+    it(
+        'preserves other attributes on the element',
+        migrate({
+            template: /* HTML */ `
+                <tui-action-bar
+                    *tuiActionBar="open"
+                    size="s"
+                    [expanded]="expanded"
+                >
+                    <span>Action bar opened</span>
+                </tui-action-bar>
+            `,
+        }),
+    );
+
+    afterEach(() => resetActiveProject());
+});


### PR DESCRIPTION
## Which issue does this PR close?

Addresses **#11917** — the `*tuiActionBar` structural directive was flagged as a remaining template-shape gap in the missing-migrations audit (the `TuiActionBarComponent → TuiActionBar` import rename is already covered by #14609; the template directive had no migration).

## Context

In v4 the action bar was toggled with the `*tuiActionBar` structural directive — `ng-template[tuiActionBar]`, a `TuiDropdownPortal` subclass bundled into `TuiActionBar = [TuiActionBarComponent, TuiActionBarDirective]`. A consumer wrote:

```html
<tui-action-bar *tuiActionBar="open()">…</tui-action-bar>
```

In v5 that directive is removed. `TuiActionBar` is now the component itself (selector `tui-action-bar`), and the bar is shown/hidden with `*tuiPopup` instead — the same directive the sidebar→drawer and other portal migrations already target. A leftover `*tuiActionBar` silently stops toggling the bar (Angular reports an unknown structural directive).

Because the `<tui-action-bar>` tag and its own inputs (`size`, `[expanded]`, …) are unchanged and only the structural directive is renamed, this is a one-line declarative `ATTRS_TO_REPLACE` entry — the same mechanism already used for `*tuiTextfieldDropdown → *tuiDropdown` and `*tuiDataList → *tuiDropdown`. The `TuiActionBar` import is deliberately left untouched (still valid in v5); as with the sibling structural renames, adding the `TuiPopup` import is left to the developer (the compiler flags the missing binding).

## Before / After

```html
<!-- Before -->
<tui-action-bar *tuiActionBar="open()">
    <span>Action bar opened</span>
</tui-action-bar>

<!-- After -->
<tui-action-bar *tuiPopup="open()">
    <span>Action bar opened</span>
</tui-action-bar>
```

## Tests

- New `schematic-migrate-action-bar.spec.ts` (method-call binding; plain-variable binding with `size` / `[expanded]` attributes preserved).
- Full v5 suite green: **110 suites / 675 tests / 770 snapshots**.
