### PR TITLE
fix(layout): support block content in `tuiList` items

### DIFF
--- a/projects/demo-cypress/cypress.config.ts
+++ b/projects/demo-cypress/cypress.config.ts
@@ -79,6 +79,7 @@ export default defineConfig({
                             'projects/styles/components/compass.less',
                             'projects/styles/components/like.less',
                             'projects/layout/components/card/large.style.less',
+                            'projects/layout/components/list/list.style.less',
                             'projects/styles/components/message.less',
                             'projects/styles/components/pin.less',
                             'projects/styles/components/progress-bar.less',

--- a/projects/demo-cypress/src/tests/list.cy.ts
+++ b/projects/demo-cypress/src/tests/list.cy.ts
@@ -1,0 +1,64 @@
+import {ChangeDetectionStrategy, Component} from '@angular/core';
+import {TuiRoot} from '@taiga-ui/core';
+import {TuiList} from '@taiga-ui/layout';
+
+@Component({
+    imports: [TuiList, TuiRoot],
+    template: `
+        <tui-root>
+            <section style="inline-size: 18rem; padding: 1rem">
+                <ul
+                    style="--tui-list-marker: #70b6f6"
+                    tuiList
+                >
+                    <li>List item</li>
+                    <li>Another list item</li>
+                    <li>
+                        <div>Block title</div>
+                        <div>Block subtitle</div>
+                    </li>
+                    <li>
+                        <p>
+                            This item uses
+                            <strong>nested tags</strong>
+                            inside which should not break
+                        </p>
+                        <p>Subtitle</p>
+                    </li>
+                </ul>
+
+                <ol tuiList>
+                    <!-- prettier-ignore -->
+                    <li>First level
+                        <ol tuiList>
+                            <li>Second level</li>
+                            <li><span>Second level</span>
+                                <ol tuiList>
+                                    <li>Third level</li>
+                                </ol>
+                            </li>
+                        </ol>
+                    </li>
+                    <li>
+                        <p>Numbered title</p>
+                        <p>Numbered subtitle</p>
+                    </li>
+                    <li>List item</li>
+                </ol>
+            </section>
+        </tui-root>
+    `,
+    changeDetection: ChangeDetectionStrategy.OnPush,
+})
+class TestList {}
+
+describe('List', () => {
+    it('supports block content without changing nested list spacing', () => {
+        cy.mount(TestList);
+
+        cy.get('section').compareSnapshot('list-with-block-content');
+        cy.get('section')
+            .invoke('attr', 'dir', 'rtl')
+            .compareSnapshot('list-with-block-content-rtl');
+    });
+});

--- a/projects/demo-cypress/src/tests/list.cy.ts
+++ b/projects/demo-cypress/src/tests/list.cy.ts
@@ -12,7 +12,10 @@ import {TuiList} from '@taiga-ui/layout';
                     tuiList
                 >
                     <li>List item</li>
-                    <li>Another list item</li>
+                    <li>
+                        This inline list item is long enough to wrap onto multiple lines
+                        without losing alignment
+                    </li>
                     <li>
                         <div>Block title</div>
                         <div>Block subtitle</div>
@@ -31,10 +34,18 @@ import {TuiList} from '@taiga-ui/layout';
                     <!-- prettier-ignore -->
                     <li>First level
                         <ol tuiList>
-                            <li>Second level</li>
+                            <li>
+                                Second level with inline text long enough to wrap onto
+                                multiple lines
+                            </li>
                             <li><span>Second level</span>
                                 <ol tuiList>
-                                    <li>Third level</li>
+                                    <li>
+                                        Third level
+                                        <ol tuiList>
+                                            <li>Fourth level</li>
+                                        </ol>
+                                    </li>
                                 </ol>
                             </li>
                         </ol>
@@ -53,12 +64,12 @@ import {TuiList} from '@taiga-ui/layout';
 class TestList {}
 
 describe('List', () => {
-    it('supports block content without changing nested list spacing', () => {
+    it('aligns inline and block content at every nesting level', () => {
         cy.mount(TestList);
 
-        cy.get('section').compareSnapshot('list-with-block-content');
+        cy.get('section').compareSnapshot('list-nested-content-alignment');
         cy.get('section')
             .invoke('attr', 'dir', 'rtl')
-            .compareSnapshot('list-with-block-content-rtl');
+            .compareSnapshot('list-nested-content-alignment-rtl');
     });
 });

--- a/projects/demo/src/pages/components/list/examples/4/index.html
+++ b/projects/demo/src/pages/components/list/examples/4/index.html
@@ -1,8 +1,13 @@
 <ul tuiList>
     <li>If a list item is long, the bullet stays aligned to the top.</li>
     <li>There are no restrictions on the text length at all. You can write as much text as you want.</li>
-    <!-- prettier-ignore -->
-    <li>This item uses <strong>nested tags</strong> inside which should not break</li>
+    <li>
+        <p [style.margin]="0">
+            This item uses
+            <strong>nested tags</strong>
+            inside which should not break
+        </p>
+    </li>
 </ul>
 
 <ol tuiList>

--- a/projects/demo/src/pages/components/list/examples/4/index.html
+++ b/projects/demo/src/pages/components/list/examples/4/index.html
@@ -2,11 +2,11 @@
     <li>If a list item is long, the bullet stays aligned to the top.</li>
     <li>There are no restrictions on the text length at all. You can write as much text as you want.</li>
     <li>
-        <p [style.margin]="0">
+        <div>
             This item uses
             <strong>nested tags</strong>
             inside which should not break
-        </p>
+        </div>
     </li>
 </ul>
 

--- a/projects/layout/components/list/list.style.less
+++ b/projects/layout/components/list/list.style.less
@@ -10,6 +10,10 @@
         margin-inline-start: 1.25rem;
     }
 
+    ol[tuiList] {
+        margin-inline-start: calc(1.25rem + 1.5ch);
+    }
+
     & > li {
         counter-increment: item;
         margin: 0.5rem 0;
@@ -18,11 +22,17 @@
     & > li::before {
         content: counters(item, '.') '.';
         display: inline-flex;
+        float: left;
         unicode-bidi: plaintext;
         font-variant-numeric: tabular-nums;
         // physical shorthand margins keep the marker on the wrong side in RTL
         margin-block: 0;
         margin-inline: -1.5rem 0.5625rem;
+    }
+
+    [dir='rtl'] & > li::before,
+    &[dir='rtl'] > li::before {
+        float: right;
     }
 
     &:is(ul) > li::before {
@@ -34,6 +44,14 @@
         );
         inline-size: 0.75rem;
         margin-inline-end: 0.75rem;
+    }
+
+    &:is(ol) > li::before {
+        position: relative;
+        inset-inline-end: 0.5625rem;
+        justify-content: flex-end;
+        inline-size: 0;
+        margin-inline: 0;
     }
 
     &[data-size='l'] {
@@ -56,16 +74,6 @@
 
         & > li {
             margin: 0.625rem 0;
-        }
-    }
-
-    & > li:has(> :where(p, div)) {
-        position: relative;
-
-        &::before {
-            position: absolute;
-            inset-block-start: 0;
-            inset-inline-start: 0;
         }
     }
 }

--- a/projects/layout/components/list/list.style.less
+++ b/projects/layout/components/list/list.style.less
@@ -58,4 +58,14 @@
             margin: 0.625rem 0;
         }
     }
+
+    & > li:has(> :where(p, div)) {
+        position: relative;
+
+        &::before {
+            position: absolute;
+            inset-block-start: 0;
+            inset-inline-start: 0;
+        }
+    }
 }

--- a/projects/layout/components/list/list.style.less
+++ b/projects/layout/components/list/list.style.less
@@ -3,15 +3,11 @@
     padding: 0.25rem 0;
     margin-block: 0;
     counter-reset: item;
-    margin-inline-start: 1.5rem;
+    margin-inline-start: 1.625rem;
 
     [tuiList] {
         padding: 0;
-        margin-inline-start: 1.25rem;
-    }
-
-    ol[tuiList] {
-        margin-inline-start: calc(1.25rem + 1.5ch);
+        margin-inline-start: 2.5rem;
     }
 
     & > li {
@@ -48,7 +44,7 @@
 
     &:is(ol) > li::before {
         position: relative;
-        inset-inline-end: 0.5625rem;
+        inset-inline-end: 0.75rem;
         justify-content: flex-end;
         inline-size: 0;
         margin-inline: 0;


### PR DESCRIPTION
## Problem

`tuiList` does not correctly support direct `p` elements inside `li`.

Paragraph margins and whitespace before inline content can affect marker alignment. Positioning all markers outside the content flow also changes the existing spacing of nested ordered lists.
