### PR TITLE
feat(i18n): add taskList translation for editor toolbar tooltip

### DIFF
--- a/projects/i18n/languages/arabic/addon-editor.ts
+++ b/projects/i18n/languages/arabic/addon-editor.ts
@@ -22,6 +22,7 @@ export const TUI_ARABIC_LANGUAGE_ADDON_EDITOR: TuiLanguageEditor = {
         outdent: 'تقليل المسافة البادئة',
         unorderedList: 'قائمة غير مرتبة',
         orderedList: 'قائمة مرتبة',
+        taskList: 'قائمة المهام',
         quote: 'اقتباس',
         foreColor: 'اللون',
         backColor: 'لون الخلفية',

--- a/projects/i18n/languages/belarusian/addon-editor.ts
+++ b/projects/i18n/languages/belarusian/addon-editor.ts
@@ -22,6 +22,7 @@ export const TUI_BELARUSIAN_LANGUAGE_ADDON_EDITOR: TuiLanguageEditor = {
         outdent: 'Паменшыць водступ',
         unorderedList: 'Маркіраваны спіс',
         orderedList: 'Нумараваны спіс',
+        taskList: 'Спіс задач',
         quote: 'Цытата',
         foreColor: 'Колер тэксту',
         hiliteColor: 'Колер вылучэння',

--- a/projects/i18n/languages/chinese/addon-editor.ts
+++ b/projects/i18n/languages/chinese/addon-editor.ts
@@ -22,6 +22,7 @@ export const TUI_CHINESE_LANGUAGE_ADDON_EDITOR: TuiLanguageEditor = {
         outdent: '减小缩进',
         unorderedList: '无序列表',
         orderedList: '有序列表',
+        taskList: '任务列表',
         quote: '引用',
         foreColor: '颜色',
         backColor: '背景颜色',

--- a/projects/i18n/languages/dutch/addon-editor.ts
+++ b/projects/i18n/languages/dutch/addon-editor.ts
@@ -22,6 +22,7 @@ export const TUI_DUTCH_LANGUAGE_ADDON_EDITOR: TuiLanguageEditor = {
         outdent: 'Uitspringen',
         unorderedList: 'Ongesorteerde lijst',
         orderedList: 'Gesorteerde lijst',
+        taskList: 'Takenlijst',
         quote: 'Citeren',
         foreColor: 'Kleur',
         backColor: 'Achtergrondkleur',

--- a/projects/i18n/languages/english/addon-editor.ts
+++ b/projects/i18n/languages/english/addon-editor.ts
@@ -22,6 +22,7 @@ export const TUI_ENGLISH_LANGUAGE_ADDON_EDITOR: TuiLanguageEditor = {
         outdent: 'Outdent',
         unorderedList: 'Unordered list',
         orderedList: 'Ordered list',
+        taskList: 'Task list',
         quote: 'Quote',
         foreColor: 'Color',
         backColor: 'Background color',

--- a/projects/i18n/languages/french/addon-editor.ts
+++ b/projects/i18n/languages/french/addon-editor.ts
@@ -22,6 +22,7 @@ export const TUI_FRENCH_LANGUAGE_ADDON_EDITOR: TuiLanguageEditor = {
         outdent: 'Réduire le retrait',
         unorderedList: 'Liste à puces',
         orderedList: 'Liste numérotée',
+        taskList: 'Liste de tâches',
         quote: 'Citation',
         foreColor: 'Couleur de texte',
         backColor: 'Couleur de fond',

--- a/projects/i18n/languages/german/addon-editor.ts
+++ b/projects/i18n/languages/german/addon-editor.ts
@@ -22,6 +22,7 @@ export const TUI_GERMAN_LANGUAGE_ADDON_EDITOR: TuiLanguageEditor = {
         outdent: 'Ausrücken',
         unorderedList: 'Ungeordnete Liste',
         orderedList: 'Geordnete Liste',
+        taskList: 'Aufgabenliste',
         quote: 'Blockquote',
         foreColor: 'Farbe',
         backColor: 'Hintergrundfarbe',

--- a/projects/i18n/languages/greek/addon-editor.ts
+++ b/projects/i18n/languages/greek/addon-editor.ts
@@ -22,6 +22,7 @@ export const TUI_GREEK_LANGUAGE_ADDON_EDITOR: TuiLanguageEditor = {
         outdent: 'Αφαίρεση εσοχής',
         unorderedList: 'Μη ταξινομημένη λίστα',
         orderedList: 'Ταξινομημένη λίστα',
+        taskList: 'Λίστα εργασιών',
         quote: 'Παράθεση',
         foreColor: 'Χρώμα',
         backColor: 'Χρώμα φόντου',

--- a/projects/i18n/languages/hebrew/addon-editor.ts
+++ b/projects/i18n/languages/hebrew/addon-editor.ts
@@ -22,6 +22,7 @@ export const TUI_HEBREW_LANGUAGE_ADDON_EDITOR: TuiLanguageEditor = {
         outdent: 'שקע החוצה',
         unorderedList: 'רשימה לא מסודרת',
         orderedList: 'רשימה מסודרת',
+        taskList: 'רשימת משימות',
         quote: 'ציטוט',
         foreColor: 'צֶבַע',
         backColor: 'צבע רקע',

--- a/projects/i18n/languages/italian/addon-editor.ts
+++ b/projects/i18n/languages/italian/addon-editor.ts
@@ -22,6 +22,7 @@ export const TUI_ITALIAN_LANGUAGE_ADDON_EDITOR: TuiLanguageEditor = {
         outdent: 'Elimina rientro',
         unorderedList: 'Lista non ordinata',
         orderedList: 'Lista ordinata',
+        taskList: 'Lista di attività',
         quote: 'Virgolette',
         foreColor: 'Colore',
         backColor: 'Colore sfondo',

--- a/projects/i18n/languages/japanese/addon-editor.ts
+++ b/projects/i18n/languages/japanese/addon-editor.ts
@@ -22,6 +22,7 @@ export const TUI_JAPANESE_LANGUAGE_ADDON_EDITOR: TuiLanguageEditor = {
         outdent: 'アウトデント',
         unorderedList: '順序なしリスト',
         orderedList: '順序付きリスト',
+        taskList: 'タスクリスト',
         quote: '引用',
         foreColor: '色',
         backColor: '背景色',

--- a/projects/i18n/languages/kazakh/addon-editor.ts
+++ b/projects/i18n/languages/kazakh/addon-editor.ts
@@ -22,6 +22,7 @@ export const TUI_KAZAKH_LANGUAGE_ADDON_EDITOR: TuiLanguageEditor = {
         outdent: 'Ашық',
         unorderedList: 'Реттелмеген тізім',
         orderedList: 'Реттелген тізім',
+        taskList: 'Тапсырмалар тізімі',
         quote: 'Дәйексөз',
         foreColor: 'Түс',
         backColor: 'Фон түсі',

--- a/projects/i18n/languages/korean/addon-editor.ts
+++ b/projects/i18n/languages/korean/addon-editor.ts
@@ -22,6 +22,7 @@ export const TUI_KOREAN_LANGUAGE_ADDON_EDITOR: TuiLanguageEditor = {
         outdent: '내어쓰기',
         unorderedList: '순서 없는 목록',
         orderedList: '정렬된 목록',
+        taskList: '작업 목록',
         quote: '인용하다',
         foreColor: '색상',
         backColor: '배경색',

--- a/projects/i18n/languages/lithuanian/addon-editor.ts
+++ b/projects/i18n/languages/lithuanian/addon-editor.ts
@@ -22,6 +22,7 @@ export const TUI_LITHUANIAN_LANGUAGE_ADDON_EDITOR: TuiLanguageEditor = {
         outdent: 'Ištraukti',
         unorderedList: 'Nenumeruotas sąrašas',
         orderedList: 'Numeruotas sąrašas',
+        taskList: 'Užduočių sąrašas',
         quote: 'Citata',
         foreColor: 'Spalva',
         backColor: 'Fono spalva',

--- a/projects/i18n/languages/malay/addon-editor.ts
+++ b/projects/i18n/languages/malay/addon-editor.ts
@@ -22,6 +22,7 @@ export const TUI_MALAY_LANGUAGE_ADDON_EDITOR: TuiLanguageEditor = {
         outdent: 'Outden',
         unorderedList: 'Senarai tidak teratur',
         orderedList: 'Senarai teratur',
+        taskList: 'Senarai tugasan',
         quote: 'petikan',
         foreColor: 'Warna',
         backColor: 'Warna latar belakang',

--- a/projects/i18n/languages/polish/addon-editor.ts
+++ b/projects/i18n/languages/polish/addon-editor.ts
@@ -22,6 +22,7 @@ export const TUI_POLISH_LANGUAGE_ADDON_EDITOR: TuiLanguageEditor = {
         outdent: 'Zmniejsz wcięcie',
         unorderedList: 'Lista punktowana',
         orderedList: 'Lista numerowana',
+        taskList: 'Lista zadań',
         quote: 'Cytat',
         foreColor: 'Kolor tekstu',
         backColor: 'Kolor tła',

--- a/projects/i18n/languages/portuguese/addon-editor.ts
+++ b/projects/i18n/languages/portuguese/addon-editor.ts
@@ -22,6 +22,7 @@ export const TUI_PORTUGUESE_LANGUAGE_ADDON_EDITOR: TuiLanguageEditor = {
         outdent: 'Recuo externo',
         unorderedList: 'Lista desordenada',
         orderedList: 'Lista ordenada',
+        taskList: 'Lista de tarefas',
         quote: 'Frase',
         foreColor: 'Cor',
         backColor: 'Cor de fundo',

--- a/projects/i18n/languages/russian/addon-editor.ts
+++ b/projects/i18n/languages/russian/addon-editor.ts
@@ -22,6 +22,7 @@ export const TUI_RUSSIAN_LANGUAGE_ADDON_EDITOR: TuiLanguageEditor = {
         outdent: 'Уменьшить отступ',
         unorderedList: 'Маркированный список',
         orderedList: 'Нумерованный список',
+        taskList: 'Список задач',
         quote: 'Цитата',
         foreColor: 'Цвет: Текст',
         hiliteColor: 'Цвет выделения',

--- a/projects/i18n/languages/spanish/addon-editor.ts
+++ b/projects/i18n/languages/spanish/addon-editor.ts
@@ -22,6 +22,7 @@ export const TUI_SPANISH_LANGUAGE_ADDON_EDITOR: TuiLanguageEditor = {
         outdent: 'Sin sangría',
         unorderedList: 'Lista desordenada',
         orderedList: 'Lista ordenada',
+        taskList: 'Lista de tareas',
         quote: 'Cita',
         foreColor: 'Color',
         backColor: 'Color de fondo',

--- a/projects/i18n/languages/turkish/addon-editor.ts
+++ b/projects/i18n/languages/turkish/addon-editor.ts
@@ -22,6 +22,7 @@ export const TUI_TURKISH_LANGUAGE_ADDON_EDITOR: TuiLanguageEditor = {
         outdent: 'Çıkıntı',
         unorderedList: 'Noktalı liste',
         orderedList: 'Numerik liste',
+        taskList: 'Görev listesi',
         quote: 'Alıntı',
         foreColor: 'Renk',
         backColor: 'Arka plan rengi',

--- a/projects/i18n/languages/ukrainian/addon-editor.ts
+++ b/projects/i18n/languages/ukrainian/addon-editor.ts
@@ -22,6 +22,7 @@ export const TUI_UKRAINIAN_LANGUAGE_ADDON_EDITOR: TuiLanguageEditor = {
         outdent: 'Зменшити відступ',
         unorderedList: 'Маркований список',
         orderedList: 'Нумерований список',
+        taskList: 'Список завдань',
         quote: 'Цитата',
         foreColor: 'Колір: Текст',
         hiliteColor: 'Колір виділення',

--- a/projects/i18n/languages/vietnamese/addon-editor.ts
+++ b/projects/i18n/languages/vietnamese/addon-editor.ts
@@ -22,6 +22,7 @@ export const TUI_VIETNAMESE_LANGUAGE_ADDON_EDITOR: TuiLanguageEditor = {
         outdent: 'Thụt ra',
         unorderedList: 'Danh sách không đánh số',
         orderedList: 'Danh sách được đánh số',
+        taskList: 'Danh sách công việc',
         quote: 'Trích dẫn',
         foreColor: 'Màu',
         backColor: 'Màu nền',

--- a/projects/i18n/types/language.ts
+++ b/projects/i18n/types/language.ts
@@ -210,6 +210,7 @@ export interface TuiLanguageEditor {
         strikeThrough: string;
         subscript: string;
         superscript: string;
+        taskList: string;
         tex: string;
         underline: string;
         undo: string;


### PR DESCRIPTION
Hi! In taiga-family/editor#2238 I moved the task list toggle out of the lists dropdown into the main toolbar as a standalone button.

Turns out this button never had a tooltip — `getHint()` always returned an empty string, even before this move. That was fine while it lived inside a dropdown, but now as a standalone icon-only button it needs one: every other toolbar button already has a tooltip, and without a label there's no way to tell what the icon does (also matters for accessibility).

This PR adds the `taskList` key to `toolbarTools` and fills it in for all languages.

**Please double-check the translations.** I don't speak most of these languages and used AI translation for anything beyond English/Russian.
