### PR TITLE
chore(schematics): migrate removed TuiInputRangeModule/TuiInputDateMultiModule to kit in v5 (#11917)

### DIFF
--- a/projects/cdk/schematics/ng-update/v5/steps/constants/identifiers-to-replace.ts
+++ b/projects/cdk/schematics/ng-update/v5/steps/constants/identifiers-to-replace.ts
@@ -20,6 +20,26 @@ export const IDENTIFIERS_TO_REPLACE: ReplacementIdentifierMulti[] = [
     },
     {
         from: {
+            name: 'TuiInputRangeModule',
+            moduleSpecifier: '@taiga-ui/legacy',
+        },
+        to: {
+            name: 'TuiInputRange',
+            moduleSpecifier: '@taiga-ui/kit',
+        },
+    },
+    {
+        from: {
+            name: 'TuiInputDateMultiModule',
+            moduleSpecifier: '@taiga-ui/legacy',
+        },
+        to: {
+            name: 'TuiInputDateMulti',
+            moduleSpecifier: '@taiga-ui/kit',
+        },
+    },
+    {
+        from: {
             name: 'TuiInputMonthRangeModule',
             moduleSpecifier: '@taiga-ui/legacy',
         },

--- a/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-input-date-multi.spec.ts.snap
+++ b/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-input-date-multi.spec.ts.snap
@@ -305,6 +305,28 @@ exports[`ng-update removes [tuiTextfieldLabelOutside] from tui-input-date (multi
 }
 `;
 
+exports[`ng-update renames TuiInputDateMultiModule import to TuiInputDateMulti: test.ts 1`] = `
+{
+  "0. Before": "
+                import {TuiInputDateMultiModule} from '@taiga-ui/legacy';
+
+                @Component({
+                    standalone: true,
+                    imports: [TuiInputDateMultiModule],
+                })
+                export class TestComponent {}
+            ",
+  "1. After": "import { TuiInputDateMulti } from "@taiga-ui/kit";
+
+                                @Component({
+                    standalone: true,
+                    imports: [TuiInputDateMulti],
+                })
+                export class TestComponent {}
+            ",
+}
+`;
+
 exports[`ng-update silently removes [editable] and [inputHidden]: test.html 1`] = `
 {
   "0. Before": "

--- a/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-input-range.spec.ts.snap
+++ b/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-input-range.spec.ts.snap
@@ -49,3 +49,25 @@ exports[`ng-update input-range removes label[tuiLabel] inside tui-input-range: t
             ",
 }
 `;
+
+exports[`ng-update input-range renames TuiInputRangeModule import to TuiInputRange: test.ts 1`] = `
+{
+  "0. Before": "
+                import {TuiInputRangeModule} from '@taiga-ui/legacy';
+
+                @Component({
+                    standalone: true,
+                    imports: [TuiInputRangeModule],
+                })
+                export class TestComponent {}
+            ",
+  "1. After": "import { TuiInputRange } from "@taiga-ui/kit";
+
+                                @Component({
+                    standalone: true,
+                    imports: [TuiInputRange],
+                })
+                export class TestComponent {}
+            ",
+}
+`;

--- a/projects/cdk/schematics/ng-update/v5/tests/schematic-migrate-input-date-multi.spec.ts
+++ b/projects/cdk/schematics/ng-update/v5/tests/schematic-migrate-input-date-multi.spec.ts
@@ -178,5 +178,20 @@ describe('ng-update', () => {
         }),
     );
 
+    it(
+        'renames TuiInputDateMultiModule import to TuiInputDateMulti',
+        migrate({
+            component: /* TypeScript */ `
+                import {TuiInputDateMultiModule} from '@taiga-ui/legacy';
+
+                @Component({
+                    standalone: true,
+                    imports: [TuiInputDateMultiModule],
+                })
+                export class TestComponent {}
+            `,
+        }),
+    );
+
     afterEach(() => resetActiveProject());
 });

--- a/projects/cdk/schematics/ng-update/v5/tests/schematic-migrate-input-range.spec.ts
+++ b/projects/cdk/schematics/ng-update/v5/tests/schematic-migrate-input-range.spec.ts
@@ -50,5 +50,20 @@ describe('ng-update input-range', () => {
         }),
     );
 
+    it(
+        'renames TuiInputRangeModule import to TuiInputRange',
+        migrate({
+            component: /* TypeScript */ `
+                import {TuiInputRangeModule} from '@taiga-ui/legacy';
+
+                @Component({
+                    standalone: true,
+                    imports: [TuiInputRangeModule],
+                })
+                export class TestComponent {}
+            `,
+        }),
+    );
+
     afterEach(() => resetActiveProject());
 });


### PR DESCRIPTION
## Why

Two v4 `@taiga-ui/legacy` input modules had **no `ng update` identifier rename** to their v5 `@taiga-ui/kit` standalone successors, even though the sibling inputs already do (`TuiInputSliderModule`, `TuiInputMonthRangeModule`, `TuiInputDateModule`, `TuiInputDateTimeModule`, `TuiInputDateRangeModule`, `TuiInputPhoneModule`, `TuiInputNumberModule`, `TuiInputTagModule` …). This closes that gap. Part of #11917.

## What

Two entries in `ng-update/v5/steps/constants/identifiers-to-replace.ts`:

| from (`@taiga-ui/legacy`) | → to (`@taiga-ui/kit`) |
| --- | --- |
| `TuiInputRangeModule` | `TuiInputRange` |
| `TuiInputDateMultiModule` | `TuiInputDateMulti` |

Import + `imports: [...]` usage are rewritten (see snapshots).

## Why a plain rename is correct here

- **Established convention**: identical shape to the maintainer-owned `TuiInput*Module@legacy → TuiInput*@kit` renames already in the file.
- **Successors exist & are public on `main`**: `TuiInputRange` (`export class`, selector `tui-input-range` — **same tag as v4**, so templates keep working) and `TuiInputDateMulti` (`export const [...]` standalone array), both importable from `@taiga-ui/kit`.
- **Complements existing template migrations**: `migrate-input-date-multi.ts` already rewrites the `<tui-input-date multiple>` template but the import rename was missing — this fills exactly that half. `input-range` keeps its selector, so the import rename is all that's needed.
- **Not already covered**: neither `from` identifier appears anywhere in `ng-update/v5` on `main`.

## Tests

Added a rename case to each existing spec (`schematic-migrate-input-range`, `schematic-migrate-input-date-multi`); assertions via `migrate()` snapshots only. Full `ng-update/v5` suite green (132 suites / 766 tests).
