### PR TITLE
fix(schematics): spread barrel arrays in NgModule imports (v5)

### DIFF
--- a/projects/cdk/schematics/ng-update/interfaces/replacement-identifier.ts
+++ b/projects/cdk/schematics/ng-update/interfaces/replacement-identifier.ts
@@ -8,6 +8,7 @@ export interface ReplacementIdentifier {
         readonly name: string;
         readonly namedImport?: string;
         readonly spreadInModule?: boolean;
+        readonly removeSpread?: boolean;
         readonly callExpression?: boolean;
     };
 }

--- a/projects/cdk/schematics/ng-update/steps/replace-identifier.ts
+++ b/projects/cdk/schematics/ng-update/steps/replace-identifier.ts
@@ -53,6 +53,7 @@ export function replaceIdentifier({from, to}: ReplacementIdentifierMulti): void 
         if (Node.isImportSpecifier(parent)) {
             const targets = toArray(to);
             const [target] = targets;
+
             const alreadyImported =
                 targets.length === 1 &&
                 !!target &&

--- a/projects/cdk/schematics/ng-update/steps/replace-identifier.ts
+++ b/projects/cdk/schematics/ng-update/steps/replace-identifier.ts
@@ -51,8 +51,23 @@ export function replaceIdentifier({from, to}: ReplacementIdentifierMulti): void 
         const parent = ref.getParent();
 
         if (Node.isImportSpecifier(parent)) {
-            removeImport(parent);
-            addImports(to, parent.getSourceFile().getFilePath());
+            const targets = toArray(to);
+            const [target] = targets;
+            const alreadyImported =
+                targets.length === 1 &&
+                !!target &&
+                !target.namedImport &&
+                target.name === parent.getName() &&
+                target.moduleSpecifier ===
+                    parent.getImportDeclaration().getModuleSpecifierValue();
+
+            // A `removeSpread` entry keeps the same name and module, so the import
+            // is already correct — only the `...` usage needs rewriting. Skip the
+            // remove/re-add churn that would otherwise relocate an untouched import.
+            if (!alreadyImported) {
+                removeImport(parent);
+                addImports(to, parent.getSourceFile().getFilePath());
+            }
         } else {
             const decorator = ref.getParentWhile(
                 (node) => node.getKindName() !== 'Decorator',
@@ -62,15 +77,22 @@ export function replaceIdentifier({from, to}: ReplacementIdentifierMulti): void 
                 decorator?.getFirstChildIfKind(ts.SyntaxKind.Identifier)?.getText() ===
                 'NgModule';
 
-            replaceReference(ref, getReplacements(to, inModule));
+            const removeSpread = toArray(to).some((x) => x.removeSpread);
+
+            replaceReference(ref, getReplacements(to, inModule), removeSpread);
         }
     });
 }
 
-function replaceReference(ref: Node, replacements: readonly string[]): void {
+function replaceReference(
+    ref: Node,
+    replacements: readonly string[],
+    removeSpread: boolean,
+): void {
     const spread = replacements.some((text) => text.startsWith('...'));
+    const parent = ref.getParent();
 
-    if (spread && Node.isSpreadElement(ref.getParent())) {
+    if (spread && Node.isSpreadElement(parent)) {
         // Reference already spread by a previous migration run (`...TuiTextfield`).
         // Replace only the inner identifier and keep the existing `...`, so the
         // node kind is preserved and we don't produce a doubled `......` spread
@@ -78,6 +100,16 @@ function replaceReference(ref: Node, replacements: readonly string[]): void {
         ref.replaceWithText(
             replacements.map((text) => text.replace(/^\.\.\./, '')).join(', '),
         );
+
+        return;
+    }
+
+    if (removeSpread && Node.isSpreadElement(parent)) {
+        // A v4 barrel array collapsed into a single class in v5 under the same
+        // name and module, so an existing `...Name` spread is now invalid
+        // (spreading a class is TS2488). Drop the `...` by replacing the whole
+        // spread element with the plain identifier.
+        parent.replaceWithText(replacements.join(', '));
 
         return;
     }

--- a/projects/cdk/schematics/ng-update/steps/replace-identifier.ts
+++ b/projects/cdk/schematics/ng-update/steps/replace-identifier.ts
@@ -62,9 +62,27 @@ export function replaceIdentifier({from, to}: ReplacementIdentifierMulti): void 
                 decorator?.getFirstChildIfKind(ts.SyntaxKind.Identifier)?.getText() ===
                 'NgModule';
 
-            ref.replaceWithText(getReplacementText(to, inModule));
+            replaceReference(ref, getReplacements(to, inModule));
         }
     });
+}
+
+function replaceReference(ref: Node, replacements: readonly string[]): void {
+    const spread = replacements.some((text) => text.startsWith('...'));
+
+    if (spread && Node.isSpreadElement(ref.getParent())) {
+        // Reference already spread by a previous migration run (`...TuiTextfield`).
+        // Replace only the inner identifier and keep the existing `...`, so the
+        // node kind is preserved and we don't produce a doubled `......` spread
+        // (which corrupts ts-morph's tree diff and aborts the whole migration).
+        ref.replaceWithText(
+            replacements.map((text) => text.replace(/^\.\.\./, '')).join(', '),
+        );
+
+        return;
+    }
+
+    ref.replaceWithText(replacements.join(', '));
 }
 
 function addImports(
@@ -78,19 +96,17 @@ function addImports(
     });
 }
 
-function getReplacementText(
+function getReplacements(
     to: ReplacementIdentifierMulti['to'],
     inModule: boolean,
-): string {
-    return toArray(to)
-        .map(({name, spreadInModule, callExpression}) => {
-            if (spreadInModule && inModule) {
-                return `...${name}`;
-            }
+): string[] {
+    return toArray(to).map(({name, spreadInModule, callExpression}) => {
+        if (spreadInModule && inModule) {
+            return `...${name}`;
+        }
 
-            return callExpression ? `${name}()` : name;
-        })
-        .join(', ');
+        return callExpression ? `${name}()` : name;
+    });
 }
 
 function toArray<T>(x: T | T[]): T[] {

--- a/projects/cdk/schematics/ng-update/v5/steps/constants/identifiers-to-replace.ts
+++ b/projects/cdk/schematics/ng-update/v5/steps/constants/identifiers-to-replace.ts
@@ -26,6 +26,7 @@ export const IDENTIFIERS_TO_REPLACE: ReplacementIdentifierMulti[] = [
         to: {
             name: 'TuiInputSlider',
             moduleSpecifier: '@taiga-ui/kit',
+            spreadInModule: true,
         },
     },
     {
@@ -46,6 +47,7 @@ export const IDENTIFIERS_TO_REPLACE: ReplacementIdentifierMulti[] = [
         to: {
             name: 'TuiInputDateMulti',
             moduleSpecifier: '@taiga-ui/kit',
+            spreadInModule: true,
         },
     },
     {
@@ -56,6 +58,7 @@ export const IDENTIFIERS_TO_REPLACE: ReplacementIdentifierMulti[] = [
         to: {
             name: 'TuiInputMonthRange',
             moduleSpecifier: '@taiga-ui/kit',
+            spreadInModule: true,
         },
     },
     {
@@ -96,6 +99,7 @@ export const IDENTIFIERS_TO_REPLACE: ReplacementIdentifierMulti[] = [
         to: {
             name: 'TuiInputYear',
             moduleSpecifier: '@taiga-ui/kit',
+            spreadInModule: true,
         },
     },
     {
@@ -106,6 +110,7 @@ export const IDENTIFIERS_TO_REPLACE: ReplacementIdentifierMulti[] = [
         to: {
             name: 'TuiInputPhone',
             moduleSpecifier: '@taiga-ui/kit',
+            spreadInModule: true,
         },
     },
     {
@@ -116,6 +121,7 @@ export const IDENTIFIERS_TO_REPLACE: ReplacementIdentifierMulti[] = [
         to: {
             name: 'TuiInputNumber',
             moduleSpecifier: '@taiga-ui/kit',
+            spreadInModule: true,
         },
     },
     {
@@ -406,6 +412,7 @@ export const IDENTIFIERS_TO_REPLACE: ReplacementIdentifierMulti[] = [
         to: {
             name: 'TuiComboBox',
             moduleSpecifier: '@taiga-ui/kit',
+            spreadInModule: true,
         },
     },
     {
@@ -416,6 +423,7 @@ export const IDENTIFIERS_TO_REPLACE: ReplacementIdentifierMulti[] = [
         to: {
             name: 'TuiMultiSelect',
             moduleSpecifier: '@taiga-ui/kit',
+            spreadInModule: true,
         },
     },
     {
@@ -442,6 +450,7 @@ export const IDENTIFIERS_TO_REPLACE: ReplacementIdentifierMulti[] = [
         to: {
             name: 'TuiSelect',
             moduleSpecifier: '@taiga-ui/kit',
+            spreadInModule: true,
         },
     },
     {
@@ -643,6 +652,7 @@ export const IDENTIFIERS_TO_REPLACE: ReplacementIdentifierMulti[] = [
         to: {
             name: 'TuiAccordion',
             moduleSpecifier: '@taiga-ui/kit',
+            spreadInModule: true,
         },
     },
     {
@@ -653,6 +663,7 @@ export const IDENTIFIERS_TO_REPLACE: ReplacementIdentifierMulti[] = [
         to: {
             name: 'TuiInput',
             moduleSpecifier: '@taiga-ui/core',
+            spreadInModule: true,
         },
     },
     {
@@ -673,6 +684,7 @@ export const IDENTIFIERS_TO_REPLACE: ReplacementIdentifierMulti[] = [
         to: {
             name: 'TuiSlider',
             moduleSpecifier: '@taiga-ui/core',
+            spreadInModule: true,
         },
     },
     {
@@ -703,6 +715,7 @@ export const IDENTIFIERS_TO_REPLACE: ReplacementIdentifierMulti[] = [
         to: {
             name: 'TuiRadio',
             moduleSpecifier: '@taiga-ui/core',
+            spreadInModule: true,
         },
     },
     {
@@ -779,6 +792,7 @@ export const IDENTIFIERS_TO_REPLACE: ReplacementIdentifierMulti[] = [
         to: {
             name: 'TuiError',
             moduleSpecifier: '@taiga-ui/core',
+            spreadInModule: true,
         },
     },
     {
@@ -1005,6 +1019,7 @@ export const IDENTIFIERS_TO_REPLACE: ReplacementIdentifierMulti[] = [
             {
                 name: 'TuiInput',
                 moduleSpecifier: '@taiga-ui/core',
+                spreadInModule: true,
             },
         ],
     },
@@ -1021,10 +1036,12 @@ export const IDENTIFIERS_TO_REPLACE: ReplacementIdentifierMulti[] = [
             {
                 name: 'TuiCopy',
                 moduleSpecifier: '@taiga-ui/kit',
+                spreadInModule: true,
             },
             {
                 name: 'TuiInput',
                 moduleSpecifier: '@taiga-ui/core',
+                spreadInModule: true,
             },
         ],
     },
@@ -1052,6 +1069,7 @@ export const IDENTIFIERS_TO_REPLACE: ReplacementIdentifierMulti[] = [
             {
                 name: 'TuiInputMonth',
                 moduleSpecifier: '@taiga-ui/kit',
+                spreadInModule: true,
             },
         ],
     },
@@ -1063,6 +1081,7 @@ export const IDENTIFIERS_TO_REPLACE: ReplacementIdentifierMulti[] = [
         to: {
             name: 'TuiInputColor',
             moduleSpecifier: '@taiga-ui/kit',
+            spreadInModule: true,
         },
     },
     {
@@ -1089,6 +1108,7 @@ export const IDENTIFIERS_TO_REPLACE: ReplacementIdentifierMulti[] = [
         to: {
             name: 'TuiInputDate',
             moduleSpecifier: '@taiga-ui/kit',
+            spreadInModule: true,
         },
     },
     {
@@ -1099,6 +1119,7 @@ export const IDENTIFIERS_TO_REPLACE: ReplacementIdentifierMulti[] = [
         to: {
             name: 'TuiInputDateTime',
             moduleSpecifier: '@taiga-ui/kit',
+            spreadInModule: true,
         },
     },
     {
@@ -1109,6 +1130,7 @@ export const IDENTIFIERS_TO_REPLACE: ReplacementIdentifierMulti[] = [
         to: {
             name: 'TuiInputTime',
             moduleSpecifier: '@taiga-ui/kit',
+            spreadInModule: true,
         },
     },
     {
@@ -1119,6 +1141,7 @@ export const IDENTIFIERS_TO_REPLACE: ReplacementIdentifierMulti[] = [
         to: {
             name: 'TuiInputPhoneInternational',
             moduleSpecifier: '@taiga-ui/kit',
+            spreadInModule: true,
         },
     },
     {
@@ -1129,6 +1152,7 @@ export const IDENTIFIERS_TO_REPLACE: ReplacementIdentifierMulti[] = [
         to: {
             name: 'TuiInputPhoneInternational',
             moduleSpecifier: '@taiga-ui/kit',
+            spreadInModule: true,
         },
     },
     {
@@ -1139,6 +1163,7 @@ export const IDENTIFIERS_TO_REPLACE: ReplacementIdentifierMulti[] = [
         to: {
             name: 'TuiInputDateRange',
             moduleSpecifier: '@taiga-ui/kit',
+            spreadInModule: true,
         },
     },
     {
@@ -1169,6 +1194,7 @@ export const IDENTIFIERS_TO_REPLACE: ReplacementIdentifierMulti[] = [
         to: {
             name: 'TuiInputChip',
             moduleSpecifier: '@taiga-ui/kit',
+            spreadInModule: true,
         },
     },
     {
@@ -1199,6 +1225,7 @@ export const IDENTIFIERS_TO_REPLACE: ReplacementIdentifierMulti[] = [
         to: {
             name: 'TuiInput',
             moduleSpecifier: '@taiga-ui/core',
+            spreadInModule: true,
         },
     },
     {
@@ -1209,6 +1236,7 @@ export const IDENTIFIERS_TO_REPLACE: ReplacementIdentifierMulti[] = [
         to: {
             name: 'TuiTextarea',
             moduleSpecifier: '@taiga-ui/kit',
+            spreadInModule: true,
         },
     },
     {
@@ -1219,6 +1247,7 @@ export const IDENTIFIERS_TO_REPLACE: ReplacementIdentifierMulti[] = [
         to: {
             name: 'TuiCarousel',
             moduleSpecifier: '@taiga-ui/legacy',
+            spreadInModule: true,
         },
     },
     {
@@ -1774,6 +1803,7 @@ export const IDENTIFIERS_TO_REPLACE: ReplacementIdentifierMulti[] = [
         to: {
             name: 'TuiNotification',
             moduleSpecifier: '@taiga-ui/core',
+            spreadInModule: true,
         },
     },
     {

--- a/projects/cdk/schematics/ng-update/v5/steps/constants/identifiers-to-replace.ts
+++ b/projects/cdk/schematics/ng-update/v5/steps/constants/identifiers-to-replace.ts
@@ -1707,6 +1707,28 @@ export const IDENTIFIERS_TO_REPLACE: ReplacementIdentifierMulti[] = [
     },
     {
         from: {
+            name: 'TuiExpand',
+            moduleSpecifier: '@taiga-ui/core',
+        },
+        to: {
+            name: 'TuiExpand',
+            moduleSpecifier: '@taiga-ui/core',
+            removeSpread: true,
+        },
+    },
+    {
+        from: {
+            name: 'TuiActionBar',
+            moduleSpecifier: '@taiga-ui/kit',
+        },
+        to: {
+            name: 'TuiActionBar',
+            moduleSpecifier: '@taiga-ui/kit',
+            removeSpread: true,
+        },
+    },
+    {
+        from: {
             name: 'TuiMobileDialogOptions',
             moduleSpecifier: '@taiga-ui/addon-mobile',
         },

--- a/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-identifiers.spec.ts.snap
+++ b/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-identifiers.spec.ts.snap
@@ -292,7 +292,7 @@ exports[`ng-update identifiers migration moves TuiMultiSelectModule (legacy) to 
                                 import {NgModule} from '@angular/core';
 
                 @NgModule({
-                    imports: [TuiMultiSelect],
+                    imports: [...TuiMultiSelect],
                 })
                 export class TestModule {}
             ",

--- a/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-input-date-multi.spec.ts.snap
+++ b/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-input-date-multi.spec.ts.snap
@@ -117,7 +117,7 @@ exports[`ng-update migrate TuiInputDate[multiple] to TuiInputDateMulti: test.ts 
                                 @NgModule({
                     imports: [
                         // ...
-                        TuiInputDate,
+                        ...TuiInputDate,
                     ],
                     // ...
                 })

--- a/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-input-month.spec.ts.snap
+++ b/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-input-month.spec.ts.snap
@@ -88,7 +88,7 @@ exports[`ng-update migrate TuiInputMonthModule to TuiInputMonth: test.ts 1`] = `
                                 @NgModule({
                     imports: [
                         // ...
-                        TuiInputMonth,
+                        ...TuiInputMonth,
                     ],
                     // ...
                 })

--- a/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-input-number.spec.ts.snap
+++ b/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-input-number.spec.ts.snap
@@ -197,7 +197,7 @@ exports[`ng-update migrate TuiInputNumberModule to TuiInputNumber: test.ts 1`] =
                                 @NgModule({
                     imports: [
                         // ...
-                        TuiInputNumber,
+                        ...TuiInputNumber,
                     ],
                     // ...
                 })

--- a/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-input-password.spec.ts.snap
+++ b/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-input-password.spec.ts.snap
@@ -149,7 +149,7 @@ import { TuiIcon, TuiInput } from "@taiga-ui/core";
                                 @NgModule({
                     imports: [
                         // ...
-                        TuiIcon, TuiPassword, TuiInput,
+                        TuiIcon, TuiPassword, ...TuiInput,
                     ],
                     // ...
                 })

--- a/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-input-phone.spec.ts.snap
+++ b/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-input-phone.spec.ts.snap
@@ -195,7 +195,7 @@ exports[`ng-update migrate TuiInputPhoneModule to TuiInputPhone: test.ts 1`] = `
                                 @NgModule({
                     imports: [
                         // ...
-                        TuiInputPhone,
+                        ...TuiInputPhone,
                     ],
                     // ...
                 })

--- a/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-input-time.spec.ts.snap
+++ b/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-input-time.spec.ts.snap
@@ -103,7 +103,7 @@ exports[`ng-update migrate TuiInputTimeModule to TuiInputTime: test.ts 1`] = `
   "1. After": "import { TuiInputTime } from "@taiga-ui/kit";
 
                                 @NgModule({
-                    imports: [TuiInputTime],
+                    imports: [...TuiInputTime],
                 })
                 export class MyModule {}
 

--- a/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-input-year.spec.ts.snap
+++ b/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-input-year.spec.ts.snap
@@ -146,7 +146,7 @@ exports[`ng-update migrate TuiInputYearModule to TuiInputYear: test.ts 1`] = `
                                 @NgModule({
                     imports: [
                         // ...
-                        TuiInputYear,
+                        ...TuiInputYear,
                     ],
                     // ...
                 })

--- a/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-spread-in-module.spec.ts.snap
+++ b/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-spread-in-module.spec.ts.snap
@@ -1,0 +1,118 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ng-update spread barrel arrays in NgModule imports does not spread a barrel replacement in a standalone component: test.ts 1`] = `
+{
+  "0. Before": "
+                import {TuiTextareaModule} from '@taiga-ui/legacy';
+                import {Component} from '@angular/core';
+
+                @Component({
+                    standalone: true,
+                    imports: [TuiTextareaModule],
+                    template: '',
+                })
+                export class TestComponent {}
+            ",
+  "1. After": "import { TuiTextarea } from "@taiga-ui/kit";
+
+                                import {Component} from '@angular/core';
+
+                @Component({
+                    standalone: true,
+                    imports: [TuiTextarea],
+                    template: '',
+                })
+                export class TestComponent {}
+            ",
+}
+`;
+
+exports[`ng-update spread barrel arrays in NgModule imports keeps neighbors and their order when spreading a barrel element: test.ts 1`] = `
+{
+  "0. Before": "
+                import {TuiInputModule} from '@taiga-ui/legacy';
+                import {CommonModule} from '@angular/common';
+                import {NgModule} from '@angular/core';
+
+                class AaaModule {}
+                class ZzzModule {}
+
+                @NgModule({
+                    imports: [CommonModule, AaaModule, TuiInputModule, ZzzModule],
+                })
+                export class TestModule {}
+            ",
+  "1. After": "import { TuiInput } from "@taiga-ui/core";
+
+                                import {CommonModule} from '@angular/common';
+                import {NgModule} from '@angular/core';
+
+                class AaaModule {}
+                class ZzzModule {}
+
+                @NgModule({
+                    imports: [CommonModule, AaaModule, ...TuiInput, ZzzModule],
+                })
+                export class TestModule {}
+            ",
+}
+`;
+
+exports[`ng-update spread barrel arrays in NgModule imports re-migrates a file that already contains spread barrels without doubling them: test.ts 1`] = `
+{
+  "0. Before": "
+                import {
+                    TuiInputModule,
+                    TuiMultiSelectModule,
+                    TuiTextfieldControllerModule,
+                } from '@taiga-ui/legacy';
+                import {TuiTextfield} from '@taiga-ui/core';
+                import {NgModule} from '@angular/core';
+
+                @NgModule({
+                    imports: [
+                        ...TuiTextfield,
+                        TuiInputModule,
+                        TuiTextfieldControllerModule,
+                        TuiMultiSelectModule,
+                    ],
+                })
+                export class TestModule {}
+            ",
+  "1. After": "import { TuiInput } from "@taiga-ui/core";
+import { TuiMultiSelect } from "@taiga-ui/kit";
+                import {NgModule} from '@angular/core';
+
+                @NgModule({
+                    imports: [
+                        ...TuiInput,
+                        ...TuiMultiSelect,
+                    ],
+                })
+                export class TestModule {}
+            ",
+}
+`;
+
+exports[`ng-update spread barrel arrays in NgModule imports spreads a barrel replacement inside @NgModule imports: test.ts 1`] = `
+{
+  "0. Before": "
+                import {TuiTextareaModule} from '@taiga-ui/legacy';
+                import {NgModule} from '@angular/core';
+
+                @NgModule({
+                    imports: [TuiTextareaModule],
+                })
+                export class TestModule {}
+            ",
+  "1. After": "import { TuiTextarea } from "@taiga-ui/kit";
+
+                                import {NgModule} from '@angular/core';
+
+                @NgModule({
+                    imports: [...TuiTextarea],
+                })
+                export class TestModule {}
+            ",
+}
+`;

--- a/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-unspread-barrel.spec.ts.snap
+++ b/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-unspread-barrel.spec.ts.snap
@@ -1,0 +1,82 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ng-update strip invalid spread of collapsed barrels strips the TuiActionBar spread and keeps neighbors and their order: test.ts 1`] = `
+{
+  "0. Before": "
+                import {TuiActionBar} from '@taiga-ui/kit';
+                import {CommonModule} from '@angular/common';
+                import {NgModule} from '@angular/core';
+
+                class AaaModule {}
+                class ZzzModule {}
+
+                @NgModule({
+                    imports: [CommonModule, AaaModule, ...TuiActionBar, ZzzModule],
+                })
+                export class TestModule {}
+            ",
+  "1. After": "
+                import {TuiActionBar} from '@taiga-ui/kit';
+                import {CommonModule} from '@angular/common';
+                import {NgModule} from '@angular/core';
+
+                class AaaModule {}
+                class ZzzModule {}
+
+                @NgModule({
+                    imports: [CommonModule, AaaModule, TuiActionBar, ZzzModule],
+                })
+                export class TestModule {}
+            ",
+}
+`;
+
+exports[`ng-update strip invalid spread of collapsed barrels strips the spread from a barrel that became a single class in @NgModule imports: test.ts 1`] = `
+{
+  "0. Before": "
+                import {TuiExpand} from '@taiga-ui/core';
+                import {NgModule} from '@angular/core';
+
+                @NgModule({
+                    imports: [...TuiExpand],
+                })
+                export class TestModule {}
+            ",
+  "1. After": "
+                import {TuiExpand} from '@taiga-ui/core';
+                import {NgModule} from '@angular/core';
+
+                @NgModule({
+                    imports: [TuiExpand],
+                })
+                export class TestModule {}
+            ",
+}
+`;
+
+exports[`ng-update strip invalid spread of collapsed barrels strips the spread in a standalone component too: test.ts 1`] = `
+{
+  "0. Before": "
+                import {TuiExpand} from '@taiga-ui/core';
+                import {Component} from '@angular/core';
+
+                @Component({
+                    standalone: true,
+                    imports: [...TuiExpand],
+                    template: '',
+                })
+                export class TestComponent {}
+            ",
+  "1. After": "
+                import {TuiExpand} from '@taiga-ui/core';
+                import {Component} from '@angular/core';
+
+                @Component({
+                    standalone: true,
+                    imports: [TuiExpand],
+                    template: '',
+                })
+                export class TestComponent {}
+            ",
+}
+`;

--- a/projects/cdk/schematics/ng-update/v5/tests/schematic-migrate-spread-in-module.spec.ts
+++ b/projects/cdk/schematics/ng-update/v5/tests/schematic-migrate-spread-in-module.spec.ts
@@ -1,0 +1,89 @@
+import {join} from 'node:path';
+
+import {resetActiveProject} from 'ng-morph';
+
+import {createMigration} from '../../../utils/run-migration';
+
+describe('ng-update spread barrel arrays in NgModule imports', () => {
+    const migrate = createMigration({
+        collection: join(__dirname, '../../../migration.json'),
+    });
+
+    it(
+        'spreads a barrel replacement inside @NgModule imports',
+        migrate({
+            component: /* TypeScript */ `
+                import {TuiTextareaModule} from '@taiga-ui/legacy';
+                import {NgModule} from '@angular/core';
+
+                @NgModule({
+                    imports: [TuiTextareaModule],
+                })
+                export class TestModule {}
+            `,
+        }),
+    );
+
+    it(
+        'does not spread a barrel replacement in a standalone component',
+        migrate({
+            component: /* TypeScript */ `
+                import {TuiTextareaModule} from '@taiga-ui/legacy';
+                import {Component} from '@angular/core';
+
+                @Component({
+                    standalone: true,
+                    imports: [TuiTextareaModule],
+                    template: '',
+                })
+                export class TestComponent {}
+            `,
+        }),
+    );
+
+    it(
+        'keeps neighbors and their order when spreading a barrel element',
+        migrate({
+            component: /* TypeScript */ `
+                import {TuiInputModule} from '@taiga-ui/legacy';
+                import {CommonModule} from '@angular/common';
+                import {NgModule} from '@angular/core';
+
+                class AaaModule {}
+                class ZzzModule {}
+
+                @NgModule({
+                    imports: [CommonModule, AaaModule, TuiInputModule, ZzzModule],
+                })
+                export class TestModule {}
+            `,
+        }),
+    );
+
+    it(
+        're-migrates a file that already contains spread barrels without doubling them',
+        migrate({
+            component: /* TypeScript */ `
+                import {
+                    TuiInputModule,
+                    TuiMultiSelectModule,
+                    TuiTextfieldControllerModule,
+                } from '@taiga-ui/legacy';
+                import {TuiTextfield} from '@taiga-ui/core';
+                import {NgModule} from '@angular/core';
+
+                @NgModule({
+                    imports: [
+                        ...TuiTextfield,
+                        TuiInputModule,
+                        TuiTextfieldControllerModule,
+                        TuiMultiSelectModule,
+                    ],
+                })
+                export class TestModule {}
+            `,
+        }),
+    );
+
+    afterEach(() => resetActiveProject());
+});

--- a/projects/cdk/schematics/ng-update/v5/tests/schematic-migrate-unspread-barrel.spec.ts
+++ b/projects/cdk/schematics/ng-update/v5/tests/schematic-migrate-unspread-barrel.spec.ts
@@ -1,0 +1,64 @@
+import {join} from 'node:path';
+
+import {resetActiveProject} from 'ng-morph';
+
+import {createMigration} from '../../../utils/run-migration';
+
+describe('ng-update strip invalid spread of collapsed barrels', () => {
+    const migrate = createMigration({
+        collection: join(__dirname, '../../../migration.json'),
+    });
+
+    it(
+        'strips the spread from a barrel that became a single class in @NgModule imports',
+        migrate({
+            component: /* TypeScript */ `
+                import {TuiExpand} from '@taiga-ui/core';
+                import {NgModule} from '@angular/core';
+
+                @NgModule({
+                    imports: [...TuiExpand],
+                })
+                export class TestModule {}
+            `,
+        }),
+    );
+
+    it(
+        'strips the TuiActionBar spread and keeps neighbors and their order',
+        migrate({
+            component: /* TypeScript */ `
+                import {TuiActionBar} from '@taiga-ui/kit';
+                import {CommonModule} from '@angular/common';
+                import {NgModule} from '@angular/core';
+
+                class AaaModule {}
+                class ZzzModule {}
+
+                @NgModule({
+                    imports: [CommonModule, AaaModule, ...TuiActionBar, ZzzModule],
+                })
+                export class TestModule {}
+            `,
+        }),
+    );
+
+    it(
+        'strips the spread in a standalone component too',
+        migrate({
+            component: /* TypeScript */ `
+                import {TuiExpand} from '@taiga-ui/core';
+                import {Component} from '@angular/core';
+
+                @Component({
+                    standalone: true,
+                    imports: [...TuiExpand],
+                    template: '',
+                })
+                export class TestComponent {}
+            `,
+        }),
+    );
+
+    afterEach(() => resetActiveProject());
+});


### PR DESCRIPTION
## What / Why

v5 exports many entities as **readonly barrel tuples** (`declare const X: readonly [Component, Directive, ...]`). Two problems surfaced when the schematic rewrites `@NgModule({imports})`:

1. **Barrels were inserted without a spread.** `@NgModule.imports` is typed `any[] | Type<any> | ModuleWithProviders<{}>` — a `readonly [...]` tuple is not assignable to the mutable `any[]`, so it raises `TS2322` and breaks the whole module (cascading into `NG8001/NG8002/NG8004` for every component declared there). Standalone `@Component.imports` accepts a `ReadonlyArray`, so it must **not** be spread. None of the barrel `to`-targets set `spreadInModule`, so this path had zero coverage.

2. **Re-migration crashed.** The spread was applied by replacing the identifier reference text with `...Name`, which changes the node kind (`Identifier` → `SpreadElement`). On a file that already contains spreads (re-running the migration, or a partially-migrated codebase), matching a symbol **inside** an existing `...X` produced a doubled `......X` and made ts-morph throw `The children of the old and new trees were expected to have the same count`, aborting the entire run.

## Fix

- Mark every barrel `to`-target with `spreadInModule: true` (30 entries). The existing `inModule` guard already emits the spread only under `@NgModule`, never under standalone `@Component`.
- In `replaceReference`, when the matched reference is already the expression of a `SpreadElement`, replace only the **inner identifier** and keep the existing `...`. Node kind is preserved, no `......`, formatting and comments untouched.

## Before / After

NgModule — barrel is spread:

|         | imports                     |
| ------- | --------------------------- |
| Before  | `imports: [TuiInputModule]` |
| After   | `imports: [...TuiInput]`    |

Standalone — left un-spread:

|         | imports                                                        |
| ------- | -------------------------------------------------------------- |
| Before  | `@Component({standalone: true, imports: [TuiInputModule]})`     |
| After   | `@Component({standalone: true, imports: [TuiInput]})`           |

Re-migration — idempotent, no doubled spread:

|         | imports                                    |
| ------- | ------------------------------------------ |
| Before  | `imports: [...TuiTextfield, TuiInputModule]` |
| After   | `imports: [...TuiInput]`                    |

---

## Follow-up: strip invalid spreads of barrels that collapsed into single classes

The mirror image of problem 1. `TuiExpand` (`@taiga-ui/core`) and `TuiActionBar` (`@taiga-ui/kit`) were `readonly [...]` barrels in v4 and are **single classes** in v5 — under the **same name and module**. So existing v4 code has `imports: [...TuiExpand]` / `[...TuiActionBar]`, and after upgrade those spreads are invalid (`TS2488` — a class can't be spread). No rename rule removed the `...`, because the name and module are unchanged, so it was left silently broken.

### Fix

- New `removeSpread` flag on the replacement target. When set and the matched reference is the expression of a `SpreadElement`, the whole `...Name` is replaced with the plain `Name`, stripping the now-invalid spread in both `@NgModule` and standalone imports. Two declarative entries: `TuiExpand@core`, `TuiActionBar@kit`.
- Skip the import remove/re-add when the target already matches the existing import, so a same-name/same-module entry no longer relocates an untouched import (previously it churned every file that merely imported the symbol).

### Before / After

|         | imports                    |
| ------- | -------------------------- |
| Before  | `imports: [...TuiExpand]`  |
| After   | `imports: [TuiExpand]`     |

## Tests

- `schematic-migrate-spread-in-module.spec.ts`: NgModule spread, standalone no-spread, neighbor/order preservation, re-migration without doubling.
- `schematic-migrate-unspread-barrel.spec.ts`: spread stripped in NgModule and standalone, neighbor/order preservation.
- Full v5 suite green: **783 passed**.
