### PR TITLE
fix(schematics): migrate TuiBreakpointService constructor injection to TUI_BREAKPOINT

### DIFF
--- a/projects/cdk/schematics/ng-update/v5/steps/migrate-breakpoint-service.ts
+++ b/projects/cdk/schematics/ng-update/v5/steps/migrate-breakpoint-service.ts
@@ -1,6 +1,6 @@
 import {type Tree} from '@angular-devkit/schematics';
 import {getSourceFiles, Node, SyntaxKind} from 'ng-morph';
-import {type SourceFile} from 'ts-morph';
+import {type ParameterDeclaration, type SourceFile} from 'ts-morph';
 
 import {ALL_TS_FILES} from '../../../constants';
 import {type TuiSchema} from '../../../ng-add/schema';
@@ -9,17 +9,21 @@ import {removeImport} from '../../../utils/import-manipulations';
 import {TODO_MARK} from '../../../utils/insert-todo';
 
 const TAIGA_CORE = '@taiga-ui/core';
+const ANGULAR_CORE = '@angular/core';
 const BREAKPOINT_SERVICE = 'TuiBreakpointService';
 const BREAKPOINT_TOKEN = 'TUI_BREAKPOINT';
 const RXJS_INTEROP = '@angular/core/rxjs-interop';
 const TO_OBSERVABLE = 'toObservable';
+const INJECT = 'inject';
 
 const BREAKPOINT_TODO_MESSAGE =
-    'TuiBreakpointService is deprecated. Use TUI_BREAKPOINT (signal token), wrap with toObservable(...) for Observable-based code if needed';
+    'TuiBreakpointService has been removed. Use TUI_BREAKPOINT (signal token); wrap with toObservable(...) for Observable-based code if needed';
 
 export function migrateBreakpointService(_tree: Tree, _options: TuiSchema): void {
     getSourceFiles(ALL_TS_FILES).forEach((sourceFile) => {
-        const changed = migrateSourceFile(sourceFile);
+        const changedInjectCalls = migrateInjectCalls(sourceFile);
+        const changedConstructorInjections = migrateConstructorInjections(sourceFile);
+        const changed = changedInjectCalls || changedConstructorInjections;
 
         addTodoForUnsupportedUsages(sourceFile);
 
@@ -29,15 +33,16 @@ export function migrateBreakpointService(_tree: Tree, _options: TuiSchema): void
 
         addUniqueImport(sourceFile.getFilePath(), BREAKPOINT_TOKEN, TAIGA_CORE);
         addUniqueImport(sourceFile.getFilePath(), TO_OBSERVABLE, RXJS_INTEROP);
+        addUniqueImport(sourceFile.getFilePath(), INJECT, ANGULAR_CORE);
         cleanupBreakpointServiceImport(sourceFile);
     });
 }
 
-function migrateSourceFile(sourceFile: SourceFile): boolean {
+function migrateInjectCalls(sourceFile: SourceFile): boolean {
     let changed = false;
 
     sourceFile.getDescendantsOfKind(SyntaxKind.CallExpression).forEach((call) => {
-        if (call.getExpression().getText() !== 'inject') {
+        if (call.getExpression().getText() !== INJECT) {
             return;
         }
 
@@ -64,6 +69,53 @@ function migrateSourceFile(sourceFile: SourceFile): boolean {
     });
 
     return changed;
+}
+
+/**
+ * Constructor injection cannot stay as a parameter: TuiBreakpointService is
+ * removed, so `@Inject(TuiBreakpointService)` / `: TuiBreakpointService` would
+ * not compile. Convert each such parameter into a class field initialized with
+ * `toObservable(inject(TUI_BREAKPOINT))`, preserving its access modifiers.
+ */
+function migrateConstructorInjections(sourceFile: SourceFile): boolean {
+    let changed = false;
+
+    sourceFile.getClasses().forEach((classDeclaration) => {
+        classDeclaration.getConstructors().forEach((constructor) => {
+            constructor
+                .getParameters()
+                .filter(isBreakpointParameter)
+                .forEach((parameter) => {
+                    const insertIndex = classDeclaration
+                        .getMembers()
+                        .indexOf(constructor);
+
+                    classDeclaration.insertProperty(insertIndex, {
+                        name: parameter.getName(),
+                        isReadonly: parameter.isReadonly(),
+                        scope: parameter.hasScopeKeyword()
+                            ? parameter.getScope()
+                            : undefined,
+                        initializer: `${TO_OBSERVABLE}(${INJECT}(${BREAKPOINT_TOKEN}))`,
+                    });
+
+                    parameter.remove();
+                    changed = true;
+                });
+        });
+    });
+
+    return changed;
+}
+
+function isBreakpointParameter(parameter: ParameterDeclaration): boolean {
+    const injectDecorator = parameter.getDecorator('Inject');
+
+    if (injectDecorator?.getArguments()[0]?.getText() === BREAKPOINT_SERVICE) {
+        return true;
+    }
+
+    return parameter.getTypeNode()?.getText() === BREAKPOINT_SERVICE;
 }
 
 function cleanupBreakpointServiceImport(sourceFile: SourceFile): void {

--- a/projects/cdk/schematics/ng-update/v5/steps/migrate-breakpoint-service.ts
+++ b/projects/cdk/schematics/ng-update/v5/steps/migrate-breakpoint-service.ts
@@ -111,11 +111,9 @@ function migrateConstructorInjections(sourceFile: SourceFile): boolean {
 function isBreakpointParameter(parameter: ParameterDeclaration): boolean {
     const injectDecorator = parameter.getDecorator('Inject');
 
-    if (injectDecorator?.getArguments()[0]?.getText() === BREAKPOINT_SERVICE) {
-        return true;
-    }
-
-    return parameter.getTypeNode()?.getText() === BREAKPOINT_SERVICE;
+    return injectDecorator?.getArguments()[0]?.getText() === BREAKPOINT_SERVICE
+        ? true
+        : parameter.getTypeNode()?.getText() === BREAKPOINT_SERVICE;
 }
 
 function cleanupBreakpointServiceImport(sourceFile: SourceFile): void {

--- a/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-breakpoint-service.spec.ts.snap
+++ b/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-breakpoint-service.spec.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`ng-update breakpoint service adds TODO comment for unsupported constructor injection usage: test.ts 1`] = `
+exports[`ng-update breakpoint service adds a removed-service TODO for unsupported non-parameter type usage: test.ts 1`] = `
 {
   "0. Before": "
                 import {Component} from '@angular/core';
@@ -10,9 +10,7 @@ exports[`ng-update breakpoint service adds TODO comment for unsupported construc
                     templateUrl: './test.html',
                 })
                 export class TestComponent {
-                    constructor(
-                        private readonly breakpointService: TuiBreakpointService,
-                    ) {}
+                    protected service!: TuiBreakpointService;
                 }
             ",
   "1. After": "
@@ -23,57 +21,8 @@ exports[`ng-update breakpoint service adds TODO comment for unsupported construc
                     templateUrl: './test.html',
                 })
                 export class TestComponent {
-                    constructor(
-// TODO: (Taiga UI migration) TuiBreakpointService is deprecated. Use TUI_BREAKPOINT (signal token), wrap with toObservable(...) for Observable-based code if needed
-                        private readonly breakpointService: TuiBreakpointService,
-                    ) {}
-                }
-            ",
-}
-`;
-
-exports[`ng-update breakpoint service adds TODO comments for multiple unsupported @Inject usages in one file: test.ts 1`] = `
-{
-  "0. Before": "
-                import {Component, Inject} from '@angular/core';
-                import {
-                    TuiBreakpointMediaKey,
-                    TuiBreakpointService,
-                } from '@taiga-ui/core';
-                import {type Observable} from 'rxjs';
-
-                @Component({
-                    templateUrl: './test.html',
-                })
-                export class TestComponent {
-                    constructor(
-                        @Inject(TuiBreakpointService)
-                        private readonly breakpoint$: TuiBreakpointService,
-                        @Inject(TuiBreakpointService)
-                        private readonly media$: Observable<TuiBreakpointMediaKey>,
-                    ) {}
-                }
-            ",
-  "1. After": "
-                import {Component, Inject} from '@angular/core';
-                import {
-                    TuiBreakpointMediaKey,
-                    TuiBreakpointService,
-                } from '@taiga-ui/core';
-                import {type Observable} from 'rxjs';
-
-                @Component({
-                    templateUrl: './test.html',
-                })
-                export class TestComponent {
-                    constructor(
-// TODO: (Taiga UI migration) TuiBreakpointService is deprecated. Use TUI_BREAKPOINT (signal token), wrap with toObservable(...) for Observable-based code if needed
-                        @Inject(TuiBreakpointService)
-                        private readonly breakpoint$: TuiBreakpointService,
-// TODO: (Taiga UI migration) TuiBreakpointService is deprecated. Use TUI_BREAKPOINT (signal token), wrap with toObservable(...) for Observable-based code if needed
-                        @Inject(TuiBreakpointService)
-                        private readonly media$: Observable<TuiBreakpointMediaKey>,
-                    ) {}
+// TODO: (Taiga UI migration) TuiBreakpointService has been removed. Use TUI_BREAKPOINT (signal token); wrap with toObservable(...) for Observable-based code if needed
+                    protected service!: TuiBreakpointService;
                 }
             ",
 }
@@ -167,6 +116,48 @@ exports[`ng-update breakpoint service migrates inline inject(TuiBreakpointServic
 }
 `;
 
+exports[`ng-update breakpoint service migrates multiple @Inject(TuiBreakpointService) constructor params to fields: test.ts 1`] = `
+{
+  "0. Before": "
+                import {Component, Inject} from '@angular/core';
+                import {
+                    TuiBreakpointMediaKey,
+                    TuiBreakpointService,
+                } from '@taiga-ui/core';
+                import {type Observable} from 'rxjs';
+
+                @Component({
+                    templateUrl: './test.html',
+                })
+                export class TestComponent {
+                    constructor(
+                        @Inject(TuiBreakpointService)
+                        private readonly breakpoint$: TuiBreakpointService,
+                        @Inject(TuiBreakpointService)
+                        private readonly media$: Observable<TuiBreakpointMediaKey>,
+                    ) {}
+                }
+            ",
+  "1. After": "import { toObservable } from "@angular/core/rxjs-interop";
+
+                import { Component, Inject, inject } from '@angular/core';
+                import { TuiBreakpointMediaKey, TUI_BREAKPOINT } from '@taiga-ui/core';
+                import {type Observable} from 'rxjs';
+
+                @Component({
+                    templateUrl: './test.html',
+                })
+                export class TestComponent {
+    private readonly breakpoint$ = toObservable(inject(TUI_BREAKPOINT));
+    private readonly media$ = toObservable(inject(TUI_BREAKPOINT));
+
+                    constructor(
+) {}
+                }
+            ",
+}
+`;
+
 exports[`ng-update breakpoint service migrates multiple inject(TuiBreakpointService) usages in one file: test.ts 1`] = `
 {
   "0. Before": "
@@ -204,6 +195,39 @@ exports[`ng-update breakpoint service migrates multiple inject(TuiBreakpointServ
                     protected readonly b$ = toObservable(inject(TUI_BREAKPOINT)).pipe(
                         map((breakpoint) => breakpoint === 'desktop'),
                     );
+                }
+            ",
+}
+`;
+
+exports[`ng-update breakpoint service migrates typed constructor parameter to a TUI_BREAKPOINT field: test.ts 1`] = `
+{
+  "0. Before": "
+                import {Component} from '@angular/core';
+                import {TuiBreakpointService} from '@taiga-ui/core';
+
+                @Component({
+                    templateUrl: './test.html',
+                })
+                export class TestComponent {
+                    constructor(
+                        private readonly breakpointService: TuiBreakpointService,
+                    ) {}
+                }
+            ",
+  "1. After": "import { toObservable } from "@angular/core/rxjs-interop";
+
+                import { Component, inject } from '@angular/core';
+                import { TUI_BREAKPOINT } from '@taiga-ui/core';
+
+                @Component({
+                    templateUrl: './test.html',
+                })
+                export class TestComponent {
+    private readonly breakpointService = toObservable(inject(TUI_BREAKPOINT));
+
+                    constructor(
+) {}
                 }
             ",
 }

--- a/projects/cdk/schematics/ng-update/v5/tests/schematic-migrate-breakpoint-service.spec.ts
+++ b/projects/cdk/schematics/ng-update/v5/tests/schematic-migrate-breakpoint-service.spec.ts
@@ -62,7 +62,7 @@ describe('ng-update breakpoint service', () => {
     );
 
     it(
-        'adds TODO comment for unsupported constructor injection usage',
+        'migrates typed constructor parameter to a TUI_BREAKPOINT field',
         migrate({
             component: /* TypeScript */ `
                 import {Component} from '@angular/core';
@@ -105,7 +105,7 @@ describe('ng-update breakpoint service', () => {
     );
 
     it(
-        'adds TODO comments for multiple unsupported @Inject usages in one file',
+        'migrates multiple @Inject(TuiBreakpointService) constructor params to fields',
         migrate({
             component: /* TypeScript */ `
                 import {Component, Inject} from '@angular/core';
@@ -125,6 +125,23 @@ describe('ng-update breakpoint service', () => {
                         @Inject(TuiBreakpointService)
                         private readonly media$: Observable<TuiBreakpointMediaKey>,
                     ) {}
+                }
+            `,
+        }),
+    );
+
+    it(
+        'adds a removed-service TODO for unsupported non-parameter type usage',
+        migrate({
+            component: /* TypeScript */ `
+                import {Component} from '@angular/core';
+                import {TuiBreakpointService} from '@taiga-ui/core';
+
+                @Component({
+                    templateUrl: './test.html',
+                })
+                export class TestComponent {
+                    protected service!: TuiBreakpointService;
                 }
             `,
         }),


### PR DESCRIPTION
## Summary

The v5 `migrate-breakpoint-service` step only rewrites the **functional** `inject(TuiBreakpointService)` form. The **constructor** forms — `@Inject(TuiBreakpointService)` parameters and plain `: TuiBreakpointService` typed parameters — were left untouched with only a TODO. Since `TuiBreakpointService` is **removed** from `@taiga-ui/core` in v5 (not just deprecated), that left projects with a non-compiling import (TS2305) after migration.

Found while migrating a real NgModule-based application where every breakpoint usage was constructor-injected — the migration ran "successfully" but the app would not build.

## Changes

- Migrate `@Inject(TuiBreakpointService)` / typed `: TuiBreakpointService` **constructor parameters** into a class field initialized with `toObservable(inject(TUI_BREAKPOINT))`, preserving the original access modifiers; the constructor parameter is removed and the `inject` import is added.
- Genuinely unsupported usages (e.g. a non-parameter type reference) still receive a TODO — now with correct **"has been removed"** wording (was "is deprecated").
- Tests: the two former *"adds TODO for constructor usage"* cases now assert the migration output; added a case covering the still-unsupported non-parameter usage. Full `ng-update/v5` suite green.

## Notes

- Output is intentionally not prettified (schematics don't format); the repo's post-migration lint step handles indentation, and now-unused imports (`Inject`, `TuiBreakpointMediaKey`) are dropped by organize-imports — consistent with the other v5 steps.
