### PR TITLE
fix(kit): `Hint` should close on mobile when scrolling begins

### DIFF
--- a/projects/cdk/directives/hovered/hovered.service.ts
+++ b/projects/cdk/directives/hovered/hovered.service.ts
@@ -20,7 +20,7 @@ export class TuiHoveredService extends Observable<boolean> {
     private readonly zone = inject(NgZone);
 
     private readonly stream$ = merge(
-        tuiTypedFromEvent(this.el, 'mouseenter').pipe(map(TUI_TRUE_HANDLER)),
+        tuiTypedFromEvent(this.el, 'pointerenter').pipe(map(TUI_TRUE_HANDLER)),
         tuiTypedFromEvent(this.el, 'mouseleave').pipe(map(TUI_FALSE_HANDLER)),
         // Hello, Safari
         tuiTypedFromEvent(this.el, 'mouseout').pipe(

--- a/projects/cdk/directives/hovered/hovered.service.ts
+++ b/projects/cdk/directives/hovered/hovered.service.ts
@@ -20,7 +20,7 @@ export class TuiHoveredService extends Observable<boolean> {
     private readonly zone = inject(NgZone);
 
     private readonly stream$ = merge(
-        tuiTypedFromEvent(this.el, 'pointerenter').pipe(map(TUI_TRUE_HANDLER)),
+        tuiTypedFromEvent(this.el, 'mouseenter').pipe(map(TUI_TRUE_HANDLER)),
         tuiTypedFromEvent(this.el, 'mouseleave').pipe(map(TUI_FALSE_HANDLER)),
         // Hello, Safari
         tuiTypedFromEvent(this.el, 'mouseout').pipe(

--- a/projects/core/portals/hint/hint-hover.directive.ts
+++ b/projects/core/portals/hint/hint-hover.directive.ts
@@ -24,6 +24,7 @@ const MOBILE_HIDE_DELAY_MS = 100;
 @Directive({
     providers: [tuiAsDriver(TuiHintHover), TuiHoveredService],
     exportAs: 'tuiHintHover',
+    host: {'(click)': 'onClick()'},
 })
 export class TuiHintHover extends TuiDriver {
     private readonly isMobile = inject(WA_IS_MOBILE);
@@ -91,5 +92,15 @@ export class TuiHintHover extends TuiDriver {
 
     public close(): void {
         this.toggle$.next(false);
+    }
+
+    /**
+     * Synthesized `mouseenter` is not fired again until another element is tapped, so showing on mobile
+     * cannot rely on it.
+     */
+    protected onClick(): void {
+        if (this.isMobile) {
+            this.toggle();
+        }
     }
 }

--- a/projects/core/portals/hint/hint-hover.directive.ts
+++ b/projects/core/portals/hint/hint-hover.directive.ts
@@ -19,6 +19,8 @@ import {
 
 import {TUI_HINT_OPTIONS} from './hint-options.directive';
 
+const MOBILE_HIDE_DELAY_MS = 100;
+
 @Directive({
     providers: [tuiAsDriver(TuiHintHover), TuiHoveredService],
     exportAs: 'tuiHintHover',
@@ -35,7 +37,7 @@ export class TuiHintHover extends TuiDriver {
         this.toggle$.pipe(
             switchMap((show) =>
                 this.isMobile
-                    ? of(show).pipe(delay(0))
+                    ? of(show).pipe(delay(show ? 0 : MOBILE_HIDE_DELAY_MS))
                     : of(show).pipe(delay(show ? 0 : this.hideDelay())),
             ),
             takeUntil(this.hovered$),

--- a/projects/core/portals/hint/hint.component.ts
+++ b/projects/core/portals/hint/hint.component.ts
@@ -67,7 +67,7 @@ const ARROW_OFFSET = 22;
         role: 'tooltip',
         '[attr.tuiTheme]': 'theme',
         '[class._untouchable]': 'pointer',
-        '(document:click)': 'onClick($event.target)',
+        '(document:pointerdown)': 'onPointerDown($event.target)',
     },
 })
 export class TuiHintComponent {
@@ -112,7 +112,7 @@ export class TuiHintComponent {
             .subscribe((hover) => this.hover.toggle(hover));
     }
 
-    protected onClick(target: HTMLElement): void {
+    protected onPointerDown(target: HTMLElement): void {
         if (
             (!target.closest(this.el.tagName) && !this.hint.el.contains(target)) ||
             tuiIsObscured(this.hint.el)

--- a/projects/demo-playwright/tests/core/hint/hint.pw.spec.ts
+++ b/projects/demo-playwright/tests/core/hint/hint.pw.spec.ts
@@ -181,7 +181,61 @@ test.describe('TuiHint', () => {
             await expect.soft(page).toHaveScreenshot('09-hint-on-mobile.png');
 
             await example.click();
+            await expect(page.locator('tui-hint')).not.toBeAttached();
             await expect.soft(page).toHaveScreenshot('10-hint-on-mobile.png');
+        });
+
+        test('Hides on scroll start (pointerdown is not followed by click)', async ({
+            page,
+        }) => {
+            await tuiGoto(page, DemoRoute.Hint);
+
+            const example = new TuiDocumentationPagePO(page).getExample('#basic');
+            const hint = page.locator('tui-hint');
+
+            await example.scrollIntoViewIfNeeded();
+            await example.locator('[tuiAvatar]').click();
+            await expect(hint).toBeAttached();
+
+            await page.locator('body').dispatchEvent('pointerdown');
+
+            await expect(hint).not.toBeAttached();
+        });
+
+        test('Shows again after being hidden without hover out', async ({page}) => {
+            await tuiGoto(page, DemoRoute.Hint);
+
+            const example = new TuiDocumentationPagePO(page).getExample('#basic');
+            const avatar = example.locator('[tuiAvatar]');
+            const hint = page.locator('tui-hint');
+
+            await example.scrollIntoViewIfNeeded();
+            await avatar.click();
+            await expect(hint).toBeAttached();
+
+            await page.locator('body').dispatchEvent('pointerdown');
+            await expect(hint).not.toBeAttached();
+
+            await avatar.click();
+            await expect(hint).toBeAttached();
+        });
+
+        test('Tooltip opens on tap and hides on tap outside', async ({page}) => {
+            await tuiGoto(page, DemoRoute.Tooltip);
+
+            const example = new TuiDocumentationPagePO(page).getExample('#basic');
+            const tooltip = example.locator('[tuiTooltip]').first();
+            const hint = page.locator('tui-hint');
+
+            await example.scrollIntoViewIfNeeded();
+            await tooltip.click();
+            await expect(hint).toBeAttached();
+
+            await page.locator('body').dispatchEvent('pointerdown');
+            await expect(hint).not.toBeAttached();
+
+            await tooltip.click();
+            await expect(hint).toBeAttached();
         });
     });
 

--- a/projects/kit/directives/tooltip/tooltip.directive.ts
+++ b/projects/kit/directives/tooltip/tooltip.directive.ts
@@ -77,7 +77,6 @@ class Styles {}
 export class TuiTooltip implements DoCheck {
     private readonly textfield = inject(TuiTextfieldComponent, {optional: true});
     private readonly isMobile = inject(WA_IS_MOBILE);
-    private readonly driver = inject(TuiHintHover);
 
     protected readonly describe = inject(TuiHintDescribe);
     protected readonly nothing = tuiWithStyles(Styles);
@@ -106,6 +105,5 @@ export class TuiTooltip implements DoCheck {
         }
 
         event.stopPropagation();
-        this.driver.toggle();
     }
 }


### PR DESCRIPTION
Fixes #12378
