### PR TITLE
chore(demo): `FloatingContainer` add compact trailing-action example

### DIFF
--- a/projects/demo/src/pages/components/floating-container/examples/7/index.html
+++ b/projects/demo/src/pages/components/floating-container/examples/7/index.html
@@ -1,4 +1,13 @@
 <div class="content">
+    <tui-textfield class="field">
+        <label tuiLabel>Name</label>
+        <input
+            placeholder="Tap to open the keyboard"
+            tuiInput
+            [(ngModel)]="value"
+        />
+    </tui-textfield>
+
     @for (_ of '-'.repeat(30); track $index) {
         <div tuiCell>
             <div
@@ -12,14 +21,12 @@
         </div>
     }
 
-    <footer
-        tuiFloatingContainer="transparent"
-        class="bar"
-    >
+    <footer tuiFloatingContainer="transparent">
         <button
             size="m"
             tuiButton
             type="button"
+            class="action"
         >
             Next
         </button>

--- a/projects/demo/src/pages/components/floating-container/examples/7/index.html
+++ b/projects/demo/src/pages/components/floating-container/examples/7/index.html
@@ -1,0 +1,27 @@
+<div class="content">
+    @for (_ of '-'.repeat(30); track $index) {
+        <div tuiCell>
+            <div
+                appearance="primary"
+                tuiAvatar="@tui.star"
+            ></div>
+            <div tuiTitle>
+                Title
+                <div tuiSubtitle>Description</div>
+            </div>
+        </div>
+    }
+
+    <footer
+        tuiFloatingContainer="transparent"
+        class="bar"
+    >
+        <button
+            size="m"
+            tuiButton
+            type="button"
+        >
+            Next
+        </button>
+    </footer>
+</div>

--- a/projects/demo/src/pages/components/floating-container/examples/7/index.less
+++ b/projects/demo/src/pages/components/floating-container/examples/7/index.less
@@ -8,11 +8,12 @@
     background: var(--tui-background-elevation-1);
 }
 
-.bar {
-    margin-inline: 1rem;
+.field {
+    margin: 1rem 1rem 0;
+}
 
+.action {
     // shrink the single action to its content and pin it to the trailing edge
-    button {
-        justify-self: end;
-    }
+    justify-self: end;
+    margin-inline: 1rem;
 }

--- a/projects/demo/src/pages/components/floating-container/examples/7/index.less
+++ b/projects/demo/src/pages/components/floating-container/examples/7/index.less
@@ -1,0 +1,18 @@
+.content {
+    position: relative;
+    display: block;
+    inline-size: 18rem;
+    block-size: 30rem;
+    overflow: auto;
+    box-shadow: 0 0.25rem 1.25rem rgba(0, 0, 0, 0.1);
+    background: var(--tui-background-elevation-1);
+}
+
+.bar {
+    margin-inline: 1rem;
+
+    // shrink the single action to its content and pin it to the trailing edge
+    button {
+        justify-self: end;
+    }
+}

--- a/projects/demo/src/pages/components/floating-container/examples/7/index.ts
+++ b/projects/demo/src/pages/components/floating-container/examples/7/index.ts
@@ -1,15 +1,26 @@
 import {Component} from '@angular/core';
+import {FormsModule} from '@angular/forms';
 import {changeDetection} from '@demo/emulate/change-detection';
 import {encapsulation} from '@demo/emulate/encapsulation';
-import {TuiButton, TuiCell, TuiTitle} from '@taiga-ui/core';
+import {TuiButton, TuiCell, TuiInput, TuiTitle} from '@taiga-ui/core';
 import {TuiAvatar} from '@taiga-ui/kit';
 import {TuiFloatingContainer} from '@taiga-ui/layout';
 
 @Component({
-    imports: [TuiAvatar, TuiButton, TuiCell, TuiFloatingContainer, TuiTitle],
+    imports: [
+        FormsModule,
+        TuiAvatar,
+        TuiButton,
+        TuiCell,
+        TuiFloatingContainer,
+        TuiInput,
+        TuiTitle,
+    ],
     templateUrl: './index.html',
     styleUrl: './index.less',
     encapsulation,
     changeDetection,
 })
-export default class Example {}
+export default class Example {
+    protected value = '';
+}

--- a/projects/demo/src/pages/components/floating-container/examples/7/index.ts
+++ b/projects/demo/src/pages/components/floating-container/examples/7/index.ts
@@ -1,0 +1,15 @@
+import {Component} from '@angular/core';
+import {changeDetection} from '@demo/emulate/change-detection';
+import {encapsulation} from '@demo/emulate/encapsulation';
+import {TuiButton, TuiCell, TuiTitle} from '@taiga-ui/core';
+import {TuiAvatar} from '@taiga-ui/kit';
+import {TuiFloatingContainer} from '@taiga-ui/layout';
+
+@Component({
+    imports: [TuiAvatar, TuiButton, TuiCell, TuiFloatingContainer, TuiTitle],
+    templateUrl: './index.html',
+    styleUrl: './index.less',
+    encapsulation,
+    changeDetection,
+})
+export default class Example {}

--- a/projects/demo/src/pages/components/floating-container/index.html
+++ b/projects/demo/src/pages/components/floating-container/index.html
@@ -51,6 +51,11 @@
                         </a>
                         to crossfade a button.
                     }
+                    @case (6) {
+                        Shrink a single action with
+                        <code>justify-self</code>
+                        to pin it to the trailing edge.
+                    }
                 }
             </ng-template>
         }

--- a/projects/demo/src/pages/components/floating-container/index.ts
+++ b/projects/demo/src/pages/components/floating-container/index.ts
@@ -36,6 +36,7 @@ export default class Example {
         'Content',
         'Overlay',
         'Crossfade',
+        'Compact',
     ];
 
     protected readonly colors = [


### PR DESCRIPTION
## Description

Adds a **Compact** example to the `FloatingContainer` showcase, demonstrating a single action shrunk to its content and pinned to the trailing edge — instead of the default full-width, centered button (think of an iOS-style "Next" keyboard accessory).

By default `[tuiFloatingContainer]` lays its children out in a single-column grid with `justify-items: stretch`, so a button fills the whole width. Overriding `justify-self: end` on the button lets it size to its content and align to the trailing edge:

```html
<footer tuiFloatingContainer="transparent" class="bar">
    <button size="m" tuiButton type="button">Next</button>
</footer>
```

```less
.bar button {
    justify-self: end;
}
```

## Notes

- Pure demo change: new `examples/7/` component + registration on the page (`examples` array and a matching `@case` description). No library code touched.
- Lint clean: ESLint (TS + templates), stylelint, prettier.
- Draft: opened for review of the approach; a rendered screenshot can be added once the demo is served.