### PR TITLE
fix(schematics): warn on removed legacy TuiTextarea/NativeFocusable/TableBarsHost in v5

### DIFF
--- a/projects/cdk/schematics/ng-update/v5/steps/constants/migration-warnings.ts
+++ b/projects/cdk/schematics/ng-update/v5/steps/constants/migration-warnings.ts
@@ -812,6 +812,6 @@ export const MIGRATION_WARNINGS: MigrationWarning[] = [
         name: 'TuiTableBarsHostComponent',
         moduleSpecifier: '@taiga-ui/legacy',
         message:
-            'TuiTableBarsHostComponent (<tui-table-bars-host>) has been removed with no public replacement. Recreate the bars-host container in your own code.',
+            'TuiTableBarsHostComponent (<tui-table-bars-host>) has been removed. Use TuiActionBar (<tui-action-bar>) from @taiga-ui/kit instead — it has a different API and no host container is required. See https://taiga-ui.dev/components/actions-bar',
     },
 ];

--- a/projects/cdk/schematics/ng-update/v5/steps/constants/migration-warnings.ts
+++ b/projects/cdk/schematics/ng-update/v5/steps/constants/migration-warnings.ts
@@ -796,4 +796,22 @@ export const MIGRATION_WARNINGS: MigrationWarning[] = [
         message:
             'tuiFlatLength has been removed. Inline the calculation instead: array.flat().length.',
     },
+    {
+        name: 'TuiTextareaComponent',
+        moduleSpecifier: '@taiga-ui/legacy',
+        message:
+            'TuiTextareaComponent has been removed with no drop-in class replacement. <tui-textarea> now migrates to <tui-textfield> with <textarea tuiTextfield>, so there is no component to @ViewChild/inject. Add a template ref to the migrated <textarea tuiTextfield>, query it with @ViewChild(ref, {read: ElementRef}) and replace .nativeFocusableElement with .nativeElement. See https://taiga-ui.dev/components/textarea',
+    },
+    {
+        name: 'TuiNativeFocusableElement',
+        moduleSpecifier: '@taiga-ui/legacy',
+        message:
+            'TuiNativeFocusableElement has been removed. It was a type alias for the native focusable element; replace it with the concrete element type (HTMLInputElement / HTMLTextAreaElement) or HTMLElement.',
+    },
+    {
+        name: 'TuiTableBarsHostComponent',
+        moduleSpecifier: '@taiga-ui/legacy',
+        message:
+            'TuiTableBarsHostComponent (<tui-table-bars-host>) has been removed with no public replacement. Recreate the bars-host container in your own code.',
+    },
 ];

--- a/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-legacy-removals-warning.spec.ts.snap
+++ b/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-legacy-removals-warning.spec.ts.snap
@@ -48,6 +48,22 @@ exports[`ng-update legacy removals warnings adds TODO for TuiColorSelectorCompon
 }
 `;
 
+exports[`ng-update legacy removals warnings adds TODO for TuiNativeFocusableElement: test.ts 1`] = `
+{
+  "0. Before": "
+            import {TuiNativeFocusableElement} from '@taiga-ui/legacy';
+
+            export const ref = TuiNativeFocusableElement;
+        ",
+  "1. After": "
+// TODO: (Taiga UI migration) TuiNativeFocusableElement has been removed. It was a type alias for the native focusable element; replace it with the concrete element type (HTMLInputElement / HTMLTextAreaElement) or HTMLElement.
+            import {TuiNativeFocusableElement} from '@taiga-ui/legacy';
+
+            export const ref = TuiNativeFocusableElement;
+        ",
+}
+`;
+
 exports[`ng-update legacy removals warnings adds TODO for TuiPrimitiveTextfieldComponent: test.ts 1`] = `
 {
   "0. Before": "
@@ -76,6 +92,38 @@ exports[`ng-update legacy removals warnings adds TODO for TuiTableBarComponent: 
             import {TuiTableBarComponent} from '@taiga-ui/legacy';
 
             export const ref = TuiTableBarComponent;
+        ",
+}
+`;
+
+exports[`ng-update legacy removals warnings adds TODO for TuiTableBarsHostComponent: test.ts 1`] = `
+{
+  "0. Before": "
+            import {TuiTableBarsHostComponent} from '@taiga-ui/legacy';
+
+            export const ref = TuiTableBarsHostComponent;
+        ",
+  "1. After": "
+// TODO: (Taiga UI migration) TuiTableBarsHostComponent (<tui-table-bars-host>) has been removed with no public replacement. Recreate the bars-host container in your own code.
+            import {TuiTableBarsHostComponent} from '@taiga-ui/legacy';
+
+            export const ref = TuiTableBarsHostComponent;
+        ",
+}
+`;
+
+exports[`ng-update legacy removals warnings adds TODO for TuiTextareaComponent: test.ts 1`] = `
+{
+  "0. Before": "
+            import {TuiTextareaComponent} from '@taiga-ui/legacy';
+
+            export const ref = TuiTextareaComponent;
+        ",
+  "1. After": "
+// TODO: (Taiga UI migration) TuiTextareaComponent has been removed with no drop-in class replacement. <tui-textarea> now migrates to <tui-textfield> with <textarea tuiTextfield>, so there is no component to @ViewChild/inject. Add a template ref to the migrated <textarea tuiTextfield>, query it with @ViewChild(ref, {read: ElementRef}) and replace .nativeFocusableElement with .nativeElement. See https://taiga-ui.dev/components/textarea
+            import {TuiTextareaComponent} from '@taiga-ui/legacy';
+
+            export const ref = TuiTextareaComponent;
         ",
 }
 `;

--- a/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-legacy-removals-warning.spec.ts.snap
+++ b/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-legacy-removals-warning.spec.ts.snap
@@ -104,7 +104,7 @@ exports[`ng-update legacy removals warnings adds TODO for TuiTableBarsHostCompon
             export const ref = TuiTableBarsHostComponent;
         ",
   "1. After": "
-// TODO: (Taiga UI migration) TuiTableBarsHostComponent (<tui-table-bars-host>) has been removed with no public replacement. Recreate the bars-host container in your own code.
+// TODO: (Taiga UI migration) TuiTableBarsHostComponent (<tui-table-bars-host>) has been removed. Use TuiActionBar (<tui-action-bar>) from @taiga-ui/kit instead — it has a different API and no host container is required. See https://taiga-ui.dev/components/actions-bar
             import {TuiTableBarsHostComponent} from '@taiga-ui/legacy';
 
             export const ref = TuiTableBarsHostComponent;

--- a/projects/cdk/schematics/ng-update/v5/tests/schematic-migrate-legacy-removals-warning.spec.ts
+++ b/projects/cdk/schematics/ng-update/v5/tests/schematic-migrate-legacy-removals-warning.spec.ts
@@ -52,5 +52,20 @@ describe('ng-update legacy removals warnings', () => {
         migrate({component: importFrom('TuiTableBarComponent')}),
     );
 
+    it(
+        'adds TODO for TuiTextareaComponent',
+        migrate({component: importFrom('TuiTextareaComponent')}),
+    );
+
+    it(
+        'adds TODO for TuiNativeFocusableElement',
+        migrate({component: importFrom('TuiNativeFocusableElement')}),
+    );
+
+    it(
+        'adds TODO for TuiTableBarsHostComponent',
+        migrate({component: importFrom('TuiTableBarsHostComponent')}),
+    );
+
     afterEach(() => resetActiveProject());
 });


### PR DESCRIPTION
## What / Why

Three symbols removed from `@taiga-ui/legacy` in v5 were missing from `MIGRATION_WARNINGS`, so after `ng update` a project importing them was left with a broken `@taiga-ui/legacy` import (TS2305) and **no TODO** explaining what to do — a silent break:

- **TuiTextareaComponent** — used via `@ViewChild`; `<tui-textarea>` migrates to `<tui-textfield>` + `<textarea tuiTextfield>`, so there is no component to query (same shape as the existing `TuiInputTagComponent` guidance).
- **TuiNativeFocusableElement** — a removed type alias.
- **TuiTableBarsHostComponent** (`<tui-table-bars-host>`) — removed with no public replacement.

Found on a real v4→v5 migration of an Angular app importing these from `@taiga-ui/legacy`.

## Changes
- Add three `MIGRATION_WARNINGS` entries (declarative — `showWarnings` inserts a TODO at the import site).
- Extend `schematic-migrate-legacy-removals-warning.spec.ts` with a case + snapshot per symbol.

## Testing
- `npx jest ng-update/v5` — 809/809 green.

> Note: the repo-wide Lint check may be red until #14775 merges — an unrelated pre-existing `markdown/no-missing-label-refs` failure on the generated CHANGELOG.md, not from this PR.