### PR TITLE
fix(kit): `Chevron` increase style specificity to prevent font size from resetting

### DIFF
--- a/projects/kit/directives/chevron/chevron.style.less
+++ b/projects/kit/directives/chevron/chevron.style.less
@@ -19,7 +19,7 @@ tui-icon[tuiChevron]:where(*&)._chevron-rotated::before {
     transform: rotate(180deg);
 }
 
-tui-textfield[tuiChevron][tuiIcons]:where(*&) {
+tui-textfield[tuiChevron][tuiChevron][tuiIcons]:where(*&) {
     --t-stroke: var(--tui-stroke-width);
 
     &::after {

--- a/projects/kit/directives/chevron/chevron.style.less
+++ b/projects/kit/directives/chevron/chevron.style.less
@@ -1,6 +1,6 @@
 @import '@taiga-ui/styles/utils';
 
-[tuiChevron][tuiIcons]:where(*&)::after,
+[tuiChevron][tuiChevron][tuiIcons]:where(*&)::after,
 tui-icon[tuiChevron]:where(*&)::before {
     .transition(~'transform, color');
 


### PR DESCRIPTION

<img width="400" height="385" alt="Снимок экрана 2026-08-14 в 15 51 43" src="https://github.com/user-attachments/assets/aa4d9dc8-6c7f-4f70-8b32-969deca52595" />
<img width="189" height="42" alt="Снимок экрана 2026-08-14 в 16 03 41" src="https://github.com/user-attachments/assets/f3cc5b72-375c-4ded-97df-cae47b939901" />


Fixes # <!-- link to a relevant issue. -->
