### PR TITLE
chore(schematics): escape angular binding brackets in v5 changelog entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,7 +66,7 @@ All notable changes to this project will be documented in this file. See
 - **schematics:** finish tui-input-tag v5 migration and drop unused AsyncPipe
   ([#14752](https://github.com/taiga-family/taiga-ui/issues/14752))
   ([e8e83da](https://github.com/taiga-family/taiga-ui/commit/e8e83da25bbc113e2d29dafc4ed86f2a524017b2))
-- **schematics:** migrate [(tuiDropdownOpen)] to [(open)] on textfield inputs in v5
+- **schematics:** migrate \[(tuiDropdownOpen)\] to \[(open)\] on textfield inputs in v5
   ([#14754](https://github.com/taiga-family/taiga-ui/issues/14754))
   ([aa72a8b](https://github.com/taiga-family/taiga-ui/commit/aa72a8bbeb6ecd5f6bb70e4344e662d01b319bb4))
 - **schematics:** migrate legacy TuiPrimitiveTextfield to TuiTextfield in v5


### PR DESCRIPTION
The v5.20.0 release changelog entry (from #14754) contains Angular binding syntax that ESLint's `markdown/no-missing-label-refs` rule reads as broken reference-link labels, so `eslint .` fails **repo-wide** and blocks every open PR (e.g. #14740).

Escape the brackets on that line, matching the existing `\*` escaping already used elsewhere in this file (see the \*tuiLet entry). Verified locally: `npx eslint CHANGELOG.md` is clean.

Note: this recurs if a future commit subject contains unescaped square brackets; a follow-up could instead exclude the generated CHANGELOG from markdown label-ref linting.