### PR TITLE
chore(demo): update tests and documentation for tui-calendar-range component v5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,7 +66,7 @@ All notable changes to this project will be documented in this file. See
 - **schematics:** finish tui-input-tag v5 migration and drop unused AsyncPipe
   ([#14752](https://github.com/taiga-family/taiga-ui/issues/14752))
   ([e8e83da](https://github.com/taiga-family/taiga-ui/commit/e8e83da25bbc113e2d29dafc4ed86f2a524017b2))
-- **schematics:** migrate [(tuiDropdownOpen)] to [(open)] on textfield inputs in v5
+- **schematics:** migrate `tuiDropdownOpen` to `open` on textfield inputs in v5
   ([#14754](https://github.com/taiga-family/taiga-ui/issues/14754))
   ([aa72a8b](https://github.com/taiga-family/taiga-ui/commit/aa72a8bbeb6ecd5f6bb70e4344e662d01b319bb4))
 - **schematics:** migrate legacy TuiPrimitiveTextfield to TuiTextfield in v5

--- a/projects/demo/src/pages/components/calendar-range/index.html
+++ b/projects/demo/src/pages/components/calendar-range/index.html
@@ -37,6 +37,7 @@
                 [maxLength]="maxLength"
                 [min]="min"
                 [minLength]="minLength"
+                [(month)]="month"
                 (valueChange)="documentationPropertyRangeChange.emitEvent($event)"
             />
         </tui-doc-demo>
@@ -95,6 +96,15 @@
                 [(value)]="max"
             >
                 max date
+            </tr>
+            <tr
+                name="[(month)]"
+                tuiDocAPIItem
+                type="TuiMonth"
+                [items]="defaultViewedMonthVariants"
+                [(value)]="month"
+            >
+                currently viewed month, also updated when a year is picked
             </tr>
             <tr
                 name="[minLength]"

--- a/projects/demo/src/pages/components/calendar-range/index.ts
+++ b/projects/demo/src/pages/components/calendar-range/index.ts
@@ -92,6 +92,7 @@ export default class Example {
     protected disabledItemHandler = this.disabledItemHandlerVariants[0]!;
     protected items = this.itemsVariants[0]!;
     protected defaultViewedMonth = this.defaultViewedMonthVariants[0]!;
+    protected month = this.defaultViewedMonthVariants[0]!;
     protected minLength: TuiDayLike | null = null;
     protected maxLength: TuiDayLike | null = null;
     protected readonly routes = DemoRoute;

--- a/projects/kit/components/calendar-range/test/calendar-range.component.spec.ts
+++ b/projects/kit/components/calendar-range/test/calendar-range.component.spec.ts
@@ -34,6 +34,7 @@ describe('rangeCalendarComponent', () => {
                 [maxLength]="maxLength"
                 [min]="min"
                 [minLength]="minLength"
+                [(month)]="month"
                 [(value)]="value"
             />
         `,
@@ -50,6 +51,7 @@ describe('rangeCalendarComponent', () => {
         public value: TuiDayRange | null = null;
         public defaultViewedMonth = TuiMonth.currentLocal();
         public markerHandler: TuiMarkerHandler | null = null;
+        public month = TuiMonth.currentLocal();
     }
 
     let fixture: ComponentFixture<Test>;
@@ -383,6 +385,38 @@ describe('rangeCalendarComponent', () => {
         });
     });
 
+    describe('month change', () => {
+        beforeEach(() => {
+            testComponent.items = [];
+            fixture.detectChanges();
+        });
+
+        it('append month by forward chevron', () => {
+            const month = TuiMonth.currentLocal();
+
+            clickNextMonth();
+
+            expect(testComponent.month.monthSame(month.append({month: 1}))).toBe(true);
+        });
+
+        it('reduce month by back chevron', () => {
+            const month = TuiMonth.currentLocal();
+
+            clickPreviousMonth();
+
+            expect(testComponent.month.monthSame(month.append({month: -1}))).toBe(true);
+        });
+
+        it('use month from value', () => {
+            const day = TuiDay.currentLocal().append({month: 5});
+
+            testComponent.value = new TuiDayRange(day, day);
+            fixture.detectChanges();
+
+            expect(testComponent.month.monthSame(day)).toBe(true);
+        });
+    });
+
     function getCalendar(): DebugElement | null {
         return pageObject.getByAutomationId('tui-calendar-range__calendar');
     }
@@ -394,5 +428,19 @@ describe('rangeCalendarComponent', () => {
 
     function getItems(): DebugElement[] {
         return pageObject.getAllByAutomationId('tui-calendar-range__menu__item');
+    }
+
+    function clickPreviousMonth(): void {
+        pageObject
+            .getAllByAutomationId('tui-spin-button__left')[0]!
+            .nativeElement.click();
+        fixture.detectChanges();
+    }
+
+    function clickNextMonth(): void {
+        pageObject
+            .getAllByAutomationId('tui-spin-button__right')[1]!
+            .nativeElement.click();
+        fixture.detectChanges();
     }
 });


### PR DESCRIPTION
The follow-up PR to the https://github.com/taiga-family/taiga-ui/issues/14746

@waterplea **month** signal model was already in place for v5. So, I just added tests and updated documentation for the component. Please take a look.

<img width="1171" height="676" alt="Screenshot 2026-08-17 at 20 59 59" src="https://github.com/user-attachments/assets/69ce747b-ad7b-4492-b156-e9b2ffff6d64" />
