### PR TITLE
chore(demo): add custom checked appearance examples to toggles

### DIFF
--- a/projects/demo/src/pages/components/checkbox/examples/4/index.html
+++ b/projects/demo/src/pages/components/checkbox/examples/4/index.html
@@ -1,0 +1,5 @@
+<input
+    tuiCheckbox
+    type="checkbox"
+    [(ngModel)]="checked"
+/>

--- a/projects/demo/src/pages/components/checkbox/examples/4/index.ts
+++ b/projects/demo/src/pages/components/checkbox/examples/4/index.ts
@@ -2,7 +2,7 @@ import {Component} from '@angular/core';
 import {FormsModule} from '@angular/forms';
 import {changeDetection} from '@demo/emulate/change-detection';
 import {encapsulation} from '@demo/emulate/encapsulation';
-import {TuiButton, TuiCheckbox, tuiCheckboxOptionsProvider} from '@taiga-ui/core';
+import {TuiCheckbox, tuiCheckboxOptionsProvider} from '@taiga-ui/core';
 
 @Component({
     imports: [FormsModule, TuiCheckbox],

--- a/projects/demo/src/pages/components/checkbox/examples/4/index.ts
+++ b/projects/demo/src/pages/components/checkbox/examples/4/index.ts
@@ -1,0 +1,20 @@
+import {Component} from '@angular/core';
+import {FormsModule} from '@angular/forms';
+import {changeDetection} from '@demo/emulate/change-detection';
+import {encapsulation} from '@demo/emulate/encapsulation';
+import {TuiButton, TuiCheckbox, tuiCheckboxOptionsProvider} from '@taiga-ui/core';
+
+@Component({
+    imports: [FormsModule, TuiCheckbox],
+    templateUrl: './index.html',
+    encapsulation,
+    changeDetection,
+    providers: [
+        tuiCheckboxOptionsProvider({
+            appearance: (el) => (el.checked ? 'primary-grayscale' : 'outline-grayscale'),
+        }),
+    ],
+})
+export default class Example {
+    protected checked = true;
+}

--- a/projects/demo/src/pages/components/checkbox/index.ts
+++ b/projects/demo/src/pages/components/checkbox/index.ts
@@ -8,5 +8,10 @@ import {TuiDemo} from '@demo/utils';
     changeDetection,
 })
 export default class Page {
-    public readonly examples = ['Platforms', 'Decorative', 'Form'];
+    public readonly examples = [
+        'Platforms',
+        'Decorative',
+        'Form',
+        'Custom checked appearance',
+    ];
 }

--- a/projects/demo/src/pages/components/checkbox/index.ts
+++ b/projects/demo/src/pages/components/checkbox/index.ts
@@ -8,10 +8,5 @@ import {TuiDemo} from '@demo/utils';
     changeDetection,
 })
 export default class Page {
-    public readonly examples = [
-        'Platforms',
-        'Decorative',
-        'Form',
-        'Custom checked appearance',
-    ];
+    public readonly examples = ['Platforms', 'Decorative', 'Form', 'Customization'];
 }

--- a/projects/demo/src/pages/components/radio/examples/4/index.html
+++ b/projects/demo/src/pages/components/radio/examples/4/index.html
@@ -1,0 +1,36 @@
+<p>
+    <label tuiLabel>
+        <input
+            name="example"
+            tuiRadio
+            type="radio"
+            value="1"
+            [(ngModel)]="value"
+        />
+        example 1
+    </label>
+</p>
+<p>
+    <label tuiLabel>
+        <input
+            name="example"
+            tuiRadio
+            type="radio"
+            value="2"
+            [(ngModel)]="value"
+        />
+        example 2
+    </label>
+</p>
+<p>
+    <label tuiLabel>
+        <input
+            name="example"
+            tuiRadio
+            type="radio"
+            value="3"
+            [(ngModel)]="value"
+        />
+        example 3
+    </label>
+</p>

--- a/projects/demo/src/pages/components/radio/examples/4/index.ts
+++ b/projects/demo/src/pages/components/radio/examples/4/index.ts
@@ -1,0 +1,20 @@
+import {Component} from '@angular/core';
+import {FormsModule} from '@angular/forms';
+import {changeDetection} from '@demo/emulate/change-detection';
+import {encapsulation} from '@demo/emulate/encapsulation';
+import {TuiLabel, TuiRadio, tuiRadioOptionsProvider} from '@taiga-ui/core';
+
+@Component({
+    imports: [FormsModule, TuiLabel, TuiRadio],
+    templateUrl: './index.html',
+    encapsulation,
+    changeDetection,
+    providers: [
+        tuiRadioOptionsProvider({
+            appearance: (el) => (el.checked ? 'primary-grayscale' : 'outline-grayscale'),
+        }),
+    ],
+})
+export default class Example {
+    protected value = '1';
+}

--- a/projects/demo/src/pages/components/radio/index.ts
+++ b/projects/demo/src/pages/components/radio/index.ts
@@ -12,6 +12,6 @@ export default class Page {
         'Platforms',
         'Identity matcher',
         'List',
-        'Custom checked appearance',
+        'Customization',
     ];
 }

--- a/projects/demo/src/pages/components/radio/index.ts
+++ b/projects/demo/src/pages/components/radio/index.ts
@@ -8,5 +8,10 @@ import {TuiDemo} from '@demo/utils';
     changeDetection,
 })
 export default class Page {
-    protected readonly examples = ['Platforms', 'Identity matcher', 'List'];
+    protected readonly examples = [
+        'Platforms',
+        'Identity matcher',
+        'List',
+        'Custom checked appearance',
+    ];
 }

--- a/projects/demo/src/pages/components/switch/examples/2/index.less
+++ b/projects/demo/src/pages/components/switch/examples/2/index.less
@@ -1,25 +1,3 @@
 :host {
-    display: flex;
-
     --tui-background-accent-2: var(--tui-status-info);
-}
-
-.wrapper {
-    display: flex;
-    flex-direction: column;
-    justify-content: space-around;
-    align-items: center;
-    flex: 1;
-    gap: 1rem;
-    padding: 1rem;
-
-    &_web {
-        border: 1px solid var(--tui-border-normal);
-        border-inline-start-width: 0;
-
-        &:first-child {
-            border-inline-end-width: 0;
-            border-inline-start-width: 1px;
-        }
-    }
 }

--- a/projects/demo/src/pages/components/switch/examples/3/index.html
+++ b/projects/demo/src/pages/components/switch/examples/3/index.html
@@ -1,0 +1,5 @@
+<input
+    tuiSwitch
+    type="checkbox"
+    [(ngModel)]="value"
+/>

--- a/projects/demo/src/pages/components/switch/examples/3/index.ts
+++ b/projects/demo/src/pages/components/switch/examples/3/index.ts
@@ -1,0 +1,20 @@
+import {Component} from '@angular/core';
+import {FormsModule} from '@angular/forms';
+import {changeDetection} from '@demo/emulate/change-detection';
+import {encapsulation} from '@demo/emulate/encapsulation';
+import {TuiSwitch, tuiSwitchOptionsProvider} from '@taiga-ui/kit';
+
+@Component({
+    imports: [FormsModule, TuiSwitch],
+    templateUrl: './index.html',
+    encapsulation,
+    changeDetection,
+    providers: [
+        tuiSwitchOptionsProvider({
+            appearance: (el) => (el.checked ? 'accent' : 'secondary'),
+        }),
+    ],
+})
+export default class Example {
+    protected value = true;
+}

--- a/projects/demo/src/pages/components/switch/index.ts
+++ b/projects/demo/src/pages/components/switch/index.ts
@@ -8,5 +8,9 @@ import {TuiDemo} from '@demo/utils';
     changeDetection,
 })
 export default class Page {
-    protected readonly examples = ['Platforms', 'Same color'];
+    protected readonly examples = [
+        'Platforms',
+        'Same color',
+        'Custom checked appearance',
+    ];
 }

--- a/projects/demo/src/pages/components/switch/index.ts
+++ b/projects/demo/src/pages/components/switch/index.ts
@@ -8,9 +8,5 @@ import {TuiDemo} from '@demo/utils';
     changeDetection,
 })
 export default class Page {
-    protected readonly examples = [
-        'Platforms',
-        'Same color',
-        'Custom checked appearance',
-    ];
+    protected readonly examples = ['Platforms', 'Same color', 'Customization'];
 }


### PR DESCRIPTION
Fixes #14015

- add examples for switch, checkbox, and radio, demonstrating how to set a custom appearance in the checked state
- remove unused styles from one switch example
