### PR TITLE
feat(kit): add public monthChange event to tui-calendar-range

### DIFF
--- a/projects/demo/src/modules/components/calendar-range/index.html
+++ b/projects/demo/src/modules/components/calendar-range/index.html
@@ -44,6 +44,7 @@
                 [maxLength]="maxLength"
                 [min]="min"
                 [minLength]="minLength"
+                (monthChange)="documentationPropertyMonthChange.emitEvent($event)"
                 (valueChange)="documentationPropertyRangeChange.emitEvent($event)"
             />
         </tui-doc-demo>
@@ -129,6 +130,14 @@
                 type="TuiDayRange"
             >
                 Selected date range
+            </tr>
+            <tr
+                #documentationPropertyMonthChange
+                name="(monthChange)"
+                tuiDocAPIItem
+                type="TuiMonth"
+            >
+                Month changed (also emitted when a year is picked)
             </tr>
         </table>
     </ng-template>

--- a/projects/kit/components/calendar-range/calendar-range.component.ts
+++ b/projects/kit/components/calendar-range/calendar-range.component.ts
@@ -109,6 +109,9 @@ export class TuiCalendarRange implements OnInit, OnChanges {
     @Output()
     public readonly itemChange = new EventEmitter<TuiDayRangePeriod | null>();
 
+    @Output()
+    public readonly monthChange = new EventEmitter<TuiMonth>();
+
     constructor() {
         inject<Observable<TuiDayRange | null>>(TUI_CALENDAR_DATE_STREAM, {optional: true})
             ?.pipe(tuiWatch(), takeUntilDestroyed())
@@ -235,6 +238,7 @@ export class TuiCalendarRange implements OnInit, OnChanges {
 
     protected onMonthChange(month: TuiMonth): void {
         this.month = month;
+        this.monthChange.emit(month);
     }
 
     protected onDayClick(day: TuiDay): void {

--- a/projects/kit/components/calendar-range/test/calendar-range.component.spec.ts
+++ b/projects/kit/components/calendar-range/test/calendar-range.component.spec.ts
@@ -414,6 +414,42 @@ describe('rangeCalendarComponent', () => {
 
             expect(component.defaultViewedMonth.toString()).toBe(updatedMonth.toString());
         });
+
+        it('emits monthChange when viewed month changes via chevron', () => {
+            const monthChangeSpy = jest.spyOn(component.monthChange, 'emit');
+
+            component['onMonthChange'](updatedMonth);
+            fixture.detectChanges();
+
+            expect(monthChangeSpy).toHaveBeenCalledWith(updatedMonth);
+            expect(component.defaultViewedMonth.toString()).toBe(updatedMonth.toString());
+        });
+
+        it('does not emit monthChange when defaultViewedMonth is updated programmatically', () => {
+            const monthChangeSpy = jest.spyOn(component.monthChange, 'emit');
+
+            testComponent.defaultViewedMonth = updatedMonth;
+            fixture.detectChanges();
+
+            expect(component.defaultViewedMonth.toString()).toBe(updatedMonth.toString());
+            expect(monthChangeSpy).not.toHaveBeenCalled();
+        });
+
+        it('does not emit monthChange when selecting a period', () => {
+            testComponent.items = tuiCreateDefaultDayRangePeriods();
+            fixture.detectChanges();
+
+            const monthChangeSpy = jest.spyOn(component.monthChange, 'emit');
+            const [item] = testComponent.items;
+
+            if (item) {
+                component['onItemSelect'](item);
+            }
+
+            fixture.detectChanges();
+
+            expect(monthChangeSpy).not.toHaveBeenCalled();
+        });
     });
 
     function getCalendar(): DebugElement | null {


### PR DESCRIPTION
monthChange event has been added to tui-calendar-range.

Relates to https://github.com/taiga-family/taiga-ui/issues/14746
