### PR TITLE
fix(core): `Input` should prevent premature invalid appearance for untouched state with signal forms

### DIFF
--- a/projects/cdk/utils/di/index.ts
+++ b/projects/cdk/utils/di/index.ts
@@ -1,4 +1,5 @@
 export * from './create-options';
 export * from './directive-binding';
+export * from './inject-form-field';
 export * from './provide';
 export * from './provide-options';

--- a/projects/cdk/utils/di/inject-form-field.ts
+++ b/projects/cdk/utils/di/inject-form-field.ts
@@ -1,4 +1,4 @@
-import {computed, inject, type InjectOptions, type Signal} from '@angular/core';
+import {computed, inject, InjectOptions, type Signal} from '@angular/core';
 import {NgControl} from '@angular/forms';
 
 /**
@@ -8,5 +8,5 @@ export function tuiInjectFormField(options: InjectOptions = {}): Signal<unknown>
     const control = inject(NgControl, options);
 
     // @ts-expect-error
-    return computed(() => control.field?.());
+    return computed(() => control?.field?.());
 }

--- a/projects/cdk/utils/di/inject-form-field.ts
+++ b/projects/cdk/utils/di/inject-form-field.ts
@@ -1,4 +1,4 @@
-import {computed, inject, InjectOptions, type Signal} from '@angular/core';
+import {computed, inject, type InjectOptions, type Signal} from '@angular/core';
 import {NgControl} from '@angular/forms';
 
 /**

--- a/projects/cdk/utils/di/inject-form-field.ts
+++ b/projects/cdk/utils/di/inject-form-field.ts
@@ -1,0 +1,12 @@
+import {computed, inject, type InjectOptions, type Signal} from '@angular/core';
+import {NgControl} from '@angular/forms';
+
+/**
+ * @deprecated use inject(FORM_FIELD) from `@angular/forms/signals` if Angular >= 21
+ */
+export function tuiInjectFormField(options: InjectOptions = {}): Signal<unknown> {
+    const control = inject(NgControl, options);
+
+    // @ts-expect-error
+    return computed(() => control.field?.());
+}

--- a/projects/core/components/error/error.directive.ts
+++ b/projects/core/components/error/error.directive.ts
@@ -158,7 +158,7 @@ export class TuiErrorField
     extends AbstractTuiErrorDirective
     implements TuiFormValueControl<unknown>
 {
-    private readonly field = tuiInjectFormField();
+    private readonly field = tuiInjectFormField({self: true});
 
     public readonly errors = input<readonly TuiSignalValidationError[]>([]);
     public readonly touched = input(false);

--- a/projects/core/components/error/error.directive.ts
+++ b/projects/core/components/error/error.directive.ts
@@ -14,7 +14,6 @@ import {
     type ControlValueAccessor,
     NG_VALIDATORS,
     NG_VALUE_ACCESSOR,
-    NgControl,
     type ValidationErrors,
     type Validator,
 } from '@angular/forms';
@@ -25,7 +24,11 @@ import {
 } from '@taiga-ui/cdk/classes';
 import {TuiId} from '@taiga-ui/cdk/directives/id';
 import {type TuiNativeValidator} from '@taiga-ui/cdk/directives/native-validator';
-import {tuiDirectiveBinding, tuiProvide} from '@taiga-ui/cdk/utils/di';
+import {
+    tuiDirectiveBinding,
+    tuiInjectFormField,
+    tuiProvide,
+} from '@taiga-ui/cdk/utils/di';
 import {tuiInjectElement} from '@taiga-ui/cdk/utils/dom';
 import {tuiIsString} from '@taiga-ui/cdk/utils/miscellaneous';
 import {TUI_VALIDATION_ERRORS} from '@taiga-ui/core/tokens';
@@ -155,9 +158,7 @@ export class TuiErrorField
     extends AbstractTuiErrorDirective
     implements TuiFormValueControl<unknown>
 {
-    // TODO: use inject(FORM_FIELD) from `@angular/forms/signals` after update to Angular >= 21
-    // @ts-expect-error
-    private readonly field = inject(NgControl, {self: true}).field;
+    private readonly field = tuiInjectFormField();
 
     public readonly errors = input<readonly TuiSignalValidationError[]>([]);
     public readonly touched = input(false);
@@ -195,7 +196,7 @@ export class TuiErrorField
          */
         // @ts-ignore
         const validatorField = validator.control.field?.();
-        const field = this.field?.();
+        const field = this.field();
 
         if (field && validatorField === field) {
             validator.id = this.el.id;

--- a/projects/core/components/input/input.directive.ts
+++ b/projects/core/components/input/input.directive.ts
@@ -40,7 +40,10 @@ import {type TuiInteractiveState} from '@taiga-ui/core/types';
     },
 })
 export class TuiInputDirective<T> implements TuiTextfieldAccessor<T> {
-    private readonly field = tuiInjectFormField();
+    private readonly field = tuiInjectFormField({self: true, optional: true});
+    private readonly computedInvalid = computed(
+        () => this.textfield.invalid() ?? (this.field() ? null : this.invalid()),
+    );
 
     protected readonly el = tuiInjectElement<HTMLInputElement>();
     protected readonly control = inject(NgControl, {optional: true});
@@ -96,8 +99,7 @@ export class TuiInputDirective<T> implements TuiTextfieldAccessor<T> {
     public readonly value = tuiValue(this.el);
 
     public readonly mode = computed<string | null>(() => {
-        const fallback = this.field() ? null : this.invalid();
-        const invalid = this.textfield.invalid() ?? fallback;
+        const invalid = this.computedInvalid();
 
         if (this.readOnly()) {
             return 'readonly';
@@ -122,7 +124,7 @@ export class TuiInputDirective<T> implements TuiTextfieldAccessor<T> {
             const control = injector.get(TuiControl, null, {self: true});
 
             if (control) {
-                tuiSetSignal(control.pseudoInvalid, this.textfield.invalid());
+                tuiSetSignal(control.pseudoInvalid, this.computedInvalid());
             }
         });
     }

--- a/projects/core/components/input/input.directive.ts
+++ b/projects/core/components/input/input.directive.ts
@@ -3,6 +3,7 @@ import {NgControl} from '@angular/forms';
 import {TuiControl} from '@taiga-ui/cdk/classes';
 import {TuiId} from '@taiga-ui/cdk/directives/id';
 import {TuiNativeValidator} from '@taiga-ui/cdk/directives/native-validator';
+import {tuiInjectFormField} from '@taiga-ui/cdk/utils';
 import {tuiInjectElement, tuiValue} from '@taiga-ui/cdk/utils/dom';
 import {tuiSetSignal} from '@taiga-ui/cdk/utils/miscellaneous';
 import {
@@ -39,6 +40,8 @@ import {type TuiInteractiveState} from '@taiga-ui/core/types';
     },
 })
 export class TuiInputDirective<T> implements TuiTextfieldAccessor<T> {
+    private readonly field = tuiInjectFormField();
+
     protected readonly el = tuiInjectElement<HTMLInputElement>();
     protected readonly control = inject(NgControl, {optional: true});
     protected readonly handlers: TuiItemsHandlers<T> = inject(TUI_ITEMS_HANDLERS);
@@ -93,7 +96,8 @@ export class TuiInputDirective<T> implements TuiTextfieldAccessor<T> {
     public readonly value = tuiValue(this.el);
 
     public readonly mode = computed<string | null>(() => {
-        const invalid = this.textfield.invalid() ?? this.invalid();
+        const fallback = this.field() ? null : this.invalid();
+        const invalid = this.textfield.invalid() ?? fallback;
 
         if (this.readOnly()) {
             return 'readonly';
@@ -113,13 +117,12 @@ export class TuiInputDirective<T> implements TuiTextfieldAccessor<T> {
      */
     constructor() {
         const injector = inject(INJECTOR);
-        const invalid = computed(() => this.textfield.invalid() ?? this.invalid());
 
         effect(() => {
             const control = injector.get(TuiControl, null, {self: true});
 
             if (control) {
-                tuiSetSignal(control.pseudoInvalid, invalid());
+                tuiSetSignal(control.pseudoInvalid, this.textfield.invalid());
             }
         });
     }

--- a/projects/core/components/input/input.directive.ts
+++ b/projects/core/components/input/input.directive.ts
@@ -3,7 +3,7 @@ import {NgControl} from '@angular/forms';
 import {TuiControl} from '@taiga-ui/cdk/classes';
 import {TuiId} from '@taiga-ui/cdk/directives/id';
 import {TuiNativeValidator} from '@taiga-ui/cdk/directives/native-validator';
-import {tuiInjectFormField} from '@taiga-ui/cdk/utils';
+import {tuiInjectFormField} from '@taiga-ui/cdk/utils/di';
 import {tuiInjectElement, tuiValue} from '@taiga-ui/cdk/utils/dom';
 import {tuiSetSignal} from '@taiga-ui/cdk/utils/miscellaneous';
 import {

--- a/projects/demo-cypress/src/tests/input-phone-international.cy.ts
+++ b/projects/demo-cypress/src/tests/input-phone-international.cy.ts
@@ -10,6 +10,8 @@ import {
 } from '@angular/core';
 import {takeUntilDestroyed} from '@angular/core/rxjs-interop';
 import {FormControl, ReactiveFormsModule} from '@angular/forms';
+import {By} from '@angular/platform-browser';
+import {TuiControl} from '@taiga-ui/cdk/classes';
 import {TuiIcon, TuiRoot} from '@taiga-ui/core';
 import {type TuiCountryIsoCode} from '@taiga-ui/i18n';
 import {
@@ -267,6 +269,73 @@ describe('InputPhoneInternational', () => {
 
                 cy.get('@input').should('have.value', '+375 12 345-67-89');
                 cy.get('@countryIsoCodeChange').should('have.been.calledWith', 'BY');
+            });
+        });
+    });
+
+    describe('Manual [invalid] override (template driven / reactive forms API)', () => {
+        let ngControl!: FormControl<string>;
+        
+        @Component({
+            imports: [ReactiveFormsModule, TuiInputPhoneInternational, TuiRoot],
+            template: `
+                <tui-root>
+                    <tui-textfield>
+                        <input
+                            tuiInputPhoneInternational
+                            [formControl]="control()"
+                            [invalid]="true"
+                        />
+                    </tui-textfield>
+                </tui-root>
+            `,
+            changeDetection: ChangeDetectionStrategy.OnPush,
+            providers: [
+                tuiInputPhoneInternationalOptionsProvider({
+                    metadata: import('libphonenumber-js/min/metadata').then((m) => m.default),
+                }),
+            ],
+        })
+        class ManualInvalidSandbox {
+            public readonly control = input(new FormControl('', {nonNullable: true}));
+        }
+        
+        it('looks invalid', () => {
+            cy.mount(ManualInvalidSandbox, componentProperties: {
+
+                        control: ngControl,
+                    }).then(({fixture}) => {
+                initAliases();
+
+                cy.get('@input').focus().blur();
+
+                cy.get('tui-textfield')
+                    .should('have.class', 'tui-invalid')
+                    .should(
+                            'have.attr',
+                            'data-mode',
+                            'invalid',
+                        );
+
+                cy.get('@input').should('have.attr', 'aria-invalid', 'true');
+            
+                cy.get<HTMLInputElement>('@input').should(($input) =>
+                    expect($input[0]!.validationMessage).to.equal('Invalid'),
+                );
+
+                cy.wrap(null).should(() => {
+                    const tuiControl = fixture.debugElement
+                        .query(By.css('input[tuiInputPhoneInternational]'))
+                        .injector.get(TuiControl);
+
+                    expect(tuiControl.invalid()).to.equal(true);
+                    expect(ngControl.status).to.equal('VALID');
+                });
+
+                cy.get('tui-textfield').compareSnapshot({
+                    name: 'phone-manual-invalid',
+                    cypressScreenshotOptions: {padding: 8},
+                });
             });
         });
     });

--- a/projects/demo-cypress/src/tests/input-phone-international.cy.ts
+++ b/projects/demo-cypress/src/tests/input-phone-international.cy.ts
@@ -319,7 +319,9 @@ describe('InputPhoneInternational', () => {
                 cy.get('@input').should('have.attr', 'aria-invalid', 'false');
 
                 cy.get('@input').should(($input) => {
-                    expect(($input[0] as HTMLInputElement).validationMessage).to.equal('')
+                    expect(($input[0] as HTMLInputElement).validationMessage).to.equal(
+                        '',
+                    );
 
                     const tuiControl = fixture.debugElement
                         .query(By.css('input[tuiInputPhoneInternational]'))

--- a/projects/demo-cypress/src/tests/input-phone-international.cy.ts
+++ b/projects/demo-cypress/src/tests/input-phone-international.cy.ts
@@ -11,7 +11,7 @@ import {
 import {takeUntilDestroyed} from '@angular/core/rxjs-interop';
 import {FormControl, ReactiveFormsModule} from '@angular/forms';
 import {By} from '@angular/platform-browser';
-import {TuiControl} from '@taiga-ui/cdk/classes';
+import {TuiControl} from '@taiga-ui/cdk';
 import {TuiIcon, TuiRoot} from '@taiga-ui/core';
 import {type TuiCountryIsoCode} from '@taiga-ui/i18n';
 import {
@@ -314,21 +314,19 @@ describe('InputPhoneInternational', () => {
 
                 cy.get('@input').focus().blur();
 
-                cy.get('tui-textfield')
-                    .should('have.attr', 'data-mode', 'invalid');
+                cy.get('tui-textfield').should('have.attr', 'data-mode', 'invalid');
 
                 cy.get('@input').should('have.attr', 'aria-invalid', 'false');
-                cy.get<HTMLInputElement>('@input')
-                    .should(($input) => {
-                        expect($input[0]!.validationMessage).to.equal('');
+                cy.get<HTMLInputElement>('@input').should(($input) => {
+                    expect($input[0]!.validationMessage).to.equal('');
 
-                        const tuiControl = fixture.debugElement
-                                .query(By.css('input[tuiInputPhoneInternational]'))
-                                .injector.get(TuiControl);
+                    const tuiControl = fixture.debugElement
+                        .query(By.css('input[tuiInputPhoneInternational]'))
+                        .injector.get(TuiControl);
 
-                        expect(tuiControl.invalid()).to.equal(true);
-                        expect(ngControl.status).to.equal('VALID');
-                    });
+                    expect(tuiControl.invalid()).to.equal(true);
+                    expect(ngControl.status).to.equal('VALID');
+                });
 
                 cy.get('tui-textfield').compareSnapshot({
                     name: 'phone-manual-invalid',

--- a/projects/demo-cypress/src/tests/input-phone-international.cy.ts
+++ b/projects/demo-cypress/src/tests/input-phone-international.cy.ts
@@ -317,8 +317,9 @@ describe('InputPhoneInternational', () => {
                 cy.get('tui-textfield').should('have.attr', 'data-mode', 'invalid');
 
                 cy.get('@input').should('have.attr', 'aria-invalid', 'false');
-                cy.get<HTMLInputElement>('@input').should(($input) => {
-                    expect($input[0]!.validationMessage).to.equal('');
+
+                cy.get('@input').should(($input) => {
+                    expect(($input[0] as HTMLInputElement).validationMessage).to.equal('')
 
                     const tuiControl = fixture.debugElement
                         .query(By.css('input[tuiInputPhoneInternational]'))

--- a/projects/demo-cypress/src/tests/input-phone-international.cy.ts
+++ b/projects/demo-cypress/src/tests/input-phone-international.cy.ts
@@ -275,7 +275,7 @@ describe('InputPhoneInternational', () => {
 
     describe('Manual [invalid] override (template driven / reactive forms API)', () => {
         let ngControl!: FormControl<string>;
-        
+
         @Component({
             imports: [ReactiveFormsModule, TuiInputPhoneInternational, TuiRoot],
             template: `
@@ -292,45 +292,43 @@ describe('InputPhoneInternational', () => {
             changeDetection: ChangeDetectionStrategy.OnPush,
             providers: [
                 tuiInputPhoneInternationalOptionsProvider({
-                    metadata: import('libphonenumber-js/min/metadata').then((m) => m.default),
+                    metadata: import('libphonenumber-js/min/metadata').then(
+                        (m) => m.default,
+                    ),
                 }),
             ],
         })
         class ManualInvalidSandbox {
             public readonly control = input(new FormControl('', {nonNullable: true}));
         }
-        
-        it('looks invalid', () => {
-            cy.mount(ManualInvalidSandbox, componentProperties: {
 
-                        control: ngControl,
-                    }).then(({fixture}) => {
+        beforeEach(() => {
+            ngControl = new FormControl('', {nonNullable: true});
+        });
+
+        it('paints the appearance but keeps native validity intact', () => {
+            cy.mount(ManualInvalidSandbox, {
+                componentProperties: {control: ngControl},
+            }).then(({fixture}) => {
                 initAliases();
 
                 cy.get('@input').focus().blur();
 
                 cy.get('tui-textfield')
-                    .should('have.class', 'tui-invalid')
-                    .should(
-                            'have.attr',
-                            'data-mode',
-                            'invalid',
-                        );
+                    .should('have.attr', 'data-mode', 'invalid');
 
-                cy.get('@input').should('have.attr', 'aria-invalid', 'true');
-            
-                cy.get<HTMLInputElement>('@input').should(($input) =>
-                    expect($input[0]!.validationMessage).to.equal('Invalid'),
-                );
+                cy.get('@input').should('have.attr', 'aria-invalid', 'false');
+                cy.get<HTMLInputElement>('@input')
+                    .should(($input) => {
+                        expect($input[0]!.validationMessage).to.equal('');
 
-                cy.wrap(null).should(() => {
-                    const tuiControl = fixture.debugElement
-                        .query(By.css('input[tuiInputPhoneInternational]'))
-                        .injector.get(TuiControl);
+                        const tuiControl = fixture.debugElement
+                                .query(By.css('input[tuiInputPhoneInternational]'))
+                                .injector.get(TuiControl);
 
-                    expect(tuiControl.invalid()).to.equal(true);
-                    expect(ngControl.status).to.equal('VALID');
-                });
+                        expect(tuiControl.invalid()).to.equal(true);
+                        expect(ngControl.status).to.equal('VALID');
+                    });
 
                 cy.get('tui-textfield').compareSnapshot({
                     name: 'phone-manual-invalid',

--- a/projects/demo-cypress/src/tests/input/input.cy.ts
+++ b/projects/demo-cypress/src/tests/input/input.cy.ts
@@ -31,6 +31,31 @@ export class TestTextfield {
 describe('Input', () => {
     beforeEach(() => cy.viewport(200, 150));
 
+    describe('without any form binding', () => {
+        @Component({
+            imports: [TuiInput, TuiRoot],
+            template: `
+                <tui-root>
+                    <tui-textfield>
+                        <label tuiLabel>Name</label>
+                        <input tuiInput />
+                    </tui-textfield>
+                </tui-root>
+            `,
+            changeDetection: ChangeDetectionStrategy.OnPush,
+        })
+        class TextfieldWithoutFormsSandbox {}
+
+        it('renders and stays editable', () => {
+            cy.mount(TextfieldWithoutFormsSandbox);
+
+            cy.get('tui-textfield input[tuiInput]')
+                .type('abc')
+                .should('have.value', 'abc');
+            cy.get('tui-textfield').should('not.have.attr', 'data-mode');
+        });
+    });
+
     describe('[filler] property', () => {
         describe('with initial value', () => {
             ['2', '23', '23:', '23:5', '23:59'].forEach((initialValue) => {

--- a/projects/demo-cypress/src/tests/input/signal-forms.cy.ts
+++ b/projects/demo-cypress/src/tests/input/signal-forms.cy.ts
@@ -1,0 +1,399 @@
+/*
+// TODO: Uncomment the whole file when the `@angular/forms/signals` entry point becomes available,
+// when Taiga UI drops support of Angular below 22 (stable API for signal forms appeared in Angular 22)
+import {
+    ChangeDetectionStrategy,
+    Component,
+    input,
+    linkedSignal,
+    signal,
+} from '@angular/core';
+import {
+    disabled,
+    form,
+    FormField,
+    minLength,
+    readonly,
+    required,
+} from '@angular/forms/signals';
+import {TuiInput, TuiRoot} from '@taiga-ui/core';
+
+@Component({
+    imports: [FormField, TuiInput, TuiRoot],
+    template: `
+        <tui-root>
+            <tui-textfield
+                style="margin-block-end: 1rem"
+                [invalid]="manualInvalid()"
+            >
+                <label tuiLabel>Name</label>
+                <input
+                    tuiInput
+                    [formField]="f.name"
+                />
+            </tui-textfield>
+
+            <output id="value">{{ f.name().value() }}</output>
+            <output id="touched">{{ f.name().touched() }}</output>
+            <output id="dirty">{{ f.name().dirty() }}</output>
+            <output id="invalid">{{ f.name().invalid() }}</output>
+
+            <button
+                id="set-value"
+                type="button"
+                (click)="f.name().value.set('Neo')"
+            >
+                Set value
+            </button>
+
+            <button
+                id="mark-touched"
+                type="button"
+                (click)="f().markAsTouched()"
+            >
+                Mark as touched
+            </button>
+
+            <button
+                id="reset"
+                type="button"
+                (click)="f().reset({name: initial()})"
+            >
+                Reset
+            </button>
+
+            <button
+                id="disable"
+                type="button"
+                (click)="off.set(!off())"
+            >
+                Toggle disabled
+            </button>
+
+            <button
+                id="readonly"
+                type="button"
+                (click)="ro.set(!ro())"
+            >
+                Toggle readonly
+            </button>
+
+            <button
+                id="force-invalid"
+                type="button"
+                (click)="manualInvalid.set(true)"
+            >
+                Force invalid
+            </button>
+
+            <button
+                id="force-valid"
+                type="button"
+                (click)="manualInvalid.set(false)"
+            >
+                Force valid
+            </button>
+
+            <button
+                id="follow-state"
+                type="button"
+                (click)="manualInvalid.set(null)"
+            >
+                Follow the field state
+            </button>
+        </tui-root>
+    `,
+    changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class Sandbox {
+    private readonly model = linkedSignal(() => ({name: this.initial()}));
+
+    public readonly initial = input('');
+    public readonly off = signal(false);
+    public readonly ro = signal(false);
+    public readonly manualInvalid = signal<boolean | null>(null);
+
+    public readonly f = form(this.model, (path) => {
+        required(path.name);
+        minLength(path.name, 3);
+        disabled(path.name, {when: () => this.off()});
+        readonly(path.name, {when: () => this.ro()});
+    });
+}
+
+function snapshot(name: string): void {
+    cy.get('tui-textfield').compareSnapshot({
+        name: `tuiInput-${name}`,
+        cypressScreenshotOptions: {padding: 8},
+    });
+}
+
+describe('tuiInput + signal forms', () => {
+    beforeEach(() => {
+        cy.viewport(250, 150);
+        cy.mount(Sandbox);
+        cy.get('tui-textfield input[tuiInput]').as('input');
+    });
+
+    describe('Value synchronization', () => {
+        it('initial model value is rendered inside the input', () => {
+            cy.mount(Sandbox, {componentProperties: {initial: 'John'}});
+
+            cy.get('tui-textfield input[tuiInput]').should('have.value', 'John');
+        });
+
+        it('typing updates the model', () => {
+            cy.get('@input').type('Morpheus');
+
+            cy.get('#value').should('have.text', 'Morpheus');
+        });
+
+        it('programmatic value.set() updates the input and keeps the field pristine', () => {
+            cy.get('#set-value').click();
+
+            cy.get('@input').should('have.value', 'Neo');
+            cy.get('#dirty').should('have.text', 'false');
+            cy.get('#touched').should('have.text', 'false');
+        });
+
+        it('clearing the input empties the model', () => {
+            cy.get('@input').type('Neo').clear();
+
+            cy.get('#value').should('have.text', '');
+            cy.get('#invalid').should('have.text', 'true');
+        });
+
+        it('reset() returns the initial value back to the input', () => {
+            cy.get('@input').type('Trinity');
+            cy.get('#reset').click();
+
+            cy.get('@input').should('have.value', '');
+            cy.get('#value').should('have.text', '');
+            cy.get('#dirty').should('have.text', 'false');
+        });
+    });
+
+    describe('Native validation attributes', () => {
+        it('required and minlength are mirrored onto the native input', () => {
+            cy.get('@input').should('have.attr', 'required');
+            cy.get('@input').should('have.attr', 'minlength', '3');
+        });
+    });
+
+    describe('Touched / dirty', () => {
+        it('field is untouched and pristine initially', () => {
+            cy.get('#touched').should('have.text', 'false');
+            cy.get('#dirty').should('have.text', 'false');
+            snapshot('initial-untouched-pristine');
+        });
+
+        it('blur without typing marks the field as touched, but not dirty', () => {
+            cy.get('@input').focus().blur();
+
+            cy.get('#touched').should('have.text', 'true');
+            cy.get('#dirty').should('have.text', 'false');
+            snapshot('touched-pristine');
+        });
+
+        it('typing marks the field as dirty', () => {
+            cy.get('@input').type('a');
+
+            cy.get('#dirty').should('have.text', 'true');
+            cy.get('#touched').should('have.text', 'false');
+
+            snapshot('dirty-untouched');
+
+            cy.get('@input').blur();
+
+            cy.get('#touched').should('have.text', 'true');
+
+            snapshot('dirty-touched');
+        });
+    });
+
+    describe('Invalid state is shown only after touch', () => {
+        it('invalid but untouched => no invalid decoration', () => {
+            cy.get('#invalid').should('have.text', 'true');
+
+            cy.get('@input')
+                .should('match', ':invalid')
+                .should('have.attr', 'aria-invalid', 'false');
+            cy.get('tui-textfield')
+                .should('not.have.class', 'tui-invalid')
+                .should('not.have.attr', 'data-mode');
+            snapshot('untouched-invalid');
+        });
+
+        it('invalid and blurred => invalid decoration appears', () => {
+            cy.get('@input').focus().blur();
+
+            cy.get('@input')
+                .should('match', ':invalid')
+                .should('have.attr', 'aria-invalid', 'true');
+            cy.get('tui-textfield')
+                .should('have.class', 'tui-invalid');
+            snapshot('touched-invalid');
+        });
+
+        it('external markAsTouched() => field is invalid', () => {
+            cy.get('#mark-touched').click();
+
+            cy.get('@input').should('have.attr', 'aria-invalid', 'true');
+            cy.get('tui-textfield').should('have.class', 'tui-invalid');
+            snapshot('mark-as-touched-invalid');
+        });
+
+        it('valid value entered => invalid decoration disappears', () => {
+            cy.get('@input').type('Morpheus').blur();
+
+            cy.get('@input')
+                .should('not.match', ':invalid')
+                .should('have.attr', 'aria-invalid', 'false');
+            cy.get('tui-textfield')
+                .should('not.have.class', 'tui-invalid');
+            snapshot('touched-valid');
+        });
+
+        it('touched field switches invalid => valid => invalid states', () => {
+            cy.get('@input').focus().blur();
+            cy.get('tui-textfield').should('have.class', 'tui-invalid'); // `required` error
+
+            cy.get('@input').type('Morpheus');
+            cy.get('tui-textfield').should('not.have.class', 'tui-invalid');
+
+            cy.get('@input').clear().type('ab');
+            cy.get('tui-textfield').should('have.class', 'tui-invalid'); // `minLength` error
+
+            cy.get('@input').type('c');
+            cy.get('tui-textfield').should('not.have.class', 'tui-invalid');
+            snapshot('valid-again');
+        });
+
+        it('reset() of a touched invalid field => invalid decoration disappears', () => {
+            cy.get('@input').focus().blur();
+            cy.get('tui-textfield').should('have.class', 'tui-invalid');
+
+            cy.get('#reset').click();
+
+            cy.get('#touched').should('have.text', 'false');
+            cy.get('tui-textfield').should('not.have.class', 'tui-invalid');
+            snapshot('after-reset');
+        });
+    });
+
+    describe('Disabled', () => {
+        it('disabled(path) disables the native input', () => {
+            cy.get('#disable').click();
+
+            cy.get('@input').should('be.disabled');
+        });
+
+        it('re-enabled field becomes editable again', () => {
+            cy.get('#disable').click();
+            cy.get('@input').should('be.disabled');
+            snapshot('disabled');
+
+            cy.get('#disable').click();
+
+            cy.get('@input').should('be.enabled').type('Neo');
+            cy.get('#value').should('have.text', 'Neo');
+            snapshot('enabled-again');
+        });
+    });
+
+    describe('Readonly', () => {
+        it('readonly(path) makes the native input readonly', () => {
+            cy.get('#readonly').click();
+
+            cy.get('@input').should('have.attr', 'readonly');
+        });
+
+        it('readonly switched back => input is editable again', () => {
+            cy.get('#readonly').click();
+            cy.get('@input').should('have.attr', 'readonly');
+            snapshot('readonly-toggled-on');
+
+            cy.get('#readonly').click();
+
+            cy.get('@input').should('not.have.attr', 'readonly');
+            cy.get('@input').type('Neo');
+            cy.get('#value').should('have.text', 'Neo');
+            snapshot('not-readonly-again');
+        });
+
+        it('textfield is painted as readonly', () => {
+            cy.get('#readonly').click();
+
+            cy.get('tui-textfield').should('match', "[data-mode~='readonly']");
+            snapshot('readonly');
+        });
+    });
+
+    describe('Manual [invalid] override on tui-textfield', () => {
+        it('[invalid]=true => invalid decoration even though the field is valid and untouched', () => {
+            cy.get('@input').type('Morpheus');
+            cy.get('tui-textfield').should('not.have.attr', 'data-mode');
+
+            cy.get('#force-invalid').click();
+
+            cy.get('tui-textfield')
+                .should('have.attr', 'data-mode', 'invalid');
+            // the override is appearance-only — native validity is not affected
+            cy.get('@input').should('not.match', ':invalid');
+            snapshot('[invalid]-true-over-valid-field');
+        });
+
+        it('[invalid]=false => no invalid decoration even though the field is touched and invalid', () => {
+            cy.get('@input').focus().blur();
+            cy.get('tui-textfield').should('have.class', 'tui-invalid');
+
+            cy.get('#force-valid').click();
+
+            cy.get('tui-textfield')
+                .should('have.attr', 'data-mode', 'valid');
+            snapshot('[invalid]-false-over-invalid-field');
+        });
+
+        it('[invalid]=null => decoration follows the field state again', () => {
+            cy.get('@input').type('Morpheus').blur();
+            cy.get('#force-invalid').click();
+            cy.get('tui-textfield').should('have.attr', 'data-mode', 'invalid');
+
+            cy.get('#follow-state').click();
+            cy.get('tui-textfield')
+                .should('not.have.class', 'tui-invalid')
+                .should('not.have.attr', 'data-mode');
+
+            cy.get('@input').clear().blur();
+            // `required` error, the field is touched
+            cy.get('tui-textfield').should('have.class', 'tui-invalid');
+        });
+
+        it('[invalid]=true override survives field state changes', () => {
+            cy.get('@input').type('Morpheus').blur();
+            cy.get('#force-invalid').click();
+            cy.get('tui-textfield').should('have.attr', 'data-mode', 'invalid');
+
+            cy.get('@input').clear(); // the field itself becomes invalid...
+            cy.get('@input').type('Trinity'); // ...and valid again
+
+            cy.get('tui-textfield').should('have.attr', 'data-mode', 'invalid');
+            snapshot('[invalid]-true-survives-state-changes');
+        });
+
+        it('[invalid]=false override survives field state changes', () => {
+            cy.get('@input').focus().blur();
+            cy.get('#force-valid').click();
+            cy.get('tui-textfield').should('have.attr', 'data-mode', 'valid');
+
+            cy.get('@input').type('Morpheus'); // the field itself becomes valid...
+            cy.get('@input').clear(); // ...and invalid again
+
+            cy.get('tui-textfield')
+                .should('have.class', 'tui-invalid')
+                .should('have.attr', 'data-mode', 'valid');
+        });
+    });
+});
+*/
+// eslint-disable-next-line unicorn/no-empty-file

--- a/projects/demo-cypress/src/tests/input/signal-forms.cy.ts
+++ b/projects/demo-cypress/src/tests/input/signal-forms.cy.ts
@@ -23,7 +23,7 @@ import {TuiInput, TuiRoot} from '@taiga-ui/core';
     template: `
         <tui-root>
             <tui-textfield
-                style="margin-block-end: 1rem"
+                style="margin-block-end: 1rem; margin-inline-end: 1rem"
                 [invalid]="manualInvalid()"
             >
                 <label tuiLabel>Name</label>

--- a/projects/demo-cypress/src/tests/input/signal-forms.cy.ts
+++ b/projects/demo-cypress/src/tests/input/signal-forms.cy.ts
@@ -230,8 +230,7 @@ describe('tuiInput + signal forms', () => {
             cy.get('@input')
                 .should('match', ':invalid')
                 .should('have.attr', 'aria-invalid', 'true');
-            cy.get('tui-textfield')
-                .should('have.class', 'tui-invalid');
+            cy.get('tui-textfield').should('have.class', 'tui-invalid');
             snapshot('touched-invalid');
         });
 
@@ -249,8 +248,7 @@ describe('tuiInput + signal forms', () => {
             cy.get('@input')
                 .should('not.match', ':invalid')
                 .should('have.attr', 'aria-invalid', 'false');
-            cy.get('tui-textfield')
-                .should('not.have.class', 'tui-invalid');
+            cy.get('tui-textfield').should('not.have.class', 'tui-invalid');
             snapshot('touched-valid');
         });
 
@@ -336,8 +334,7 @@ describe('tuiInput + signal forms', () => {
 
             cy.get('#force-invalid').click();
 
-            cy.get('tui-textfield')
-                .should('have.attr', 'data-mode', 'invalid');
+            cy.get('tui-textfield').should('have.attr', 'data-mode', 'invalid');
             // the override is appearance-only — native validity is not affected
             cy.get('@input').should('not.match', ':invalid');
             snapshot('[invalid]-true-over-valid-field');
@@ -349,8 +346,7 @@ describe('tuiInput + signal forms', () => {
 
             cy.get('#force-valid').click();
 
-            cy.get('tui-textfield')
-                .should('have.attr', 'data-mode', 'valid');
+            cy.get('tui-textfield').should('have.attr', 'data-mode', 'valid');
             snapshot('[invalid]-false-over-invalid-field');
         });
 


### PR DESCRIPTION
Relates:
- https://github.com/taiga-family/taiga-ui/issues/14341