### PR TITLE
fix(schematics): avoid forgotten-node crash in v5 TuiBreakpointService migration

### DIFF
--- a/projects/cdk/schematics/ng-update/v5/steps/migrate-breakpoint-service.ts
+++ b/projects/cdk/schematics/ng-update/v5/steps/migrate-breakpoint-service.ts
@@ -121,7 +121,17 @@ function addTodoForUnsupportedUsages(sourceFile: SourceFile): void {
                         ref.getSourceFile().getFilePath() === sourceFile.getFilePath() &&
                         !Node.isImportSpecifier(ref.getParent()),
                 )
-                .forEach((ref) => linePositions.add(ref.getStartLinePos()));
+                .forEach((ref) => {
+                    // A single constructor parameter can reference the service twice
+                    // (e.g. `@Inject(X)` decorator + `: X` type annotation). When
+                    // prettier wraps it onto separate lines those references have
+                    // different line positions, so anchor to the enclosing parameter
+                    // to emit exactly one TODO per injection site.
+                    const anchor =
+                        ref.getFirstAncestorByKind(SyntaxKind.Parameter) ?? ref;
+
+                    linePositions.add(anchor.getStartLinePos());
+                });
         });
 
     // Positions are collected before any insertion: sourceFile.insertText forgets

--- a/projects/cdk/schematics/ng-update/v5/steps/migrate-breakpoint-service.ts
+++ b/projects/cdk/schematics/ng-update/v5/steps/migrate-breakpoint-service.ts
@@ -6,7 +6,7 @@ import {ALL_TS_FILES} from '../../../constants';
 import {type TuiSchema} from '../../../ng-add/schema';
 import {addUniqueImport} from '../../../utils/add-unique-import';
 import {removeImport} from '../../../utils/import-manipulations';
-import {insertTodo} from '../../../utils/insert-todo';
+import {TODO_MARK} from '../../../utils/insert-todo';
 
 const TAIGA_CORE = '@taiga-ui/core';
 const BREAKPOINT_SERVICE = 'TuiBreakpointService';
@@ -98,6 +98,8 @@ function cleanupBreakpointServiceImport(sourceFile: SourceFile): void {
 }
 
 function addTodoForUnsupportedUsages(sourceFile: SourceFile): void {
+    const linePositions = new Set<number>();
+
     sourceFile
         .getImportDeclarations()
         .filter((decl) => decl.getModuleSpecifierValue() === TAIGA_CORE)
@@ -106,28 +108,28 @@ function addTodoForUnsupportedUsages(sourceFile: SourceFile): void {
                 .getNamedImports()
                 .find((namedImport) => namedImport.getName() === BREAKPOINT_SERVICE);
 
-            if (!specifier) {
+            const nameNode = specifier?.getNameNode();
+
+            if (!Node.isIdentifier(nameNode)) {
                 return;
             }
 
-            const nameNode = specifier.getNameNode();
-
-            const refs = Node.isIdentifier(nameNode)
-                ? nameNode
-                      .findReferencesAsNodes()
-                      .filter(
-                          (ref) =>
-                              ref.getSourceFile().getFilePath() ===
-                              sourceFile.getFilePath(),
-                      )
-                : [];
-
-            refs.forEach((ref) => {
-                if (Node.isImportSpecifier(ref.getParent())) {
-                    return;
-                }
-
-                insertTodo(ref, BREAKPOINT_TODO_MESSAGE);
-            });
+            nameNode
+                .findReferencesAsNodes()
+                .filter(
+                    (ref) =>
+                        ref.getSourceFile().getFilePath() === sourceFile.getFilePath() &&
+                        !Node.isImportSpecifier(ref.getParent()),
+                )
+                .forEach((ref) => linePositions.add(ref.getStartLinePos()));
         });
+
+    // Positions are collected before any insertion: sourceFile.insertText forgets
+    // every node in the file, so a held ref node would throw on the next iteration.
+    // Insert bottom-up so each insertion cannot shift the offsets still pending.
+    [...linePositions]
+        .sort((a, b) => b - a)
+        .forEach((pos) =>
+            sourceFile.insertText(pos, `// ${TODO_MARK} ${BREAKPOINT_TODO_MESSAGE}\n`),
+        );
 }

--- a/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-breakpoint-service.spec.ts.snap
+++ b/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-breakpoint-service.spec.ts.snap
@@ -32,6 +32,43 @@ exports[`ng-update breakpoint service adds TODO comment for unsupported construc
 }
 `;
 
+exports[`ng-update breakpoint service adds TODO comments for multiple unsupported @Inject usages in one file: test.ts 1`] = `
+{
+  "0. Before": "
+                import {Component, Inject} from '@angular/core';
+                import {TuiBreakpointMediaKey, TuiBreakpointService} from '@taiga-ui/core';
+                import {type Observable} from 'rxjs';
+
+                @Component({
+                    templateUrl: './test.html',
+                })
+                export class TestComponent {
+                    constructor(
+                        @Inject(TuiBreakpointService) private readonly breakpoint$: TuiBreakpointService,
+                        @Inject(TuiBreakpointService) private readonly media$: Observable<TuiBreakpointMediaKey>,
+                    ) {}
+                }
+            ",
+  "1. After": "
+                import {Component, Inject} from '@angular/core';
+                import {TuiBreakpointMediaKey, TuiBreakpointService} from '@taiga-ui/core';
+                import {type Observable} from 'rxjs';
+
+                @Component({
+                    templateUrl: './test.html',
+                })
+                export class TestComponent {
+                    constructor(
+// TODO: (Taiga UI migration) TuiBreakpointService is deprecated. Use TUI_BREAKPOINT (signal token), wrap with toObservable(...) for Observable-based code if needed
+                        @Inject(TuiBreakpointService) private readonly breakpoint$: TuiBreakpointService,
+// TODO: (Taiga UI migration) TuiBreakpointService is deprecated. Use TUI_BREAKPOINT (signal token), wrap with toObservable(...) for Observable-based code if needed
+                        @Inject(TuiBreakpointService) private readonly media$: Observable<TuiBreakpointMediaKey>,
+                    ) {}
+                }
+            ",
+}
+`;
+
 exports[`ng-update breakpoint service migrates TuiBreakpointService inject usage to TUI_BREAKPOINT observable wrapper: test.ts 1`] = `
 {
   "0. Before": "
@@ -114,6 +151,48 @@ exports[`ng-update breakpoint service migrates inline inject(TuiBreakpointServic
                 export class TestComponent {
                     protected readonly s$ = toObservable(inject(TUI_BREAKPOINT)).pipe(
                         map((breakpoint) => breakpoint === 'mobile'),
+                    );
+                }
+            ",
+}
+`;
+
+exports[`ng-update breakpoint service migrates multiple inject(TuiBreakpointService) usages in one file: test.ts 1`] = `
+{
+  "0. Before": "
+                import {Component, inject} from '@angular/core';
+                import {TuiBreakpointService} from '@taiga-ui/core';
+                import {map} from 'rxjs';
+
+                @Component({
+                    templateUrl: './test.html',
+                })
+                export class TestComponent {
+                    protected readonly a$ = inject(TuiBreakpointService).pipe(
+                        map((breakpoint) => breakpoint === 'mobile'),
+                    );
+
+                    protected readonly b$ = inject(TuiBreakpointService).pipe(
+                        map((breakpoint) => breakpoint === 'desktop'),
+                    );
+                }
+            ",
+  "1. After": "import { toObservable } from "@angular/core/rxjs-interop";
+
+                import {Component, inject} from '@angular/core';
+                import { TUI_BREAKPOINT } from '@taiga-ui/core';
+                import {map} from 'rxjs';
+
+                @Component({
+                    templateUrl: './test.html',
+                })
+                export class TestComponent {
+                    protected readonly a$ = toObservable(inject(TUI_BREAKPOINT)).pipe(
+                        map((breakpoint) => breakpoint === 'mobile'),
+                    );
+
+                    protected readonly b$ = toObservable(inject(TUI_BREAKPOINT)).pipe(
+                        map((breakpoint) => breakpoint === 'desktop'),
                     );
                 }
             ",

--- a/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-breakpoint-service.spec.ts.snap
+++ b/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-breakpoint-service.spec.ts.snap
@@ -36,7 +36,10 @@ exports[`ng-update breakpoint service adds TODO comments for multiple unsupporte
 {
   "0. Before": "
                 import {Component, Inject} from '@angular/core';
-                import {TuiBreakpointMediaKey, TuiBreakpointService} from '@taiga-ui/core';
+                import {
+                    TuiBreakpointMediaKey,
+                    TuiBreakpointService,
+                } from '@taiga-ui/core';
                 import {type Observable} from 'rxjs';
 
                 @Component({
@@ -44,14 +47,19 @@ exports[`ng-update breakpoint service adds TODO comments for multiple unsupporte
                 })
                 export class TestComponent {
                     constructor(
-                        @Inject(TuiBreakpointService) private readonly breakpoint$: TuiBreakpointService,
-                        @Inject(TuiBreakpointService) private readonly media$: Observable<TuiBreakpointMediaKey>,
+                        @Inject(TuiBreakpointService)
+                        private readonly breakpoint$: TuiBreakpointService,
+                        @Inject(TuiBreakpointService)
+                        private readonly media$: Observable<TuiBreakpointMediaKey>,
                     ) {}
                 }
             ",
   "1. After": "
                 import {Component, Inject} from '@angular/core';
-                import {TuiBreakpointMediaKey, TuiBreakpointService} from '@taiga-ui/core';
+                import {
+                    TuiBreakpointMediaKey,
+                    TuiBreakpointService,
+                } from '@taiga-ui/core';
                 import {type Observable} from 'rxjs';
 
                 @Component({
@@ -60,9 +68,11 @@ exports[`ng-update breakpoint service adds TODO comments for multiple unsupporte
                 export class TestComponent {
                     constructor(
 // TODO: (Taiga UI migration) TuiBreakpointService is deprecated. Use TUI_BREAKPOINT (signal token), wrap with toObservable(...) for Observable-based code if needed
-                        @Inject(TuiBreakpointService) private readonly breakpoint$: TuiBreakpointService,
+                        @Inject(TuiBreakpointService)
+                        private readonly breakpoint$: TuiBreakpointService,
 // TODO: (Taiga UI migration) TuiBreakpointService is deprecated. Use TUI_BREAKPOINT (signal token), wrap with toObservable(...) for Observable-based code if needed
-                        @Inject(TuiBreakpointService) private readonly media$: Observable<TuiBreakpointMediaKey>,
+                        @Inject(TuiBreakpointService)
+                        private readonly media$: Observable<TuiBreakpointMediaKey>,
                     ) {}
                 }
             ",

--- a/projects/cdk/schematics/ng-update/v5/tests/schematic-migrate-breakpoint-service.spec.ts
+++ b/projects/cdk/schematics/ng-update/v5/tests/schematic-migrate-breakpoint-service.spec.ts
@@ -80,5 +80,50 @@ describe('ng-update breakpoint service', () => {
         }),
     );
 
+    it(
+        'migrates multiple inject(TuiBreakpointService) usages in one file',
+        migrate({
+            component: /* TypeScript */ `
+                import {Component, inject} from '@angular/core';
+                import {TuiBreakpointService} from '@taiga-ui/core';
+                import {map} from 'rxjs';
+
+                @Component({
+                    templateUrl: './test.html',
+                })
+                export class TestComponent {
+                    protected readonly a$ = inject(TuiBreakpointService).pipe(
+                        map((breakpoint) => breakpoint === 'mobile'),
+                    );
+
+                    protected readonly b$ = inject(TuiBreakpointService).pipe(
+                        map((breakpoint) => breakpoint === 'desktop'),
+                    );
+                }
+            `,
+        }),
+    );
+
+    it(
+        'adds TODO comments for multiple unsupported @Inject usages in one file',
+        migrate({
+            component: /* TypeScript */ `
+                import {Component, Inject} from '@angular/core';
+                import {TuiBreakpointMediaKey, TuiBreakpointService} from '@taiga-ui/core';
+                import {type Observable} from 'rxjs';
+
+                @Component({
+                    templateUrl: './test.html',
+                })
+                export class TestComponent {
+                    constructor(
+                        @Inject(TuiBreakpointService) private readonly breakpoint$: TuiBreakpointService,
+                        @Inject(TuiBreakpointService) private readonly media$: Observable<TuiBreakpointMediaKey>,
+                    ) {}
+                }
+            `,
+        }),
+    );
+
     afterEach(() => resetActiveProject());
 });

--- a/projects/cdk/schematics/ng-update/v5/tests/schematic-migrate-breakpoint-service.spec.ts
+++ b/projects/cdk/schematics/ng-update/v5/tests/schematic-migrate-breakpoint-service.spec.ts
@@ -109,7 +109,10 @@ describe('ng-update breakpoint service', () => {
         migrate({
             component: /* TypeScript */ `
                 import {Component, Inject} from '@angular/core';
-                import {TuiBreakpointMediaKey, TuiBreakpointService} from '@taiga-ui/core';
+                import {
+                    TuiBreakpointMediaKey,
+                    TuiBreakpointService,
+                } from '@taiga-ui/core';
                 import {type Observable} from 'rxjs';
 
                 @Component({
@@ -117,8 +120,10 @@ describe('ng-update breakpoint service', () => {
                 })
                 export class TestComponent {
                     constructor(
-                        @Inject(TuiBreakpointService) private readonly breakpoint$: TuiBreakpointService,
-                        @Inject(TuiBreakpointService) private readonly media$: Observable<TuiBreakpointMediaKey>,
+                        @Inject(TuiBreakpointService)
+                        private readonly breakpoint$: TuiBreakpointService,
+                        @Inject(TuiBreakpointService)
+                        private readonly media$: Observable<TuiBreakpointMediaKey>,
                     ) {}
                 }
             `,


### PR DESCRIPTION
## Bug

Running `ng update` v5 on a project that uses `TuiBreakpointService` crashes the schematic:

```
[error] Error: Attempted to get information from a node that was removed or forgotten.
Node text: TuiBreakpointService
    at Identifier.getParent (…/ts-morph.js)
    at …/ng-update/v5/steps/migrate-breakpoint-service.js:91:55   // ref.getParent()
    at addTodoForUnsupportedUsages (…/migrate-breakpoint-service.js:76)
    at migrateBreakpointService (…/migrate-breakpoint-service.js:16)
```

Because the step throws, the whole `migrateBreakpointService` run aborts and **no** file gets its TODO.

## Root cause

`addTodoForUnsupportedUsages` collected the reference nodes of `TuiBreakpointService` and then called `insertTodo` (→ `sourceFile.insertText`) **inside the loop over those nodes**. `insertText` is a file-level text manipulation and forgets *every* node in the file. So when a single file has **two or more** manual (non-`inject`) usages, the first insertion forgets all nodes and the next iteration's `ref.getParent()` throws.

This is a misuse of the ts-morph API in the migration, not a ts-morph/ng-morph defect — the library correctly throws instead of silently corrupting.

The existing tests never hit it: none had two manual usages in one file. Real projects do, e.g. old-style constructor DI where the identifier appears twice on one line:

```ts
@Inject(TuiBreakpointService) private readonly breakpoint$: TuiBreakpointService,
```

## Fix

Collect the target line positions up front while the nodes are still valid, dedupe by line, then insert **bottom-up** so pending offsets can't be invalidated by an earlier insertion. No node reference is held across a mutation.

## Tests

- New: multiple `@Inject(TuiBreakpointService)` usages in one file (the real-world trigger) — crashes on the old code, passes now.
- New: multiple `inject(TuiBreakpointService)` calls in one file — regression guard for the sibling `migrateSourceFile` (already safe via `replaceWithText`, now covered).
- Existing 3 cases unchanged.
- Full `ng-update/v5` suite: 770 passed / 132 suites.

Related to #11917.
