### PR TITLE
fix(schematics): rename closeable->closable in type-annotated dialog option objects

### DIFF
--- a/projects/cdk/schematics/ng-update/v5/steps/migrate-closeable.ts
+++ b/projects/cdk/schematics/ng-update/v5/steps/migrate-closeable.ts
@@ -22,6 +22,13 @@ const SERVICE_NAMES = [
 
 const METHOD_NAME = 'open';
 
+const OPTION_TYPE_NAMES = [
+    'TuiDialogOptions',
+    'TuiSheetDialogOptions',
+    'TuiAlertOptions',
+    'TuiNotificationOptions',
+];
+
 export function migrateCloseable(_tree: Tree, _options: TuiSchema): void {
     getSourceFiles(ALL_TS_FILES).forEach((sourceFile) => {
         migrateSourceFile(sourceFile);
@@ -29,6 +36,11 @@ export function migrateCloseable(_tree: Tree, _options: TuiSchema): void {
 }
 
 function migrateSourceFile(sourceFile: SourceFile): void {
+    migrateOpenOptions(sourceFile);
+    migrateTypedDeclarations(sourceFile);
+}
+
+function migrateOpenOptions(sourceFile: SourceFile): void {
     const calls = sourceFile.getDescendantsOfKind(SyntaxKind.CallExpression);
 
     calls.forEach((call) => {
@@ -49,6 +61,38 @@ function migrateSourceFile(sourceFile: SourceFile): void {
             renameCloseableKey(options);
         });
     });
+}
+
+// An options object may be declared apart from the open()/provider call and passed by reference.
+// Rename it only when the declaration is explicitly typed as one of the dialog option types,
+// so plain objects that merely have a `closeable` key are left untouched.
+function migrateTypedDeclarations(sourceFile: SourceFile): void {
+    const declarations = [
+        ...sourceFile.getDescendantsOfKind(SyntaxKind.PropertyDeclaration),
+        ...sourceFile.getDescendantsOfKind(SyntaxKind.VariableDeclaration),
+    ];
+
+    declarations.forEach((declaration) => {
+        const typeNode = declaration.getTypeNode();
+        const initializer = declaration.getInitializer();
+
+        if (
+            !typeNode ||
+            !initializer ||
+            !Node.isObjectLiteralExpression(initializer) ||
+            !referencesOptionType(typeNode.getText())
+        ) {
+            return;
+        }
+
+        renameCloseableKey(initializer);
+    });
+}
+
+function referencesOptionType(typeText: string): boolean {
+    return OPTION_TYPE_NAMES.some((name) =>
+        new RegExp(String.raw`\b${name}\b`).test(typeText),
+    );
 }
 
 function renameCloseableKey(obj: ObjectLiteralExpression): void {

--- a/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-closeable.spec.ts.snap
+++ b/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-closeable.spec.ts.snap
@@ -385,6 +385,45 @@ exports[`ng-update closeable replaces closeable with closable for tuiSheetDialog
 }
 `;
 
+exports[`ng-update closeable replaces closeable with closable in an options object typed apart from the open() call: test.ts 1`] = `
+{
+  "0. Before": "
+                import {Component} from '@angular/core';
+                import {TuiDialogOptions} from '@taiga-ui/core';
+                import {TuiSheetDialogOptions} from '@taiga-ui/addon-mobile';
+
+                @Component({standalone: true})
+                export class TestComponent {
+                    protected readonly sheetOptions: Partial<TuiSheetDialogOptions> = {
+                        closeable: true,
+                    };
+
+                    protected readonly dialogOptions: TuiDialogOptions = {
+                        closeable: false,
+                        label: 'Test',
+                    };
+                }
+            ",
+  "1. After": "
+                import {Component} from '@angular/core';
+                import {TuiDialogOptions} from '@taiga-ui/core';
+                import {TuiSheetDialogOptions} from '@taiga-ui/addon-mobile';
+
+                @Component({standalone: true})
+                export class TestComponent {
+                    protected readonly sheetOptions: Partial<TuiSheetDialogOptions> = {
+                        closable: true,
+                    };
+
+                    protected readonly dialogOptions: TuiDialogOptions = {
+                        closable: false,
+                        label: 'Test',
+                    };
+                }
+            ",
+}
+`;
+
 exports[`ng-update closeable replaces string literal key "closeable" with "closable": test.ts 1`] = `
 {
   "0. Before": "

--- a/projects/cdk/schematics/ng-update/v5/tests/schematic-migrate-closeable.spec.ts
+++ b/projects/cdk/schematics/ng-update/v5/tests/schematic-migrate-closeable.spec.ts
@@ -355,5 +355,28 @@ describe('ng-update closeable', () => {
         }),
     );
 
+    it(
+        'replaces closeable with closable in an options object typed apart from the open() call',
+        migrate({
+            component: /* TypeScript */ `
+                import {Component} from '@angular/core';
+                import {TuiDialogOptions} from '@taiga-ui/core';
+                import {TuiSheetDialogOptions} from '@taiga-ui/addon-mobile';
+
+                @Component({standalone: true})
+                export class TestComponent {
+                    protected readonly sheetOptions: Partial<TuiSheetDialogOptions> = {
+                        closeable: true,
+                    };
+
+                    protected readonly dialogOptions: TuiDialogOptions = {
+                        closeable: false,
+                        label: 'Test',
+                    };
+                }
+            `,
+        }),
+    );
+
     afterEach(() => resetActiveProject());
 });


### PR DESCRIPTION
## What / why

The `closeable` → `closable` rename in v5 is handled by `migrate-closeable.ts` for object literals passed **directly** as:
- the 2nd arg of `service.open(content, {...})` / `tuiDialog(content, {...})`, and
- (via other steps) provider 1st args and `[tuiDialogOptions]` template attrs.

But an options object **declared apart from the call and passed by reference** is missed:

```ts
protected readonly sheetOptions: Partial<TuiSheetDialogOptions> = {
    closeable: true,   // ← left as-is → TS2559 after migration
};
// ...
this.dialogService.open(content, this.sheetOptions);
```

## Fix

`migrate-closeable.ts` now also renames `closeable` → `closable` in object-literal initializers of `PropertyDeclaration`/`VariableDeclaration` **explicitly typed** as one of `TuiDialogOptions` / `TuiSheetDialogOptions` / `TuiAlertOptions` / `TuiNotificationOptions` (`Partial<…>` aware).

Type-scoped on purpose: untyped objects that merely have a `closeable` key are still left untouched (the existing `does not change object properties named closeable outside dialog.open options` guard passes unchanged).

## Before / after

```ts
readonly sheetOptions: Partial<TuiSheetDialogOptions> = { closeable: true };
```
→
```ts
readonly sheetOptions: Partial<TuiSheetDialogOptions> = { closable: true };
```

## Not covered (follow-up)
`as`/`satisfies` assertions (`{closeable} as TuiSheetDialogOptions`) and `TuiDialogContext.closeable`.

## Tests
New case in `schematic-migrate-closeable.spec.ts`; all 17 existing cases pass unchanged.

> Found while migrating a large downstream Angular project from Taiga v4 to v5.