### PR TITLE
feat(styles): mixin-based theme for scoped/micro frontend usage

### DIFF
--- a/projects/styles/mixins/theme.less
+++ b/projects/styles/mixins/theme.less
@@ -1,0 +1,67 @@
+@import (once) '@taiga-ui/design-tokens/angular/mixins/animation.less';
+@import (once) '@taiga-ui/design-tokens/angular/mixins/shadow.less';
+@import 'theme/variables.less';
+@import 'theme/palette.less';
+
+// Scoped counterpart of `taiga-ui-theme.less`. Call it inside your own selector to keep
+// the theme out of `:root` / `:host`, e.g. when several micro frontends share a page:
+//
+//     [my-app] {
+//         .taiga-ui-theme();
+//     }
+.taiga-ui-theme() {
+    .tui-animation();
+    .tui-shadow-light();
+    .tui-theme-variables();
+
+    &[dir='rtl'],
+    [dir='rtl'] & {
+        .tui-theme-rtl();
+    }
+
+    @media screen {
+        & {
+            .tui-theme-light();
+        }
+
+        &[tuiTheme='light'],
+        & [tuiTheme='light'] {
+            color-scheme: light;
+
+            .tui-theme-light();
+        }
+
+        &[tuiTheme='dark'],
+        & [tuiTheme='dark'] {
+            color-scheme: dark;
+
+            .tui-theme-dark();
+        }
+    }
+
+    @media print {
+        &,
+        &[tuiTheme],
+        & [tuiTheme] {
+            color-scheme: light;
+
+            .tui-theme-light();
+        }
+    }
+
+    @import '../theme/appearance.less';
+    @import '../theme/appearance/textfield.less';
+
+    // `tuiTheme` can sit on the scoping element itself, which the selectors above do not cover
+    &[tuiTheme='dark'] [tuiAppearance][data-appearance='textfield'] {
+        background-color: var(--tui-background-neutral-1);
+
+        .appearance-hover({
+            background-color: var(--tui-background-neutral-1-hover);
+        });
+
+        .appearance-focus({
+            background-color: transparent !important;
+        });
+    }
+}

--- a/projects/styles/mixins/theme/palette.less
+++ b/projects/styles/mixins/theme/palette.less
@@ -1,0 +1,133 @@
+.tui-theme-dark() {
+    // Backgrounds
+    --tui-background-base: #222;
+    --tui-background-base-alt: #333;
+    --tui-background-neutral-1: rgba(255, 255, 255, 0.08);
+    --tui-background-neutral-1-hover: rgba(255, 255, 255, 0.16);
+    --tui-background-neutral-1-pressed: rgba(255, 255, 255, 0.24);
+    --tui-background-neutral-2: rgba(255, 255, 255, 0.24);
+    --tui-background-neutral-2-hover: rgba(255, 255, 255, 0.32);
+    --tui-background-neutral-2-pressed: rgba(255, 255, 255, 0.4);
+    --tui-background-accent-opposite: #fff;
+    --tui-background-accent-opposite-hover: #f6f6f6;
+    --tui-background-accent-opposite-pressed: #ededed;
+    --tui-background-elevation-1: #292929;
+    --tui-background-elevation-2: #2f2f2f;
+    --tui-background-elevation-3: #373737;
+    // Other
+    --tui-service-autofill-background: rgb(85, 74, 42);
+    --tui-border-normal: rgba(255, 255, 255, 0.14);
+    --tui-border-hover: rgba(255, 255, 255, 0.6);
+    --tui-border-focus: rgba(255, 255, 255, 0.64);
+    // Statuses
+    --tui-status-negative: #ff4d4d;
+    --tui-status-negative-pale: rgba(255, 77, 77, 0.24);
+    --tui-status-negative-pale-hover: rgba(255, 77, 77, 0.32);
+    --tui-status-positive: rgb(74, 201, 155);
+    --tui-status-positive-pale: rgba(74, 201, 155, 0.32);
+    --tui-status-positive-pale-hover: rgba(74, 201, 155, 0.4);
+    --tui-status-warning: rgb(255, 199, 0);
+    --tui-status-warning-pale: rgba(255, 199, 0, 0.32);
+    --tui-status-warning-pale-hover: rgba(255, 199, 0, 0.4);
+    --tui-status-info: rgb(112, 182, 246);
+    --tui-status-info-pale: rgba(112, 182, 246, 0.32);
+    --tui-status-info-pale-hover: rgba(112, 182, 246, 0.4);
+    --tui-status-neutral: rgb(149, 155, 164);
+    // Text
+    --tui-text-primary: rgba(255, 255, 255, 1);
+    --tui-text-secondary: rgba(255, 255, 255, 0.72);
+    --tui-text-tertiary: rgba(255, 255, 255, 0.6);
+    --tui-text-action: #6788ff;
+    --tui-text-action-hover: #526ed3;
+    --tui-text-positive: #44c596;
+    --tui-text-positive-hover: #3aa981;
+    --tui-text-negative: #ff4d4d;
+    --tui-text-negative-hover: #f66;
+}
+
+.tui-theme-light() {
+    // Backgrounds
+    --tui-background-base: #fff;
+    --tui-background-base-alt: #f6f6f6;
+    --tui-background-neutral-1: rgba(0, 0, 0, 0.04);
+    --tui-background-neutral-1-hover: rgba(0, 0, 0, 0.08);
+    --tui-background-neutral-1-pressed: rgba(0, 0, 0, 0.12);
+    --tui-background-neutral-2: rgba(0, 0, 0, 0.08);
+    --tui-background-neutral-2-hover: rgba(0, 0, 0, 0.1);
+    --tui-background-neutral-2-pressed: rgba(0, 0, 0, 0.14);
+    --tui-background-accent-1: #526ed3;
+    --tui-background-accent-1-hover: #6c86e2;
+    --tui-background-accent-1-pressed: #314692;
+    --tui-background-accent-2: #ff7043;
+    --tui-background-accent-2-hover: #ff9a94;
+    --tui-background-accent-2-pressed: #e7716a;
+    --tui-background-accent-opposite: #000;
+    --tui-background-accent-opposite-hover: #333;
+    --tui-background-accent-opposite-pressed: #808080;
+    --tui-background-elevation-1: #fff;
+    --tui-background-elevation-2: #fff;
+    --tui-background-elevation-3: #fff;
+    // Other
+    --tui-service-autofill-background: #fff5c0;
+    --tui-service-selection-background: rgba(112, 182, 246, 0.12);
+    --tui-service-backdrop: rgba(0, 0, 0, 0.75);
+    --tui-border-normal: rgba(0, 0, 0, 0.1);
+    --tui-border-hover: rgba(0, 0, 0, 0.16);
+    --tui-border-focus: rgba(51, 51, 51, 0.64);
+    // Statuses
+    --tui-status-negative: #ff291a;
+    --tui-status-negative-pale: rgba(245, 34, 34, 0.08);
+    --tui-status-negative-pale-hover: rgba(245, 34, 34, 0.16);
+    --tui-status-positive: rgba(74, 201, 155, 1);
+    --tui-status-positive-pale: rgba(74, 201, 155, 0.12);
+    --tui-status-positive-pale-hover: rgba(74, 201, 155, 0.24);
+    --tui-status-warning: rgba(255, 199, 0, 1);
+    --tui-status-warning-pale: rgba(255, 199, 0, 0.12);
+    --tui-status-warning-pale-hover: rgba(255, 199, 0, 0.24);
+    --tui-status-info: rgba(112, 182, 246, 1);
+    --tui-status-info-pale: rgba(112, 182, 246, 0.12);
+    --tui-status-info-pale-hover: rgba(112, 182, 246, 0.24);
+    --tui-status-neutral: rgb(121, 129, 140);
+    // Text
+    --tui-text-primary: rgba(27, 31, 59, 1);
+    --tui-text-secondary: rgba(27, 31, 59, 0.65);
+    --tui-text-tertiary: rgba(27, 31, 59, 0.4);
+    --tui-text-primary-on-accent-1: #fff;
+    --tui-text-primary-on-accent-2: #fff;
+    --tui-text-action: #4c66c3;
+    --tui-text-action-hover: #6c86e2;
+    --tui-text-positive: #3aa981;
+    --tui-text-positive-hover: #7ac5aa;
+    --tui-text-negative: #ff291a;
+    --tui-text-negative-hover: #ff4d4d;
+    // Charts
+    --tui-chart-categorical-00: var(--tui-background-accent-1);
+    --tui-chart-categorical-01: #ea97c4;
+    --tui-chart-categorical-02: #a0c5df;
+    --tui-chart-categorical-03: #fee797;
+    --tui-chart-categorical-04: #b0b0b0;
+    --tui-chart-categorical-05: #e29398;
+    --tui-chart-categorical-06: #b8474e;
+    --tui-chart-categorical-07: #fcc068;
+    --tui-chart-categorical-08: #ff8a00;
+    --tui-chart-categorical-09: #dab3f9;
+    --tui-chart-categorical-10: #7b439e;
+    --tui-chart-categorical-11: #8dda71;
+    --tui-chart-categorical-12: #fcbb14;
+    --tui-chart-categorical-13: #a8cef1;
+    --tui-chart-categorical-14: #bd65a4;
+    --tui-chart-categorical-15: #7fd7cc;
+    --tui-chart-categorical-16: #2fad96;
+    --tui-chart-categorical-17: #d4aca2;
+    --tui-chart-categorical-18: #9d6f64;
+    --tui-chart-categorical-19: #d2e9a2;
+    --tui-chart-categorical-20: #aadc42;
+    --tui-chart-categorical-21: #3682db;
+    --tui-chart-categorical-22: #34b41f;
+    // Shadows
+    --tui-shadow-small: 0 0.25rem 1.25rem rgba(0, 0, 0, 0.1);
+    --tui-shadow-small-hover: 0 1rem 2.5rem rgba(0, 0, 0, 0.14);
+    --tui-shadow-medium: 0 0.375rem 2rem rgba(0, 0, 0, 0.12);
+    --tui-shadow-medium-hover: 0 1.25rem 4rem rgba(0, 0, 0, 0.18);
+    --tui-shadow-popup: 0 1.25rem 3rem rgba(0, 0, 0, 0.2);
+}

--- a/projects/styles/mixins/theme/variables.less
+++ b/projects/styles/mixins/theme/variables.less
@@ -1,0 +1,65 @@
+.tui-theme-variables() {
+    // Fonts
+    --tui-typography-family-text: 'Manrope', system-ui, sans-serif;
+    --tui-typography-family-display: 'Manrope', system-ui, sans-serif;
+    --tui-font-offset: calc(var(--t-font-offset, 0) * 1px);
+    --tui-font-scale: calc((22 + var(--t-font-offset, 0)) / 22);
+    // Heading
+    --tui-typography-heading-h1: bold calc(var(--tui-font-offset) + 3.125rem) / calc(56 / 50) var(--tui-typography-family-display);
+    --tui-typography-heading-h2: bold calc(var(--tui-font-offset) + 2.75rem) / calc(48 / 44) var(--tui-typography-family-display);
+    --tui-typography-heading-h3: bold calc(var(--tui-font-offset) + 2.25rem) / calc(40 / 36) var(--tui-typography-family-display);
+    --tui-typography-heading-h4: bold calc(var(--tui-font-offset) + 1.75rem) / calc(32 / 28) var(--tui-typography-family-display);
+    --tui-typography-heading-h5: bold calc(var(--tui-font-offset) + 1.5rem) / calc(28 / 24) var(--tui-typography-family-display);
+    --tui-typography-heading-h6: bold calc(var(--tui-font-offset) + 1.25rem) / calc(24 / 20) var(--tui-typography-family-display);
+    // Body
+    --tui-typography-body-l: normal calc(var(--tui-font-offset) + 1.0625rem) / calc(28 / 17) var(--tui-typography-family-text);
+    --tui-typography-body-m: normal calc(var(--tui-font-offset) + 1rem) / calc(24 / 16) var(--tui-typography-family-text);
+    --tui-typography-body-s: normal calc(var(--tui-font-offset) + 0.875rem) / calc(20 / 14) var(--tui-typography-family-text);
+    --tui-typography-body-xs: normal calc(var(--tui-font-offset) + 0.75rem) / calc(16 / 12) var(--tui-typography-family-text);
+    // Reduced
+    --tui-typography-ui-l: normal calc(var(--tui-font-offset) + 1.0625rem) / calc(24 / 17) var(--tui-typography-family-text);
+    --tui-typography-ui-m: normal calc(var(--tui-font-offset) + 1rem) / calc(20 / 16) var(--tui-typography-family-text);
+    --tui-typography-ui-s: normal calc(var(--tui-font-offset) + 0.875rem) / calc(16 / 14) var(--tui-typography-family-text);
+    --tui-typography-ui-xs: normal calc(var(--tui-font-offset) + 0.75rem) / calc(15 / 12) var(--tui-typography-family-text);
+    --tui-typography-ui-2xs: normal calc(var(--tui-font-offset) + 0.6875rem) / calc(12 / 11) var(--tui-typography-family-text);
+    // Radii
+    --tui-radius-xs: 0.25rem;
+    --tui-radius-s: 0.5rem;
+    --tui-radius-m: 0.625rem;
+    --tui-radius-l: 0.75rem;
+    --tui-radius-xl: 1.5rem;
+    // Sizes
+    --tui-height-xs: 1.5rem;
+    --tui-height-s: 2rem;
+    --tui-height-m: 2.75rem;
+    --tui-height-l: 3.5rem;
+    // Input padding
+    --tui-padding-s: 0.625rem;
+    --tui-padding-m: 0.75rem;
+    --tui-padding-l: 1rem;
+    // Misc
+    --tui-stroke-width: 0.125rem;
+    --tui-duration: 0.3s;
+    --tui-disabled-opacity: 0.56;
+    --tui-lh: 1.4em;
+    // logical
+    --tui-inline-start: left;
+    --tui-inline-end: right;
+    --tui-inline: 1;
+
+    @supports (font-size: 1lh) {
+        --tui-lh: 1lh;
+    }
+
+    // TODO: drop in v6
+    --tui-duration-slowest: calc(var(--tui-duration) / 0.429);
+    --tui-duration-slow: calc(var(--tui-duration) / 0.6);
+    --tui-duration-fast: calc(var(--tui-duration) / 2);
+    --tui-duration-fastest: calc(var(--tui-duration) / 4);
+}
+
+.tui-theme-rtl() {
+    --tui-inline-start: right;
+    --tui-inline-end: left;
+    --tui-inline: -1;
+}

--- a/projects/styles/theme/palette.less
+++ b/projects/styles/theme/palette.less
@@ -1,142 +1,10 @@
-.dark() {
-    // Backgrounds
-    --tui-background-base: #222;
-    --tui-background-base-alt: #333;
-    --tui-background-neutral-1: rgba(255, 255, 255, 0.08);
-    --tui-background-neutral-1-hover: rgba(255, 255, 255, 0.16);
-    --tui-background-neutral-1-pressed: rgba(255, 255, 255, 0.24);
-    --tui-background-neutral-2: rgba(255, 255, 255, 0.24);
-    --tui-background-neutral-2-hover: rgba(255, 255, 255, 0.32);
-    --tui-background-neutral-2-pressed: rgba(255, 255, 255, 0.4);
-    --tui-background-accent-opposite: #fff;
-    --tui-background-accent-opposite-hover: #f6f6f6;
-    --tui-background-accent-opposite-pressed: #ededed;
-    --tui-background-elevation-1: #292929;
-    --tui-background-elevation-2: #2f2f2f;
-    --tui-background-elevation-3: #373737;
-    // Other
-    --tui-service-autofill-background: rgb(85, 74, 42);
-    --tui-border-normal: rgba(255, 255, 255, 0.14);
-    --tui-border-hover: rgba(255, 255, 255, 0.6);
-    --tui-border-focus: rgba(255, 255, 255, 0.64);
-    // Statuses
-    --tui-status-negative: #ff4d4d;
-    --tui-status-negative-pale: rgba(255, 77, 77, 0.24);
-    --tui-status-negative-pale-hover: rgba(255, 77, 77, 0.32);
-    --tui-status-positive: rgb(74, 201, 155);
-    --tui-status-positive-pale: rgba(74, 201, 155, 0.32);
-    --tui-status-positive-pale-hover: rgba(74, 201, 155, 0.4);
-    --tui-status-warning: rgb(255, 199, 0);
-    --tui-status-warning-pale: rgba(255, 199, 0, 0.32);
-    --tui-status-warning-pale-hover: rgba(255, 199, 0, 0.4);
-    --tui-status-info: rgb(112, 182, 246);
-    --tui-status-info-pale: rgba(112, 182, 246, 0.32);
-    --tui-status-info-pale-hover: rgba(112, 182, 246, 0.4);
-    --tui-status-neutral: rgb(149, 155, 164);
-    // Text
-    --tui-text-primary: rgba(255, 255, 255, 1);
-    --tui-text-secondary: rgba(255, 255, 255, 0.72);
-    --tui-text-tertiary: rgba(255, 255, 255, 0.6);
-    --tui-text-action: #6788ff;
-    --tui-text-action-hover: #526ed3;
-    --tui-text-positive: #44c596;
-    --tui-text-positive-hover: #3aa981;
-    --tui-text-negative: #ff4d4d;
-    --tui-text-negative-hover: #f66;
-}
-
-.light() {
-    // Backgrounds
-    --tui-background-base: #fff;
-    --tui-background-base-alt: #f6f6f6;
-    --tui-background-neutral-1: rgba(0, 0, 0, 0.04);
-    --tui-background-neutral-1-hover: rgba(0, 0, 0, 0.08);
-    --tui-background-neutral-1-pressed: rgba(0, 0, 0, 0.12);
-    --tui-background-neutral-2: rgba(0, 0, 0, 0.08);
-    --tui-background-neutral-2-hover: rgba(0, 0, 0, 0.1);
-    --tui-background-neutral-2-pressed: rgba(0, 0, 0, 0.14);
-    --tui-background-accent-1: #526ed3;
-    --tui-background-accent-1-hover: #6c86e2;
-    --tui-background-accent-1-pressed: #314692;
-    --tui-background-accent-2: #ff7043;
-    --tui-background-accent-2-hover: #ff9a94;
-    --tui-background-accent-2-pressed: #e7716a;
-    --tui-background-accent-opposite: #000;
-    --tui-background-accent-opposite-hover: #333;
-    --tui-background-accent-opposite-pressed: #808080;
-    --tui-background-elevation-1: #fff;
-    --tui-background-elevation-2: #fff;
-    --tui-background-elevation-3: #fff;
-    // Other
-    --tui-service-autofill-background: #fff5c0;
-    --tui-service-selection-background: rgba(112, 182, 246, 0.12);
-    --tui-service-backdrop: rgba(0, 0, 0, 0.75);
-    --tui-border-normal: rgba(0, 0, 0, 0.1);
-    --tui-border-hover: rgba(0, 0, 0, 0.16);
-    --tui-border-focus: rgba(51, 51, 51, 0.64);
-    // Statuses
-    --tui-status-negative: #ff291a;
-    --tui-status-negative-pale: rgba(245, 34, 34, 0.08);
-    --tui-status-negative-pale-hover: rgba(245, 34, 34, 0.16);
-    --tui-status-positive: rgba(74, 201, 155, 1);
-    --tui-status-positive-pale: rgba(74, 201, 155, 0.12);
-    --tui-status-positive-pale-hover: rgba(74, 201, 155, 0.24);
-    --tui-status-warning: rgba(255, 199, 0, 1);
-    --tui-status-warning-pale: rgba(255, 199, 0, 0.12);
-    --tui-status-warning-pale-hover: rgba(255, 199, 0, 0.24);
-    --tui-status-info: rgba(112, 182, 246, 1);
-    --tui-status-info-pale: rgba(112, 182, 246, 0.12);
-    --tui-status-info-pale-hover: rgba(112, 182, 246, 0.24);
-    --tui-status-neutral: rgb(121, 129, 140);
-    // Text
-    --tui-text-primary: rgba(27, 31, 59, 1);
-    --tui-text-secondary: rgba(27, 31, 59, 0.65);
-    --tui-text-tertiary: rgba(27, 31, 59, 0.4);
-    --tui-text-primary-on-accent-1: #fff;
-    --tui-text-primary-on-accent-2: #fff;
-    --tui-text-action: #4c66c3;
-    --tui-text-action-hover: #6c86e2;
-    --tui-text-positive: #3aa981;
-    --tui-text-positive-hover: #7ac5aa;
-    --tui-text-negative: #ff291a;
-    --tui-text-negative-hover: #ff4d4d;
-    // Charts
-    --tui-chart-categorical-00: var(--tui-background-accent-1);
-    --tui-chart-categorical-01: #ea97c4;
-    --tui-chart-categorical-02: #a0c5df;
-    --tui-chart-categorical-03: #fee797;
-    --tui-chart-categorical-04: #b0b0b0;
-    --tui-chart-categorical-05: #e29398;
-    --tui-chart-categorical-06: #b8474e;
-    --tui-chart-categorical-07: #fcc068;
-    --tui-chart-categorical-08: #ff8a00;
-    --tui-chart-categorical-09: #dab3f9;
-    --tui-chart-categorical-10: #7b439e;
-    --tui-chart-categorical-11: #8dda71;
-    --tui-chart-categorical-12: #fcbb14;
-    --tui-chart-categorical-13: #a8cef1;
-    --tui-chart-categorical-14: #bd65a4;
-    --tui-chart-categorical-15: #7fd7cc;
-    --tui-chart-categorical-16: #2fad96;
-    --tui-chart-categorical-17: #d4aca2;
-    --tui-chart-categorical-18: #9d6f64;
-    --tui-chart-categorical-19: #d2e9a2;
-    --tui-chart-categorical-20: #aadc42;
-    --tui-chart-categorical-21: #3682db;
-    --tui-chart-categorical-22: #34b41f;
-    // Shadows
-    --tui-shadow-small: 0 0.25rem 1.25rem rgba(0, 0, 0, 0.1);
-    --tui-shadow-small-hover: 0 1rem 2.5rem rgba(0, 0, 0, 0.14);
-    --tui-shadow-medium: 0 0.375rem 2rem rgba(0, 0, 0, 0.12);
-    --tui-shadow-medium-hover: 0 1.25rem 4rem rgba(0, 0, 0, 0.18);
-    --tui-shadow-popup: 0 1.25rem 3rem rgba(0, 0, 0, 0.2);
-}
+@import '../mixins/theme/palette.less';
 
 @media screen {
     [tuiTheme='dark'] {
         color-scheme: dark;
 
-        .dark();
+        .tui-theme-dark();
     }
 
     [tuiTheme='light'] {
@@ -146,7 +14,7 @@
     &:root,
     :host,
     [tuiTheme='light'] {
-        .light();
+        .tui-theme-light();
     }
 }
 
@@ -156,6 +24,6 @@
     [tuiTheme] {
         color-scheme: light;
 
-        .light();
+        .tui-theme-light();
     }
 }

--- a/projects/styles/theme/variables.less
+++ b/projects/styles/theme/variables.less
@@ -1,69 +1,13 @@
 @import (inline, once) '@taiga-ui/design-tokens/palette/animation.css';
 @import (inline, once) '@taiga-ui/design-tokens/palette/shadow.css';
 
+@import '../mixins/theme/variables.less';
+
 &:root,
 &:host {
-    // Fonts
-    --tui-typography-family-text: 'Manrope', system-ui, sans-serif;
-    --tui-typography-family-display: 'Manrope', system-ui, sans-serif;
-    --tui-font-offset: calc(var(--t-font-offset, 0) * 1px);
-    --tui-font-scale: calc((22 + var(--t-font-offset, 0)) / 22);
-    // Heading
-    --tui-typography-heading-h1: bold calc(var(--tui-font-offset) + 3.125rem) / calc(56 / 50) var(--tui-typography-family-display);
-    --tui-typography-heading-h2: bold calc(var(--tui-font-offset) + 2.75rem) / calc(48 / 44) var(--tui-typography-family-display);
-    --tui-typography-heading-h3: bold calc(var(--tui-font-offset) + 2.25rem) / calc(40 / 36) var(--tui-typography-family-display);
-    --tui-typography-heading-h4: bold calc(var(--tui-font-offset) + 1.75rem) / calc(32 / 28) var(--tui-typography-family-display);
-    --tui-typography-heading-h5: bold calc(var(--tui-font-offset) + 1.5rem) / calc(28 / 24) var(--tui-typography-family-display);
-    --tui-typography-heading-h6: bold calc(var(--tui-font-offset) + 1.25rem) / calc(24 / 20) var(--tui-typography-family-display);
-    // Body
-    --tui-typography-body-l: normal calc(var(--tui-font-offset) + 1.0625rem) / calc(28 / 17) var(--tui-typography-family-text);
-    --tui-typography-body-m: normal calc(var(--tui-font-offset) + 1rem) / calc(24 / 16) var(--tui-typography-family-text);
-    --tui-typography-body-s: normal calc(var(--tui-font-offset) + 0.875rem) / calc(20 / 14) var(--tui-typography-family-text);
-    --tui-typography-body-xs: normal calc(var(--tui-font-offset) + 0.75rem) / calc(16 / 12) var(--tui-typography-family-text);
-    // Reduced
-    --tui-typography-ui-l: normal calc(var(--tui-font-offset) + 1.0625rem) / calc(24 / 17) var(--tui-typography-family-text);
-    --tui-typography-ui-m: normal calc(var(--tui-font-offset) + 1rem) / calc(20 / 16) var(--tui-typography-family-text);
-    --tui-typography-ui-s: normal calc(var(--tui-font-offset) + 0.875rem) / calc(16 / 14) var(--tui-typography-family-text);
-    --tui-typography-ui-xs: normal calc(var(--tui-font-offset) + 0.75rem) / calc(15 / 12) var(--tui-typography-family-text);
-    --tui-typography-ui-2xs: normal calc(var(--tui-font-offset) + 0.6875rem) / calc(12 / 11) var(--tui-typography-family-text);
-    // Radii
-    --tui-radius-xs: 0.25rem;
-    --tui-radius-s: 0.5rem;
-    --tui-radius-m: 0.625rem;
-    --tui-radius-l: 0.75rem;
-    --tui-radius-xl: 1.5rem;
-    // Sizes
-    --tui-height-xs: 1.5rem;
-    --tui-height-s: 2rem;
-    --tui-height-m: 2.75rem;
-    --tui-height-l: 3.5rem;
-    // Input padding
-    --tui-padding-s: 0.625rem;
-    --tui-padding-m: 0.75rem;
-    --tui-padding-l: 1rem;
-    // Misc
-    --tui-stroke-width: 0.125rem;
-    --tui-duration: 0.3s;
-    --tui-disabled-opacity: 0.56;
-    --tui-lh: 1.4em;
-    // logical
-    --tui-inline-start: left;
-    --tui-inline-end: right;
-    --tui-inline: 1;
-
-    @supports (font-size: 1lh) {
-        --tui-lh: 1lh;
-    }
-
-    // TODO: drop in v6
-    --tui-duration-slowest: calc(var(--tui-duration) / 0.429);
-    --tui-duration-slow: calc(var(--tui-duration) / 0.6);
-    --tui-duration-fast: calc(var(--tui-duration) / 2);
-    --tui-duration-fastest: calc(var(--tui-duration) / 4);
+    .tui-theme-variables();
 }
 
 [dir='rtl'] {
-    --tui-inline-start: right;
-    --tui-inline-end: left;
-    --tui-inline: -1;
+    .tui-theme-rtl();
 }


### PR DESCRIPTION
Part of #10435

## What does this PR do?

Adds `.taiga-ui-theme()` — a mixin entry point for the theme, so it can be applied inside an
arbitrary selector instead of `:root` / `:host`.

Today styles are connected through global entry points:

```less
@import '@taiga-ui/styles/taiga-ui-theme.less';
@import '@taiga-ui/styles/taiga-ui-fonts.less';
@import '@taiga-ui/addon-mobile/styles/taiga-ui-mobile.less'; // optional
```

That is fine for a regular application, but not for micro frontends: `taiga-ui-theme.less` emits
`:root` / `:host` rules, so several micro frontends on one page fight over the same custom
properties and there is no way to isolate them.

With this PR a micro frontend can scope the theme to itself:

```less
@import '@taiga-ui/styles/mixins/theme.less';

[my-app] {
    .taiga-ui-theme();

    // mobile styles have no `:root` / `:host`, so a plain nested import is enough
    @import '@taiga-ui/addon-mobile/styles/taiga-ui-mobile.less';
}
```

Everything the global entry point would put on `:root` / `:host` now lands on `[my-app]`, and
everything it would put on a bare selector is nested under it.


## Notes on `@import` deduplication

`@import` in Less is `once` by default and dedupes by file path, not by insertion point. A few
consequences worth knowing:

**`.taiga-ui-theme()` is not affected — several scopes in one build just work:**

```less
[app-a] { .taiga-ui-theme(); }
[app-b] { .taiga-ui-theme(); }
```

Both get the complete rule set (verified: `accent` = 4 rules in each). The nested `@import` lives
inside the mixin body, so it is resolved once at parse time and the resulting rules are replayed on
every call — dedup never comes into play.

**A raw nested `@import` written twice is affected:**

```less
[app-a] { @import '@taiga-ui/addon-mobile/styles/taiga-ui-mobile.less'; }
[app-b] { @import '@taiga-ui/addon-mobile/styles/taiga-ui-mobile.less'; }
```

`app-a` gets 443 rules, `app-b` gets **0**, silently. If you really need the same file scoped twice
in one compilation, `@import (multiple)` fixes it (449 / 449) — but use it deliberately: `multiple`
propagates down the **whole import subtree**, so files that only define mixins get re-parsed too.
Less then runs *every* same-named definition, and nested calls multiply, so the duplication is
`N^depth`. 

**Do not mix the global and the scoped path in a single Less compilation:**

```less
@import '@taiga-ui/styles/taiga-ui-theme.less';
@import '@taiga-ui/styles/mixins/theme.less';

[my-app] { .taiga-ui-theme(); }
```

Both pull in `theme/appearance.less`, so whichever comes second emits nothing. Separate builds — the
usual micro frontend setup, and also how Angular compiles global styles vs component styles — are
unaffected.