### PR TITLE
fix(schematics): add TODO for removed focusedChange output on migrated v5 controls

### DIFF
--- a/projects/cdk/schematics/ng-update/v5/steps/constants/html-comments.ts
+++ b/projects/cdk/schematics/ng-update/v5/steps/constants/html-comments.ts
@@ -166,4 +166,10 @@ export const HTML_COMMENTS: HtmlComment[] = [
         comment:
             'The [hidden] input has been removed from <tui-scrollbar>. Configure a hidden scrollbar via tuiScrollbarOptionsProvider({mode: "hidden"}) (or TUI_SCROLLBAR_OPTIONS) instead — [hidden] now binds the native DOM attribute and would hide the whole element.',
     },
+    {
+        tag: '*',
+        withAttrs: ['(focusedChange)', '[(focused)]'],
+        comment:
+            'focusedChange was removed in v5 — legacy controls no longer emit a focus output. There is no drop-in: read the readonly `focused` signal on <tui-textfield>, or use native (focusin)/(focusout) on the <input>. See https://taiga-ui.dev/components/textfield',
+    },
 ];

--- a/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-focused-change.spec.ts.snap
+++ b/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-focused-change.spec.ts.snap
@@ -1,0 +1,71 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ng-update focusedChange removed from legacy controls adds TODO for (focusedChange) on tui-input (rebuilt element): test.html 1`] = `
+{
+  "0. Before": "
+                <tui-input
+                    [(ngModel)]="value"
+                    (focusedChange)="onFocused($event)"
+                >
+                    Label
+                </tui-input>
+            ",
+  "1. After": "
+                <!-- TODO: (Taiga UI migration) focusedChange was removed in v5 — legacy controls no longer emit a focus output. There is no drop-in: read the readonly \`focused\` signal on <tui-textfield>, or use native (focusin)/(focusout) on the <input>. See https://taiga-ui.dev/components/textfield -->
+<!-- TODO: (Taiga UI migration) tui-input migration (see https://taiga-ui.dev/components/input):
+     - "(focusedChange)" is an unrecognized attribute and was placed on <tui-textfield>. Move it to <input tuiInput> if it targets the native element.
+-->
+                <tui-textfield (focusedChange)="onFocused($event)">
+                <label tuiLabel>Label</label>
+                <input tuiInput [(ngModel)]="value" />
+                </tui-textfield>
+            ",
+}
+`;
+
+exports[`ng-update focusedChange removed from legacy controls adds TODO for (focusedChange) on tui-input-tag: test.html 1`] = `
+{
+  "0. Before": "
+                <tui-input-tag
+                    [(ngModel)]="tags"
+                    (focusedChange)="inputFocusChanged($event)"
+                />
+            ",
+  "1. After": "
+                <!-- TODO: (Taiga UI migration) focusedChange was removed in v5 — legacy controls no longer emit a focus output. There is no drop-in: read the readonly \`focused\` signal on <tui-textfield>, or use native (focusin)/(focusout) on the <input>. See https://taiga-ui.dev/components/textfield -->
+<tui-textfield multi (focusedChange)="inputFocusChanged($event)">
+                <input tuiInputChip [(ngModel)]="tags" />
+                </tui-textfield>
+            ",
+}
+`;
+
+exports[`ng-update focusedChange removed from legacy controls adds TODO for two-way [(focused)] on tui-select: test.html 1`] = `
+{
+  "0. Before": "
+                <tui-select
+                    [formControl]="control"
+                    [(focused)]="focused"
+                >
+                    <tui-data-list-wrapper
+                        *tuiDataList
+                        [items]="items"
+                    />
+                </tui-select>
+            ",
+  "1. After": "
+                <!-- TODO: (Taiga UI migration) focusedChange was removed in v5 — legacy controls no longer emit a focus output. There is no drop-in: read the readonly \`focused\` signal on <tui-textfield>, or use native (focusin)/(focusout) on the <input>. See https://taiga-ui.dev/components/textfield -->
+<!-- TODO: (Taiga UI migration) tui-select was partially migrated. Complete migration manually. See examples: https://taiga-ui.dev/components/select -->
+<tui-textfield tuiChevron
+                    [(focused)]="focused"
+                >
+                    
+<input tuiSelect [formControl]="control" />
+<tui-data-list-wrapper
+                        *tuiDropdown
+                        [items]="items"
+                    />
+                </tui-textfield>
+            ",
+}
+`;

--- a/projects/cdk/schematics/ng-update/v5/tests/schematic-migrate-focused-change.spec.ts
+++ b/projects/cdk/schematics/ng-update/v5/tests/schematic-migrate-focused-change.spec.ts
@@ -1,0 +1,56 @@
+import {join} from 'node:path';
+
+import {resetActiveProject} from 'ng-morph';
+
+import {createMigration} from '../../../utils/run-migration';
+
+describe('ng-update focusedChange removed from legacy controls', () => {
+    const migrate = createMigration({
+        collection: join(__dirname, '../../../migration.json'),
+    });
+
+    it(
+        'adds TODO for (focusedChange) on tui-input-tag',
+        migrate({
+            template: /* HTML */ `
+                <tui-input-tag
+                    [(ngModel)]="tags"
+                    (focusedChange)="inputFocusChanged($event)"
+                />
+            `,
+        }),
+    );
+
+    it(
+        'adds TODO for two-way [(focused)] on tui-select',
+        migrate({
+            template: /* HTML */ `
+                <tui-select
+                    [formControl]="control"
+                    [(focused)]="focused"
+                >
+                    <tui-data-list-wrapper
+                        *tuiDataList
+                        [items]="items"
+                    />
+                </tui-select>
+            `,
+        }),
+    );
+
+    it(
+        'adds TODO for (focusedChange) on tui-input (rebuilt element)',
+        migrate({
+            template: /* HTML */ `
+                <tui-input
+                    [(ngModel)]="value"
+                    (focusedChange)="onFocused($event)"
+                >
+                    Label
+                </tui-input>
+            `,
+        }),
+    );
+
+    afterEach(() => resetActiveProject());
+});


### PR DESCRIPTION
## What

Legacy v4 form controls exposed a focus output — `(focusedChange)` (and the two-way `[(focused)]`) — through `TuiFocusableElementAccessor` (`focusedChange: Observable<boolean>`, backed by `AbstractTuiInteractive.focusedChange`). In v5 this output was removed: `focused` is now a **read-only** `Signal<boolean>` on `<tui-textfield>` and an `InputSignal` on `TuiInputDirective`, neither of which emits a focus change.

The v5 migration turns those controls into `<tui-textfield>` but carried `(focusedChange)` / `[(focused)]` over verbatim, with no TODO. The binding silently degrades to a native DOM event (or an NG8002 for the two-way form) and breaks the build — e.g. `TS2345: Argument of type 'Event' is not assignable to parameter of type 'boolean'` — with no local hint about what happened.

## Fix

Add a declarative `HTML_COMMENTS` entry (mirroring the existing removed-output patterns for `tuiSortByChange` and `directionOrder`) that inserts a TODO comment before any element still carrying `(focusedChange)` or `[(focused)]`:

```
focusedChange was removed in v5 — legacy controls no longer emit a focus output. There is no
drop-in: read the readonly `focused` signal on <tui-textfield>, or use native (focusin)/(focusout)
on the <input>.
```

No auto-rewrite: there is no 1:1 replacement (focus is now a readable signal, not an output), so an honest TODO is safer than a misleading scaffold — consistent with how the migration already handles other removed APIs.

## Affected hosts

All 22 v4 legacy controls that implemented `TuiFocusableElementAccessor` (i.e. every control with a textfield): `tui-combo-box`, `tui-input`, `tui-input-color`, `tui-input-copy`, `tui-input-date`, `tui-input-date-multi`, `tui-input-date-range`, `tui-input-date-time`, `tui-input-month`, `tui-input-month-range`, `tui-input-number`, `tui-input-password`, `tui-input-phone`, `tui-input-phone-international`, `tui-input-range`, `tui-input-slider`, `tui-input-tag`, `tui-input-time`, `tui-input-year`, `tui-multi-select`, `tui-select`, `tui-textarea`. The entry is scoped with `tag: '*'` + the attribute condition (like the existing `[appearance]` / `directionOrder` entries) so it covers all of them without enumerating tags.

The one-way `[focused]` input is intentionally **not** flagged — it can still be valid on the `tuiInput` directive.

## Verification

- New spec `schematic-migrate-focused-change.spec.ts` covers `(focusedChange)` on `tui-input-tag`, two-way `[(focused)]` on `tui-select`, and `(focusedChange)` on `tui-input` (the wholesale-rebuild path); the TODO is inserted and survives both the tag rename and the rebuild. Full `ng-update/v5` suite green.
- Verified end-to-end on a real-world Nx workspace: the migrated component now carries the TODO next to the (still-manual) focus binding.
