### PR TITLE
fix(cdk): `TuiControl` is compatible with `[formField]` (signal forms directive)

### DIFF
--- a/projects/cdk/classes/control.ts
+++ b/projects/cdk/classes/control.ts
@@ -132,7 +132,6 @@ export abstract class TuiControl<T> implements ControlValueAccessor {
          * Signal forms provide a fake `NgControl` which is not an `AbstractControl` and has no
          * observables — its state is exposed as signals, so reading it here subscribes to them.
          * For an `AbstractControl` nothing is tracked and this only makes the initial update.
-         * @see https://github.com/taiga-family/taiga-ui/issues/14341
          */
         effect(() => this.update());
         this.refresh$

--- a/projects/cdk/classes/control.ts
+++ b/projects/cdk/classes/control.ts
@@ -42,7 +42,7 @@ const FLAGS = {self: true, optional: true};
  *
  * TODO(v6): implement `FormValueControl` from `@angular/forms/signals` once Angular 22 is the
  * minimal supported version. Most of the existed logic below goes away.
- * 
+ *
  * [According to documentation](https://angular.dev/guide/forms/signals/migration#custom-controls):
  * > Any custom Signal Form Control can be used with Reactive (and Template-Driven) Forms as-is
  *
@@ -58,7 +58,7 @@ const FLAGS = {self: true, optional: true};
  *     public readonly touched = input(false);
  *     public readonly readonly = input(false);
  *     public readonly touch = output<void>();
- * 
+ *
  *     public readonly value = model(this.fallback);
  *
  *     // https://angular.dev/guide/forms/signals/custom-controls#value-transformation
@@ -67,11 +67,11 @@ const FLAGS = {self: true, optional: true};
  *         parse: (raw: T) => ({value: this.transformer.toControlValue(raw)}),
  *         format: (value) => this.transformer.fromControlValue(value),
  *     });
- * 
+ *
  *     reset() {
  *         // [...]
  *     }
- * 
+ *
  *     // [...]
  * }
  * ```

--- a/projects/cdk/classes/control.ts
+++ b/projects/cdk/classes/control.ts
@@ -3,6 +3,7 @@ import {
     ChangeDetectorRef,
     computed,
     Directive,
+    effect,
     inject,
     input,
     type Provider,
@@ -12,6 +13,7 @@ import {
 } from '@angular/core';
 import {takeUntilDestroyed} from '@angular/core/rxjs-interop';
 import {
+    AbstractControl,
     type ControlValueAccessor,
     type FormControlStatus,
     NgControl,
@@ -37,6 +39,42 @@ const FLAGS = {self: true, optional: true};
 
 /**
  * Basic ControlValueAccessor class to build form components upon
+ *
+ * TODO(v6): implement `FormValueControl` from `@angular/forms/signals` once Angular 22 is the
+ * minimal supported version. Most of the existed logic below goes away.
+ * 
+ * [According to documentation](https://angular.dev/guide/forms/signals/migration#custom-controls):
+ * > Any custom Signal Form Control can be used with Reactive (and Template-Driven) Forms as-is
+ *
+ * ```ts
+ * export abstract class TuiControl<T> implements FormValueControl<T> {
+ *     private readonly fallback = inject(TUI_FALLBACK_VALUE, FLAGS) as T;
+ *
+ *     protected transformer =
+ *         inject(TuiValueTransformer, FLAGS) ?? TUI_IDENTITY_VALUE_TRANSFORMER;
+ *
+ *     public readonly disabled = input(false);
+ *     public readonly invalid = input(false);
+ *     public readonly touched = input(false);
+ *     public readonly readonly = input(false);
+ *     public readonly touch = output<void>();
+ * 
+ *     public readonly value = model(this.fallback);
+ *
+ *     // https://angular.dev/guide/forms/signals/custom-controls#value-transformation
+ *     // https://angular.dev/api/forms/signals/transformedValue
+ *     protected readonly rawValue = transformedValue(this.value, {
+ *         parse: (raw: T) => ({value: this.transformer.toControlValue(raw)}),
+ *         format: (value) => this.transformer.fromControlValue(value),
+ *     });
+ * 
+ *     reset() {
+ *         // [...]
+ *     }
+ * 
+ *     // [...]
+ * }
+ * ```
  */
 @Directive()
 export abstract class TuiControl<T> implements ControlValueAccessor {
@@ -90,12 +128,19 @@ export abstract class TuiControl<T> implements ControlValueAccessor {
 
     constructor() {
         this.control.valueAccessor = this;
+        /**
+         * Signal forms provide a fake `NgControl` which is not an `AbstractControl` and has no
+         * observables — its state is exposed as signals, so reading it here subscribes to them.
+         * For an `AbstractControl` nothing is tracked and this only makes the initial update.
+         * @see https://github.com/taiga-family/taiga-ui/issues/14341
+         */
+        effect(() => this.update());
         this.refresh$
             .pipe(
                 delay(0),
                 startWith(null),
                 map(() => this.control.control),
-                filter(Boolean),
+                filter((c) => c instanceof AbstractControl),
                 distinctUntilChanged(),
                 switchMap((c) =>
                     merge(c.valueChanges, c.statusChanges, c.events).pipe(

--- a/projects/demo-cypress/src/tests/input-number/signal-forms.cy.ts
+++ b/projects/demo-cypress/src/tests/input-number/signal-forms.cy.ts
@@ -1,0 +1,164 @@
+/*
+// TODO: Uncomment the whole file when the `@angular/forms/signals` entry point becomes available,
+// when Taiga UI drops support of Angular below 22 (stable API for signal forms appeared in Angular 22)
+import {ChangeDetectionStrategy, Component, signal} from '@angular/core';
+import {
+    disabled,
+    form,
+    FormField,
+    maxError,
+    required,
+    validate,
+} from '@angular/forms/signals';
+import {TuiRoot} from '@taiga-ui/core';
+import {TuiInputNumber} from '@taiga-ui/kit';
+
+@Component({
+    imports: [FormField, TuiInputNumber, TuiRoot],
+    template: `
+        <tui-root>
+            <tui-textfield>
+                <label tuiLabel>Amount</label>
+                <input
+                    tuiInputNumber
+                    [formField]="$any(f.amount)"
+                />
+            </tui-textfield>
+
+            <output id="value">{{ f.amount().value() }}</output>
+            <output id="touched">{{ f.amount().touched() }}</output>
+            <output id="invalid">{{ f.amount().invalid() }}</output>
+
+            <button
+                id="set-value"
+                type="button"
+                (click)="f.amount().value.set(42)"
+            >
+                Set value
+            </button>
+
+            <button
+                id="mark-touched"
+                type="button"
+                (click)="f().markAsTouched()"
+            >
+                Mark as touched
+            </button>
+
+            <button
+                id="strict"
+                type="button"
+                (click)="strict.set(!strict())"
+            >
+                Toggle strict
+            </button>
+
+            <button
+                id="disable"
+                type="button"
+                (click)="off.set(!off())"
+            >
+                Toggle disabled
+            </button>
+        </tui-root>
+    `,
+    changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class Sandbox {
+    public readonly off = signal(false);
+    public readonly strict = signal(false);
+    public readonly model = signal<{amount: number | null}>({amount: null});
+
+    public readonly f = form(this.model, (path) => {
+        required(path.amount);
+        disabled(path.amount, {when: () => this.off()});
+        validate(path.amount, ({value}) =>
+            this.strict() && (value() ?? 0) > 10 ? maxError(10) : null,
+        );
+    });
+}
+
+describe('tuiInputNumber + signal forms', () => {
+    beforeEach(() => {
+        cy.window().then((win) => cy.spy(win.console, 'error').as('console'));
+        cy.mount(Sandbox);
+        cy.get('input[tuiInputNumber]').as('input');
+    });
+
+    it('mounts without runtime errors', () => {
+        cy.get('@input').type('42').blur();
+
+        cy.get('@console').then((spy) => {
+            const messages = (spy as unknown as {args: unknown[][]}).args
+                .map(([error]) => String(error))
+                // Dev server noise of the component testing harness, not the application
+                .filter((message) => !message.startsWith('[webpack-dev-server]'));
+
+            expect(messages).to.deep.equal([]);
+        });
+    });
+
+    describe('Value synchronization', () => {
+        it('typing updates the model', () => {
+            cy.get('@input').type('42').should('have.value', '42');
+
+            cy.get('#value').should('have.text', '42');
+            cy.get('#invalid').should('have.text', 'false');
+        });
+
+        it('programmatic value.set() updates the input', () => {
+            cy.get('#set-value').click();
+
+            cy.get('@input').should('have.value', '42');
+            cy.get('#touched').should('have.text', 'false');
+        });
+    });
+
+    describe('Invalid state is shown only after touch', () => {
+        it('invalid but untouched => no invalid decoration', () => {
+            cy.get('#invalid').should('have.text', 'true');
+
+            cy.get('tui-textfield').should('not.have.class', 'tui-invalid');
+            cy.get('@input').should('have.attr', 'aria-invalid', 'false');
+        });
+
+        it('blur without typing => invalid decoration appears', () => {
+            cy.get('@input').focus().blur();
+
+            cy.get('#touched').should('have.text', 'true');
+            cy.get('tui-textfield').should('have.class', 'tui-invalid');
+            cy.get('@input').should('have.attr', 'aria-invalid', 'true');
+        });
+
+        it('external markAsTouched() => invalid decoration appears', () => {
+            cy.get('#mark-touched').click();
+
+            cy.get('#touched').should('have.text', 'true');
+            cy.get('tui-textfield').should('have.class', 'tui-invalid');
+            cy.get('@input').should('have.attr', 'aria-invalid', 'true');
+        });
+    });
+
+    it('external validator change repaints a touched field', () => {
+        cy.get('@input').type('42').blur();
+
+        cy.get('#invalid').should('have.text', 'false');
+        cy.get('tui-textfield').should('not.have.class', 'tui-invalid');
+
+        cy.get('#strict').click();
+
+        cy.get('#invalid').should('have.text', 'true');
+        cy.get('tui-textfield').should('have.class', 'tui-invalid');
+        cy.get('@input').should('have.attr', 'aria-invalid', 'true');
+    });
+
+    it('disabled() reaches the native input', () => {
+        cy.get('@input').should('not.be.disabled');
+
+        cy.get('#disable').click();
+
+        cy.get('@input').should('be.disabled');
+    });
+});
+*/
+// eslint-disable-next-line unicorn/no-empty-file


### PR DESCRIPTION
Relates:
- https://github.com/taiga-family/taiga-ui/issues/14341

```ts
import {form} from '@angular/forms/signals';

@Component(...)
export class App {
    model = signal<{amount: number | null}>({amount: null});
    f = form(this.model);
}
```

```html
<tui-textfield>
  <label tuiLabel>Amount</label>
  <input
    tuiInputNumber
    [formField]="f.amount"
  />
</tui-textfield>
```

throws

```
ERROR RuntimeError: NG0950: Input "field" is required but no value is available yet. 
Find more at https://v22.angular.dev/errors/NG0950
    at _FormField.inputValueFn [as field] (core.mjs:48:13)
    at FormField.state.ngDevMode.debugName [as computation] (signals.mjs:1197:31)
    at Object.producerRecomputeValue (_effect-chunk.mjs:302:25)
    at producerUpdateValueVersion (_effect-chunk.mjs:104:8)
    at InteropNgControl.computed [as field] (_effect-chunk.mjs:264:5)
    at get status (signals.mjs:728:14)
    at _TuiInputNumberDirective.update (control.ts:188:38)
    at Object.next (control.ts:149:35)
    at ConsumerObserver2.next (Subscriber.js:96:33)
    at Subscriber2._next (Subscriber.js:63:26)
```
