### PR TITLE
fix(schematics): avoid self-referential @let when migrating *tuiLet (v5)

### DIFF
--- a/projects/cdk/schematics/ng-update/v5/steps/migrate-tui-let.ts
+++ b/projects/cdk/schematics/ng-update/v5/steps/migrate-tui-let.ts
@@ -78,7 +78,27 @@ function migrateStructuralLet(
         return;
     }
 
-    insertLetDeclaration({recorder, offset, element, template, expr, key});
+    // `*tuiLet="foo() as foo"` scopes the alias to the element, so the alias name
+    // may repeat an identifier used in the expression. A plain `@let foo = foo()`
+    // is self-referential, which Angular rejects (NG8016), so rename the `@let` and
+    // update the alias references inside the element.
+    const selfReferential = referencesIdentifier(expr, key);
+    const letKey = selfReferential ? deriveSafeKey(template, key) : key;
+
+    insertLetDeclaration({recorder, offset, element, template, expr, key: letKey});
+
+    if (selfReferential) {
+        renameAliasReferences({
+            recorder,
+            offset,
+            element,
+            attr,
+            template,
+            from: key,
+            to: letKey,
+        });
+    }
+
     removeStructuralAttribute({recorder, offset, element, attr});
 }
 
@@ -92,6 +112,71 @@ function containsDuplicateLet(template: string, key: string): boolean {
     const pattern = new RegExp(String.raw`@let\s+${key}\s+=`);
 
     return pattern.test(template);
+}
+
+function escapeRegExp(value: string): string {
+    return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+// `$` is a valid identifier character, so it must count as part of the word.
+// Otherwise `foo` would falsely match inside `foo$` (the common
+// `foo$ | async as foo` pattern) and be treated as a self-reference.
+function identifierPattern(key: string, flags = ''): RegExp {
+    return new RegExp(String.raw`(?<![\w$])${escapeRegExp(key)}(?![\w$])`, flags);
+}
+
+function referencesIdentifier(expr: string, key: string): boolean {
+    return identifierPattern(key).test(expr);
+}
+
+function deriveSafeKey(template: string, key: string): string {
+    let candidate = `${key}Value`;
+    let counter = 2;
+
+    while (containsDuplicateLet(template, candidate)) {
+        candidate = `${key}Value${counter++}`;
+    }
+
+    return candidate;
+}
+
+function renameAliasReferences({
+    recorder,
+    offset,
+    element,
+    attr,
+    template,
+    from,
+    to,
+}: {
+    recorder: UpdateRecorder;
+    offset: number;
+    element: Element;
+    attr: {name: string; value: string};
+    template: string;
+    from: string;
+    to: string;
+}): void {
+    const loc = element.sourceCodeLocation!;
+    const attrLoc = loc.attrs?.[attr.name];
+    const pattern = identifierPattern(from, 'g');
+
+    for (let match = pattern.exec(template); match; match = pattern.exec(template)) {
+        const index = match.index;
+
+        if (index < loc.startOffset || index >= loc.endOffset) {
+            continue;
+        }
+
+        // The alias itself lives inside the *tuiLet attribute, which is removed
+        // separately — never rewrite anything within its range.
+        if (attrLoc && index >= attrLoc.startOffset && index < attrLoc.endOffset) {
+            continue;
+        }
+
+        recorder.remove(offset + index, from.length);
+        recorder.insertRight(offset + index, to);
+    }
 }
 
 function insertLetDeclaration({

--- a/projects/cdk/schematics/ng-update/v5/steps/migrate-tui-let.ts
+++ b/projects/cdk/schematics/ng-update/v5/steps/migrate-tui-let.ts
@@ -115,7 +115,7 @@ function containsDuplicateLet(template: string, key: string): boolean {
 }
 
 function escapeRegExp(value: string): string {
-    return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    return value.replaceAll(/[.*+?^${}()|[\]\\]/g, String.raw`\$&`);
 }
 
 // `$` is a valid identifier character, so it must count as part of the word.

--- a/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-tui-let.spec.ts.snap
+++ b/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-tui-let.spec.ts.snap
@@ -1,5 +1,51 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`ng-update tuiLet keeps the alias when only an observable (foo$) shares its stem: test.html 1`] = `
+{
+  "0. Before": "
+                <test *tuiLet="isOrderCompleted$ | async as isOrderCompleted">
+                    {{ isOrderCompleted }}
+                </test>
+            ",
+  "1. After": "
+                @let isOrderCompleted = isOrderCompleted$ | async;
+                <test>
+                    {{ isOrderCompleted }}
+                </test>
+            ",
+}
+`;
+
+exports[`ng-update tuiLet keeps the alias when only an observable (foo$) shares its stem: test.ts 1`] = `
+{
+  "0. Before": "
+            import {Component} from '@angular/core';
+            import {TuiLet} from '@taiga-ui/cdk';
+
+            @Component({
+                standalone: true,
+                templateUrl: './test.html',
+                imports: [TuiLet],
+            })
+            export class Test {
+                readonly value = 'foo';
+            }
+        ",
+  "1. After": "
+            import {Component} from '@angular/core';
+
+            @Component({
+                standalone: true,
+                templateUrl: './test.html',
+                imports: [],
+            })
+            export class Test {
+                readonly value = 'foo';
+            }
+        ",
+}
+`;
+
 exports[`ng-update tuiLet migrates nested case with additional attributes: test.html 1`] = `
 {
   "0. Before": "
@@ -188,6 +234,54 @@ exports[`ng-update tuiLet migrates simple structural directive: test.html 1`] = 
 `;
 
 exports[`ng-update tuiLet migrates simple structural directive: test.ts 1`] = `
+{
+  "0. Before": "
+            import {Component} from '@angular/core';
+            import {TuiLet} from '@taiga-ui/cdk';
+
+            @Component({
+                standalone: true,
+                templateUrl: './test.html',
+                imports: [TuiLet],
+            })
+            export class Test {
+                readonly value = 'foo';
+            }
+        ",
+  "1. After": "
+            import {Component} from '@angular/core';
+
+            @Component({
+                standalone: true,
+                templateUrl: './test.html',
+                imports: [],
+            })
+            export class Test {
+                readonly value = 'foo';
+            }
+        ",
+}
+`;
+
+exports[`ng-update tuiLet renames the @let when the alias repeats an identifier in the expression: test.html 1`] = `
+{
+  "0. Before": "
+                <test *tuiLet="isOrderCompleted() as isOrderCompleted">
+                    {{ isOrderCompleted }}
+                    <span [class.done]="isOrderCompleted">done</span>
+                </test>
+            ",
+  "1. After": "
+                @let isOrderCompletedValue = isOrderCompleted();
+                <test>
+                    {{ isOrderCompletedValue }}
+                    <span [class.done]="isOrderCompletedValue">done</span>
+                </test>
+            ",
+}
+`;
+
+exports[`ng-update tuiLet renames the @let when the alias repeats an identifier in the expression: test.ts 1`] = `
 {
   "0. Before": "
             import {Component} from '@angular/core';

--- a/projects/cdk/schematics/ng-update/v5/tests/schematic-migrate-tui-let.spec.ts
+++ b/projects/cdk/schematics/ng-update/v5/tests/schematic-migrate-tui-let.spec.ts
@@ -83,5 +83,28 @@ describe('ng-update tuiLet', () => {
         }),
     );
 
+    it(
+        'renames the @let when the alias repeats an identifier in the expression',
+        migration({
+            template: /* HTML */ `
+                <test *tuiLet="isOrderCompleted() as isOrderCompleted">
+                    {{ isOrderCompleted }}
+                    <span [class.done]="isOrderCompleted">done</span>
+                </test>
+            `,
+        }),
+    );
+
+    it(
+        'keeps the alias when only an observable (foo$) shares its stem',
+        migration({
+            template: /* HTML */ `
+                <test *tuiLet="isOrderCompleted$ | async as isOrderCompleted">
+                    {{ isOrderCompleted }}
+                </test>
+            `,
+        }),
+    );
+
     afterEach(() => resetActiveProject());
 });


### PR DESCRIPTION
## What / Why

The `*tuiLet` → `@let` migration produces invalid output for the common `expr() as alias` memoization pattern when the alias repeats an identifier used in the expression.

`*tuiLet="isOrderCompleted() as isOrderCompleted"` scopes the alias to the element, so it is valid v4 code. Converting it verbatim yields:

```
@let isOrderCompleted = isOrderCompleted();
```

The `@let` name is in scope for its own initializer, so `isOrderCompleted()` resolves to the `@let` (not the component method) and Angular throws **NG8016** — "Cannot read @let declaration 'isOrderCompleted' before it has been defined". `TuiLet` is removed in v5, so there is no valid un-migrated fallback either.

## Fix

- Detect when the alias name is referenced as an identifier in the expression.
- In that case, rename the generated `@let` (e.g. `isOrderCompletedValue`) and rewrite the alias references **inside the element's scope** to the new name. The expression keeps the original identifier, so it refers to the component member again.
- The identifier check treats `$` as a word character, so the common `foo$ | async as foo` pattern is correctly left untouched (no rename).

## Before / After

|             | template                                                                             |
| ----------- | ------------------------------------------------------------------------------------ |
| Before      | `<div *tuiLet="isOrderCompleted() as isOrderCompleted">{{ isOrderCompleted }}</div>` |
| After (old) | `@let isOrderCompleted = isOrderCompleted();` → **NG8016**                            |
| After (fix) | `@let isOrderCompletedValue = isOrderCompleted();` + in-scope refs renamed           |

## Tests

- New cases in `schematic-migrate-tui-let.spec.ts`: the self-referential rename, and a guard that `foo$ | async as foo` is **not** treated as a collision.
- Full v5 suite green: **778 passed**.

## Notes

Reference rewriting is scoped to the element's source range and skips the `*tuiLet` attribute itself. Open to feedback on whether a rename (chosen here, so the migrated project builds) or a TODO-comment escape hatch is preferred.
