### PR TITLE
fix(schematics): skip templateUrl resolution for non-literal expressions

### DIFF
--- a/projects/cdk/schematics/ng-update/v5/tests/schematic-migrate-dynamic-template-url.spec.ts
+++ b/projects/cdk/schematics/ng-update/v5/tests/schematic-migrate-dynamic-template-url.spec.ts
@@ -1,0 +1,33 @@
+import {join} from 'node:path';
+
+import {resetActiveProject} from 'ng-morph';
+
+import {createMigration} from '../../../utils/run-migration';
+
+describe('ng-update', () => {
+    const migrate = createMigration({
+        collection: join(__dirname, '../../../migration.json'),
+    });
+
+    it(
+        'does not crash when templateUrl is a non-literal expression (e.g. config.templateUrl)',
+        migrate({
+            component: /* TypeScript */ `
+                import {Component} from '@angular/core';
+
+                import {config} from './config';
+
+                @Component({
+                    selector: '[prmUiTableSortable]',
+                    imports: config.imports,
+                    templateUrl: config.templateUrl,
+                    styleUrls: config.styleUrls,
+                    changeDetection: config.changeDetection,
+                })
+                export class MyComponent {}
+            `,
+        }),
+    );
+
+    afterEach(() => resetActiveProject());
+});

--- a/projects/cdk/schematics/utils/templates/get-component-templates.ts
+++ b/projects/cdk/schematics/utils/templates/get-component-templates.ts
@@ -4,6 +4,7 @@ import {
     type ClassDeclaration,
     type Decorator,
     getClasses,
+    Node,
     type ObjectLiteralExpression,
     type Pattern,
     type PropertyAssignment,
@@ -12,6 +13,13 @@ import {
 } from 'ng-morph';
 
 import {type TemplateResource} from '../../ng-update/interfaces/template-resource';
+
+function isStaticString(node?: Node): boolean {
+    return (
+        !!node &&
+        (Node.isStringLiteral(node) || Node.isNoSubstitutionTemplateLiteral(node))
+    );
+}
 
 function decoratorToTemplateResource(decorator: Decorator): TemplateResource | null {
     const [metadata] = decorator.getArguments() as ObjectLiteralExpression[];
@@ -22,10 +30,11 @@ function decoratorToTemplateResource(decorator: Decorator): TemplateResource | n
 
     const template = metadata?.getProperty('template') as PropertyAssignment | undefined;
     const componentPath = decorator.getSourceFile().getFilePath();
+    const templateUrlInitializer = templateUrl?.getInitializer();
 
-    if (templateUrl) {
+    if (isStaticString(templateUrlInitializer)) {
         const templatePath = path.parse(
-            templateUrl?.getInitializer()?.getText().replaceAll(/['"`]/g, '') || '',
+            templateUrlInitializer?.getText().replaceAll(/['"`]/g, '') || '',
         );
 
         return {


### PR DESCRIPTION
## Problem

The v5 template migration (`getComponentTemplates` in `get-component-templates.ts`) assumes a component's `templateUrl` is always a **string literal** and uses its raw text as a file path:

```ts
templateUrl?.getInitializer()?.getText().replaceAll(/['"`]/g, '')
```

When `templateUrl` is a **non-literal expression** — e.g. a component that spreads config from a shared constant:

```ts
@Component({
    selector: '[prmUiTableSortable]',
    templateUrl: config.templateUrl,
    // ...
})
```

`getText()` returns the string `"config.templateUrl"`, quote-stripping is a no-op, and the migration builds a bogus path like `.../components/table/config.templateUrl`. The subsequent `fileSystem.edit(path)` then throws:

```
Path "/libs/.../components/table/config.templateUrl" does not exist
```

…which aborts the **entire** `updateToV5` migration.

## Fix

Only resolve a `templateUrl` to a file path when its initializer is a static string literal (`'...'`, `"..."`, or a no-substitution template literal). For any non-literal expression the component is skipped instead of crashing.

## Caveat (documented for consumers)

A component whose `templateUrl` is computed at runtime is now **skipped** by the template migration — its HTML template can't be statically located, so it must be migrated manually. This is unavoidable: the path only exists at runtime. Trade-off is: skip one component vs. abort the whole migration.

## Test

Adds `schematic-migrate-dynamic-template-url.spec.ts`, reproducing the exact `config.templateUrl` case. It crashes with `does not exist` before the fix and passes after. Existing template-migration specs remain green.