### PR TITLE
fix(schematics): map native select[tuiTextfield] to tuiSelect (not tuiInput) in v5

### DIFF
--- a/projects/cdk/schematics/ng-update/v5/steps/constants/attrs-to-replace.ts
+++ b/projects/cdk/schematics/ng-update/v5/steps/constants/attrs-to-replace.ts
@@ -55,8 +55,14 @@ export const ATTRS_TO_REPLACE: readonly ReplacementAttribute[] = [
         to: {attrName: '*tuiPopup'},
     },
     {
-        from: {attrName: 'tuiTextfield', withTagNames: ['*']},
+        from: {attrName: 'tuiTextfield', withTagNames: ['input']},
         to: {attrName: 'tuiInput'},
+    },
+    // `select[tuiTextfield]` was the native select; its v5 successor is the native
+    // `select[tuiSelect]` (TuiNativeSelect), not `tuiInput` (there is no select[tuiInput]).
+    {
+        from: {attrName: 'tuiTextfield', withTagNames: ['select']},
+        to: {attrName: 'tuiSelect'},
     },
     {
         from: {attrName: 'tuiDropdownOpen', withTagNames: ['*']},

--- a/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-textfield-to-input.spec.ts.snap
+++ b/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-textfield-to-input.spec.ts.snap
@@ -22,6 +22,13 @@ exports[`ng-update TuiTextfield to TuiInput identifier migration should rename T
 }
 `;
 
+exports[`ng-update TuiTextfield to TuiInput template migration should rename native select tuiTextfield to tuiSelect (not tuiInput): test.html 1`] = `
+{
+  "0. Before": "<select tuiTextfield></select>",
+  "1. After": "<select tuiSelect></select>",
+}
+`;
+
 exports[`ng-update TuiTextfield to TuiInput template migration should rename tuiTextfield inside tui-textfield tag: test.html 1`] = `
 {
   "0. Before": "<tui-textfield><input tuiTextfield /></tui-textfield>",

--- a/projects/cdk/schematics/ng-update/v5/tests/schematic-migrate-textfield-to-input.spec.ts
+++ b/projects/cdk/schematics/ng-update/v5/tests/schematic-migrate-textfield-to-input.spec.ts
@@ -19,6 +19,11 @@ describe('ng-update TuiTextfield to TuiInput', () => {
             'should rename tuiTextfield inside tui-textfield tag',
             migrate({template: '<tui-textfield><input tuiTextfield /></tui-textfield>'}),
         );
+
+        it(
+            'should rename native select tuiTextfield to tuiSelect (not tuiInput)',
+            migrate({template: '<select tuiTextfield></select>'}),
+        );
     });
 
     describe('identifier migration', () => {


### PR DESCRIPTION
## What / Why

Fixes an existing template-migration rule that produces **non-functional markup** for the native `select` textfield.

The rule in `attrs-to-replace.ts` renamed `tuiTextfield` → `tuiInput` on **every** tag:
```ts
{from: {attrName: 'tuiTextfield', withTagNames: ['*']}, to: {attrName: 'tuiInput'}}
```
In v4 the `tuiTextfield` attribute existed on exactly two elements:
- `input[tuiTextfield]` → correct target is `input[tuiInput]` ✅
- `select[tuiTextfield]` (the deprecated native `<select>`, `TuiSelect extends TuiTextfieldBase`) → the rule turned it into `<select tuiInput>`, but **v5 has no `select[tuiInput]` directive**, so the attribute is dead and the select loses all textfield behaviour/styling (silently — no build/runtime error).

The native `<select>` successor in v5 is **`select[tuiSelect]`** (`TuiNativeSelect`) — distinct from the documented dropdown `input[tuiSelect]`.

## Change

Split the over-broad `['*']` rule into two tag-scoped rules:
```ts
{from: {attrName: 'tuiTextfield', withTagNames: ['input']},  to: {attrName: 'tuiInput'}},
{from: {attrName: 'tuiTextfield', withTagNames: ['select']}, to: {attrName: 'tuiSelect'}},
```
- `<input tuiTextfield>` → `<input tuiInput>` — unchanged behaviour
- `<select tuiTextfield>` → `<select tuiSelect>` — now the correct native select

Since `tuiTextfield` only ever appeared on `input` and `select` in v4, narrowing from `['*']` loses no coverage.

## Tests

Added a case to `schematic-migrate-textfield-to-input.spec.ts` for `<select tuiTextfield></select>` → `<select tuiSelect></select>`; existing `input[tuiTextfield]` snapshots are unchanged (regression guard). Full `cdk` suite green (`--ci`), no other snapshot moved.

> Draft. Small correctness fix found during the v4→v5 template-API audit (ref #11917). Low real-world frequency (the native select was `@deprecated` in v4), but the migration was actively emitting broken output for it.
