### PR TITLE
fix(schematics): warn WA_IS_TOUCH is a signal after TUI_IS_TOUCH rename (v5)

### DIFF
--- a/projects/cdk/schematics/ng-update/v5/steps/constants/migration-warnings.ts
+++ b/projects/cdk/schematics/ng-update/v5/steps/constants/migration-warnings.ts
@@ -438,6 +438,12 @@ export const MIGRATION_WARNINGS: MigrationWarning[] = [
             'TUI_TOUCH_SUPPORTED has been removed. Use WA_IS_TOUCH from @ng-web-apis/platform instead — note it is a Signal<boolean> (the old token was a plain boolean), so read it with a call: inject(WA_IS_TOUCH)().',
     },
     {
+        name: 'WA_IS_TOUCH',
+        moduleSpecifier: '@ng-web-apis/platform',
+        message:
+            'TUI_IS_TOUCH was renamed to WA_IS_TOUCH from @ng-web-apis/platform, which is a Signal<boolean> (the old token was a plain boolean), so read it with a call: inject(WA_IS_TOUCH)().',
+    },
+    {
         name: 'TUI_IS_CHROMIUM',
         moduleSpecifier: '@taiga-ui/legacy',
         message:

--- a/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-misc-removed-tokens-warning.spec.ts.snap
+++ b/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-misc-removed-tokens-warning.spec.ts.snap
@@ -29,7 +29,8 @@ exports[`ng-update misc removed tokens and helpers warning renames deprecated-al
                     protected readonly toggle = tuiToggleDay;
                 }
             ",
-  "1. After": "import { WA_IS_TOUCH } from "@ng-web-apis/platform";
+  "1. After": "// TODO: (Taiga UI migration) TUI_IS_TOUCH was renamed to WA_IS_TOUCH from @ng-web-apis/platform, which is a Signal<boolean> (the old token was a plain boolean), so read it with a call: inject(WA_IS_TOUCH)().
+import { WA_IS_TOUCH } from "@ng-web-apis/platform";
 
                 import {Component, inject} from '@angular/core';
 // TODO: (Taiga UI migration) TUI_SPIN_ICONS has been removed. Spinner increment/decrement icons were merged into the common icons — configure them via tuiCommonIconsProvider (TUI_COMMON_ICONS) from @taiga-ui/core instead.

--- a/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-touch-flag-warning.spec.ts.snap
+++ b/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-touch-flag-warning.spec.ts.snap
@@ -1,0 +1,25 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ng-update WA_IS_TOUCH signal warning adds TODO comment when TUI_IS_TOUCH is renamed to the WA_IS_TOUCH signal: test.ts 1`] = `
+{
+  "0. Before": "
+                import {Component, inject} from '@angular/core';
+                import {TUI_IS_TOUCH} from '@taiga-ui/cdk';
+
+                @Component({})
+                export class TestComponent {
+                    protected readonly touch = inject(TUI_IS_TOUCH);
+                }
+            ",
+  "1. After": "// TODO: (Taiga UI migration) TUI_IS_TOUCH was renamed to WA_IS_TOUCH from @ng-web-apis/platform, which is a Signal<boolean> (the old token was a plain boolean), so read it with a call: inject(WA_IS_TOUCH)().
+import { WA_IS_TOUCH } from "@ng-web-apis/platform";
+
+                import {Component, inject} from '@angular/core';
+
+                @Component({})
+                export class TestComponent {
+                    protected readonly touch = inject(WA_IS_TOUCH);
+                }
+            ",
+}
+`;

--- a/projects/cdk/schematics/ng-update/v5/tests/schematic-migrate-touch-flag-warning.spec.ts
+++ b/projects/cdk/schematics/ng-update/v5/tests/schematic-migrate-touch-flag-warning.spec.ts
@@ -1,0 +1,28 @@
+import {join} from 'node:path';
+
+import {resetActiveProject} from 'ng-morph';
+
+import {createMigration} from '../../../utils/run-migration';
+
+describe('ng-update WA_IS_TOUCH signal warning', () => {
+    const migrate = createMigration({
+        collection: join(__dirname, '../../../migration.json'),
+    });
+
+    it(
+        'adds TODO comment when TUI_IS_TOUCH is renamed to the WA_IS_TOUCH signal',
+        migrate({
+            component: /* TypeScript */ `
+                import {Component, inject} from '@angular/core';
+                import {TUI_IS_TOUCH} from '@taiga-ui/cdk';
+
+                @Component({})
+                export class TestComponent {
+                    protected readonly touch = inject(TUI_IS_TOUCH);
+                }
+            `,
+        }),
+    );
+
+    afterEach(() => resetActiveProject());
+});


### PR DESCRIPTION
## What / why

The v5 identifier migration renames `TUI_IS_TOUCH` (`@taiga-ui/cdk`) → `WA_IS_TOUCH` (`@ng-web-apis/platform`). But `WA_IS_TOUCH` is an `InjectionToken<Signal<boolean>>`, whereas the old `TUI_IS_TOUCH` was a plain `boolean`.

So code like:

```ts
protected readonly touch = inject(TUI_IS_TOUCH); // boolean
if (this.touch) { ... }
```

is silently rewritten to `inject(WA_IS_TOUCH)` — now a `Signal<boolean>` object that is **always truthy**. No TODO was emitted, so the behavior change is invisible.

The legacy equivalent `TUI_TOUCH_SUPPORTED` already has a warning about exactly this; the `@taiga-ui/cdk` `TUI_IS_TOUCH` path was missing it.

## Fix

Add a `MIGRATION_WARNINGS` entry keyed on the **post-rename** symbol `WA_IS_TOUCH` (`@ng-web-apis/platform`) so a TODO is emitted (warnings run last in the pipeline, after the rename).

## Before / after

Input:
```ts
import {TUI_IS_TOUCH} from '@taiga-ui/cdk';
protected readonly touch = inject(TUI_IS_TOUCH);
```
Output after migration:
```ts
// TODO: (Taiga UI migration) TUI_IS_TOUCH was renamed to WA_IS_TOUCH from @ng-web-apis/platform, which is a Signal<boolean> (the old token was a plain boolean), so read it with a call: inject(WA_IS_TOUCH)().
import { WA_IS_TOUCH } from "@ng-web-apis/platform";
protected readonly touch = inject(WA_IS_TOUCH);
```

## Tests

- New `schematic-migrate-touch-flag-warning.spec.ts` (snapshot).
- Updated `schematic-migrate-misc-removed-tokens-warning` snapshot (its `TUI_IS_TOUCH` case now shows the TODO).

> Found while migrating a large downstream Angular project from Taiga v4 to v5.