### PR TITLE
chore(schematics): migrate legacy TuiInputCopy to TuiTextfield with tuiCopy in v5

### DIFF
--- a/projects/cdk/schematics/ng-update/v5/steps/constants/identifiers-to-replace.ts
+++ b/projects/cdk/schematics/ng-update/v5/steps/constants/identifiers-to-replace.ts
@@ -858,6 +858,41 @@ export const IDENTIFIERS_TO_REPLACE: ReplacementIdentifierMulti[] = [
     },
     {
         from: {
+            name: 'TuiInputCopyModule',
+            moduleSpecifier: '@taiga-ui/legacy',
+        },
+        to: [
+            {
+                name: 'TuiIcon',
+                moduleSpecifier: '@taiga-ui/core',
+            },
+            {
+                name: 'TuiCopy',
+                moduleSpecifier: '@taiga-ui/kit',
+            },
+            {
+                name: 'TuiInput',
+                moduleSpecifier: '@taiga-ui/core',
+            },
+        ],
+    },
+    {
+        from: {name: 'TuiInputCopyOptions', moduleSpecifier: '@taiga-ui/legacy'},
+        to: {name: 'TuiCopyOptions', moduleSpecifier: '@taiga-ui/kit'},
+    },
+    {
+        from: {name: 'TUI_INPUT_COPY_OPTIONS', moduleSpecifier: '@taiga-ui/legacy'},
+        to: {name: 'TUI_COPY_OPTIONS', moduleSpecifier: '@taiga-ui/kit'},
+    },
+    {
+        from: {
+            name: 'tuiInputCopyOptionsProvider',
+            moduleSpecifier: '@taiga-ui/legacy',
+        },
+        to: {name: 'tuiCopyOptionsProvider', moduleSpecifier: '@taiga-ui/kit'},
+    },
+    {
+        from: {
             name: 'TuiInputMonthModule',
             moduleSpecifier: '@taiga-ui/legacy',
         },

--- a/projects/cdk/schematics/ng-update/v5/steps/constants/migration-warnings.ts
+++ b/projects/cdk/schematics/ng-update/v5/steps/constants/migration-warnings.ts
@@ -291,4 +291,10 @@ export const MIGRATION_WARNINGS: MigrationWarning[] = [
         message:
             'TuiTableBarComponent (<tui-table-bar>) has been removed. Use TuiActionBar (<tui-action-bar>) from @taiga-ui/kit instead. See https://taiga-ui.dev/components/actions-bar',
     },
+    {
+        name: 'TuiInputCopyComponent',
+        moduleSpecifier: '@taiga-ui/legacy',
+        message:
+            'TuiInputCopyComponent has been removed. Use TuiCopy from @taiga-ui/kit instead (the <tui-copy> component, the tui-icon[tuiCopy] directive or TuiButtonCopy). See https://taiga-ui.dev/components/copy',
+    },
 ];

--- a/projects/cdk/schematics/ng-update/v5/steps/migrate-templates.ts
+++ b/projects/cdk/schematics/ng-update/v5/steps/migrate-templates.ts
@@ -40,6 +40,7 @@ import {migrateFormatPhonePipe} from './templates/migrate-format-phone-pipe';
 import {migrateHintOnLegacyControls} from './templates/migrate-hint-on-legacy-controls';
 import {migrateInput} from './templates/migrate-input';
 import {migrateInputColor} from './templates/migrate-input-color';
+import {migrateInputCopy} from './templates/migrate-input-copy';
 import {migrateInputDate} from './templates/migrate-input-date';
 import {migrateInputDateMulti} from './templates/migrate-input-date-multi';
 import {migrateInputDateRange} from './templates/migrate-input-date-range';
@@ -120,6 +121,7 @@ export function migrateTemplates(fileSystem: DevkitFileSystem, options: TuiSchem
         migrateInputNumber,
         migrateInputDateRange,
         migrateInputColor,
+        migrateInputCopy,
         migrateInputRange,
         migrateMultiSelect,
         migrateSelect,

--- a/projects/cdk/schematics/ng-update/v5/steps/templates/migrate-input-copy.ts
+++ b/projects/cdk/schematics/ng-update/v5/steps/templates/migrate-input-copy.ts
@@ -1,0 +1,192 @@
+import {type UpdateRecorder} from '@angular-devkit/schematics';
+import {type DevkitFileSystem} from 'ng-morph';
+import {type DefaultTreeAdapterTypes} from 'parse5';
+
+import {TODO_MARK} from '../../../../utils/insert-todo';
+import {findElementsByTagName} from '../../../../utils/templates/elements';
+import {
+    getTemplateFromTemplateResource,
+    getTemplateOffset,
+} from '../../../../utils/templates/template-resource';
+import {type TemplateResource} from '../../../interfaces/template-resource';
+import {removeAttr} from '../../../utils/templates/remove-attr';
+import {replaceTag} from '../../../utils/templates/replace-tag';
+
+type ChildNode = DefaultTreeAdapterTypes.ChildNode;
+
+type TextNode = DefaultTreeAdapterTypes.TextNode;
+
+type Element = DefaultTreeAdapterTypes.Element;
+
+// v4 message inputs with no v5 successor: the copied-confirmation hint is now baked
+// into tuiCopy and is no longer configurable. parse5 lowercases attribute names, so
+// map every lowercased form back to its canonical name for a readable TODO.
+const NO_EQUIVALENT_ATTRS = new Map<string, string>(
+    ['successMessage', 'messageDirection', 'messageAppearance'].flatMap((name) => [
+        [name.toLowerCase(), name] as const,
+        [`[${name.toLowerCase()}]`, name] as const,
+    ]),
+);
+
+export function migrateInputCopy({
+    resource,
+    recorder,
+    fileSystem,
+}: {
+    fileSystem: DevkitFileSystem;
+    recorder: UpdateRecorder;
+    resource: TemplateResource;
+}): void {
+    const template = getTemplateFromTemplateResource(resource, fileSystem);
+    const templateOffset = getTemplateOffset(resource);
+    const elements = findElementsByTagName(template, 'tui-input-copy');
+
+    elements.forEach((element: Element) => {
+        const sourceCodeLocation = element.sourceCodeLocation;
+
+        replaceTag(
+            recorder,
+            sourceCodeLocation,
+            'tui-input-copy',
+            'tui-textfield',
+            template,
+            templateOffset,
+        );
+
+        const controlAttrs = [...element.attrs].filter((attr) =>
+            /formcontrol|ngmodel/.exec(attr.name.toLocaleLowerCase()),
+        );
+
+        const noEquivalentAttrs = [...element.attrs].filter((attr) =>
+            NO_EQUIVALENT_ATTRS.has(attr.name.toLowerCase()),
+        );
+
+        for (const attr of [...controlAttrs, ...noEquivalentAttrs]) {
+            const {startOffset = 0, endOffset = 0} =
+                element.sourceCodeLocation?.attrs?.[attr.name] ?? {};
+
+            recorder.remove(templateOffset + startOffset, endOffset - startOffset);
+        }
+
+        const {value: labelOutsideValue, isBinding: labelOutsideIsBinding} = removeAttr(
+            element,
+            'tuiTextfieldLabelOutside',
+            recorder,
+            templateOffset,
+        );
+
+        const isLabelOutsideTrue =
+            labelOutsideValue === 'true' ||
+            (!labelOutsideIsBinding && labelOutsideValue === '');
+
+        const isDynamic =
+            labelOutsideValue !== null &&
+            labelOutsideValue !== 'true' &&
+            labelOutsideValue !== 'false' &&
+            labelOutsideValue !== '';
+
+        const labelIndex = element.childNodes.findIndex(
+            (node: ChildNode) =>
+                node.nodeName === '#text' && (node as TextNode)?.value.trim(),
+        );
+
+        let placeholderAttr = '';
+
+        if (labelIndex !== -1) {
+            const labelNode = element.childNodes[labelIndex];
+            const labelText = (labelNode as TextNode).value.trim();
+
+            const labelTextStart =
+                (labelNode?.sourceCodeLocation?.startOffset ?? 0) + templateOffset;
+
+            const labelTextEnd =
+                (labelNode?.sourceCodeLocation?.endOffset ?? 0) + templateOffset;
+
+            if (isLabelOutsideTrue) {
+                recorder.remove(labelTextStart, labelTextEnd - labelTextStart);
+                placeholderAttr = ` placeholder="${labelText}"`;
+            } else if (!isDynamic) {
+                recorder.insertRight(labelTextStart, '\n<label tuiLabel>');
+                recorder.insertRight(labelTextEnd, '</label>\n');
+            }
+        }
+
+        const todoNotes: string[] = [];
+
+        if (isDynamic) {
+            todoNotes.push(
+                `[tuiTextfieldLabelOutside]="${labelOutsideValue}" is dynamic and cannot be migrated automatically. Use <label tuiLabel> inside <tui-textfield> for floating label or outside for static label.`,
+            );
+        }
+
+        if (noEquivalentAttrs.length > 0) {
+            const removedNames = [
+                ...new Set(
+                    noEquivalentAttrs
+                        .map((attr) => NO_EQUIVALENT_ATTRS.get(attr.name.toLowerCase()))
+                        .filter((name): name is string => Boolean(name)),
+                ),
+            ];
+
+            todoNotes.push(
+                `${removedNames.join(', ')} removed in v5. The copy confirmation hint is built into tuiCopy and is no longer configurable.`,
+            );
+        }
+
+        if (todoNotes.length > 0) {
+            const startOffset = (sourceCodeLocation?.startOffset ?? 0) + templateOffset;
+            const todoComment = `<!-- ${TODO_MARK} tui-input-copy migration:\n${todoNotes.map((note) => `     - ${note}`).join('\n')}\n-->\n`;
+
+            recorder.insertLeft(startOffset, todoComment);
+        }
+
+        const migrationAttrs = controlAttrs.reduce((result, attr) => {
+            const name = attr.name
+                .replace(/ngmodel/i, 'ngModel')
+                .replace(/formcontrol/i, 'formControl')
+                .replace(/formcontrolname/i, 'formControlName');
+
+            return `${result} ${name}="${attr.value}"`;
+        }, '');
+
+        const inputs = element.childNodes.filter(
+            (node: ChildNode): node is Element => node.nodeName === 'input',
+        );
+
+        if (!inputs.length) {
+            const insertOffset =
+                (sourceCodeLocation?.endTag?.startOffset ?? 0) + templateOffset;
+
+            recorder.insertRight(
+                insertOffset,
+                `\n<input tuiInput${migrationAttrs}${placeholderAttr} />\n<tui-icon tuiCopy />\n`,
+            );
+
+            return;
+        }
+
+        for (const input of inputs) {
+            input.attrs.forEach((attr) => {
+                if (/^tuiTextfield$|^tuiTextfieldLegacy$/i.exec(attr.name)) {
+                    const {startOffset = 0, endOffset = 0} =
+                        input.sourceCodeLocation?.attrs?.[attr.name] ?? {};
+
+                    recorder.remove(
+                        templateOffset + startOffset,
+                        endOffset - startOffset,
+                    );
+
+                    recorder.insertRight(
+                        templateOffset + startOffset,
+                        `tuiInput${migrationAttrs}${placeholderAttr}`,
+                    );
+
+                    const inputEndOffset =
+                        (input.sourceCodeLocation?.endOffset ?? 0) + templateOffset;
+
+                    recorder.insertRight(inputEndOffset, '\n<tui-icon tuiCopy />\n');
+                }
+            });
+        }
+    });
+}

--- a/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-input-copy.spec.ts.snap
+++ b/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-input-copy.spec.ts.snap
@@ -1,0 +1,165 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ng-update adds TODO for removed message inputs and drops them: test.html 1`] = `
+{
+  "0. Before": "
+                <tui-input-copy
+                    [(ngModel)]="value"
+                    successMessage="Copied!"
+                    [messageDirection]="direction"
+                >
+                    Copy value
+                </tui-input-copy>
+            ",
+  "1. After": "
+                <!-- TODO: (Taiga UI migration) tui-input-copy migration:
+     - successMessage, messageDirection removed in v5. The copy confirmation hint is built into tuiCopy and is no longer configurable.
+-->
+<tui-textfield
+                    
+                    
+                    
+                >
+<label tuiLabel>
+                    Copy value
+                </label>
+
+<input tuiInput [(ngModel)]="value" />
+<tui-icon tuiCopy />
+</tui-textfield>
+            ",
+}
+`;
+
+exports[`ng-update migrate TuiInputCopyModule to TuiTextfield with tuiCopy: test.html 1`] = `
+{
+  "0. Before": "
+                <tui-input-copy [(ngModel)]="value">Click to copy</tui-input-copy>
+
+                <tui-input-copy formControlName="token">Token</tui-input-copy>
+            ",
+  "1. After": "
+                <tui-textfield >
+<label tuiLabel>Click to copy</label>
+
+<input tuiInput [(ngModel)]="value" />
+<tui-icon tuiCopy />
+</tui-textfield>
+
+                <tui-textfield >
+<label tuiLabel>Token</label>
+
+<input tuiInput formControlName="token" />
+<tui-icon tuiCopy />
+</tui-textfield>
+            ",
+}
+`;
+
+exports[`ng-update migrate TuiInputCopyModule to TuiTextfield with tuiCopy: test.ts 1`] = `
+{
+  "0. Before": "
+                import {TuiInputCopyModule} from '@taiga-ui/legacy';
+
+                @Component({
+                    standalone: true,
+                    imports: [TuiInputCopyModule],
+                    templateUrl: './test.html',
+                })
+                export class MyComponent {}
+            ",
+  "1. After": "import { TuiCopy } from "@taiga-ui/kit";
+import { TuiIcon, TuiInput } from "@taiga-ui/core";
+
+                                @Component({
+                    standalone: true,
+                    imports: [TuiIcon, TuiCopy, TuiInput],
+                    templateUrl: './test.html',
+                })
+                export class MyComponent {}
+            ",
+}
+`;
+
+exports[`ng-update migrate options tokens to kit: test.ts 1`] = `
+{
+  "0. Before": "
+                import {
+                    TUI_INPUT_COPY_OPTIONS,
+                    tuiInputCopyOptionsProvider,
+                } from '@taiga-ui/legacy';
+                import {type TuiInputCopyOptions} from '@taiga-ui/legacy';
+
+                @Component({
+                    standalone: true,
+                    providers: [tuiInputCopyOptionsProvider({icon: '@tui.copy'})],
+                    template: '',
+                })
+                export class MyComponent {
+                    protected readonly options: TuiInputCopyOptions =
+                        inject(TUI_INPUT_COPY_OPTIONS);
+                }
+            ",
+  "1. After": "import { TuiCopyOptions, TUI_COPY_OPTIONS, tuiCopyOptionsProvider } from "@taiga-ui/kit";
+
+                @Component({
+                    standalone: true,
+                    providers: [tuiCopyOptionsProvider({icon: '@tui.copy'})],
+                    template: '',
+                })
+                export class MyComponent {
+                    protected readonly options: TuiCopyOptions =
+                        inject(TUI_COPY_OPTIONS);
+                }
+            ",
+}
+`;
+
+exports[`ng-update migrates a projected <input> inside tui-input-copy: test.html 1`] = `
+{
+  "0. Before": "
+                <tui-input-copy [formControl]="control">
+                    Copy me
+                    <input
+                        tuiTextfieldLegacy
+                        placeholder="value"
+                    />
+                </tui-input-copy>
+            ",
+  "1. After": "
+                <tui-textfield >
+<label tuiLabel>
+                    Copy me
+                    </label>
+<input
+                        tuiInput [formControl]="control"
+                        placeholder="value"
+                    />
+<tui-icon tuiCopy />
+
+                </tui-textfield>
+            ",
+}
+`;
+
+exports[`ng-update moves static tuiTextfieldLabelOutside label to placeholder: test.html 1`] = `
+{
+  "0. Before": "
+                <tui-input-copy
+                    [formControl]="control"
+                    [tuiTextfieldLabelOutside]="true"
+                >
+                    Copy value
+                </tui-input-copy>
+            ",
+  "1. After": "
+                <tui-textfield
+                    
+                    
+                >
+<input tuiInput [formControl]="control" placeholder="Copy value" />
+<tui-icon tuiCopy />
+</tui-textfield>
+            ",
+}
+`;

--- a/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-removed-symbols-warning.spec.ts.snap
+++ b/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-removed-symbols-warning.spec.ts.snap
@@ -38,6 +38,30 @@ exports[`ng-update removed symbols warnings adds TODO comment for TUI_MONTH_FORM
 }
 `;
 
+exports[`ng-update removed symbols warnings adds TODO comment for TuiInputCopyComponent import: test.ts 1`] = `
+{
+  "0. Before": "
+                import {Component} from '@angular/core';
+                import {TuiInputCopyComponent} from '@taiga-ui/legacy';
+
+                @Component({})
+                export class TestComponent {
+                    protected readonly ref = TuiInputCopyComponent;
+                }
+            ",
+  "1. After": "
+                import {Component} from '@angular/core';
+// TODO: (Taiga UI migration) TuiInputCopyComponent has been removed. Use TuiCopy from @taiga-ui/kit instead (the <tui-copy> component, the tui-icon[tuiCopy] directive or TuiButtonCopy). See https://taiga-ui.dev/components/copy
+                import {TuiInputCopyComponent} from '@taiga-ui/legacy';
+
+                @Component({})
+                export class TestComponent {
+                    protected readonly ref = TuiInputCopyComponent;
+                }
+            ",
+}
+`;
+
 exports[`ng-update removed symbols warnings adds TODO comment for TuiStaticRequestService import: test.ts 1`] = `
 {
   "0. Before": "

--- a/projects/cdk/schematics/ng-update/v5/tests/schematic-migrate-input-copy.spec.ts
+++ b/projects/cdk/schematics/ng-update/v5/tests/schematic-migrate-input-copy.spec.ts
@@ -1,0 +1,99 @@
+import {join} from 'node:path';
+
+import {resetActiveProject} from 'ng-morph';
+
+import {createMigration} from '../../../utils/run-migration';
+
+const migrate = createMigration({collection: join(__dirname, '../../../migration.json')});
+
+describe('ng-update', () => {
+    it(
+        'migrate TuiInputCopyModule to TuiTextfield with tuiCopy',
+        migrate({
+            component: /* TypeScript */ `
+                import {TuiInputCopyModule} from '@taiga-ui/legacy';
+
+                @Component({
+                    standalone: true,
+                    imports: [TuiInputCopyModule],
+                    templateUrl: './test.html',
+                })
+                export class MyComponent {}
+            `,
+            template: /* HTML */ `
+                <tui-input-copy [(ngModel)]="value">Click to copy</tui-input-copy>
+
+                <tui-input-copy formControlName="token">Token</tui-input-copy>
+            `,
+        }),
+    );
+
+    it(
+        'migrates a projected <input> inside tui-input-copy',
+        migrate({
+            template: /* HTML */ `
+                <tui-input-copy [formControl]="control">
+                    Copy me
+                    <input
+                        tuiTextfieldLegacy
+                        placeholder="value"
+                    />
+                </tui-input-copy>
+            `,
+        }),
+    );
+
+    it(
+        'moves static tuiTextfieldLabelOutside label to placeholder',
+        migrate({
+            template: /* HTML */ `
+                <tui-input-copy
+                    [formControl]="control"
+                    [tuiTextfieldLabelOutside]="true"
+                >
+                    Copy value
+                </tui-input-copy>
+            `,
+        }),
+    );
+
+    it(
+        'adds TODO for removed message inputs and drops them',
+        migrate({
+            template: /* HTML */ `
+                <tui-input-copy
+                    [(ngModel)]="value"
+                    successMessage="Copied!"
+                    [messageDirection]="direction"
+                >
+                    Copy value
+                </tui-input-copy>
+            `,
+        }),
+    );
+
+    it(
+        'migrate options tokens to kit',
+        migrate({
+            component: /* TypeScript */ `
+                import {
+                    TUI_INPUT_COPY_OPTIONS,
+                    tuiInputCopyOptionsProvider,
+                } from '@taiga-ui/legacy';
+                import {type TuiInputCopyOptions} from '@taiga-ui/legacy';
+
+                @Component({
+                    standalone: true,
+                    providers: [tuiInputCopyOptionsProvider({icon: '@tui.copy'})],
+                    template: '',
+                })
+                export class MyComponent {
+                    protected readonly options: TuiInputCopyOptions =
+                        inject(TUI_INPUT_COPY_OPTIONS);
+                }
+            `,
+        }),
+    );
+
+    afterEach(() => resetActiveProject());
+});

--- a/projects/cdk/schematics/ng-update/v5/tests/schematic-migrate-removed-symbols-warning.spec.ts
+++ b/projects/cdk/schematics/ng-update/v5/tests/schematic-migrate-removed-symbols-warning.spec.ts
@@ -45,6 +45,21 @@ describe('ng-update removed symbols warnings', () => {
     );
 
     it(
+        'adds TODO comment for TuiInputCopyComponent import',
+        migrate({
+            component: /* TypeScript */ `
+                import {Component} from '@angular/core';
+                import {TuiInputCopyComponent} from '@taiga-ui/legacy';
+
+                @Component({})
+                export class TestComponent {
+                    protected readonly ref = TuiInputCopyComponent;
+                }
+            `,
+        }),
+    );
+
+    it(
         'adds TODO comment for TUI_MONTH_FORMATTER import',
         migrate({
             component: /* TypeScript */ `


### PR DESCRIPTION
### Description

Full v4→v5 handling for the legacy `tui-input-copy` component (removed in v5). The copy affordance is now `tuiCopy` on a plain `<tui-textfield>` with `<input tuiInput>`.

**Template** (`migrateInputCopy`): rewrites `<tui-input-copy>` → `<tui-textfield>`, moves control bindings (`ngModel`/`formControl`/`formControlName`) onto the inner `<input tuiInput>`, appends `<tui-icon tuiCopy />`, handles the label (`tuiTextfieldLabelOutside` static → `placeholder`, floating → `<label tuiLabel>`, dynamic → TODO).

**Imports** (`IDENTIFIERS_TO_REPLACE`):
- `TuiInputCopyModule` (`@taiga-ui/legacy`) → `TuiIcon`, `TuiInput` (`@taiga-ui/core`) + `TuiCopy` (`@taiga-ui/kit`)
- `TuiInputCopyOptions` → `TuiCopyOptions`, `TUI_INPUT_COPY_OPTIONS` → `TUI_COPY_OPTIONS`, `tuiInputCopyOptionsProvider` → `tuiCopyOptionsProvider` (all `@taiga-ui/legacy` → `@taiga-ui/kit`)

**Warning** (`MIGRATION_WARNINGS`): direct references to the class `TuiInputCopyComponent` cannot be auto-rewritten, so they get a TODO pointing to `TuiCopy`. (Moved here from #14596 so all `tui-input-copy` handling lives in one PR.)

The removed message inputs `successMessage` / `messageDirection` / `messageAppearance` have no v5 equivalent (the copy confirmation is built into `tuiCopy` and is no longer configurable) — the migration drops them and emits a TODO. `TUI_INPUT_COPY_DEFAULT_OPTIONS` has no v5 successor and is intentionally not mapped.

### Before / After

| Before | After |
| --- | --- |
| `<tui-input-copy [(ngModel)]="value">Click to copy</tui-input-copy>` | `<tui-textfield><label tuiLabel>Click to copy</label><input tuiInput [(ngModel)]="value" /><tui-icon tuiCopy /></tui-textfield>` |

### Checklist

- [x] Template migration + import/token mappings + component-class warning
- [x] Tests via `migrate()` snapshots (basic, projected `<input>`, static label→placeholder, removed-inputs TODO, options tokens, component-class warning)
- [x] Full `ng-update/v5` suite green (110 suites / 679 tests / 775 snapshots)

Part of #11917.
