### PR TITLE
feat(core): support protected context in tuiDialog

### DIFF
--- a/projects/core/components/dialog/dialog.factory.ts
+++ b/projects/core/components/dialog/dialog.factory.ts
@@ -1,4 +1,10 @@
-import {assertInInjectionContext, inject, INJECTOR, type Injector} from '@angular/core';
+import {
+    assertInInjectionContext,
+    inject,
+    INJECTOR,
+    type Injector,
+    type Type,
+} from '@angular/core';
 import {PolymorpheusComponent} from '@taiga-ui/polymorpheus';
 import {type Observable} from 'rxjs';
 
@@ -14,6 +20,11 @@ type SingleUnionOrNever<T, U = T> = [T] extends [never]
       : never;
 
 type ReplaceAny<T> = 0 extends T & 1 ? void : T;
+
+// Keeps the explicit overload out of inference-only calls.
+interface Unspecified {
+    readonly value: unique symbol;
+}
 
 type ContextKeys<T> = {
     [K in keyof T]: ReplaceAny<T[K]> extends TuiDialogContext<any, any> | null
@@ -52,6 +63,18 @@ export function tuiDialog<
     R extends ExtractDialogResult<T, K>,
 >(
     component: AssertNotMultipleContexts<T, K>,
+    options?: Partial<Options<D>>,
+): (data: D) => Observable<R>;
+export function tuiDialog<R = Unspecified, D = Unspecified>(
+    component: [R] extends [Unspecified]
+        ? never
+        : [D] extends [Unspecified]
+          ? never
+          : Type<unknown>,
+    options?: Partial<Options<D>>,
+): (data: D) => Observable<R>;
+export function tuiDialog<T, D, R>(
+    component: Type<T>,
     {injector, ...options}: Partial<Options<D>> = {},
 ): (data: D) => Observable<R> {
     if (!injector) {

--- a/projects/core/components/dialog/test/dialog.factory.spec.ts
+++ b/projects/core/components/dialog/test/dialog.factory.spec.ts
@@ -36,6 +36,23 @@ const tuiDialogMock: typeof tuiDialog = jest.fn(() => jest.fn(() => EMPTY));
 }
 
 {
+    // component with protected context
+    class TestComponent {
+        protected readonly context!: TuiDialogContext<string, number>;
+    }
+
+    const dialog = tuiDialogMock<string, number>(TestComponent);
+
+    dialog(123).subscribe((_value: string) => {});
+    // @ts-expect-error TS2554: Expected 1 arguments, but got 0
+    dialog();
+    // @ts-expect-error TS2345: Argument of type `string` is not assignable to parameter of type `number`
+    dialog('');
+    // @ts-expect-error TS2769: Type `string` is not assignable to type `number`
+    dialog(123).subscribe((_value: number) => {});
+}
+
+{
     // component with context and some other property
     class TestComponent {
         public readonly someContextProp!: TuiDialogContext<string, number>;


### PR DESCRIPTION
## What was done

- Added an explicit `tuiDialog<Result, Data>` overload.
- Allowed dialog components to keep `context` protected.
- Preserved automatic type inference for components with a public context.
- Preserved existing validation for components with multiple contexts.

## Usage

```ts
class DialogComponent {
    protected readonly context =
        injectContext<TuiDialogContext<Result, Data>>();
}

const dialog = tuiDialog<Result, Data>(DialogComponent);
```

## Motivation

`tuiDialog` currently infers data and result types through public component properties. Since protected properties are not included in keyof, components have to expose their dialog context publicly.

The explicit overload provides an opt-in alternative without changing the existing API behavior.