### PR TITLE
chore(schematics): warn on removed data-list/textarea CSS variables in v5 migration

### DIFF
--- a/projects/cdk/schematics/ng-update/v5/steps/migrate-css-variables.ts
+++ b/projects/cdk/schematics/ng-update/v5/steps/migrate-css-variables.ts
@@ -37,10 +37,28 @@ const FONT_VARIABLES_REPLACEMENTS = [
 export const TUI_THICKNESS_COMMENT =
     'use --tui-thumb-size. Learn more: https://taiga-ui.dev/components/slider#size';
 
+const TUI_DATA_LIST_SPACING_COMMENT =
+    'The tui-data-list spacing variables (padding and margin) have been removed. tui-data-list spacing is now fixed in the component and is no longer exposed as a CSS variable; restyle [tuiOption] (or tui-data-list) directly if you need different spacing.';
+
+const TUI_TEXTAREA_HEIGHT_COMMENT =
+    'The tui-textarea height variable has been removed. The textarea moved to @taiga-ui/kit and auto-sizes to its content; control the height with the [min] and [max] row inputs (or set min-block-size on the element) instead.';
+
 const DEPRECATED_VARS_WITH_COMMENT = [
     {
         sourceText: '--tui-thickness',
         comment: `TODO: (Taiga UI migration) ${TUI_THICKNESS_COMMENT}`,
+    },
+    {
+        sourceText: '--tui-data-list-padding',
+        comment: `TODO: (Taiga UI migration) ${TUI_DATA_LIST_SPACING_COMMENT}`,
+    },
+    {
+        sourceText: '--tui-data-list-margin',
+        comment: `TODO: (Taiga UI migration) ${TUI_DATA_LIST_SPACING_COMMENT}`,
+    },
+    {
+        sourceText: '--tui-textarea-height',
+        comment: `TODO: (Taiga UI migration) ${TUI_TEXTAREA_HEIGHT_COMMENT}`,
     },
 ];
 

--- a/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-removed-css-vars.spec.ts.snap
+++ b/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-removed-css-vars.spec.ts.snap
@@ -1,0 +1,33 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ng-update comment for removed CSS variables adds comment for removed data-list and textarea variables in styles: test.less 1`] = `
+{
+  "0. Before": "
+                @import '@taiga-ui/core/styles/taiga-ui-local';
+
+                tui-data-list {
+                    --tui-data-list-padding: 0.5rem;
+                    --tui-data-list-margin: 0.125rem;
+                }
+
+                tui-textarea {
+                    --tui-textarea-height: 8rem;
+                }
+            ",
+  "1. After": "
+                @import '@taiga-ui/styles/utils';
+
+                tui-data-list {
+// TODO: (Taiga UI migration) The tui-data-list spacing variables (padding and margin) have been removed. tui-data-list spacing is now fixed in the component and is no longer exposed as a CSS variable; restyle [tuiOption] (or tui-data-list) directly if you need different spacing.
+                    --tui-data-list-padding: 0.5rem;
+// TODO: (Taiga UI migration) The tui-data-list spacing variables (padding and margin) have been removed. tui-data-list spacing is now fixed in the component and is no longer exposed as a CSS variable; restyle [tuiOption] (or tui-data-list) directly if you need different spacing.
+                    --tui-data-list-margin: 0.125rem;
+                }
+
+                tui-textarea {
+// TODO: (Taiga UI migration) The tui-textarea height variable has been removed. The textarea moved to @taiga-ui/kit and auto-sizes to its content; control the height with the [min] and [max] row inputs (or set min-block-size on the element) instead.
+                    --tui-textarea-height: 8rem;
+                }
+            ",
+}
+`;

--- a/projects/cdk/schematics/ng-update/v5/tests/schematic-migrate-removed-css-vars.spec.ts
+++ b/projects/cdk/schematics/ng-update/v5/tests/schematic-migrate-removed-css-vars.spec.ts
@@ -1,0 +1,31 @@
+import {join} from 'node:path';
+
+import {resetActiveProject} from 'ng-morph';
+
+import {createMigration} from '../../../utils/run-migration';
+
+describe('ng-update comment for removed CSS variables', () => {
+    const migrate = createMigration({
+        collection: join(__dirname, '../../../migration.json'),
+    });
+
+    it(
+        'adds comment for removed data-list and textarea variables in styles',
+        migrate({
+            styles: `
+                @import '@taiga-ui/core/styles/taiga-ui-local';
+
+                tui-data-list {
+                    --tui-data-list-padding: 0.5rem;
+                    --tui-data-list-margin: 0.125rem;
+                }
+
+                tui-textarea {
+                    --tui-textarea-height: 8rem;
+                }
+            `,
+        }),
+    );
+
+    afterEach(() => resetActiveProject());
+});


### PR DESCRIPTION
## Which issue does this PR close?

Addresses **#11917** — three CSS custom properties removed in v5 had no `ng update` coverage.

## Context

`--tui-data-list-padding`, `--tui-data-list-margin` and `--tui-textarea-height` were live, consumer-overridable CSS custom properties in v4 and are gone in v5 with **no rename**, so a consumer override silently stops taking effect:

- **`--tui-data-list-*`** — in v4 `tui-data-list` defined and read these for its padding/margin; in v5 the spacing is hard-coded in the component and no longer exposed as a variable.
- **`--tui-textarea-height`** — in v4 the (legacy) textarea sized its host from this; in v5 the textarea moved to `@taiga-ui/kit` and auto-sizes to content within the `[min]`/`[max]` row bounds, with no public height variable.

They are surfaced as **warnings** (a `// TODO: (Taiga UI migration) …` left above the declaration) via the existing `DEPRECATED_VARS_WITH_COMMENT` mechanism in `migrate-css-variables.ts` — the same one already used for `--tui-thickness` — because there is no successor variable to auto-rewrite to.

The other CSS tokens a first pass might group here (`--tui-base-01`, `--tui-shadow-sidebar`, `--tui-info-bg-night`, `--tui-rating-gap`, `--tui-rating-size`) are intentionally **out of scope**: they are not v4→v5 removals but v3→v4 renames / pre-v4 removals already handled by the v4 migration (`v4/migrate-css-vars/palette.ts`).

> Note: the comment text deliberately omits the literal `--tui-*` names — `addCommentForStylesFiles` re-scans the text it just edited, so a message naming a sibling entry's token would make that entry double-comment.

## Before / After

```less
/* Before */
tui-data-list {
    --tui-data-list-padding: 0.5rem;
}

/* After */
tui-data-list {
    // TODO: (Taiga UI migration) The tui-data-list spacing variables (padding and margin) have been removed. tui-data-list spacing is now fixed in the component and is no longer exposed as a CSS variable; restyle [tuiOption] (or tui-data-list) directly if you need different spacing.
    --tui-data-list-padding: 0.5rem;
}
```

## Tests

- New `schematic-migrate-removed-css-vars.spec.ts` covering the three removed variables in a stylesheet.
- Full v5 suite green: **110 suites / 674 tests / 769 snapshots**.
