### PR TITLE
chore(schematics): remove dropped [icon] input from input[tuiInputCard] in v5

### DIFF
--- a/projects/cdk/schematics/ng-update/v5/steps/constants/inputs-to-remove.ts
+++ b/projects/cdk/schematics/ng-update/v5/steps/constants/inputs-to-remove.ts
@@ -29,6 +29,13 @@ export const INPUTS_TO_REMOVE: RemovableInput[] = [
         inputName: 'monoHandler',
         tags: ['tui-thumbnail-card'],
     },
+    // `input[tuiInputCard]` dropped its `icon` override; the card icon is now
+    // auto-detected from the payment system, so the input no longer exists.
+    {
+        inputName: 'icon',
+        tags: ['input'],
+        filterFn: (el) => hasElementAttribute(el, 'tuiInputCard'),
+    },
     // `[tuiDropdownOpenMonitor]` was a selector-only shim; v5 dropdowns are native
     // (the schematic maps `tuiDropdownOpen` -> `tuiDropdownAuto`), so drop the marker.
     {

--- a/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-input-card-icon.spec.ts.snap
+++ b/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-input-card-icon.spec.ts.snap
@@ -1,0 +1,30 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ng-update input[tuiInputCard] [icon] (#11917) removes the dropped icon override from input[tuiInputCard] and keeps icon elsewhere: test.html 1`] = `
+{
+  "0. Before": "
+                <input
+                    tuiInputCard
+                    [icon]="card"
+                />
+                <input
+                    tuiInputCard
+                    icon="visa"
+                />
+                <input tuiInputCard />
+                <tui-icon icon="@tui.user" />
+            ",
+  "1. After": "
+                <input
+                    tuiInputCard
+                    
+                />
+                <input
+                    tuiInputCard
+                    
+                />
+                <input tuiInputCard />
+                <tui-icon icon="@tui.user" />
+            ",
+}
+`;

--- a/projects/cdk/schematics/ng-update/v5/tests/schematic-migrate-input-card-icon.spec.ts
+++ b/projects/cdk/schematics/ng-update/v5/tests/schematic-migrate-input-card-icon.spec.ts
@@ -1,0 +1,31 @@
+import {join} from 'node:path';
+
+import {resetActiveProject} from 'ng-morph';
+
+import {createMigration} from '../../../utils/run-migration';
+
+describe('ng-update input[tuiInputCard] [icon] (#11917)', () => {
+    const migrate = createMigration({
+        collection: join(__dirname, '../../../migration.json'),
+    });
+
+    it(
+        'removes the dropped icon override from input[tuiInputCard] and keeps icon elsewhere',
+        migrate({
+            template: /* HTML */ `
+                <input
+                    tuiInputCard
+                    [icon]="card"
+                />
+                <input
+                    tuiInputCard
+                    icon="visa"
+                />
+                <input tuiInputCard />
+                <tui-icon icon="@tui.user" />
+            `,
+        }),
+    );
+
+    afterEach(() => resetActiveProject());
+});


### PR DESCRIPTION
## What / Why

`input[tuiInputCard]` had a public `@Input('icon')` in v4 (override for the auto-detected payment-system icon). In v5 that input was **removed** — the card icon is now rendered automatically by `tui-input-card-content`, and neither the component nor its host-directives (`MaskitoDirective`, `TuiWithInput`, `TuiTextfieldContent`) expose `icon`.

So after `ng update`, a template like `<input tuiInputCard [icon]="card" />` throws **NG8002** (binding to a non-existent input); the bare `icon="…"` form becomes a dead attribute. No existing migration covered this.

## Change

One `INPUTS_TO_REMOVE` entry, scoped with `filterFn` so it only strips `icon`/`[icon]` from `input[tuiInputCard]` — `icon` on any other element (e.g. `<tui-icon icon>`) is untouched.

```
- <input tuiInputCard [icon]="card" />
+ <input tuiInputCard />
```

## Tests

New snapshot spec `schematic-migrate-input-card-icon.spec.ts` — one case proving both forms (`[icon]` and `icon="…"`) are removed from `input[tuiInputCard]` while `icon` on `<tui-icon>` in the same template is preserved (scoping guard). Full `cdk` suite green: **174 suites / 1472 tests / 801 snapshots** (`--ci`).

## Audit context

Found in a v4→v5 template-API audit (ref #11917). Verified: public `@Input('icon')` in v4, removed in v5 (not via inheritance/host-directive), absent from `main` and all open v5-migration PRs. Three other template candidates from the same audit were dropped after verification — `select[tuiTextfield]` (a fix to existing shared logic, tracked separately), `tui-icon[badge]` (TS import already handled by `modules-to-remove`), and `tui-expand[async]` (the common accordion path already strips it) — as not worth new migrations.

> Draft for maintainer review.
