### PR TITLE
ci: fail CI `Build / demo` job on unknown prerender errors

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: taiga-family/actions/setup-variables@0940659c204565776517de7e9cafaf017f66ee81 # v2.9.0
       - uses: taiga-family/actions/setup-node@0940659c204565776517de7e9cafaf017f66ee81 # v2.9.0
-      - run: npx nx build demo
+      - run: npx nx build demo --define.strict=true
       - run: npx --yes bundlemon --config .github/.bundlemonrc.json
         continue-on-error: true
         env:

--- a/projects/core/components/scrollbar/scroll-controls.component.ts
+++ b/projects/core/components/scrollbar/scroll-controls.component.ts
@@ -24,6 +24,11 @@ export class TuiScrollControls implements OnInit {
     protected readonly refresh$ = inject(TuiScrollControlsService);
 
     public ngOnInit(): void {
-        this.scrollable?.getElementRef().nativeElement.prepend(this.el);
+        this.scrollable
+            ?.getElementRef()
+            .nativeElement.insertBefore(
+                this.el,
+                this.scrollable.getElementRef().nativeElement.firstChild,
+            );
     }
 }

--- a/projects/demo/project.json
+++ b/projects/demo/project.json
@@ -101,6 +101,9 @@
                 ],
                 "baseHref": "/",
                 "browser": "{projectRoot}/src/main.ts",
+                "define": {
+                    "strict": "false"
+                },
                 "externalDependencies": ["ng-morph"],
                 "index": "{projectRoot}/src/index.html",
                 "inlineStyleLanguage": "less",

--- a/projects/demo/src/pages/app/server-error-handler.ts
+++ b/projects/demo/src/pages/app/server-error-handler.ts
@@ -37,10 +37,7 @@ export class ServerErrorHandler implements ErrorHandler {
         errorLog(this.location.path());
         console.error(errorMessage);
 
-        if (
-            // Default environment variables for GitHub CI
-            process.env.CI // https://docs.github.com/en/actions/reference/workflows-and-actions/variables#default-environment-variables
-        ) {
+        if (strict) {
             process.exit(1);
         }
     }

--- a/projects/demo/src/typings.d.ts
+++ b/projects/demo/src/typings.d.ts
@@ -1,5 +1,7 @@
 declare module 'highlight*';
 
+declare const strict: boolean;
+
 /* SystemJS module definition */
 declare var module: NodeModule;
 


### PR DESCRIPTION
### Previous behavior

https://github.com/taiga-family/taiga-ui/pull/14554/changes#r3719530222

Job logs contains
```
/components/line-clamp
this.scrollable?.getElementRef(...).nativeElement.prepend is not a function
emitEvent false
/components/scrollbar
this.scrollable?.getElementRef(...).nativeElement.prepend is not a function
this.scrollable?.getElementRef(...).nativeElement.prepend is not a function
/components/scrollbar/API
/components/table
this.scrollable?.getElementRef(...).nativeElement.prepend is not a function
```

but job passes successfully.

### New behavior
Fails job on any new unknown errors (again!)