### PR TITLE
fix(schematics): migrate legacy TuiPrimitiveTextfield to TuiTextfield in v5

### DIFF
--- a/projects/cdk/schematics/ng-update/v5/steps/constants/identifiers-to-replace.ts
+++ b/projects/cdk/schematics/ng-update/v5/steps/constants/identifiers-to-replace.ts
@@ -1241,6 +1241,17 @@ export const IDENTIFIERS_TO_REPLACE: ReplacementIdentifierMulti[] = [
     },
     {
         from: {
+            name: 'TuiPrimitiveTextfieldModule',
+            moduleSpecifier: '@taiga-ui/legacy',
+        },
+        to: {
+            name: 'TuiTextfield',
+            moduleSpecifier: '@taiga-ui/core',
+            spreadInModule: true,
+        },
+    },
+    {
+        from: {
             name: 'TuiCarousel',
             moduleSpecifier: '@taiga-ui/kit',
         },

--- a/projects/cdk/schematics/ng-update/v5/steps/migrate-templates.ts
+++ b/projects/cdk/schematics/ng-update/v5/steps/migrate-templates.ts
@@ -61,6 +61,7 @@ import {migrateLegacyCustomContent} from './templates/migrate-legacy-custom-cont
 import {migrateMultiSelect} from './templates/migrate-multi-select';
 import {migrateTuiNotification} from './templates/migrate-notification';
 import {migratePin} from './templates/migrate-pin';
+import {migratePrimitiveTextfield} from './templates/migrate-primitive-textfield';
 import {migrateRepeatTimes} from './templates/migrate-repeat-times';
 import {migrateSelect} from './templates/migrate-select';
 import {migrateSidebar} from './templates/migrate-sidebar';
@@ -149,6 +150,7 @@ export function migrateTemplates(fileSystem: DevkitFileSystem, options: TuiSchem
         migrateLegacyCustomContent,
         migrateInput,
         migrateTextarea,
+        migratePrimitiveTextfield,
         migrateDropdownImport,
     ] as const;
 

--- a/projects/cdk/schematics/ng-update/v5/steps/templates/migrate-primitive-textfield.ts
+++ b/projects/cdk/schematics/ng-update/v5/steps/templates/migrate-primitive-textfield.ts
@@ -1,0 +1,508 @@
+import {type UpdateRecorder} from '@angular-devkit/schematics';
+import {type DevkitFileSystem} from 'ng-morph';
+import {type DefaultTreeAdapterTypes} from 'parse5';
+
+import {TODO_MARK} from '../../../../utils/insert-todo';
+import {findElementsByTagName} from '../../../../utils/templates/elements';
+import {migrateAttrValue} from '../../../../utils/templates/migrate-attr-value';
+import {
+    getTemplateFromTemplateResource,
+    getTemplateOffset,
+} from '../../../../utils/templates/template-resource';
+import {type TemplateResource} from '../../../interfaces/template-resource';
+import {
+    getControlStateAttrs,
+    stringifyControlStateAttrs,
+} from '../../../utils/templates/control-state-attrs';
+import {
+    getOriginalAttrText,
+    replaceAttrValue,
+} from '../../../utils/templates/get-original-attr-text';
+
+type Element = DefaultTreeAdapterTypes.Element;
+
+type ChildNode = DefaultTreeAdapterTypes.ChildNode;
+
+type TextNode = DefaultTreeAdapterTypes.TextNode;
+
+const DOCS_LINK = 'https://taiga-ui.dev/components/input';
+
+const TEXTFIELD_WRAPPER_ATTRS = new Set(
+    [
+        '[tuiTextfieldAppearance]',
+        '[tuiTextfieldCleaner]',
+        '[tuiTextfieldSize]',
+        'tuiTextfieldAppearance',
+        'tuiTextfieldCleaner',
+        'tuiTextfieldSize',
+    ].map((name) => name.toLowerCase()),
+);
+
+const TEXTFIELD_WRAPPER_ATTR_RENAMES = new Map<string, string>([
+    ['[tuiTextfieldFiller]'.toLowerCase(), '[filler]'],
+    ['[tuiTextfieldIcon]'.toLowerCase(), '[iconEnd]'],
+    ['[tuiTextfieldIconLeft]'.toLowerCase(), '[iconStart]'],
+    ['tuiTextfieldFiller'.toLowerCase(), 'filler'],
+    ['tuiTextfieldIcon'.toLowerCase(), 'iconEnd'],
+    ['tuiTextfieldIconLeft'.toLowerCase(), 'iconStart'],
+]);
+
+const LABEL_OUTSIDE_ATTRS = new Set(
+    ['[tuiTextfieldLabelOutside]', 'tuiTextfieldLabelOutside'].map((name) =>
+        name.toLowerCase(),
+    ),
+);
+
+// `<tui-primitive-textfield>` held the value via [(value)]; `<tui-textfield>` has no such
+// property, so the binding moves to the projected `<input tuiTextfield>` as ngModel.
+const VALUE_ATTR_RENAMES = new Map<string, string>([
+    ['(valueChange)'.toLowerCase(), '(ngModelChange)'],
+    ['[(value)]'.toLowerCase(), '[(ngModel)]'],
+    ['[value]'.toLowerCase(), '[ngModel]'],
+]);
+
+const FOCUSED_CHANGE_ATTRS = new Set(['(focusedChange)'.toLowerCase()]);
+
+// Standalone CDK directives that attach to any element (including <tui-textfield>) and stay
+// on the wrapper unchanged — they must not be reported as unrecognized attributes.
+const WRAPPER_PASSTHROUGH_ATTRS = new Set(
+    [
+        '(tuiHoveredChange)',
+        'tuiActiveZone',
+        '[tuiActiveZone]',
+        '(tuiActiveZoneChange)',
+    ].map((name) => name.toLowerCase()),
+);
+
+const HINT_ATTRS = new Set(
+    [
+        '[tuiHintAppearance]',
+        '[tuiHintContent]',
+        '[tuiHintDirection]',
+        'tuiHintAppearance',
+        'tuiHintContent',
+        'tuiHintDirection',
+    ].map((name) => name.toLowerCase()),
+);
+
+const CONTROL_ATTRS = new Set(
+    [
+        'formControlName',
+        '[formControl]',
+        'formControl',
+        '[(ngModel)]',
+        '[ngModel]',
+        'ngModel',
+        '(ngModelChange)',
+    ].map((name) => name.toLowerCase()),
+);
+
+const LEGACY_INPUT_ATTRS = new Set(
+    ['tuiTextfield', 'tuiTextfieldLegacy'].map((name) => name.toLowerCase()),
+);
+
+function isClassOrStyleAttr(nameLower: string): boolean {
+    const stripped = nameLower.replaceAll(/^\[|\]$/g, '');
+
+    return (
+        stripped === 'class' ||
+        stripped === 'style' ||
+        stripped === 'ngclass' ||
+        stripped === 'ngstyle' ||
+        stripped.startsWith('class.') ||
+        stripped.startsWith('style.')
+    );
+}
+
+function hasHintContent(element: Element): boolean {
+    return element.attrs.some((attr) => {
+        const lower = attr.name.toLowerCase();
+
+        return (
+            lower === 'tuiHintContent'.toLowerCase() ||
+            lower === '[tuiHintContent]'.toLowerCase()
+        );
+    });
+}
+
+export function migratePrimitiveTextfield({
+    resource,
+    recorder,
+    fileSystem,
+}: {
+    fileSystem: DevkitFileSystem;
+    recorder: UpdateRecorder;
+    resource: TemplateResource;
+}): void {
+    const template = getTemplateFromTemplateResource(resource, fileSystem);
+    const templateOffset = getTemplateOffset(resource);
+    const elements = findElementsByTagName(template, 'tui-primitive-textfield');
+    const processable = elements.filter((element) => !hasHintContent(element));
+
+    const replacements = processable
+        .map((element) => buildReplacement(template, element))
+        .filter((x): x is {startOffset: number; endOffset: number; replacement: string} =>
+            Boolean(x),
+        )
+        .sort((a, b) => b.startOffset - a.startOffset);
+
+    replacements.forEach(({startOffset, endOffset, replacement}) => {
+        recorder.remove(templateOffset + startOffset, endOffset - startOffset);
+        recorder.insertRight(templateOffset + startOffset, replacement);
+    });
+}
+
+interface MigrationContext {
+    placeholder: string;
+    // true = [tuiTextfieldLabelOutside]="true" → text becomes placeholder on the input
+    // false = absent/="false" → text becomes <label tuiLabel> inside <tui-textfield>
+    // 'dynamic' = bound expression, cannot be resolved statically → left as-is with a TODO
+    labelOutside: boolean | 'dynamic';
+    focusedChangeAttr: string | null;
+    unknownAttrs: string[];
+}
+
+function buildReplacement(
+    template: string,
+    element: Element,
+): {startOffset: number; endOffset: number; replacement: string} | null {
+    const loc = element.sourceCodeLocation;
+
+    if (!loc?.startTag) {
+        return null;
+    }
+
+    const isSelfClosing = !loc.endTag;
+    const endOffset = isSelfClosing ? loc.startTag.endOffset : loc.endOffset;
+    const textfieldAttrs: string[] = [];
+    const inputAttrs = ['tuiTextfield'];
+    const controlStateAttrs = getControlStateAttrs(element);
+
+    const controlStateAttrsLower = new Set(
+        controlStateAttrs.map((a) => a.name.toLowerCase()),
+    );
+
+    const ctx: MigrationContext = {
+        placeholder: '',
+        labelOutside: false,
+        focusedChangeAttr: null,
+        unknownAttrs: [],
+    };
+
+    for (const attr of element.attrs) {
+        const nameLower = attr.name.toLowerCase();
+
+        if (controlStateAttrsLower.has(nameLower)) {
+            continue;
+        }
+
+        if (LABEL_OUTSIDE_ATTRS.has(nameLower)) {
+            const val = attr.value.trim();
+
+            if (val === 'true' || (!nameLower.startsWith('[') && val === '')) {
+                ctx.labelOutside = true;
+            } else if (val === 'false') {
+                ctx.labelOutside = false;
+            } else {
+                ctx.labelOutside = 'dynamic';
+            }
+
+            continue;
+        }
+
+        const renamedWrapperAttr = TEXTFIELD_WRAPPER_ATTR_RENAMES.get(nameLower);
+
+        if (renamedWrapperAttr !== undefined) {
+            textfieldAttrs.push(
+                attr.value ? `${renamedWrapperAttr}="${attr.value}"` : renamedWrapperAttr,
+            );
+            continue;
+        }
+
+        if (TEXTFIELD_WRAPPER_ATTRS.has(nameLower)) {
+            const original = getOriginalAttrText(template, element, attr);
+            const migratedValue = migrateAttrValue(nameLower, attr.value);
+
+            textfieldAttrs.push(replaceAttrValue(original, migratedValue));
+            continue;
+        }
+
+        const renamedValueAttr = VALUE_ATTR_RENAMES.get(nameLower);
+
+        if (renamedValueAttr !== undefined) {
+            inputAttrs.push(
+                attr.value ? `${renamedValueAttr}="${attr.value}"` : renamedValueAttr,
+            );
+            continue;
+        }
+
+        if (CONTROL_ATTRS.has(nameLower)) {
+            inputAttrs.push(getOriginalAttrText(template, element, attr));
+            continue;
+        }
+
+        if (FOCUSED_CHANGE_ATTRS.has(nameLower)) {
+            ctx.focusedChangeAttr = getOriginalAttrText(template, element, attr);
+            continue;
+        }
+
+        if (HINT_ATTRS.has(nameLower)) {
+            continue;
+        }
+
+        if (isClassOrStyleAttr(nameLower) || WRAPPER_PASSTHROUGH_ATTRS.has(nameLower)) {
+            textfieldAttrs.push(getOriginalAttrText(template, element, attr));
+            continue;
+        }
+
+        const original = getOriginalAttrText(template, element, attr);
+        const originalName = /^[\w[\]()]+/.exec(original)?.[0] ?? attr.name;
+
+        ctx.unknownAttrs.push(originalName);
+        textfieldAttrs.push(original);
+    }
+
+    const controlStateStr = stringifyControlStateAttrs(controlStateAttrs);
+
+    ctx.placeholder = isSelfClosing ? '' : getPlaceholderText(element);
+
+    const lineStart = template.lastIndexOf('\n', loc.startOffset) + 1;
+    const indent = /^[ \t]*/.exec(template.slice(lineStart, loc.startOffset))?.[0] ?? '';
+
+    const wrapperAttrsStr =
+        textfieldAttrs.length > 0 ? ` ${textfieldAttrs.join(' ')}` : '';
+
+    const innerContent = buildInnerContent({
+        element,
+        template,
+        inputAttrs,
+        controlStateStr,
+        ctx,
+        indent,
+        isSelfClosing,
+    });
+
+    const todoComment = buildTodoComment(ctx);
+    // With a TODO the comment ends in `\n`, so the tag needs its own indent; without one the
+    // whitespace preserved before startOffset already positions the tag.
+    const tagIndent = todoComment ? indent : '';
+    const core = `${tagIndent}<tui-textfield${wrapperAttrsStr}>\n${innerContent}${indent}</tui-textfield>`;
+
+    return {
+        startOffset: loc.startOffset,
+        endOffset,
+        replacement: `${todoComment}${core}`,
+    };
+}
+
+function buildTodoComment(ctx: MigrationContext): string {
+    const notes: string[] = [];
+
+    if (ctx.focusedChangeAttr) {
+        notes.push(
+            `${ctx.focusedChangeAttr} has no direct equivalent. Read focus state from the TuiTextfieldComponent.focused signal, or bind (focusin)/(focusout) on <input tuiTextfield>.`,
+        );
+    }
+
+    if (ctx.placeholder && ctx.labelOutside === 'dynamic') {
+        notes.push(
+            '[tuiTextfieldLabelOutside] was dynamic and cannot be migrated automatically. Use <label tuiLabel> inside <tui-textfield> for a floating label, or place a static label outside.',
+        );
+    }
+
+    for (const name of ctx.unknownAttrs) {
+        notes.push(
+            `"${name}" is an unrecognized attribute and was placed on <tui-textfield>. Move it to <input tuiTextfield> if it targets the native element.`,
+        );
+    }
+
+    if (notes.length === 0) {
+        return '';
+    }
+
+    const lines = [
+        `<!-- ${TODO_MARK} tui-primitive-textfield migration (see ${DOCS_LINK}):`,
+        ...notes.map((n) => `     - ${n}`),
+        '-->',
+    ];
+
+    return `${lines.join('\n')}\n`;
+}
+
+function buildInnerContent({
+    element,
+    template,
+    inputAttrs,
+    controlStateStr,
+    ctx,
+    indent,
+    isSelfClosing,
+}: {
+    controlStateStr: string;
+    ctx: MigrationContext;
+    element: Element;
+    indent: string;
+    inputAttrs: string[];
+    isSelfClosing: boolean;
+    template: string;
+}): string {
+    const {placeholder, labelOutside} = ctx;
+
+    const childElements = isSelfClosing
+        ? []
+        : element.childNodes.filter(
+              (node: ChildNode): node is Element =>
+                  node.nodeName !== '#text' && node.nodeName !== '#comment',
+          );
+
+    const labelEl = buildLabelEl(placeholder, labelOutside, indent);
+
+    const placeholderAttr =
+        placeholder && labelOutside === true ? `placeholder="${placeholder}"` : '';
+
+    const legacyInnerInput = childElements.find(
+        (node) =>
+            node.nodeName === 'input' &&
+            node.attrs.some((a) => LEGACY_INPUT_ATTRS.has(a.name.toLowerCase())),
+    );
+
+    if (legacyInnerInput) {
+        const extraAttrs = [
+            ...inputAttrs.filter((a) => a !== 'tuiTextfield'),
+            ...(placeholderAttr ? [placeholderAttr] : []),
+        ];
+
+        return `${labelEl}${migrateInnerInput({
+            parent: element,
+            inner: legacyInnerInput,
+            template,
+            attrsToAdd: extraAttrs,
+            controlStateStr,
+            indent,
+        })}`;
+    }
+
+    const genAttrs = [...inputAttrs, ...(placeholderAttr ? [placeholderAttr] : [])];
+    const attrsStr = genAttrs.length > 0 ? ` ${genAttrs.join(' ')}` : '';
+
+    const otherChildren = childElements
+        .map((child) => {
+            const childLoc = child.sourceCodeLocation;
+
+            return childLoc
+                ? template.slice(childLoc.startOffset, childLoc.endOffset)
+                : '';
+        })
+        .join('');
+
+    return `${labelEl}${indent}<input${attrsStr}${controlStateStr} />\n${otherChildren}`;
+}
+
+/**
+ * Rewrites an existing `<input tuiTextfieldLegacy>` to `<input tuiTextfield ...>` by
+ * replacing the legacy directive and appending the value/control attrs moved off the host.
+ */
+function migrateInnerInput({
+    parent,
+    inner,
+    template,
+    attrsToAdd,
+    controlStateStr,
+    indent,
+}: {
+    attrsToAdd: string[];
+    controlStateStr: string;
+    indent: string;
+    inner: Element;
+    parent: Element;
+    template: string;
+}): string {
+    const innerLoc = inner.sourceCodeLocation;
+
+    if (!innerLoc?.startTag) {
+        return '';
+    }
+
+    const legacyAttr = inner.attrs.find((a) =>
+        LEGACY_INPUT_ATTRS.has(a.name.toLowerCase()),
+    );
+
+    const legacyAttrLoc = legacyAttr
+        ? innerLoc.attrs?.[legacyAttr.name.toLowerCase()]
+        : undefined;
+
+    let startTag = template.slice(
+        innerLoc.startTag.startOffset,
+        innerLoc.startTag.endOffset,
+    );
+
+    if (legacyAttrLoc) {
+        const relStart = legacyAttrLoc.startOffset - innerLoc.startTag.startOffset;
+        const relEnd = legacyAttrLoc.endOffset - innerLoc.startTag.startOffset;
+
+        startTag = `${startTag.slice(0, relStart)}tuiTextfield${startTag.slice(relEnd)}`;
+    }
+
+    // <input> is a void element — insert the extra attrs before the closing `>` or `/>`.
+    const closePos = startTag.endsWith('/>')
+        ? startTag.length - 2
+        : startTag.lastIndexOf('>');
+
+    const extraAttrs = attrsToAdd.filter((a) => a !== 'tuiTextfield').join(' ');
+    const insertStr = `${extraAttrs ? ` ${extraAttrs}` : ''}${controlStateStr}`;
+
+    startTag = `${startTag.slice(0, closePos).trimEnd()}${insertStr}${startTag.slice(closePos)}`;
+
+    const innerStart = innerLoc.startOffset;
+
+    const siblingsAfter = parent.childNodes
+        .filter((child): child is Element => {
+            if (
+                child === inner ||
+                child.nodeName === '#text' ||
+                child.nodeName === '#comment'
+            ) {
+                return false;
+            }
+
+            const childLoc = (child as Element).sourceCodeLocation;
+
+            return !!childLoc && childLoc.startOffset > innerStart;
+        })
+        .map((child) => {
+            const childLoc = child.sourceCodeLocation;
+
+            return childLoc
+                ? template.slice(childLoc.startOffset, childLoc.endOffset)
+                : '';
+        })
+        .join('');
+
+    return `${indent}${startTag}\n${siblingsAfter}`;
+}
+
+// labelOutside=false → floating <label tuiLabel>; ='dynamic' → keep raw text (a TODO explains it);
+// =true → text becomes the input placeholder, handled by the caller, so no label element here.
+function buildLabelEl(
+    placeholder: string,
+    labelOutside: boolean | 'dynamic',
+    indent: string,
+): string {
+    if (!placeholder) {
+        return '';
+    }
+
+    if (labelOutside === false) {
+        return `${indent}<label tuiLabel>${placeholder}</label>\n`;
+    }
+
+    return labelOutside === 'dynamic' ? `${indent}${placeholder}\n` : '';
+}
+
+function getPlaceholderText(element: Element): string {
+    const textNode = element.childNodes.find((node: ChildNode): node is TextNode =>
+        node.nodeName === '#text' ? !!(node as TextNode).value.trim() : false,
+    );
+
+    return textNode?.value.trim() ?? '';
+}

--- a/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-primitive-textfield.spec.ts.snap
+++ b/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-primitive-textfield.spec.ts.snap
@@ -1,0 +1,142 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ng-update legacy primitive-textfield converts text to <label tuiLabel> when labelOutside is absent: test.html 1`] = `
+{
+  "0. Before": "
+                <tui-primitive-textfield [(value)]="search">
+                    Label
+                    <input tuiTextfieldLegacy />
+                </tui-primitive-textfield>
+            ",
+  "1. After": "
+                <tui-textfield>
+                <label tuiLabel>Label</label>
+                <input tuiTextfield [(ngModel)]="search"/>
+                </tui-textfield>
+            ",
+}
+`;
+
+exports[`ng-update legacy primitive-textfield migrates TuiPrimitiveTextfieldModule import (standalone) and simple template: test.html 1`] = `
+{
+  "0. Before": "
+                <tui-primitive-textfield [(value)]="search">
+                    <input
+                        tuiTextfieldLegacy
+                        [attr.maxlength]="80"
+                    />
+                </tui-primitive-textfield>
+            ",
+  "1. After": "
+                <tui-textfield>
+                <input
+                        tuiTextfield
+                        [attr.maxlength]="80" [(ngModel)]="search"/>
+                </tui-textfield>
+            ",
+}
+`;
+
+exports[`ng-update legacy primitive-textfield migrates TuiPrimitiveTextfieldModule import (standalone) and simple template: test.ts 1`] = `
+{
+  "0. Before": "
+                import {TuiPrimitiveTextfieldModule} from '@taiga-ui/legacy';
+
+                @Component({
+                    standalone: true,
+                    imports: [TuiPrimitiveTextfieldModule],
+                    templateUrl: './test.html',
+                })
+                export class TestComponent {}
+            ",
+  "1. After": "import { TuiTextfield } from "@taiga-ui/core";
+
+                                @Component({
+                    standalone: true,
+                    imports: [TuiTextfield],
+                    templateUrl: './test.html',
+                })
+                export class TestComponent {}
+            ",
+}
+`;
+
+exports[`ng-update legacy primitive-textfield migrates wrapper attrs (iconLeft, cleaner), [(value)], labelOutside=true, focusedChange TODO: test.html 1`] = `
+{
+  "0. Before": "
+                <tui-primitive-textfield
+                    [tuiTextfieldIconLeft]="icon"
+                    [tuiTextfieldCleaner]="true"
+                    [tuiTextfieldLabelOutside]="true"
+                    [(value)]="search"
+                    (focusedChange)="onFocus($event)"
+                    (tuiHoveredChange)="onHover($event)"
+                >
+                    Search anything
+                    <input
+                        tuiTextfieldLegacy
+                        [attr.maxlength]="80"
+                    />
+                </tui-primitive-textfield>
+            ",
+  "1. After": "
+                <!-- TODO: (Taiga UI migration) focusedChange was removed in v5 — legacy controls no longer emit a focus output. There is no drop-in: read the readonly \`focused\` signal on <tui-textfield>, or use native (focusin)/(focusout) on the <input>. See https://taiga-ui.dev/components/textfield -->
+<!-- TODO: (Taiga UI migration) tui-primitive-textfield migration (see https://taiga-ui.dev/components/input):
+     - (focusedChange)="onFocus($event)" has no direct equivalent. Read focus state from the TuiTextfieldComponent.focused signal, or bind (focusin)/(focusout) on <input tuiTextfield>.
+-->
+                <tui-textfield [iconStart]="icon" [tuiTextfieldCleaner]="true" (tuiHoveredChange)="onHover($event)">
+                <input
+                        tuiTextfield
+                        [attr.maxlength]="80" [(ngModel)]="search" placeholder="Search anything"/>
+                </tui-textfield>
+            ",
+}
+`;
+
+exports[`ng-update legacy primitive-textfield spreads TuiTextfield inside @NgModule imports: test.ts 1`] = `
+{
+  "0. Before": "
+                import {TuiPrimitiveTextfieldModule} from '@taiga-ui/legacy';
+                import {NgModule} from '@angular/core';
+
+                @NgModule({
+                    imports: [TuiPrimitiveTextfieldModule],
+                })
+                export class TestModule {}
+            ",
+  "1. After": "import { TuiTextfield } from "@taiga-ui/core";
+
+                                import {NgModule} from '@angular/core';
+
+                @NgModule({
+                    imports: [...TuiTextfield],
+                })
+                export class TestModule {}
+            ",
+}
+`;
+
+exports[`ng-update legacy primitive-textfield spreads TuiTextfield next to an existing spread in @NgModule imports: test.ts 1`] = `
+{
+  "0. Before": "
+                import {TuiPrimitiveTextfieldModule} from '@taiga-ui/legacy';
+                import {NgModule} from '@angular/core';
+                import {SharedImports} from './shared';
+
+                @NgModule({
+                    imports: [...SharedImports, TuiPrimitiveTextfieldModule],
+                })
+                export class TestModule {}
+            ",
+  "1. After": "import { TuiTextfield } from "@taiga-ui/core";
+
+                                import {NgModule} from '@angular/core';
+                import {SharedImports} from './shared';
+
+                @NgModule({
+                    imports: [...SharedImports, ...TuiTextfield],
+                })
+                export class TestModule {}
+            ",
+}
+`;

--- a/projects/cdk/schematics/ng-update/v5/tests/schematic-migrate-primitive-textfield.spec.ts
+++ b/projects/cdk/schematics/ng-update/v5/tests/schematic-migrate-primitive-textfield.spec.ts
@@ -1,0 +1,100 @@
+import {join} from 'node:path';
+
+import {resetActiveProject} from 'ng-morph';
+
+import {createMigration} from '../../../utils/run-migration';
+
+const migrate = createMigration({collection: join(__dirname, '../../../migration.json')});
+
+describe('ng-update legacy primitive-textfield', () => {
+    it(
+        'migrates TuiPrimitiveTextfieldModule import (standalone) and simple template',
+        migrate({
+            component: /* TypeScript */ `
+                import {TuiPrimitiveTextfieldModule} from '@taiga-ui/legacy';
+
+                @Component({
+                    standalone: true,
+                    imports: [TuiPrimitiveTextfieldModule],
+                    templateUrl: './test.html',
+                })
+                export class TestComponent {}
+            `,
+            template: /* HTML */ `
+                <tui-primitive-textfield [(value)]="search">
+                    <input
+                        tuiTextfieldLegacy
+                        [attr.maxlength]="80"
+                    />
+                </tui-primitive-textfield>
+            `,
+        }),
+    );
+
+    it(
+        'spreads TuiTextfield inside @NgModule imports',
+        migrate({
+            component: /* TypeScript */ `
+                import {TuiPrimitiveTextfieldModule} from '@taiga-ui/legacy';
+                import {NgModule} from '@angular/core';
+
+                @NgModule({
+                    imports: [TuiPrimitiveTextfieldModule],
+                })
+                export class TestModule {}
+            `,
+        }),
+    );
+
+    it(
+        'spreads TuiTextfield next to an existing spread in @NgModule imports',
+        migrate({
+            component: /* TypeScript */ `
+                import {TuiPrimitiveTextfieldModule} from '@taiga-ui/legacy';
+                import {NgModule} from '@angular/core';
+                import {SharedImports} from './shared';
+
+                @NgModule({
+                    imports: [...SharedImports, TuiPrimitiveTextfieldModule],
+                })
+                export class TestModule {}
+            `,
+        }),
+    );
+
+    it(
+        'migrates wrapper attrs (iconLeft, cleaner), [(value)], labelOutside=true, focusedChange TODO',
+        migrate({
+            template: /* HTML */ `
+                <tui-primitive-textfield
+                    [tuiTextfieldIconLeft]="icon"
+                    [tuiTextfieldCleaner]="true"
+                    [tuiTextfieldLabelOutside]="true"
+                    [(value)]="search"
+                    (focusedChange)="onFocus($event)"
+                    (tuiHoveredChange)="onHover($event)"
+                >
+                    Search anything
+                    <input
+                        tuiTextfieldLegacy
+                        [attr.maxlength]="80"
+                    />
+                </tui-primitive-textfield>
+            `,
+        }),
+    );
+
+    it(
+        'converts text to <label tuiLabel> when labelOutside is absent',
+        migrate({
+            template: /* HTML */ `
+                <tui-primitive-textfield [(value)]="search">
+                    Label
+                    <input tuiTextfieldLegacy />
+                </tui-primitive-textfield>
+            `,
+        }),
+    );
+
+    afterEach(() => resetActiveProject());
+});


### PR DESCRIPTION
## What / Why

The v4 → v5 `ng update @taiga-ui/cdk` migration handled `TuiInputModule` / `TuiTextareaModule` and their templates, but **`TuiPrimitiveTextfieldModule` / `<tui-primitive-textfield>` were not covered at all**:

- no entry in `identifiers-to-replace.ts`, `modules-to-remove.ts`, or `migration-warnings.ts` (only the sibling `TuiPrimitiveTextfieldComponent` had a warning);
- no template migration (unlike `migrate-input.ts` / `migrate-textarea.ts`).

As a result, on a real project the import was left pointing at `@taiga-ui/legacy` (where the symbol no longer exists in v5) and the template kept the removed `<tui-primitive-textfield>` element, so the project did not compile after migration.

## Changes

1. **Import** — `identifiers-to-replace.ts`: `TuiPrimitiveTextfieldModule` (`@taiga-ui/legacy`) → `TuiTextfield` (`@taiga-ui/core`) with `spreadInModule: true` (barrel array).
2. **Template** — new `steps/templates/migrate-primitive-textfield.ts` (registered in `migrate-templates.ts`):
   - `<tui-primitive-textfield>` → `<tui-textfield>`, inner `<input tuiTextfieldLegacy>` → `<input tuiTextfield>`;
   - `tuiTextfieldIconLeft`→`iconStart`, `tuiTextfieldIcon`→`iconEnd`, `tuiTextfieldFiller`→`filler`; `cleaner`/`size`/`appearance` kept;
   - `[(value)]`→`[(ngModel)]` (and `[value]`/`(valueChange)`) moved onto the projected input;
   - text → `<label tuiLabel>` (or `placeholder` when `tuiTextfieldLabelOutside="true"`);
   - `(tuiHoveredChange)` / `(tuiActiveZoneChange)` stay on the wrapper silently;
   - `(focusedChange)` has no v5 equivalent → a TODO comment is left (read the `focused` signal or use native `focusin`/`focusout`).
3. **Test** — `tests/schematic-migrate-primitive-textfield.spec.ts` with snapshots: standalone import, `@NgModule` spread, spread next to an existing spread, full attribute set, and label/placeholder handling.

## Before / After (template)

```html
<!-- before -->
<tui-primitive-textfield
    [tuiTextfieldIconLeft]="icon"
    [tuiTextfieldCleaner]="true"
    [tuiTextfieldLabelOutside]="true"
    [(value)]="search"
>
    Search
    <input tuiTextfieldLegacy [attr.maxlength]="80" />
</tui-primitive-textfield>

<!-- after -->
<tui-textfield [iconStart]="icon" [tuiTextfieldCleaner]="true">
    <input tuiTextfield [attr.maxlength]="80" [(ngModel)]="search" placeholder="Search" />
</tui-textfield>
```

## Testing

- `npx jest ng-update/v5` — all suites green (no regressions).
- Verified end-to-end by running `ng update @taiga-ui/cdk` on a real Angular 19 app: `<tui-primitive-textfield>` and its `TuiPrimitiveTextfieldModule` import are now migrated automatically.