### PR TITLE
chore(demo): remove redundant SheetDialog API demo buttons

### DIFF
--- a/projects/demo/src/pages/components/sheet-dialog/index.html
+++ b/projects/demo/src/pages/components/sheet-dialog/index.html
@@ -24,21 +24,6 @@
             >
                 Click
             </button>
-            <button
-                tuiButton
-                type="button"
-                class="tui-space_left-4"
-                (longtap)="showDialog(sheetTemplate)"
-            >
-                Long tap
-            </button>
-            <button
-                tuiButton
-                type="button"
-                (click)="navigate()"
-            >
-                Navigate to Examples
-            </button>
             <ng-template
                 #sheetTemplate
                 let-completeWith="completeWith"

--- a/projects/demo/src/pages/components/sheet-dialog/index.ts
+++ b/projects/demo/src/pages/components/sheet-dialog/index.ts
@@ -1,5 +1,4 @@
 import {Component, inject, type TemplateRef} from '@angular/core';
-import {ActivatedRoute, Router} from '@angular/router';
 import {changeDetection} from '@demo/emulate/change-detection';
 import {TuiDemo} from '@demo/utils';
 import {
@@ -17,8 +16,6 @@ import {switchMap} from 'rxjs';
     changeDetection,
 })
 export default class Page {
-    private readonly router = inject(Router);
-    private readonly route = inject(ActivatedRoute);
     private readonly sheetDialogs = inject(TuiSheetDialogService);
     private readonly alerts = inject(TuiNotificationService);
 
@@ -63,9 +60,5 @@ export default class Page {
             })
             .pipe(switchMap((response) => this.alerts.open(String(response))))
             .subscribe();
-    }
-
-    protected navigate(): void {
-        void this.router.navigate(['./'], {relativeTo: this.route});
     }
 }


### PR DESCRIPTION
Remove two unused buttons from the SheetDialog API demo page.

- 'Long tap' merely duplicated the 'Click' trigger (same sheet via (longtap) gesture). No test used it.
- 'Navigate to Examples' was a leftover from the close-on-navigation fix (#11991 / #12038). The e2e test 'Close sheet by route navigation' now uses history.back(), so this button was dead code referenced by nothing.

Also removes the now-unused navigate() method and Router / ActivatedRoute injections.

The 'Click' trigger is kept: it opens the sheet in the demo and is the entry point for sheet-dialog.pw.spec.ts. No test coverage needed migration.