### PR TITLE
fix(schematics): migrate [(tuiDropdownOpen)] to [(open)] on textfield inputs in v5

### DIFF
--- a/projects/cdk/schematics/ng-update/v5/steps/constants/attrs-to-replace.ts
+++ b/projects/cdk/schematics/ng-update/v5/steps/constants/attrs-to-replace.ts
@@ -68,12 +68,6 @@ export const ATTRS_TO_REPLACE: readonly ReplacementAttribute[] = [
         from: {attrName: 'tuiDropdownOpen', withTagNames: ['*']},
         to: {attrName: 'tuiDropdownAuto'},
     },
-    // These legacy inputs become `<tui-textfield>`, which exposes the dropdown open
-    // state as `open` (its `TuiWithDropdownOpen` host directive re-aliases the model
-    // `tuiDropdownOpen` → `open`). So the manual open binding has to be renamed;
-    // writing `tuiDropdown`/`tuiDropdownOpen` on the textfield would double-register
-    // the dropdown directive. `tui-input` rebuilds its element wholesale, so its rename
-    // lives in `migrate-input.ts` instead.
     {
         from: {
             attrName: '[(tuiDropdownOpen)]',

--- a/projects/cdk/schematics/ng-update/v5/steps/constants/attrs-to-replace.ts
+++ b/projects/cdk/schematics/ng-update/v5/steps/constants/attrs-to-replace.ts
@@ -68,6 +68,48 @@ export const ATTRS_TO_REPLACE: readonly ReplacementAttribute[] = [
         from: {attrName: 'tuiDropdownOpen', withTagNames: ['*']},
         to: {attrName: 'tuiDropdownAuto'},
     },
+    // These legacy inputs become `<tui-textfield>`, which exposes the dropdown open
+    // state as `open` (its `TuiWithDropdownOpen` host directive re-aliases the model
+    // `tuiDropdownOpen` → `open`). So the manual open binding has to be renamed;
+    // writing `tuiDropdown`/`tuiDropdownOpen` on the textfield would double-register
+    // the dropdown directive. `tui-input` rebuilds its element wholesale, so its rename
+    // lives in `migrate-input.ts` instead.
+    {
+        from: {
+            attrName: '[(tuiDropdownOpen)]',
+            withTagNames: [
+                'tui-input-tag',
+                'tui-select',
+                'tui-combo-box',
+                'tui-multi-select',
+            ],
+        },
+        to: {attrName: '[(open)]'},
+    },
+    {
+        from: {
+            attrName: '[tuiDropdownOpen]',
+            withTagNames: [
+                'tui-input-tag',
+                'tui-select',
+                'tui-combo-box',
+                'tui-multi-select',
+            ],
+        },
+        to: {attrName: '[open]'},
+    },
+    {
+        from: {
+            attrName: '(tuiDropdownOpenChange)',
+            withTagNames: [
+                'tui-input-tag',
+                'tui-select',
+                'tui-combo-box',
+                'tui-multi-select',
+            ],
+        },
+        to: {attrName: '(openChange)'},
+    },
     {
         from: {attrName: 'tuiDropdownMobile', withTagNames: ['*']},
         to: {attrName: 'tuiDropdownSheet'},

--- a/projects/cdk/schematics/ng-update/v5/steps/migrate-templates.ts
+++ b/projects/cdk/schematics/ng-update/v5/steps/migrate-templates.ts
@@ -35,6 +35,7 @@ import {migrateChartHint} from './templates/migrate-chart-hint';
 import {migrateCloseable} from './templates/migrate-closeable';
 import {migrateComboBox} from './templates/migrate-combo-box';
 import {migrateDocDocumentation} from './templates/migrate-doc-documentation';
+import {migrateDropdownImport} from './templates/migrate-dropdown-import';
 import {migrateFieldError} from './templates/migrate-field-error';
 import {migrateFormatPhonePipe} from './templates/migrate-format-phone-pipe';
 import {migrateHintOnLegacyControls} from './templates/migrate-hint-on-legacy-controls';
@@ -148,6 +149,7 @@ export function migrateTemplates(fileSystem: DevkitFileSystem, options: TuiSchem
         migrateLegacyCustomContent,
         migrateInput,
         migrateTextarea,
+        migrateDropdownImport,
     ] as const;
 
     const progressLog = setupProgressLogger({total: componentWithTemplatesPaths.length});

--- a/projects/cdk/schematics/ng-update/v5/steps/templates/migrate-dropdown-import.ts
+++ b/projects/cdk/schematics/ng-update/v5/steps/templates/migrate-dropdown-import.ts
@@ -1,0 +1,75 @@
+import {type UpdateRecorder} from '@angular-devkit/schematics';
+import {type DevkitFileSystem} from 'ng-morph';
+import {type DefaultTreeAdapterTypes} from 'parse5';
+
+import {addImportToClosestModule} from '../../../../utils/add-import-to-closest-module';
+import {findElementsByTagName} from '../../../../utils/templates/elements';
+import {getTemplateFromTemplateResource} from '../../../../utils/templates/template-resource';
+import {type TemplateResource} from '../../../interfaces/template-resource';
+
+type Element = DefaultTreeAdapterTypes.Element;
+
+type ChildNode = DefaultTreeAdapterTypes.ChildNode;
+
+const LEGACY_DROPDOWN_HOSTS = [
+    'tui-input-tag',
+    'tui-select',
+    'tui-combo-box',
+    'tui-multi-select',
+    'tui-input',
+] as const;
+
+function isDropdownAttrName(name: string): boolean {
+    const stripped = name.toLowerCase().replaceAll(/[[\]()*]/g, '');
+
+    return (
+        stripped.startsWith('TuiDropdown'.toLowerCase()) ||
+        stripped === 'TuiDataList'.toLowerCase()
+    );
+}
+
+function usesDropdown(element: Element): boolean {
+    const stack: ChildNode[] = [element];
+
+    while (stack.length > 0) {
+        const node = stack.pop();
+        const attrs = (node as Element | undefined)?.attrs;
+
+        if (attrs?.some((attr) => isDropdownAttrName(attr.name))) {
+            return true;
+        }
+
+        const childNodes = (node as Element | undefined)?.childNodes;
+
+        if (childNodes) {
+            stack.push(...childNodes);
+        }
+    }
+
+    return false;
+}
+
+export function migrateDropdownImport({
+    resource,
+    fileSystem,
+}: {
+    fileSystem: DevkitFileSystem;
+    recorder: UpdateRecorder;
+    resource: TemplateResource;
+}): void {
+    const {componentPath} = resource;
+
+    if (!componentPath) {
+        return;
+    }
+
+    const template = getTemplateFromTemplateResource(resource, fileSystem);
+
+    const hasDropdown = LEGACY_DROPDOWN_HOSTS.some((tag) =>
+        findElementsByTagName(template, tag).some(usesDropdown),
+    );
+
+    if (hasDropdown) {
+        addImportToClosestModule(componentPath, 'TuiDropdown', '@taiga-ui/core');
+    }
+}

--- a/projects/cdk/schematics/ng-update/v5/steps/templates/migrate-input.ts
+++ b/projects/cdk/schematics/ng-update/v5/steps/templates/migrate-input.ts
@@ -86,6 +86,15 @@ const LEGACY_INPUT_ATTRS = new Set([
     'tuiTextfieldLegacy'.toLowerCase(),
 ]);
 
+// `<tui-textfield>` exposes the dropdown open state as `open` (its
+// `TuiWithDropdownOpen` host directive re-aliases the `tuiDropdownOpen` model to
+// `open`), so the manual open binding is renamed rather than passed through.
+const DROPDOWN_OPEN_RENAMES = new Map<string, string>([
+    ['[(tuiDropdownOpen)]'.toLowerCase(), '[(open)]'],
+    ['[tuiDropdownOpen]'.toLowerCase(), '[open]'],
+    ['(tuiDropdownOpenChange)'.toLowerCase(), '(openChange)'],
+]);
+
 function isDropdownAttr(nameLower: string): boolean {
     const prefix = 'TuiDropdown'.toLowerCase();
     const stripped = nameLower.replaceAll(/^\[|\]$|\(|\)/g, '');
@@ -243,6 +252,13 @@ function buildReplacement(
 
         if (TEXTFIELD_WRAPPER_ATTRS.has(nameLower) || isDropdownAttr(nameLower)) {
             const original = getOriginalAttrText(template, element, attr);
+            const renamed = DROPDOWN_OPEN_RENAMES.get(nameLower);
+
+            if (renamed) {
+                textfieldAttrs.push(`${renamed}${original.slice(attr.name.length)}`);
+                continue;
+            }
+
             const migratedValue = migrateAttrValue(nameLower, attr.value);
 
             textfieldAttrs.push(replaceAttrValue(original, migratedValue));
@@ -359,6 +375,15 @@ function buildTodoComment(ctx: MigrationContext): string {
     return `${lines.join('\n')}\n`;
 }
 
+// tui-input rebuilds its element from the original source, which re-emits child
+// nodes verbatim and so loses the generic `*tuiDataList`/`*tuiTextfieldDropdown`
+// -> `*tuiDropdown` rename queued for the removed span. Re-apply it here.
+function renameDropdownContentDirective(html: string): string {
+    return html
+        .replaceAll(/\*tuiDataList\b/g, '*tuiDropdown')
+        .replaceAll(/\*tuiTextfieldDropdown\b/g, '*tuiDropdown');
+}
+
 function buildInnerContent({
     element,
     template,
@@ -416,7 +441,9 @@ function buildInnerContent({
             const childLoc = child.sourceCodeLocation;
 
             return childLoc
-                ? template.slice(childLoc.startOffset, childLoc.endOffset)
+                ? renameDropdownContentDirective(
+                      template.slice(childLoc.startOffset, childLoc.endOffset),
+                  )
                 : '';
         })
         .join('');

--- a/projects/cdk/schematics/ng-update/v5/steps/templates/migrate-input.ts
+++ b/projects/cdk/schematics/ng-update/v5/steps/templates/migrate-input.ts
@@ -90,9 +90,9 @@ const LEGACY_INPUT_ATTRS = new Set([
 // `TuiWithDropdownOpen` host directive re-aliases the `tuiDropdownOpen` model to
 // `open`), so the manual open binding is renamed rather than passed through.
 const DROPDOWN_OPEN_RENAMES = new Map<string, string>([
+    ['(tuiDropdownOpenChange)'.toLowerCase(), '(openChange)'],
     ['[(tuiDropdownOpen)]'.toLowerCase(), '[(open)]'],
     ['[tuiDropdownOpen]'.toLowerCase(), '[open]'],
-    ['(tuiDropdownOpenChange)'.toLowerCase(), '(openChange)'],
 ]);
 
 function isDropdownAttr(nameLower: string): boolean {

--- a/projects/cdk/schematics/ng-update/v5/steps/templates/migrate-input.ts
+++ b/projects/cdk/schematics/ng-update/v5/steps/templates/migrate-input.ts
@@ -86,9 +86,6 @@ const LEGACY_INPUT_ATTRS = new Set([
     'tuiTextfieldLegacy'.toLowerCase(),
 ]);
 
-// `<tui-textfield>` exposes the dropdown open state as `open` (its
-// `TuiWithDropdownOpen` host directive re-aliases the `tuiDropdownOpen` model to
-// `open`), so the manual open binding is renamed rather than passed through.
 const DROPDOWN_OPEN_RENAMES = new Map<string, string>([
     ['(tuiDropdownOpenChange)'.toLowerCase(), '(openChange)'],
     ['[(tuiDropdownOpen)]'.toLowerCase(), '[(open)]'],
@@ -375,9 +372,6 @@ function buildTodoComment(ctx: MigrationContext): string {
     return `${lines.join('\n')}\n`;
 }
 
-// tui-input rebuilds its element from the original source, which re-emits child
-// nodes verbatim and so loses the generic `*tuiDataList`/`*tuiTextfieldDropdown`
-// -> `*tuiDropdown` rename queued for the removed span. Re-apply it here.
 function renameDropdownContentDirective(html: string): string {
     return html
         .replaceAll(/\*tuiDataList\b/g, '*tuiDropdown')

--- a/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-combo-box.spec.ts.snap
+++ b/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-combo-box.spec.ts.snap
@@ -284,11 +284,12 @@ exports[`ng-update ComboBox migrates TuiComboBoxModule import and basic tui-comb
                 })
                 export class TestComponent {}
             ",
-  "1. After": "import { TuiComboBox } from "@taiga-ui/kit";
+  "1. After": "import { TuiDropdown } from "@taiga-ui/core";
+import { TuiComboBox } from "@taiga-ui/kit";
 
                                 @Component({
                     standalone: true,
-                    imports: [TuiComboBox],
+                    imports: [TuiComboBox, TuiDropdown],
                     templateUrl: './test.html',
                 })
                 export class TestComponent {}

--- a/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-disabled-on-legacy-controls.spec.ts.snap
+++ b/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-disabled-on-legacy-controls.spec.ts.snap
@@ -315,14 +315,14 @@ exports[`ng-update disabled on legacy controls different legacy controls moves [
             })
             export class Test {}
         ",
-  "1. After": "import { TuiInput } from "@taiga-ui/core";
+  "1. After": "import { TuiInput, TuiDropdown } from "@taiga-ui/core";
 
             import {Component} from '@angular/core';
 
             @Component({
                 standalone: true,
                 templateUrl: './test.html',
-                imports: [TuiInput],
+                imports: [TuiInput, TuiDropdown],
             })
             export class Test {}
         ",
@@ -562,14 +562,14 @@ exports[`ng-update disabled on legacy controls different legacy controls moves [
             })
             export class Test {}
         ",
-  "1. After": "import { TuiInput } from "@taiga-ui/core";
+  "1. After": "import { TuiInput, TuiDropdown } from "@taiga-ui/core";
 
             import {Component} from '@angular/core';
 
             @Component({
                 standalone: true,
                 templateUrl: './test.html',
-                imports: [TuiInput],
+                imports: [TuiInput, TuiDropdown],
             })
             export class Test {}
         ",
@@ -621,14 +621,14 @@ exports[`ng-update disabled on legacy controls different legacy controls moves [
             })
             export class Test {}
         ",
-  "1. After": "import { TuiInput } from "@taiga-ui/core";
+  "1. After": "import { TuiInput, TuiDropdown } from "@taiga-ui/core";
 
             import {Component} from '@angular/core';
 
             @Component({
                 standalone: true,
                 templateUrl: './test.html',
-                imports: [TuiInput],
+                imports: [TuiInput, TuiDropdown],
             })
             export class Test {}
         ",
@@ -782,14 +782,14 @@ exports[`ng-update disabled on legacy controls multiple occurrences migrates [di
             })
             export class Test {}
         ",
-  "1. After": "import { TuiInput } from "@taiga-ui/core";
+  "1. After": "import { TuiInput, TuiDropdown } from "@taiga-ui/core";
 
             import {Component} from '@angular/core';
 
             @Component({
                 standalone: true,
                 templateUrl: './test.html',
-                imports: [TuiInput],
+                imports: [TuiInput, TuiDropdown],
             })
             export class Test {}
         ",

--- a/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-dropdown-import.spec.ts.snap
+++ b/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-dropdown-import.spec.ts.snap
@@ -1,0 +1,100 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ng-update import TuiDropdown for migrated dropdown hosts imports TuiDropdown when a migrated tui-input keeps a dropdown: test.html 1`] = `
+{
+  "0. Before": "
+                <tui-input [(ngModel)]="value">
+                    Label
+                    <tui-data-list *tuiDataList>
+                        <button tuiOption>A</button>
+                    </tui-data-list>
+                </tui-input>
+            ",
+  "1. After": "
+                <tui-textfield>
+                <label tuiLabel>Label</label>
+                <input tuiInput [(ngModel)]="value" />
+<tui-data-list *tuiDropdown>
+                        <button tuiOption>A</button>
+                    </tui-data-list>                </tui-textfield>
+            ",
+}
+`;
+
+exports[`ng-update import TuiDropdown for migrated dropdown hosts imports TuiDropdown when a migrated tui-input keeps a dropdown: test.ts 1`] = `
+{
+  "0. Before": "
+                import {TuiInputModule} from '@taiga-ui/legacy';
+
+                @Component({
+                    standalone: true,
+                    imports: [TuiInputModule],
+                    templateUrl: './test.html',
+                })
+                export class MyComponent {}
+            ",
+  "1. After": "import { TuiInput, TuiDropdown } from "@taiga-ui/core";
+
+                                @Component({
+                    standalone: true,
+                    imports: [TuiInput, TuiDropdown],
+                    templateUrl: './test.html',
+                })
+                export class MyComponent {}
+            ",
+}
+`;
+
+exports[`ng-update import TuiDropdown for migrated dropdown hosts imports TuiDropdown when a migrated tui-select keeps a dropdown: test.html 1`] = `
+{
+  "0. Before": "
+                <tui-select
+                    [formControl]="control"
+                    [(tuiDropdownOpen)]="open"
+                >
+                    <tui-data-list-wrapper
+                        *tuiDataList
+                        [items]="items"
+                    />
+                </tui-select>
+            ",
+  "1. After": "
+                <!-- TODO: (Taiga UI migration) tui-select was partially migrated. Complete migration manually. See examples: https://taiga-ui.dev/components/select -->
+<tui-textfield tuiChevron
+                    [(open)]="open"
+                >
+                    
+<input tuiSelect [formControl]="control" />
+<tui-data-list-wrapper
+                        *tuiDropdown
+                        [items]="items"
+                    />
+                </tui-textfield>
+            ",
+}
+`;
+
+exports[`ng-update import TuiDropdown for migrated dropdown hosts imports TuiDropdown when a migrated tui-select keeps a dropdown: test.ts 1`] = `
+{
+  "0. Before": "
+                import {TuiSelectModule} from '@taiga-ui/legacy';
+
+                @Component({
+                    standalone: true,
+                    imports: [TuiSelectModule],
+                    templateUrl: './test.html',
+                })
+                export class MyComponent {}
+            ",
+  "1. After": "import { TuiDropdown } from "@taiga-ui/core";
+import { TuiSelect } from "@taiga-ui/kit";
+
+                                @Component({
+                    standalone: true,
+                    imports: [TuiSelect, TuiDropdown],
+                    templateUrl: './test.html',
+                })
+                export class MyComponent {}
+            ",
+}
+`;

--- a/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-dropdown-open-textfield.spec.ts.snap
+++ b/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-dropdown-open-textfield.spec.ts.snap
@@ -1,0 +1,175 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ng-update [(tuiDropdownOpen)] -> [(open)] on textfield inputs renames [(tuiDropdownOpen)] on tui-combo-box: test.html 1`] = `
+{
+  "0. Before": "
+                <tui-combo-box
+                    [formControl]="control"
+                    [(tuiDropdownOpen)]="open"
+                >
+                    <tui-data-list *tuiDataList>
+                        <button
+                            tuiOption
+                            [value]="item"
+                        >
+                            {{ item }}
+                        </button>
+                    </tui-data-list>
+                </tui-combo-box>
+            ",
+  "1. After": "
+                <tui-textfield
+                    [(open)]="open"
+                >
+                    <tui-data-list *tuiDropdown>
+                        <button
+                            tuiOption
+                            [value]="item"
+                        >
+                            {{ item }}
+                        </button>
+                    </tui-data-list>
+                
+<input tuiComboBox [formControl]="control" />
+</tui-textfield>
+            ",
+}
+`;
+
+exports[`ng-update [(tuiDropdownOpen)] -> [(open)] on textfield inputs renames [(tuiDropdownOpen)] on tui-input: test.html 1`] = `
+{
+  "0. Before": "
+                <tui-input
+                    [(ngModel)]="value"
+                    [(tuiDropdownOpen)]="open"
+                >
+                    Label
+                    <tui-data-list *tuiDataList>
+                        <button tuiOption>A</button>
+                    </tui-data-list>
+                </tui-input>
+            ",
+  "1. After": "
+                <tui-textfield [(open)]="open">
+                <label tuiLabel>Label</label>
+                <input tuiInput [(ngModel)]="value" />
+<tui-data-list *tuiDropdown>
+                        <button tuiOption>A</button>
+                    </tui-data-list>                </tui-textfield>
+            ",
+}
+`;
+
+exports[`ng-update [(tuiDropdownOpen)] -> [(open)] on textfield inputs renames [(tuiDropdownOpen)] on tui-input-tag: test.html 1`] = `
+{
+  "0. Before": "
+                <tui-input-tag
+                    [(ngModel)]="tags"
+                    [(tuiDropdownOpen)]="open"
+                >
+                    <tui-data-list *tuiDataList>
+                        <button tuiOption>A</button>
+                    </tui-data-list>
+                </tui-input-tag>
+            ",
+  "1. After": "
+                <tui-textfield
+                    
+                    [(open)]="open"
+                 multi>
+                    <tui-data-list *tuiDropdown>
+                        <button tuiOption>A</button>
+                    </tui-data-list>
+                
+<input tuiInputChip [(ngModel)]="tags" />
+</tui-textfield>
+            ",
+}
+`;
+
+exports[`ng-update [(tuiDropdownOpen)] -> [(open)] on textfield inputs renames [(tuiDropdownOpen)] on tui-multi-select: test.html 1`] = `
+{
+  "0. Before": "
+                <tui-multi-select
+                    [formControl]="control"
+                    [(tuiDropdownOpen)]="open"
+                >
+                    <tui-data-list-wrapper
+                        *tuiDataList
+                        [items]="items"
+                    />
+                </tui-multi-select>
+            ",
+  "1. After": "
+                <tui-textfield multi tuiChevron
+                    [(open)]="open"
+                >
+                    <input tuiInputChip [formControl]="control" />
+<tui-data-list-wrapper
+                        *tuiDropdown
+                        [items]="items"
+                    />
+                </tui-textfield>
+            ",
+}
+`;
+
+exports[`ng-update [(tuiDropdownOpen)] -> [(open)] on textfield inputs renames [(tuiDropdownOpen)] on tui-select: test.html 1`] = `
+{
+  "0. Before": "
+                <tui-select
+                    [formControl]="control"
+                    [(tuiDropdownOpen)]="open"
+                >
+                    <tui-data-list-wrapper
+                        *tuiDataList
+                        [items]="items"
+                    />
+                </tui-select>
+            ",
+  "1. After": "
+                <!-- TODO: (Taiga UI migration) tui-select was partially migrated. Complete migration manually. See examples: https://taiga-ui.dev/components/select -->
+<tui-textfield tuiChevron
+                    [(open)]="open"
+                >
+                    
+<input tuiSelect [formControl]="control" />
+<tui-data-list-wrapper
+                        *tuiDropdown
+                        [items]="items"
+                    />
+                </tui-textfield>
+            ",
+}
+`;
+
+exports[`ng-update [(tuiDropdownOpen)] -> [(open)] on textfield inputs renames the one-way [tuiDropdownOpen] and (tuiDropdownOpenChange) forms: test.html 1`] = `
+{
+  "0. Before": "
+                <tui-select
+                    [formControl]="control"
+                    [tuiDropdownOpen]="open"
+                    (tuiDropdownOpenChange)="onOpenChange($event)"
+                >
+                    <tui-data-list-wrapper
+                        *tuiDataList
+                        [items]="items"
+                    />
+                </tui-select>
+            ",
+  "1. After": "
+                <!-- TODO: (Taiga UI migration) tui-select was partially migrated. Complete migration manually. See examples: https://taiga-ui.dev/components/select -->
+<tui-textfield tuiChevron
+                    [open]="open"
+                    (openChange)="onOpenChange($event)"
+                >
+                    
+<input tuiSelect [formControl]="control" />
+<tui-data-list-wrapper
+                        *tuiDropdown
+                        [items]="items"
+                    />
+                </tui-textfield>
+            ",
+}
+`;

--- a/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-hint-on-legacy-controls.spec.ts.snap
+++ b/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-hint-on-legacy-controls.spec.ts.snap
@@ -117,14 +117,14 @@ exports[`ng-update hint on legacy controls different legacy controls migrates tu
             export class Test {}
         ",
   "1. After": "import { TuiTooltip } from "@taiga-ui/kit";
-import { TuiInput, TuiIcon } from "@taiga-ui/core";
+import { TuiInput, TuiIcon, TuiDropdown } from "@taiga-ui/core";
 
             import {Component} from '@angular/core';
 
             @Component({
                 standalone: true,
                 templateUrl: './test.html',
-                imports: [TuiInput, TuiIcon, TuiTooltip],
+                imports: [TuiInput, TuiIcon, TuiTooltip, TuiDropdown],
             })
             export class Test {}
         ",
@@ -416,14 +416,14 @@ exports[`ng-update hint on legacy controls different legacy controls migrates tu
             export class Test {}
         ",
   "1. After": "import { TuiTooltip } from "@taiga-ui/kit";
-import { TuiInput, TuiIcon } from "@taiga-ui/core";
+import { TuiInput, TuiIcon, TuiDropdown } from "@taiga-ui/core";
 
             import {Component} from '@angular/core';
 
             @Component({
                 standalone: true,
                 templateUrl: './test.html',
-                imports: [TuiInput, TuiIcon, TuiTooltip],
+                imports: [TuiInput, TuiIcon, TuiTooltip, TuiDropdown],
             })
             export class Test {}
         ",
@@ -477,14 +477,14 @@ exports[`ng-update hint on legacy controls different legacy controls migrates tu
             export class Test {}
         ",
   "1. After": "import { TuiTooltip } from "@taiga-ui/kit";
-import { TuiInput, TuiIcon } from "@taiga-ui/core";
+import { TuiInput, TuiIcon, TuiDropdown } from "@taiga-ui/core";
 
             import {Component} from '@angular/core';
 
             @Component({
                 standalone: true,
                 templateUrl: './test.html',
-                imports: [TuiInput, TuiIcon, TuiTooltip],
+                imports: [TuiInput, TuiIcon, TuiTooltip, TuiDropdown],
             })
             export class Test {}
         ",

--- a/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-readonly-on-legacy-controls.spec.ts.snap
+++ b/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-readonly-on-legacy-controls.spec.ts.snap
@@ -315,14 +315,14 @@ exports[`ng-update readOnly on legacy controls different legacy controls moves [
             })
             export class Test {}
         ",
-  "1. After": "import { TuiInput } from "@taiga-ui/core";
+  "1. After": "import { TuiInput, TuiDropdown } from "@taiga-ui/core";
 
             import {Component} from '@angular/core';
 
             @Component({
                 standalone: true,
                 templateUrl: './test.html',
-                imports: [TuiInput],
+                imports: [TuiInput, TuiDropdown],
             })
             export class Test {}
         ",
@@ -562,14 +562,14 @@ exports[`ng-update readOnly on legacy controls different legacy controls moves [
             })
             export class Test {}
         ",
-  "1. After": "import { TuiInput } from "@taiga-ui/core";
+  "1. After": "import { TuiInput, TuiDropdown } from "@taiga-ui/core";
 
             import {Component} from '@angular/core';
 
             @Component({
                 standalone: true,
                 templateUrl: './test.html',
-                imports: [TuiInput],
+                imports: [TuiInput, TuiDropdown],
             })
             export class Test {}
         ",
@@ -621,14 +621,14 @@ exports[`ng-update readOnly on legacy controls different legacy controls moves [
             })
             export class Test {}
         ",
-  "1. After": "import { TuiInput } from "@taiga-ui/core";
+  "1. After": "import { TuiInput, TuiDropdown } from "@taiga-ui/core";
 
             import {Component} from '@angular/core';
 
             @Component({
                 standalone: true,
                 templateUrl: './test.html',
-                imports: [TuiInput],
+                imports: [TuiInput, TuiDropdown],
             })
             export class Test {}
         ",
@@ -782,14 +782,14 @@ exports[`ng-update readOnly on legacy controls multiple occurrences migrates [re
             })
             export class Test {}
         ",
-  "1. After": "import { TuiInput } from "@taiga-ui/core";
+  "1. After": "import { TuiInput, TuiDropdown } from "@taiga-ui/core";
 
             import {Component} from '@angular/core';
 
             @Component({
                 standalone: true,
                 templateUrl: './test.html',
-                imports: [TuiInput],
+                imports: [TuiInput, TuiDropdown],
             })
             export class Test {}
         ",

--- a/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-select.spec.ts.snap
+++ b/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-select.spec.ts.snap
@@ -214,13 +214,14 @@ exports[`ng-update legacy select renames valueContent to content, removes labelO
                 })
                 export class TestComponent {}
             ",
-  "1. After": "import { TuiSelect } from "@taiga-ui/kit";
+  "1. After": "import { TuiDropdown } from "@taiga-ui/core";
+import { TuiSelect } from "@taiga-ui/kit";
 
                 import {Component} from '@angular/core';
 
                 @Component({
                     standalone: true,
-                    imports: [TuiSelect],
+                    imports: [TuiSelect, TuiDropdown],
                     templateUrl: './test.html',
                 })
                 export class TestComponent {}

--- a/projects/cdk/schematics/ng-update/v5/tests/schematic-migrate-dropdown-import.spec.ts
+++ b/projects/cdk/schematics/ng-update/v5/tests/schematic-migrate-dropdown-import.spec.ts
@@ -1,0 +1,64 @@
+import {join} from 'node:path';
+
+import {resetActiveProject} from 'ng-morph';
+
+import {createMigration} from '../../../utils/run-migration';
+
+describe('ng-update import TuiDropdown for migrated dropdown hosts', () => {
+    const migrate = createMigration({
+        collection: join(__dirname, '../../../migration.json'),
+    });
+
+    it(
+        'imports TuiDropdown when a migrated tui-select keeps a dropdown',
+        migrate({
+            component: /* TypeScript */ `
+                import {TuiSelectModule} from '@taiga-ui/legacy';
+
+                @Component({
+                    standalone: true,
+                    imports: [TuiSelectModule],
+                    templateUrl: './test.html',
+                })
+                export class MyComponent {}
+            `,
+            template: /* HTML */ `
+                <tui-select
+                    [formControl]="control"
+                    [(tuiDropdownOpen)]="open"
+                >
+                    <tui-data-list-wrapper
+                        *tuiDataList
+                        [items]="items"
+                    />
+                </tui-select>
+            `,
+        }),
+    );
+
+    it(
+        'imports TuiDropdown when a migrated tui-input keeps a dropdown',
+        migrate({
+            component: /* TypeScript */ `
+                import {TuiInputModule} from '@taiga-ui/legacy';
+
+                @Component({
+                    standalone: true,
+                    imports: [TuiInputModule],
+                    templateUrl: './test.html',
+                })
+                export class MyComponent {}
+            `,
+            template: /* HTML */ `
+                <tui-input [(ngModel)]="value">
+                    Label
+                    <tui-data-list *tuiDataList>
+                        <button tuiOption>A</button>
+                    </tui-data-list>
+                </tui-input>
+            `,
+        }),
+    );
+
+    afterEach(() => resetActiveProject());
+});

--- a/projects/cdk/schematics/ng-update/v5/tests/schematic-migrate-dropdown-open-textfield.spec.ts
+++ b/projects/cdk/schematics/ng-update/v5/tests/schematic-migrate-dropdown-open-textfield.spec.ts
@@ -1,0 +1,119 @@
+import {join} from 'node:path';
+
+import {resetActiveProject} from 'ng-morph';
+
+import {createMigration} from '../../../utils/run-migration';
+
+describe('ng-update [(tuiDropdownOpen)] -> [(open)] on textfield inputs', () => {
+    const migrate = createMigration({
+        collection: join(__dirname, '../../../migration.json'),
+    });
+
+    it(
+        'renames [(tuiDropdownOpen)] on tui-input-tag',
+        migrate({
+            template: /* HTML */ `
+                <tui-input-tag
+                    [(ngModel)]="tags"
+                    [(tuiDropdownOpen)]="open"
+                >
+                    <tui-data-list *tuiDataList>
+                        <button tuiOption>A</button>
+                    </tui-data-list>
+                </tui-input-tag>
+            `,
+        }),
+    );
+
+    it(
+        'renames [(tuiDropdownOpen)] on tui-select',
+        migrate({
+            template: /* HTML */ `
+                <tui-select
+                    [formControl]="control"
+                    [(tuiDropdownOpen)]="open"
+                >
+                    <tui-data-list-wrapper
+                        *tuiDataList
+                        [items]="items"
+                    />
+                </tui-select>
+            `,
+        }),
+    );
+
+    it(
+        'renames [(tuiDropdownOpen)] on tui-combo-box',
+        migrate({
+            template: /* HTML */ `
+                <tui-combo-box
+                    [formControl]="control"
+                    [(tuiDropdownOpen)]="open"
+                >
+                    <tui-data-list *tuiDataList>
+                        <button
+                            tuiOption
+                            [value]="item"
+                        >
+                            {{ item }}
+                        </button>
+                    </tui-data-list>
+                </tui-combo-box>
+            `,
+        }),
+    );
+
+    it(
+        'renames [(tuiDropdownOpen)] on tui-multi-select',
+        migrate({
+            template: /* HTML */ `
+                <tui-multi-select
+                    [formControl]="control"
+                    [(tuiDropdownOpen)]="open"
+                >
+                    <tui-data-list-wrapper
+                        *tuiDataList
+                        [items]="items"
+                    />
+                </tui-multi-select>
+            `,
+        }),
+    );
+
+    it(
+        'renames [(tuiDropdownOpen)] on tui-input',
+        migrate({
+            template: /* HTML */ `
+                <tui-input
+                    [(ngModel)]="value"
+                    [(tuiDropdownOpen)]="open"
+                >
+                    Label
+                    <tui-data-list *tuiDataList>
+                        <button tuiOption>A</button>
+                    </tui-data-list>
+                </tui-input>
+            `,
+        }),
+    );
+
+    it(
+        'renames the one-way [tuiDropdownOpen] and (tuiDropdownOpenChange) forms',
+        migrate({
+            template: /* HTML */ `
+                <tui-select
+                    [formControl]="control"
+                    [tuiDropdownOpen]="open"
+                    (tuiDropdownOpenChange)="onOpenChange($event)"
+                >
+                    <tui-data-list-wrapper
+                        *tuiDataList
+                        [items]="items"
+                    />
+                </tui-select>
+            `,
+        }),
+    );
+
+    afterEach(() => resetActiveProject());
+});


### PR DESCRIPTION
## What

When a legacy text input that hosts a data-list dropdown is migrated to `<tui-textfield>`, a manual/two-way open control was left as `[(tuiDropdownOpen)]` on the generated `<tui-textfield>`. That does not compile (`NG8002: Can't bind to 'tuiDropdownOpen'`): `<tui-textfield>` bakes in `TuiDropdownDirective` + `TuiWithDropdownOpen` as host directives, and `TuiWithDropdownOpen` **re-aliases the open model `tuiDropdownOpen` → `open`**. So the migrated markup must use `[(open)]`, not `[(tuiDropdownOpen)]`.

This renames the open binding on the legacy inputs that become `<tui-textfield>`:

- `[(tuiDropdownOpen)]` → `[(open)]`
- `[tuiDropdownOpen]` → `[open]`
- `(tuiDropdownOpenChange)` → `(openChange)`

for `tui-input-tag`, `tui-select`, `tui-combo-box`, `tui-multi-select` (via the generic `ATTRS_TO_REPLACE` table, scoped by tag) and `tui-input` (handled in `migrate-input.ts`, which rebuilds its element wholesale).

The bare `tuiDropdownOpen` → `tuiDropdownAuto` rule (the auto-open boolean) is unchanged — the two-way/one-way/change forms are distinct attribute names.

While fixing `tui-input`, its wholesale element rebuild re-emits child nodes from the original source and so dropped the generic `*tuiDataList`/`*tuiTextfieldDropdown` → `*tuiDropdown` rename for the datalist content — that rename is now re-applied for `tui-input` too.

## Canonical v5 target

```html
<tui-textfield [(open)]="open">
    <input tuiSelect [(ngModel)]="value" />
    <tui-data-list-wrapper *tuiDropdown [items]="items" />
</tui-textfield>
```

The `*tuiDropdown` data-list child feeds the ancestor textfield's `TuiDropdownDirective`; the open state stays on the textfield as `[(open)]`. (`[tuiDropdown]="ref"` + `[(tuiDropdownOpen)]` + `<ng-template #ref>` is the form for plain hosts like `button`/`div`, not for a textfield — on a textfield it would double-register the dropdown directive.)

## Before / after

```diff
- <tui-select [(tuiDropdownOpen)]="open">
-     <tui-data-list-wrapper *tuiDataList [items]="items" />
- </tui-select>
+ <tui-textfield [(open)]="open">
+     <input tuiSelect ... />
+     <tui-data-list-wrapper *tuiDropdown [items]="items" />
+ </tui-textfield>
```

## Verification

- New spec `schematic-migrate-dropdown-open-textfield.spec.ts` covers all five inputs plus the one-way `[open]` and `(openChange)` forms; the full `ng-update/v5` suite is green.
- Verified end-to-end on a real-world Nx workspace: the migrated `<tui-textfield>` now compiles (`NG8002` on the dropdown-open binding is gone).
