### PR TITLE
fix(layout): support RTL for `tuiList` items

### DIFF
--- a/projects/layout/components/list/list.style.less
+++ b/projects/layout/components/list/list.style.less
@@ -18,6 +18,8 @@
     & > li::before {
         content: counters(item, '.') '.';
         display: inline-flex;
+        unicode-bidi: plaintext;
+        font-variant-numeric: tabular-nums;
         // physical shorthand margins keep the marker on the wrong side in RTL
         margin-block: 0;
         margin-inline: -1.5rem 0.5625rem;
@@ -32,12 +34,6 @@
         );
         inline-size: 0.75rem;
         margin-inline-end: 0.75rem;
-    }
-
-    &:is(ol) > li::before {
-        content: '\2066' counters(item, '.') '.\2069';
-        unicode-bidi: isolate;
-        font-variant-numeric: tabular-nums;
     }
 
     &[data-size='l'] {

--- a/projects/layout/components/list/list.style.less
+++ b/projects/layout/components/list/list.style.less
@@ -18,7 +18,9 @@
     & > li::before {
         content: counters(item, '.') '.';
         display: inline-flex;
-        margin: 0 0.5625rem 0 -1.5rem;
+        // physical shorthand margins keep the marker on the wrong side in RTL
+        margin-block: 0;
+        margin-inline: -1.5rem 0.5625rem;
     }
 
     &:is(ul) > li::before {
@@ -33,6 +35,7 @@
     }
 
     &:is(ol) > li::before {
+        content: '\2066' counters(item, '.') '.\2069';
         unicode-bidi: isolate;
         font-variant-numeric: tabular-nums;
     }
@@ -42,7 +45,9 @@
 
         &:is(ul) > li::before {
             inline-size: 0.875rem;
-            margin: 0 0.5625rem 0 -1.4375rem;
+            // physical shorthand margins keep the marker on the wrong side in RTL
+            margin-block: 0;
+            margin-inline: -1.4375rem 0.5625rem;
         }
     }
 


### PR DESCRIPTION
### Before

<img width="304" height="769" alt="image" src="https://github.com/user-attachments/assets/6a6b6bfc-d055-4254-be73-649d6cfa14f1" />


### After

<img width="403" height="779" alt="image" src="https://github.com/user-attachments/assets/66dad086-5d3f-4c62-9864-48c62ef0c736" />

