### PR TITLE
fix(schematics): add missing TuiMultiSelectModule -> TuiMultiSelect v5 rename

### DIFF
--- a/projects/cdk/schematics/ng-update/v5/steps/constants/identifiers-to-replace.ts
+++ b/projects/cdk/schematics/ng-update/v5/steps/constants/identifiers-to-replace.ts
@@ -380,6 +380,16 @@ export const IDENTIFIERS_TO_REPLACE: ReplacementIdentifierMulti[] = [
     },
     {
         from: {
+            name: 'TuiMultiSelectModule',
+            moduleSpecifier: '@taiga-ui/legacy',
+        },
+        to: {
+            name: 'TuiMultiSelect',
+            moduleSpecifier: '@taiga-ui/kit',
+        },
+    },
+    {
+        from: {
             name: 'TuiTooltipModule',
             moduleSpecifier: '@taiga-ui/legacy',
         },

--- a/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-identifiers.spec.ts.snap
+++ b/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-identifiers.spec.ts.snap
@@ -276,6 +276,29 @@ exports[`ng-update identifiers migration moves TuiFlagPipe from core to kit: tes
 }
 `;
 
+exports[`ng-update identifiers migration moves TuiMultiSelectModule (legacy) to TuiMultiSelect (kit): test.ts 1`] = `
+{
+  "0. Before": "
+                import {TuiMultiSelectModule} from '@taiga-ui/legacy';
+                import {NgModule} from '@angular/core';
+
+                @NgModule({
+                    imports: [TuiMultiSelectModule],
+                })
+                export class TestModule {}
+            ",
+  "1. After": "import { TuiMultiSelect } from "@taiga-ui/kit";
+
+                                import {NgModule} from '@angular/core';
+
+                @NgModule({
+                    imports: [TuiMultiSelect],
+                })
+                export class TestModule {}
+            ",
+}
+`;
+
 exports[`ng-update identifiers migration moves TuiPureException from cdk to legacy: test.ts 1`] = `
 {
   "0. Before": "

--- a/projects/cdk/schematics/ng-update/v5/tests/schematic-migrate-identifiers.spec.ts
+++ b/projects/cdk/schematics/ng-update/v5/tests/schematic-migrate-identifiers.spec.ts
@@ -375,5 +375,20 @@ describe('ng-update identifiers migration', () => {
         }),
     );
 
+    it(
+        'moves TuiMultiSelectModule (legacy) to TuiMultiSelect (kit)',
+        migrate({
+            component: /* TypeScript */ `
+                import {TuiMultiSelectModule} from '@taiga-ui/legacy';
+                import {NgModule} from '@angular/core';
+
+                @NgModule({
+                    imports: [TuiMultiSelectModule],
+                })
+                export class TestModule {}
+            `,
+        }),
+    );
+
     afterEach(() => resetActiveProject());
 });


### PR DESCRIPTION
## Summary

`TuiComboBoxModule` and `TuiSelectModule` (from `@taiga-ui/legacy`) have v5 rename entries to their kit successors, but `TuiMultiSelectModule` was missing. Projects importing it are therefore left with a broken `@taiga-ui/legacy` import (TS2305) after migration — the migration reports success but the app does not build.

Found while migrating a real application that used `TuiMultiSelectModule` across ~10 modules/components.

## Changes

- Add the missing identifier rename `TuiMultiSelectModule` (`@taiga-ui/legacy`) → `TuiMultiSelect` (`@taiga-ui/kit`), analogous to the existing `TuiComboBoxModule` / `TuiSelectModule` entries.
- `TuiMultiSelect` is the kit barrel `[TuiMultiSelectGroupComponent, TuiMultiSelectGroupDirective, TuiMultiSelectNative]`, so `NgModule`/standalone `imports` transparently pick up the group directives (`tuiMultiSelectGroup`, …) that templates already use — Angular flattens the array in `imports`.
- Added a test covering the `NgModule`-imports rename. Full `ng-update/v5` suite green.
