### PR TITLE
fix(core): `DropdownContext` fix click on host element (#11400)

### DIFF
--- a/projects/core/portals/dropdown/dropdown-context.directive.ts
+++ b/projects/core/portals/dropdown/dropdown-context.directive.ts
@@ -5,7 +5,11 @@ import {WA_IS_TOUCH} from '@ng-web-apis/platform';
 import {EMPTY_CLIENT_RECT} from '@taiga-ui/cdk/constants';
 import {TuiActiveZone} from '@taiga-ui/cdk/directives/active-zone';
 import {tuiTypedFromEvent, tuiZoneOptimized} from '@taiga-ui/cdk/observables';
-import {tuiGetActualTarget, tuiPointToClientRect} from '@taiga-ui/cdk/utils/dom';
+import {
+    tuiGetActualTarget,
+    tuiInjectElement,
+    tuiPointToClientRect,
+} from '@taiga-ui/cdk/utils/dom';
 import {tuiAsDriver, tuiAsRectAccessor, TuiRectAccessor} from '@taiga-ui/core/classes';
 import {filter, merge} from 'rxjs';
 
@@ -34,6 +38,7 @@ export class TuiDropdownContext extends TuiRectAccessor {
     protected readonly activeZone = inject(TuiActiveZone);
     protected readonly driver = inject(TuiDropdownDriver);
     protected readonly doc = inject(DOCUMENT);
+    protected readonly el = tuiInjectElement();
 
     protected readonly sub = merge(
         tuiTypedFromEvent(this.doc, 'pointerdown'),
@@ -41,11 +46,15 @@ export class TuiDropdownContext extends TuiRectAccessor {
         tuiTypedFromEvent(this.doc, 'contextmenu', {capture: true}),
     )
         .pipe(
-            filter(
-                (event) =>
-                    this.driver.value &&
-                    !this.activeZone.contains(tuiGetActualTarget(event)),
-            ),
+            filter((event) => {
+                const target = event ? tuiGetActualTarget(event) : null;
+
+                return (
+                    !target ||
+                    (this.driver.value &&
+                        (!this.activeZone.contains(target) || this.el.contains(target)))
+                );
+            }),
             tuiZoneOptimized(),
             takeUntilDestroyed(),
         )

--- a/projects/demo-playwright/tests/kit/dropdown-context/dropdown-context.pw.spec.ts
+++ b/projects/demo-playwright/tests/kit/dropdown-context/dropdown-context.pw.spec.ts
@@ -52,4 +52,23 @@ test.describe('DropdownContext', () => {
 
         await expect.soft(example).toHaveScreenshot('05-dropdown-context.png');
     });
+
+    test('closes dropdown when clicking on host element', async ({page}) => {
+        const api = new TuiDocumentationPagePO(page);
+        const example = api.getExample('#context-menu');
+        const tr = example.locator('tr');
+
+        await example.scrollIntoViewIfNeeded();
+        await tr.nth(1).click({button: 'right', position: {x: 1, y: 1}});
+        await expect(page.locator('tui-dropdown')).toBeAttached();
+        await api.waitStableState();
+
+        await expect.soft(example).toHaveScreenshot('06-dropdown-context.png');
+
+        await tr.nth(1).click({position: {x: 1, y: 1}});
+        await expect(page.locator('tui-dropdown')).toBeHidden();
+        await api.waitStableState();
+
+        await expect.soft(example).toHaveScreenshot('07-dropdown-context.png');
+    });
 });


### PR DESCRIPTION
Fixes #11400 
<img width="1056" height="645" alt="image" src="https://github.com/user-attachments/assets/37848eae-f631-4a68-9fed-528c5e64ec8c" />

# Fix: TuiDropdownContext closes on host element click

## Problem

When using `TuiDropdownContext` directive (context menu triggered by right-click), the dropdown did not close when clicking on the host element itself (e.g., the table row with the directive).

**Behavior before fix:**
- ✅ Click outside the host — dropdown closes
- ✅ Click inside the dropdown menu — dropdown stays open (correct)
- ❌ Click on the host element — dropdown **does not close** (bug)

## Solution

Added an additional check to close the dropdown when the click occurs within the host element bounds.

The fix extends the existing close condition with an `OR` clause:
- Close if click is **outside the active zone** (existing behavior)
- **OR** if click is **inside the host element** (new behavior)

## Result

**Behavior after fix:**
- ✅ Click outside the host — dropdown closes
- ✅ Click inside the dropdown menu — dropdown stays open
- ✅ Click on the host element — dropdown closes (fixed)
- ✅ Click on nested dropdown — dropdown stays open

## Breaking Changes

None. This is a backward-compatible bug fix that only adds the missing close behavior without changing any existing functionality.

