### PR TITLE
fix(kit): `InputPhone` no longer drops the `8` after country code on paste of `+7 8xx ...`

### DIFF
--- a/projects/demo-playwright/tests/kit/input-phone/input-phone.pw.spec.ts
+++ b/projects/demo-playwright/tests/kit/input-phone/input-phone.pw.spec.ts
@@ -25,7 +25,7 @@ test.describe('InputPhone', () => {
         }) => {
             await tuiGoto(
                 page,
-                `${DemoRoute.InputPhone}/API?mask=%2B52%20(%23%23%23)%20%23%23%23-%23%23-%23%23`,
+                `${DemoRoute.InputPhone}/API?mask=${encodeURIComponent('+52 (###) ###-##-##')}`,
             );
 
             await inputPhone.textfield.focus();
@@ -47,7 +47,7 @@ test.describe('InputPhone', () => {
         }) => {
             await tuiGoto(
                 page,
-                `${DemoRoute.InputPhone}/API?mask=%2B1%20(%23%23%23)%20%23%23%23-%23%23-%23%23`,
+                `${DemoRoute.InputPhone}/API?mask=${encodeURIComponent('+1 (###) ###-##-##')}`,
             );
 
             await inputPhone.textfield.focus();
@@ -76,11 +76,32 @@ test.describe('InputPhone', () => {
             await expect(inputPhone.textfield).toHaveValue('');
         });
 
+        test.describe('Insertion of the complete phone number (paste/autofill)', () => {
+            test.beforeEach(async ({page}) => {
+                await tuiGoto(
+                    page,
+                    `${DemoRoute.InputPhone}/API?mask=${encodeURIComponent('+7 (###) ###-##-##')}`,
+                );
+            });
+
+            test('+7 800 123-45-67 => +7 (800) 123-45-67', async () => {
+                await inputPhone.textfield.fill('+7 800 123-45-67');
+
+                await expect(inputPhone.textfield).toHaveValue('+7 (800) 123-45-67');
+            });
+
+            test('8 800 123-45-67 => +7 (800) 123-45-67', async () => {
+                await inputPhone.textfield.fill('8 800 123-45-67');
+
+                await expect(inputPhone.textfield).toHaveValue('+7 (800) 123-45-67');
+            });
+        });
+
         test.describe("Angular form control is empty is textfield's value is just country code", () => {
             test.beforeEach(async ({page}) => {
                 await tuiGoto(
                     page,
-                    `${DemoRoute.InputPhone}/API?mask=%2B1%20(%23%23%23)%20%23%23%23-%23%23-%23%23&sandboxExpanded=true`,
+                    `${DemoRoute.InputPhone}/API?mask=${encodeURIComponent('+1 (###) ###-##-##')}&sandboxExpanded=true`,
                 );
             });
 
@@ -115,7 +136,7 @@ test.describe('InputPhone', () => {
             test.beforeEach(async ({page}) => {
                 await tuiGoto(
                     page,
-                    `${DemoRoute.InputPhone}/API?mask=%2B7%20(%23%23%23)%20%23%23%23-%23%23-%23%23`,
+                    `${DemoRoute.InputPhone}/API?mask=${encodeURIComponent('+7 (###) ###-##-##')}`,
                 );
 
                 example = new TuiDocumentationApiPagePO(page).demo;
@@ -1440,7 +1461,10 @@ test.describe('InputPhone', () => {
         });
 
         test('filler', async ({page}) => {
-            await tuiGoto(page, `${DemoRoute.InputPhone}/API?filler=%2B7%20999`);
+            await tuiGoto(
+                page,
+                `${DemoRoute.InputPhone}/API?filler=${encodeURIComponent('+7 999')}`,
+            );
 
             example = new TuiDocumentationApiPagePO(page).demo;
             input = example.locator('input');

--- a/projects/kit/components/input-phone/test/complete-phone-insertion-preprocessor.spec.ts
+++ b/projects/kit/components/input-phone/test/complete-phone-insertion-preprocessor.spec.ts
@@ -29,11 +29,46 @@ describe('tuiCreateCompletePhoneInsertionPreprocessor + browser autofill', () =>
             ['+79002005577', '+7 (900) 200-55-77'],
             ['+ 790020055771', '+7 (900) 200-55-77'],
             ['+   790020055771', '+7 (900) 200-55-77'],
+            ['+7 800 123-45-67', '+7 (800) 123-45-67'],
         ];
 
         tests.forEach(([before, after]) => {
             it(`${before} => ${after}`, () => {
                 expect(maskitoTransform(before ?? '', maskOptions)).toBe(after);
+            });
+        });
+
+        describe('Paste/drop of the complete phone number', () => {
+            const preprocessor = tuiCreateCompletePhoneInsertionPreprocessor(
+                countryCode,
+                phoneMaskAfterCountryCode,
+            );
+
+            const tests = [
+                // [`pasted string`, `data to insert after country prefix trimming`]
+                ['+7 900 200-55-77', '900 200-55-77'],
+                ['+79002005577', '9002005577'],
+                ['8 800 123-45-67', '800 123-45-67'],
+                ['+7 800 123-45-67', '800 123-45-67'],
+            ] as const;
+
+            tests.forEach(([pasted, after]) => {
+                it(`${pasted} => ${after}`, () => {
+                    const initialValue = `${countryCode} `;
+
+                    const {data} = preprocessor(
+                        {
+                            elementState: {
+                                value: initialValue,
+                                selection: [initialValue.length, initialValue.length],
+                            },
+                            data: pasted,
+                        },
+                        'insert',
+                    );
+
+                    expect(data).toBe(after);
+                });
             });
         });
     });

--- a/projects/kit/components/input-phone/utils/complete-phone-insertion-preprocessor.ts
+++ b/projects/kit/components/input-phone/utils/complete-phone-insertion-preprocessor.ts
@@ -1,6 +1,6 @@
 import {type MaskitoPreprocessor} from '@maskito/core';
 
-const countDigits = (value: string): number => value.replaceAll(/\D/g, '').length;
+const countDigits = (value: string): number => value.replaceAll(/[^#\d]+/g, '').length;
 
 /**
  * `InputPhone` component sets country code as non-removable prefix.
@@ -11,20 +11,21 @@ const countDigits = (value: string): number => value.replaceAll(/\D/g, '').lengt
  */
 export function tuiCreateCompletePhoneInsertionPreprocessor(
     countryCode: string,
-    phoneMaskAfterCountryCode: string,
+    nationalPartTemplate: string,
 ): MaskitoPreprocessor {
-    const completePhoneLength = `${countryCode}${phoneMaskAfterCountryCode}`.replaceAll(
-        /[^#\d]+/g,
-        '',
-    ).length;
+    const completePhoneLength = countDigits(`${countryCode}${nationalPartTemplate}`);
 
-    const trimCountryPrefix = (value: string): string =>
-        countryCode === '+7'
-            ? value.replace(/^\+?\s*7?\s?8?\s?/, '')
-            : value.replace(
-                  new RegExp(String.raw`^(\+?\s*${countryCode.replace('+', '')}?)\s?`),
-                  '',
-              );
+    const trimCountryPrefix = (value: string): string => {
+        const trimmed = value.replace(
+            new RegExp(String.raw`^(\+?\s*${countryCode.replace('+', '')}?)\s?`),
+            '',
+        );
+
+        return countryCode === '+7' &&
+            countDigits(trimmed) > countDigits(nationalPartTemplate)
+            ? trimmed.replace(/^8\s?/, '')
+            : trimmed;
+    };
 
     return ({elementState, data}) => {
         const {value, selection} = elementState;


### PR DESCRIPTION
Fixes #13648
