### PR TITLE
fix(legacy): `TuiWithIcons` is incompatible with legacy global CSS class `tui-skeleton`

### DIFF
--- a/projects/legacy/styles/markup/tui-skeleton.less
+++ b/projects/legacy/styles/markup/tui-skeleton.less
@@ -6,10 +6,12 @@
     user-select: none;
 
     &::after {
-        .fullsize();
+        .fullsize() !important;
 
         content: '';
-        background-color: var(--tui-background-neutral-2);
+        display: block !important;
+        margin: 0 !important;
+        background-color: var(--tui-background-neutral-2) !important;
         animation: tuiSkeletonVibe ease-in-out 1s infinite alternate;
         border-radius: var(--tui-skeleton-radius, 0);
     }


### PR DESCRIPTION
```html
<div 
    tuiBadge 
    class="tui-skeleton" 
>
  Default
</div>
```

Explore more:
https://stackblitz.com/edit/tui-with-icons-legacy-skeleton?file=src%2Fapp%2Fapp.less,src%2Fapp%2Fapp.html

**Conflicts**
https://github.com/taiga-family/taiga-ui/blob/2577e480658bef391f8c5d2e9ff96a74bb3e6f6c/projects/kit/components/badge/badge.directive.ts#L31-L36

https://github.com/taiga-family/taiga-ui/blob/2577e480658bef391f8c5d2e9ff96a74bb3e6f6c/projects/legacy/styles/markup/tui-skeleton.less#L8-L15

https://github.com/taiga-family/taiga-ui/blob/2577e480658bef391f8c5d2e9ff96a74bb3e6f6c/projects/styles/components/icons.less#L26-L45

