### PR TITLE
fix(styles): `TuiWithIcons` is incompatible with legacy global CSS class `tui-skeleton`

### DIFF
--- a/projects/styles/markup/tui-skeleton.less
+++ b/projects/styles/markup/tui-skeleton.less
@@ -6,10 +6,12 @@
     user-select: none;
 
     &::after {
-        .fullsize();
+        .fullsize() !important;
 
         content: '';
-        background-color: var(--tui-background-neutral-2);
+        display: block !important;
+        margin: 0 !important;
+        background-color: var(--tui-background-neutral-2) !important;
         animation: tuiSkeletonVibe ease-in-out 1s infinite alternate;
         border-radius: var(--tui-skeleton-radius, 0);
     }


### PR DESCRIPTION
```html
<div 
    tuiBadge 
    class="tui-skeleton" 
>
  Default
</div>
```

Explore more:
https://stackblitz.com/edit/tui-with-icons-legacy-skeleton?file=src%2Fapp%2Fapp.less,src%2Fapp%2Fapp.html

**Conflicts**
https://github.com/taiga-family/taiga-ui/blob/dbced915206a6c6b217df699f4541409188f4a6e/projects/kit/components/badge/badge.directive.ts#L31-L35

https://github.com/taiga-family/taiga-ui/blob/dbced915206a6c6b217df699f4541409188f4a6e/projects/styles/markup/tui-skeleton.less#L8-L15

https://github.com/taiga-family/taiga-ui/blob/dbced915206a6c6b217df699f4541409188f4a6e/projects/core/styles/components/icons.less#L25-L35
