### PR TITLE
chore(schematics): migrate removed cdk EMPTY_ARRAY to [] literal in v5

### DIFF
--- a/projects/cdk/schematics/ng-update/interfaces/replacement-identifier.ts
+++ b/projects/cdk/schematics/ng-update/interfaces/replacement-identifier.ts
@@ -12,7 +12,17 @@ export interface ReplacementIdentifier {
     };
 }
 
+interface ReplacementIdentifierMultiTarget
+    extends Omit<ReplacementIdentifier['to'], 'moduleSpecifier'> {
+    /**
+     * Module to import the replacement from. Omit for a literal replacement
+     * (e.g. `[]`) — usages are rewritten and the old import is dropped without
+     * adding a new one.
+     */
+    readonly moduleSpecifier?: string;
+}
+
 export interface ReplacementIdentifierMulti {
     readonly from: Array<ReplacementIdentifier['from']> | ReplacementIdentifier['from'];
-    readonly to: Array<ReplacementIdentifier['to']> | ReplacementIdentifier['to'];
+    readonly to: ReplacementIdentifierMultiTarget[] | ReplacementIdentifierMultiTarget;
 }

--- a/projects/cdk/schematics/ng-update/interfaces/replacement-identifier.ts
+++ b/projects/cdk/schematics/ng-update/interfaces/replacement-identifier.ts
@@ -12,8 +12,10 @@ export interface ReplacementIdentifier {
     };
 }
 
-interface ReplacementIdentifierMultiTarget
-    extends Omit<ReplacementIdentifier['to'], 'moduleSpecifier'> {
+interface ReplacementIdentifierMultiTarget extends Omit<
+    ReplacementIdentifier['to'],
+    'moduleSpecifier'
+> {
     /**
      * Module to import the replacement from. Omit for a literal replacement
      * (e.g. `[]`) — usages are rewritten and the old import is dropped without
@@ -24,5 +26,5 @@ interface ReplacementIdentifierMultiTarget
 
 export interface ReplacementIdentifierMulti {
     readonly from: Array<ReplacementIdentifier['from']> | ReplacementIdentifier['from'];
-    readonly to: ReplacementIdentifierMultiTarget[] | ReplacementIdentifierMultiTarget;
+    readonly to: ReplacementIdentifierMultiTarget | ReplacementIdentifierMultiTarget[];
 }

--- a/projects/cdk/schematics/ng-update/steps/replace-identifier.ts
+++ b/projects/cdk/schematics/ng-update/steps/replace-identifier.ts
@@ -72,7 +72,9 @@ function addImports(
     filePath: string,
 ): void {
     toArray(identifier).forEach(({name, namedImport, moduleSpecifier}) => {
-        addUniqueImport(filePath, namedImport || name, moduleSpecifier);
+        if (moduleSpecifier) {
+            addUniqueImport(filePath, namedImport || name, moduleSpecifier);
+        }
     });
 }
 

--- a/projects/cdk/schematics/ng-update/v5/steps/constants/identifiers-to-replace.ts
+++ b/projects/cdk/schematics/ng-update/v5/steps/constants/identifiers-to-replace.ts
@@ -3,6 +3,13 @@ import {type ReplacementIdentifierMulti} from '../../../interfaces';
 export const IDENTIFIERS_TO_REPLACE: ReplacementIdentifierMulti[] = [
     {
         from: {
+            name: 'EMPTY_ARRAY',
+            moduleSpecifier: '@taiga-ui/cdk',
+        },
+        to: {name: '[]'},
+    },
+    {
+        from: {
             name: 'TuiInputSliderModule',
             moduleSpecifier: '@taiga-ui/legacy',
         },

--- a/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-empty-array.spec.ts.snap
+++ b/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-empty-array.spec.ts.snap
@@ -1,0 +1,60 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ng-update EMPTY_ARRAY handles the @taiga-ui/cdk/constants sub-path import: test.ts 1`] = `
+{
+  "0. Before": "
+                import {Component} from '@angular/core';
+                import {EMPTY_ARRAY} from '@taiga-ui/cdk/constants';
+
+                @Component({
+                    templateUrl: './test.html',
+                })
+                export class TestComponent {
+                    protected readonly value = EMPTY_ARRAY;
+                }
+            ",
+  "1. After": "
+                import {Component} from '@angular/core';
+
+                @Component({
+                    templateUrl: './test.html',
+                })
+                export class TestComponent {
+                    protected readonly value = [];
+                }
+            ",
+}
+`;
+
+exports[`ng-update EMPTY_ARRAY replaces EMPTY_ARRAY usages with [] and drops the @taiga-ui/cdk import: test.ts 1`] = `
+{
+  "0. Before": "
+                import {Component} from '@angular/core';
+                import {EMPTY_ARRAY, TuiDay} from '@taiga-ui/cdk';
+
+                @Component({
+                    templateUrl: './test.html',
+                })
+                export class TestComponent {
+                    protected readonly all = EMPTY_ARRAY;
+
+                    protected readonly handler = (day: TuiDay) =>
+                        day.isWeekend ? EMPTY_ARRAY : [1];
+                }
+            ",
+  "1. After": "
+                import {Component} from '@angular/core';
+                import {TuiDay} from '@taiga-ui/cdk';
+
+                @Component({
+                    templateUrl: './test.html',
+                })
+                export class TestComponent {
+                    protected readonly all = [];
+
+                    protected readonly handler = (day: TuiDay) =>
+                        day.isWeekend ? [] : [1];
+                }
+            ",
+}
+`;

--- a/projects/cdk/schematics/ng-update/v5/tests/schematic-migrate-empty-array.spec.ts
+++ b/projects/cdk/schematics/ng-update/v5/tests/schematic-migrate-empty-array.spec.ts
@@ -1,0 +1,50 @@
+import {join} from 'node:path';
+
+import {resetActiveProject} from 'ng-morph';
+
+import {createMigration} from '../../../utils/run-migration';
+
+describe('ng-update EMPTY_ARRAY', () => {
+    const migrate = createMigration({
+        collection: join(__dirname, '../../../migration.json'),
+    });
+
+    it(
+        'replaces EMPTY_ARRAY usages with [] and drops the @taiga-ui/cdk import',
+        migrate({
+            component: /* TypeScript */ `
+                import {Component} from '@angular/core';
+                import {EMPTY_ARRAY, TuiDay} from '@taiga-ui/cdk';
+
+                @Component({
+                    templateUrl: './test.html',
+                })
+                export class TestComponent {
+                    protected readonly all = EMPTY_ARRAY;
+
+                    protected readonly handler = (day: TuiDay) =>
+                        day.isWeekend ? EMPTY_ARRAY : [1];
+                }
+            `,
+        }),
+    );
+
+    it(
+        'handles the @taiga-ui/cdk/constants sub-path import',
+        migrate({
+            component: /* TypeScript */ `
+                import {Component} from '@angular/core';
+                import {EMPTY_ARRAY} from '@taiga-ui/cdk/constants';
+
+                @Component({
+                    templateUrl: './test.html',
+                })
+                export class TestComponent {
+                    protected readonly value = EMPTY_ARRAY;
+                }
+            `,
+        }),
+    );
+
+    afterEach(() => resetActiveProject());
+});


### PR DESCRIPTION
## Which issue does this PR close?

Part of #11917 (v4→v5 ng-update migration backlog).

## What does this PR do?

`EMPTY_ARRAY` was removed from `@taiga-ui/cdk` in v5. It was a plain `export const EMPTY_ARRAY: [] = []`, so every usage is replaced with an inline `[]` literal and the now-dead import is dropped (both `@taiga-ui/cdk` and the `@taiga-ui/cdk/constants` sub-path).

Rather than a bespoke step, this teaches `IDENTIFIERS_TO_REPLACE` to do literal replacements: `to.moduleSpecifier` is now optional, and when omitted the runner rewrites usages and drops the old import **without** adding a new one. The migration itself is then a single declarative entry:

```ts
{
    from: {name: 'EMPTY_ARRAY', moduleSpecifier: '@taiga-ui/cdk'},
    to: {name: '[]'},
},
```

Backward compatible — every existing entry provides `moduleSpecifier`, so their behaviour is unchanged. Any future "removed symbol → inline literal" case is now one config line.

## Before / After

```ts
// Before
import {EMPTY_ARRAY, TuiDay} from '@taiga-ui/cdk';

protected readonly all = EMPTY_ARRAY;

// After
import {TuiDay} from '@taiga-ui/cdk';

protected readonly all = [];
```