### PR TITLE
chore(schematics): auto-move TuiPureException from cdk to legacy in v5

### DIFF
--- a/projects/cdk/schematics/ng-update/v5/steps/constants/identifiers-to-replace.ts
+++ b/projects/cdk/schematics/ng-update/v5/steps/constants/identifiers-to-replace.ts
@@ -153,6 +153,16 @@ export const IDENTIFIERS_TO_REPLACE: ReplacementIdentifierMulti[] = [
     },
     {
         from: {
+            name: 'TuiPureException',
+            moduleSpecifier: '@taiga-ui/cdk',
+        },
+        to: {
+            name: 'TuiPureException',
+            moduleSpecifier: '@taiga-ui/legacy',
+        },
+    },
+    {
+        from: {
             name: 'TuiTimeMode',
             moduleSpecifier: '@taiga-ui/cdk',
         },

--- a/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-identifiers.spec.ts.snap
+++ b/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-identifiers.spec.ts.snap
@@ -276,6 +276,24 @@ exports[`ng-update identifiers migration moves TuiFlagPipe from core to kit: tes
 }
 `;
 
+exports[`ng-update identifiers migration moves TuiPureException from cdk to legacy: test.ts 1`] = `
+{
+  "0. Before": "
+                import {TuiPureException} from '@taiga-ui/cdk';
+
+                export class TestComponent {
+                    protected readonly error = TuiPureException;
+                }
+            ",
+  "1. After": "import { TuiPureException } from "@taiga-ui/legacy";
+
+                                export class TestComponent {
+                    protected readonly error = TuiPureException;
+                }
+            ",
+}
+`;
+
 exports[`ng-update identifiers migration moves TuiThemeColorService and TUI_THEME_COLOR from cdk to addon-mobile (#13869): test.ts 1`] = `
 {
   "0. Before": "

--- a/projects/cdk/schematics/ng-update/v5/tests/schematic-migrate-identifiers.spec.ts
+++ b/projects/cdk/schematics/ng-update/v5/tests/schematic-migrate-identifiers.spec.ts
@@ -362,5 +362,18 @@ describe('ng-update identifiers migration', () => {
         }),
     );
 
+    it(
+        'moves TuiPureException from cdk to legacy',
+        migrate({
+            component: /* TypeScript */ `
+                import {TuiPureException} from '@taiga-ui/cdk';
+
+                export class TestComponent {
+                    protected readonly error = TuiPureException;
+                }
+            `,
+        }),
+    );
+
     afterEach(() => resetActiveProject());
 });


### PR DESCRIPTION
## Which issue does this PR close?

Part of #11917 (v4→v5 ng-update migration backlog).

## What does this PR do?

Auto-migrates the `TuiPureException` import from `@taiga-ui/cdk` to `@taiga-ui/legacy`.

In v4 the whole `pure.ts` (both `tuiPure` and `TuiPureException`) lived in `@taiga-ui/cdk/utils/miscellaneous`; in v5 it moved to `@taiga-ui/legacy`. The `tuiPure` decorator move is already covered by `IDENTIFIERS_TO_REPLACE`, but its companion `TuiPureException` export was left unmapped — code that imports it (e.g. `catch`/`instanceof` handling) would break after upgrade.

The class is byte-identical between v4 cdk and v5 legacy, so this is a pure package move (import rewrite only, no code changes).

| Symbol | v4 | v5 |
| --- | --- | --- |
| `TuiPureException` | `@taiga-ui/cdk` | `@taiga-ui/legacy` |

## Before / After

```ts
// Before
import {TuiPureException} from '@taiga-ui/cdk';

// After
import {TuiPureException} from '@taiga-ui/legacy';
```
