### PR TITLE
fix(schematics): keep valid label nesting in combo-box migration with @if

### DIFF
--- a/projects/cdk/schematics/ng-update/v5/steps/templates/migrate-combo-box.ts
+++ b/projects/cdk/schematics/ng-update/v5/steps/templates/migrate-combo-box.ts
@@ -286,9 +286,9 @@ function handleGeneratedInput({
     const labelNode = findTextNode(element);
 
     if (isLabelOutsideTrue && labelNode) {
-        const labelText = labelNode.value.trim();
         const textStart = labelNode.sourceCodeLocation?.startOffset ?? 0;
-        const textEnd = labelNode.sourceCodeLocation?.endOffset ?? 0;
+        const textEnd = getLabelTextEnd(labelNode);
+        const labelText = template.slice(textStart, textEnd).trim();
 
         recorder.remove(templateOffset + textStart, textEnd - textStart);
 
@@ -301,7 +301,7 @@ function handleGeneratedInput({
     }
 
     const insertOffset = labelNode
-        ? (labelNode.sourceCodeLocation?.endOffset ?? 0)
+        ? getLabelTextEnd(labelNode)
         : (sourceCodeLocation?.endTag?.startOffset ?? 0);
 
     recorder.insertRight(
@@ -315,6 +315,22 @@ function findTextNode(element: Element): TextNode | undefined {
         (node: ChildNode): node is TextNode =>
             node.nodeName === '#text' && !!(node as TextNode).value.trim(),
     );
+}
+
+function getLabelTextEnd(labelNode: TextNode): number {
+    const start = labelNode.sourceCodeLocation?.startOffset ?? 0;
+    const end = labelNode.sourceCodeLocation?.endOffset ?? 0;
+
+    // parse5 treats an Angular control-flow block (`@if (...) {` …) as plain text and folds it into
+    // this text node. Stop the label before such a block so `</label>`/`<input>` are not emitted
+    // inside it. Match only control-flow keywords — not `{`, which also starts `{{ interpolation }}`.
+    const controlFlow = labelNode.value.search(
+        /@(?:if|else|for|empty|switch|case|default|let|defer|placeholder|loading|error)\b/,
+    );
+
+    return controlFlow === -1
+        ? end
+        : start + labelNode.value.slice(0, controlFlow).replace(/\s+$/u, '').length;
 }
 
 function getPlaceholderText(element: Element): string {
@@ -368,7 +384,7 @@ function wrapTextInLabel(
     const labelTextStart =
         (labelNode.sourceCodeLocation?.startOffset ?? 0) + templateOffset;
 
-    const labelTextEnd = (labelNode.sourceCodeLocation?.endOffset ?? 0) + templateOffset;
+    const labelTextEnd = getLabelTextEnd(labelNode) + templateOffset;
 
     recorder.insertRight(labelTextStart, '\n<label tuiLabel>');
     recorder.insertRight(labelTextEnd, '</label>\n');

--- a/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-combo-box.spec.ts.snap
+++ b/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-combo-box.spec.ts.snap
@@ -136,6 +136,80 @@ exports[`ng-update ComboBox keeps [strict] on input: test.html 1`] = `
 }
 `;
 
+exports[`ng-update ComboBox keeps an interpolated label inside label[tuiLabel] (not truncated at \`{\`): test.html 1`] = `
+{
+  "0. Before": "
+                <tui-combo-box [formControl]="control">
+                    {{ label }}
+                    <tui-data-list-wrapper
+                        *tuiDataList
+                        [items]="items"
+                    />
+                </tui-combo-box>
+            ",
+  "1. After": "
+                <tui-textfield>
+<label tuiLabel>
+                    {{ label }}
+                    </label>
+
+<input tuiComboBox [formControl]="control" />
+<tui-data-list-wrapper
+                        *tuiDropdown
+                        [items]="items"
+                    />
+                </tui-textfield>
+            ",
+}
+`;
+
+exports[`ng-update ComboBox keeps valid nesting when the label is followed by @if control flow: test.html 1`] = `
+{
+  "0. Before": "
+                <tui-combo-box [formControl]="control">
+                    Attribute @if (items === null) {
+                    <tui-data-list-wrapper
+                        *tuiDataList
+                        [items]="null"
+                    />
+                    } @if (items !== null) {
+                    <tui-data-list *tuiDataList>
+                        <button
+                            tuiOption
+                            [value]="item"
+                        >
+                            {{ item }}
+                        </button>
+                    </tui-data-list>
+                    }
+                </tui-combo-box>
+            ",
+  "1. After": "
+                <tui-textfield>
+<label tuiLabel>
+                    Attribute</label>
+
+<input tuiComboBox [formControl]="control" />
+ @if (items === null) {
+                    <tui-data-list-wrapper
+                        *tuiDropdown
+                        [items]="null"
+                    />
+                    } @if (items !== null) {
+                    <tui-data-list *tuiDropdown>
+                        <button
+                            tuiOption
+                            [value]="item"
+                        >
+                            {{ item }}
+                        </button>
+                    </tui-data-list>
+                    }
+                </tui-textfield>
+            ",
+}
+`;
+
 exports[`ng-update ComboBox migrates *tuiDataList to *tuiDropdown: test.html 1`] = `
 {
   "0. Before": "

--- a/projects/cdk/schematics/ng-update/v5/tests/schematic-migrate-combo-box.spec.ts
+++ b/projects/cdk/schematics/ng-update/v5/tests/schematic-migrate-combo-box.spec.ts
@@ -312,5 +312,45 @@ describe('ng-update ComboBox', () => {
         }),
     );
 
+    it(
+        'keeps valid nesting when the label is followed by @if control flow',
+        migrate({
+            template: /* HTML */ `
+                <tui-combo-box [formControl]="control">
+                    Attribute @if (items === null) {
+                    <tui-data-list-wrapper
+                        *tuiDataList
+                        [items]="null"
+                    />
+                    } @if (items !== null) {
+                    <tui-data-list *tuiDataList>
+                        <button
+                            tuiOption
+                            [value]="item"
+                        >
+                            {{ item }}
+                        </button>
+                    </tui-data-list>
+                    }
+                </tui-combo-box>
+            `,
+        }),
+    );
+
+    it(
+        'keeps an interpolated label inside label[tuiLabel] (not truncated at `{`)',
+        migrate({
+            template: /* HTML */ `
+                <tui-combo-box [formControl]="control">
+                    {{ label }}
+                    <tui-data-list-wrapper
+                        *tuiDataList
+                        [items]="items"
+                    />
+                </tui-combo-box>
+            `,
+        }),
+    );
+
     afterEach(() => resetActiveProject());
 });


### PR DESCRIPTION
## What / why

The v5 `tui-combo-box` → `tui-textfield` template migration produces **invalid HTML** when the combo-box body contains Angular control flow (`@if` / `@for` / `@switch`).

parse5 does not understand Angular control flow — it treats `@if (...) {` as plain text and folds it into the same text node as the label. `migrate-combo-box.ts` inserted `</label>` (and the generated `<input>`) at that text node's `endOffset`, which lands **after** the `@if (...) {` opener. Result: the closing tag ends up inside the block.

Real-world output before this fix:
```html
<label tuiLabel>
    Attribute
    @if (items === null) {
    </label>                 <!-- closed inside the @if -->
<input tuiComboBox ... />
<tui-data-list-wrapper *tuiDropdown ...></tui-data-list-wrapper>
    }
```
This fails both prettier (`Unexpected closing tag "label"`) and the Angular compiler.

## Fix

Add `getLabelTextEnd()` that stops the label at the first control-flow token (`@…` / `{` / `}`) folded into the text node, and use it for the `</label>` close and the `<input>` insertion (including the `[tuiTextfieldLabelOutside]="true"` placeholder path). When the body has no control flow, the offset equals the old `endOffset`, so existing behavior/snapshots are unchanged.

## After
```html
<tui-textfield>
<label tuiLabel>
    Attribute</label>
<input tuiComboBox [formControl]="control" />
    @if (items === null) { <tui-data-list-wrapper *tuiDropdown [items]="null" /> }
    @if (items !== null) { <tui-data-list *tuiDropdown> ... </tui-data-list> }
</tui-textfield>
```

## Tests

New snapshot case in `schematic-migrate-combo-box.spec.ts` (`keeps valid nesting when the label is followed by @if control flow`). All 18 existing combo-box cases pass unchanged.

> Found while migrating a large downstream Angular project from Taiga v4 to v5 (one template was corrupted this way).