### PR TITLE
chore(schematics): add missing v5 identifier renames and package remaps

### DIFF
--- a/projects/cdk/schematics/ng-update/v5/steps/constants/identifiers-to-replace.ts
+++ b/projects/cdk/schematics/ng-update/v5/steps/constants/identifiers-to-replace.ts
@@ -1393,4 +1393,54 @@ export const IDENTIFIERS_TO_REPLACE: ReplacementIdentifierMulti[] = [
             moduleSpecifier: '@taiga-ui/kit',
         },
     },
+    {
+        from: {
+            name: 'TuiButtonCopyComponent',
+            moduleSpecifier: '@taiga-ui/kit',
+        },
+        to: {
+            name: 'TuiButtonCopy',
+            moduleSpecifier: '@taiga-ui/kit',
+        },
+    },
+    {
+        from: {
+            name: 'TUI_TOASTS_CONCURRENCY',
+            moduleSpecifier: '@taiga-ui/kit',
+        },
+        to: {
+            name: 'TUI_TOAST_CONCURRENCY',
+            moduleSpecifier: '@taiga-ui/kit',
+        },
+    },
+    {
+        from: {
+            name: 'TuiDialogSize',
+            moduleSpecifier: '@taiga-ui/core',
+        },
+        to: {
+            name: 'TuiDialogSize',
+            moduleSpecifier: '@taiga-ui/legacy',
+        },
+    },
+    {
+        from: {
+            name: 'TuiCellStretch',
+            moduleSpecifier: '@taiga-ui/layout',
+        },
+        to: {
+            name: 'TuiCellStretch',
+            moduleSpecifier: '@taiga-ui/core',
+        },
+    },
+    {
+        from: {
+            name: 'TuiCellOptions',
+            moduleSpecifier: '@taiga-ui/layout',
+        },
+        to: {
+            name: 'TuiCellOptions',
+            moduleSpecifier: '@taiga-ui/core',
+        },
+    },
 ];

--- a/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-missing-identifier-remaps.spec.ts.snap
+++ b/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-missing-identifier-remaps.spec.ts.snap
@@ -1,0 +1,36 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ng-update missing identifier renames and package remaps renames leftover v5 identifiers and remaps their packages: test.ts 1`] = `
+{
+  "0. Before": "
+                import {Component, inject} from '@angular/core';
+                import {TUI_TOASTS_CONCURRENCY, TuiButtonCopyComponent} from '@taiga-ui/kit';
+                import {TuiCellOptions, TuiCellStretch} from '@taiga-ui/layout';
+                import {type TuiDialogSize} from '@taiga-ui/core';
+
+                @Component({
+                    imports: [TuiButtonCopyComponent, TuiCellStretch],
+                })
+                export class TestComponent {
+                    protected readonly concurrency = inject(TUI_TOASTS_CONCURRENCY);
+                    protected readonly options: TuiCellOptions | null = null;
+                    protected readonly size: TuiDialogSize = 'm';
+                }
+            ",
+  "1. After": "import { TuiCellStretch, TuiCellOptions } from "@taiga-ui/core";
+import { TuiDialogSize } from "@taiga-ui/legacy";
+
+                import {Component, inject} from '@angular/core';
+                import { TuiButtonCopy, TUI_TOAST_CONCURRENCY } from '@taiga-ui/kit';
+
+                @Component({
+                    imports: [TuiButtonCopy, TuiCellStretch],
+                })
+                export class TestComponent {
+                    protected readonly concurrency = inject(TUI_TOAST_CONCURRENCY);
+                    protected readonly options: TuiCellOptions | null = null;
+                    protected readonly size: TuiDialogSize = 'm';
+                }
+            ",
+}
+`;

--- a/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-missing-identifier-remaps.spec.ts.snap
+++ b/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-missing-identifier-remaps.spec.ts.snap
@@ -4,7 +4,10 @@ exports[`ng-update missing identifier renames and package remaps renames leftove
 {
   "0. Before": "
                 import {Component, inject} from '@angular/core';
-                import {TUI_TOASTS_CONCURRENCY, TuiButtonCopyComponent} from '@taiga-ui/kit';
+                import {
+                    TUI_TOASTS_CONCURRENCY,
+                    TuiButtonCopyComponent,
+                } from '@taiga-ui/kit';
                 import {TuiCellOptions, TuiCellStretch} from '@taiga-ui/layout';
                 import {type TuiDialogSize} from '@taiga-ui/core';
 

--- a/projects/cdk/schematics/ng-update/v5/tests/schematic-migrate-missing-identifier-remaps.spec.ts
+++ b/projects/cdk/schematics/ng-update/v5/tests/schematic-migrate-missing-identifier-remaps.spec.ts
@@ -14,7 +14,10 @@ describe('ng-update missing identifier renames and package remaps', () => {
         migrate({
             component: /* TypeScript */ `
                 import {Component, inject} from '@angular/core';
-                import {TUI_TOASTS_CONCURRENCY, TuiButtonCopyComponent} from '@taiga-ui/kit';
+                import {
+                    TUI_TOASTS_CONCURRENCY,
+                    TuiButtonCopyComponent,
+                } from '@taiga-ui/kit';
                 import {TuiCellOptions, TuiCellStretch} from '@taiga-ui/layout';
                 import {type TuiDialogSize} from '@taiga-ui/core';
 

--- a/projects/cdk/schematics/ng-update/v5/tests/schematic-migrate-missing-identifier-remaps.spec.ts
+++ b/projects/cdk/schematics/ng-update/v5/tests/schematic-migrate-missing-identifier-remaps.spec.ts
@@ -1,0 +1,34 @@
+import {join} from 'node:path';
+
+import {resetActiveProject} from 'ng-morph';
+
+import {createMigration} from '../../../utils/run-migration';
+
+describe('ng-update missing identifier renames and package remaps', () => {
+    const migrate = createMigration({
+        collection: join(__dirname, '../../../migration.json'),
+    });
+
+    it(
+        'renames leftover v5 identifiers and remaps their packages',
+        migrate({
+            component: /* TypeScript */ `
+                import {Component, inject} from '@angular/core';
+                import {TUI_TOASTS_CONCURRENCY, TuiButtonCopyComponent} from '@taiga-ui/kit';
+                import {TuiCellOptions, TuiCellStretch} from '@taiga-ui/layout';
+                import {type TuiDialogSize} from '@taiga-ui/core';
+
+                @Component({
+                    imports: [TuiButtonCopyComponent, TuiCellStretch],
+                })
+                export class TestComponent {
+                    protected readonly concurrency = inject(TUI_TOASTS_CONCURRENCY);
+                    protected readonly options: TuiCellOptions | null = null;
+                    protected readonly size: TuiDialogSize = 'm';
+                }
+            `,
+        }),
+    );
+
+    afterEach(() => resetActiveProject());
+});


### PR DESCRIPTION
## What / Why

Five public identifiers changed name or package in v5 but were missing from `IDENTIFIERS_TO_REPLACE`, so `ng update` left the old imports broken. Two of them (`TuiButtonCopyComponent`, `TUI_TOASTS_CONCURRENCY`) are leftovers of the #14609 rename batch that didn't land; the other three are sibling omissions of already-covered moves.

Part of completing v5 migration coverage (ref #11917).

## Renames (same package)

| From | To |
| --- | --- |
| `TuiButtonCopyComponent` (`@taiga-ui/kit`) | `TuiButtonCopy` |
| `TUI_TOASTS_CONCURRENCY` (`@taiga-ui/kit`) | `TUI_TOAST_CONCURRENCY` |

## Package remaps (same name)

| Symbol | From | To |
| --- | --- | --- |
| `TuiDialogSize` | `@taiga-ui/core` | `@taiga-ui/legacy` |
| `TuiCellStretch` | `@taiga-ui/layout` | `@taiga-ui/core` |
| `TuiCellOptions` | `@taiga-ui/layout` | `@taiga-ui/core` |

## Tests

- New snapshot spec `schematic-migrate-missing-identifier-remaps.spec.ts` (covers both renames and moves, incl. `imports: [...]` and `inject()` usages).
- Full `ng-update/v5` suite green (705/705).
