### PR TITLE
chore(schematics): add missing v5 identifier renames (textfield-directive, input-range, input-date-multi, doc-documentation) (#11917)

### DIFF
--- a/projects/cdk/schematics/ng-update/v5/steps/constants/identifiers-to-replace.ts
+++ b/projects/cdk/schematics/ng-update/v5/steps/constants/identifiers-to-replace.ts
@@ -10,6 +10,16 @@ export const IDENTIFIERS_TO_REPLACE: ReplacementIdentifierMulti[] = [
     },
     {
         from: {
+            name: 'TuiDocDocumentation',
+            moduleSpecifier: '@taiga-ui/addon-doc',
+        },
+        to: {
+            name: 'TuiDocAPI',
+            moduleSpecifier: '@taiga-ui/addon-doc',
+        },
+    },
+    {
+        from: {
             name: 'TuiInputSliderModule',
             moduleSpecifier: '@taiga-ui/legacy',
         },

--- a/projects/cdk/schematics/ng-update/v5/steps/constants/identifiers-to-replace.ts
+++ b/projects/cdk/schematics/ng-update/v5/steps/constants/identifiers-to-replace.ts
@@ -20,6 +20,26 @@ export const IDENTIFIERS_TO_REPLACE: ReplacementIdentifierMulti[] = [
     },
     {
         from: {
+            name: 'TuiInputRangeModule',
+            moduleSpecifier: '@taiga-ui/legacy',
+        },
+        to: {
+            name: 'TuiInputRange',
+            moduleSpecifier: '@taiga-ui/kit',
+        },
+    },
+    {
+        from: {
+            name: 'TuiInputDateMultiModule',
+            moduleSpecifier: '@taiga-ui/legacy',
+        },
+        to: {
+            name: 'TuiInputDateMulti',
+            moduleSpecifier: '@taiga-ui/kit',
+        },
+    },
+    {
+        from: {
             name: 'TuiInputMonthRangeModule',
             moduleSpecifier: '@taiga-ui/legacy',
         },

--- a/projects/cdk/schematics/ng-update/v5/steps/constants/identifiers-to-replace.ts
+++ b/projects/cdk/schematics/ng-update/v5/steps/constants/identifiers-to-replace.ts
@@ -617,6 +617,16 @@ export const IDENTIFIERS_TO_REPLACE: ReplacementIdentifierMulti[] = [
     },
     {
         from: {
+            name: 'TuiTextfieldDirective',
+            moduleSpecifier: '@taiga-ui/core',
+        },
+        to: {
+            name: 'TuiInputDirective',
+            moduleSpecifier: '@taiga-ui/core',
+        },
+    },
+    {
+        from: {
             name: 'TuiSlider',
             moduleSpecifier: '@taiga-ui/kit',
         },

--- a/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-doc-documentation.spec.ts.snap
+++ b/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-doc-documentation.spec.ts.snap
@@ -167,6 +167,28 @@ exports[`ng-update tui-doc-documentation to table[tuiDocAPI] renames [documentat
 }
 `;
 
+exports[`ng-update tui-doc-documentation to table[tuiDocAPI] renames TuiDocDocumentation import to TuiDocAPI: test.ts 1`] = `
+{
+  "0. Before": "
+                import {TuiDocDocumentation} from '@taiga-ui/addon-doc';
+
+                @Component({
+                    standalone: true,
+                    imports: [TuiDocDocumentation],
+                })
+                export class TestComponent {}
+            ",
+  "1. After": "import { TuiDocAPI } from "@taiga-ui/addon-doc";
+
+                                @Component({
+                    standalone: true,
+                    imports: [TuiDocAPI],
+                })
+                export class TestComponent {}
+            ",
+}
+`;
+
 exports[`ng-update tui-doc-documentation to table[tuiDocAPI] renames one-way [documentationPropertyValue] + (documentationPropertyValueChange) to [value] + (valueChange): test.html 1`] = `
 {
   "0. Before": "

--- a/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-input-date-multi.spec.ts.snap
+++ b/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-input-date-multi.spec.ts.snap
@@ -305,6 +305,28 @@ exports[`ng-update removes [tuiTextfieldLabelOutside] from tui-input-date (multi
 }
 `;
 
+exports[`ng-update renames TuiInputDateMultiModule import to TuiInputDateMulti: test.ts 1`] = `
+{
+  "0. Before": "
+                import {TuiInputDateMultiModule} from '@taiga-ui/legacy';
+
+                @Component({
+                    standalone: true,
+                    imports: [TuiInputDateMultiModule],
+                })
+                export class TestComponent {}
+            ",
+  "1. After": "import { TuiInputDateMulti } from "@taiga-ui/kit";
+
+                                @Component({
+                    standalone: true,
+                    imports: [TuiInputDateMulti],
+                })
+                export class TestComponent {}
+            ",
+}
+`;
+
 exports[`ng-update silently removes [editable] and [inputHidden]: test.html 1`] = `
 {
   "0. Before": "

--- a/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-input-range.spec.ts.snap
+++ b/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-input-range.spec.ts.snap
@@ -49,3 +49,25 @@ exports[`ng-update input-range removes label[tuiLabel] inside tui-input-range: t
             ",
 }
 `;
+
+exports[`ng-update input-range renames TuiInputRangeModule import to TuiInputRange: test.ts 1`] = `
+{
+  "0. Before": "
+                import {TuiInputRangeModule} from '@taiga-ui/legacy';
+
+                @Component({
+                    standalone: true,
+                    imports: [TuiInputRangeModule],
+                })
+                export class TestComponent {}
+            ",
+  "1. After": "import { TuiInputRange } from "@taiga-ui/kit";
+
+                                @Component({
+                    standalone: true,
+                    imports: [TuiInputRange],
+                })
+                export class TestComponent {}
+            ",
+}
+`;

--- a/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-textfield-to-input.spec.ts.snap
+++ b/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-textfield-to-input.spec.ts.snap
@@ -22,6 +22,28 @@ exports[`ng-update TuiTextfield to TuiInput identifier migration should rename T
 }
 `;
 
+exports[`ng-update TuiTextfield to TuiInput identifier migration should rename TuiTextfieldDirective to TuiInputDirective in imports and usages: test.ts 1`] = `
+{
+  "0. Before": "
+                    import {TuiTextfieldDirective} from '@taiga-ui/core';
+
+                    @Component({standalone: true})
+                    export class TestComponent {
+                        @ViewChild(TuiTextfieldDirective, {read: ElementRef})
+                        protected readonly field!: ElementRef;
+                    }
+                ",
+  "1. After": "import { TuiInputDirective } from "@taiga-ui/core";
+
+                                        @Component({standalone: true})
+                    export class TestComponent {
+                        @ViewChild(TuiInputDirective, {read: ElementRef})
+                        protected readonly field!: ElementRef;
+                    }
+                ",
+}
+`;
+
 exports[`ng-update TuiTextfield to TuiInput template migration should rename native select tuiTextfield to tuiSelect (not tuiInput): test.html 1`] = `
 {
   "0. Before": "<select tuiTextfield></select>",

--- a/projects/cdk/schematics/ng-update/v5/tests/schematic-migrate-doc-documentation.spec.ts
+++ b/projects/cdk/schematics/ng-update/v5/tests/schematic-migrate-doc-documentation.spec.ts
@@ -222,5 +222,20 @@ describe('ng-update tui-doc-documentation to table[tuiDocAPI]', () => {
         }),
     );
 
+    it(
+        'renames TuiDocDocumentation import to TuiDocAPI',
+        migrate({
+            component: /* TypeScript */ `
+                import {TuiDocDocumentation} from '@taiga-ui/addon-doc';
+
+                @Component({
+                    standalone: true,
+                    imports: [TuiDocDocumentation],
+                })
+                export class TestComponent {}
+            `,
+        }),
+    );
+
     afterEach(() => resetActiveProject());
 });

--- a/projects/cdk/schematics/ng-update/v5/tests/schematic-migrate-input-date-multi.spec.ts
+++ b/projects/cdk/schematics/ng-update/v5/tests/schematic-migrate-input-date-multi.spec.ts
@@ -178,5 +178,20 @@ describe('ng-update', () => {
         }),
     );
 
+    it(
+        'renames TuiInputDateMultiModule import to TuiInputDateMulti',
+        migrate({
+            component: /* TypeScript */ `
+                import {TuiInputDateMultiModule} from '@taiga-ui/legacy';
+
+                @Component({
+                    standalone: true,
+                    imports: [TuiInputDateMultiModule],
+                })
+                export class TestComponent {}
+            `,
+        }),
+    );
+
     afterEach(() => resetActiveProject());
 });

--- a/projects/cdk/schematics/ng-update/v5/tests/schematic-migrate-input-range.spec.ts
+++ b/projects/cdk/schematics/ng-update/v5/tests/schematic-migrate-input-range.spec.ts
@@ -50,5 +50,20 @@ describe('ng-update input-range', () => {
         }),
     );
 
+    it(
+        'renames TuiInputRangeModule import to TuiInputRange',
+        migrate({
+            component: /* TypeScript */ `
+                import {TuiInputRangeModule} from '@taiga-ui/legacy';
+
+                @Component({
+                    standalone: true,
+                    imports: [TuiInputRangeModule],
+                })
+                export class TestComponent {}
+            `,
+        }),
+    );
+
     afterEach(() => resetActiveProject());
 });

--- a/projects/cdk/schematics/ng-update/v5/tests/schematic-migrate-textfield-to-input.spec.ts
+++ b/projects/cdk/schematics/ng-update/v5/tests/schematic-migrate-textfield-to-input.spec.ts
@@ -41,6 +41,21 @@ describe('ng-update TuiTextfield to TuiInput', () => {
                 `,
             }),
         );
+
+        it(
+            'should rename TuiTextfieldDirective to TuiInputDirective in imports and usages',
+            migrate({
+                component: /* TypeScript */ `
+                    import {TuiTextfieldDirective} from '@taiga-ui/core';
+
+                    @Component({standalone: true})
+                    export class TestComponent {
+                        @ViewChild(TuiTextfieldDirective, {read: ElementRef})
+                        protected readonly field!: ElementRef;
+                    }
+                `,
+            }),
+        );
     });
 
     afterEach(() => resetActiveProject());


### PR DESCRIPTION
## Why

Several removed v4 symbols had a v5 successor of the **same kind that is API-compatible**, but no `ng update` identifier rename existed for them. This adds those missing 1:1 renames so `ng update` rewrites the import + usage automatically. Part of #11917.

## What — `ng-update/v5/steps/constants/identifiers-to-replace.ts`

| from | → to | package move | kind |
| --- | --- | --- | --- |
| `TuiTextfieldDirective` | `TuiInputDirective` | `@taiga-ui/core` (same) | directive class `<T>` |
| `TuiInputRangeModule` | `TuiInputRange` | `@taiga-ui/legacy` → `@taiga-ui/kit` | module → standalone component |
| `TuiInputDateMultiModule` | `TuiInputDateMulti` | `@taiga-ui/legacy` → `@taiga-ui/kit` | module → standalone array |
| `TuiDocDocumentation` | `TuiDocAPI` | `@taiga-ui/addon-doc` (same) | component |

## Why each is a safe 1:1 rename

- **`TuiTextfieldDirective` → `TuiInputDirective`**: both directive classes implementing `TuiTextfieldAccessor<T>` with the same generic; the demo's `@ViewChild(TuiTextfieldDirective, {read: ElementRef})` maps directly.
- **`TuiInputRangeModule` → `TuiInputRange`** and **`TuiInputDateMultiModule` → `TuiInputDateMulti`**: identical shape to the maintainer-owned `TuiInput*Module@legacy → TuiInput*@kit` renames already in the file (`TuiInputSlider`, `TuiInputMonthRange`, `TuiInputDate`, …). `tui-input-range` keeps the **same selector** in v5; `TuiInputDateMulti`'s template is already handled by the existing `migrate-input-date-multi.ts` — this fills the missing import half.
- **`TuiDocDocumentation` → `TuiDocAPI`**: pairs with the existing `<tui-doc-documentation>` → `<table tuiDocAPI>` template migration. `TuiDocAPI` is public on `main` via `export * from '@taiga-ui/addon-doc/components'`.

All four `from` identifiers are absent from `main`'s successors and from `ng-update/v5`; all four `to` successors exist and are publicly importable on `main`.

## Tests

One rename case added per affected spec (`textfield-to-input`, `input-range`, `input-date-multi`, `doc-documentation`); assertions via `migrate()` snapshots only. Full `ng-update/v5` suite green (132 suites / 768 tests).
