### PR TITLE
fix(addon-table): `Table` fix infinite `tuiSortChange` loop on simultaneous sort change

### DIFF
--- a/projects/addon-table/components/table/directives/sort-by.directive.ts
+++ b/projects/addon-table/components/table/directives/sort-by.directive.ts
@@ -6,6 +6,7 @@ import {
     inject,
     input,
     output,
+    untracked,
 } from '@angular/core';
 import {type TuiComparator} from '@taiga-ui/addon-table/types';
 
@@ -25,6 +26,15 @@ export class TuiTableSortBy<T extends Partial<Record<keyof T, unknown>>> {
         sortKey: this.sortables().length ? this.getKey(this.table.sorter()) : null,
         sortDirection: this.table.direction(),
     }));
+
+    protected readonly setTableSorter = effect(() => {
+        const key = this.tuiSortBy();
+        const sortable = this.sortables().find((item) => item.key === key);
+
+        if (sortable && untracked(this.table.sorter) !== sortable.sorter()) {
+            this.table.sorter.set(sortable.sorter());
+        }
+    });
 
     protected readonly sortOutput = effect(() => {
         if (this.sortables().length) {

--- a/projects/addon-table/components/table/directives/sortable.directive.ts
+++ b/projects/addon-table/components/table/directives/sortable.directive.ts
@@ -29,12 +29,6 @@ export class TuiTableSortable<T extends Partial<Record<keyof T, unknown>>> {
         this.th.sorter.set(this.sortable() ? this.sorter() : null);
     });
 
-    protected readonly setTableSorter = effect(() => {
-        if (this.match && untracked(this.table.sorter) !== this.sorter()) {
-            this.table.updateSorter(this.sorter());
-        }
-    });
-
     public readonly sorter = computed<TuiComparator<T>>(() =>
         this.sortable() && untracked(() => this.match)
             ? untracked(this.table.sorter)

--- a/projects/addon-table/components/table/directives/test/sort.spec.ts
+++ b/projects/addon-table/components/table/directives/test/sort.spec.ts
@@ -1,0 +1,189 @@
+import {ChangeDetectionStrategy, Component, signal} from '@angular/core';
+import {type ComponentFixture, TestBed} from '@angular/core/testing';
+import {type TuiSortChange, TuiSortDirection, TuiTable} from '@taiga-ui/addon-table';
+
+interface User {
+    readonly name: string;
+    readonly age: number;
+}
+
+describe('Table sort', () => {
+    @Component({
+        imports: [TuiTable],
+        template: `
+            <table
+                tuiTable
+                [columns]="columns"
+                [direction]="direction()"
+                [tuiSortBy]="sortKey()"
+                (tuiSortChange)="change($event)"
+            >
+                <thead>
+                    <tr tuiThGroup>
+                        <th
+                            *tuiHead="'name'"
+                            tuiSortable
+                            tuiTh
+                            [requiredSort]="requiredSort()"
+                        >
+                            Name
+                        </th>
+                        <th
+                            *tuiHead="'age'"
+                            tuiSortable
+                            tuiTh
+                            [requiredSort]="requiredSort()"
+                        >
+                            Age
+                        </th>
+                    </tr>
+                </thead>
+                <tbody
+                    tuiTbody
+                    [data]="data"
+                ></tbody>
+            </table>
+        `,
+        changeDetection: ChangeDetectionStrategy.OnPush,
+    })
+    class Test {
+        protected readonly columns = ['name', 'age'];
+        protected readonly data: readonly User[] = [
+            {name: 'Alice', age: 30},
+            {name: 'Bob', age: 25},
+        ];
+
+        public readonly sortKey = signal<keyof User>('name');
+        public readonly direction = signal<TuiSortDirection>(TuiSortDirection.Desc);
+        public readonly requiredSort = signal(true);
+        public changeCount = 0;
+        public last: TuiSortChange<User> | null = null;
+
+        protected change(event: TuiSortChange<User>): void {
+            this.changeCount++;
+            this.last = event;
+
+            if (this.changeCount > 50) {
+                return;
+            }
+
+            this.sortKey.set(event.sortKey!);
+            this.direction.set(event.sortDirection);
+        }
+    }
+
+    let fixture: ComponentFixture<Test>;
+    let component: Test;
+
+    function headers(): HTMLButtonElement[] {
+        return Array.from(fixture.nativeElement.querySelectorAll('.t-sort'));
+    }
+
+    beforeEach(async () => {
+        TestBed.configureTestingModule({imports: [Test]});
+        await TestBed.compileComponents();
+        fixture = TestBed.createComponent(Test);
+        component = fixture.componentInstance;
+        fixture.detectChanges();
+    });
+
+    it('reports a header click through tuiSortChange', () => {
+        const [, ageHeader] = headers();
+
+        expect(ageHeader).toBeDefined();
+
+        ageHeader?.click();
+        fixture.detectChanges();
+
+        expect(component.last?.sortKey).toBe('age');
+        expect(component.sortKey()).toBe('age');
+    });
+
+    it('does not loop when sortKey and direction change simultaneously', () => {
+        const [, ageHeader] = headers();
+
+        expect(ageHeader).toBeDefined();
+
+        ageHeader?.click();
+        fixture.detectChanges();
+
+        component.changeCount = 0;
+
+        component.sortKey.set('name');
+        component.direction.update((direction) =>
+            direction === TuiSortDirection.Asc
+                ? TuiSortDirection.Desc
+                : TuiSortDirection.Asc,
+        );
+        fixture.detectChanges();
+
+        expect(component.changeCount).toBeLessThan(10);
+        expect(component.sortKey()).toBe('name');
+        expect(component.direction()).toBe(TuiSortDirection.Desc);
+    });
+
+    it('does not loop when only direction changes', () => {
+        component.changeCount = 0;
+
+        component.direction.update((direction) =>
+            direction === TuiSortDirection.Asc
+                ? TuiSortDirection.Desc
+                : TuiSortDirection.Asc,
+        );
+        fixture.detectChanges();
+
+        expect(component.changeCount).toBeLessThan(10);
+        expect(component.sortKey()).toBe('name');
+        expect(component.direction()).toBe(TuiSortDirection.Asc);
+    });
+
+    it('does not loop when a preset flips direction for the already active key', () => {
+        const [, ageHeader] = headers();
+
+        expect(ageHeader).toBeDefined();
+
+        ageHeader?.click();
+        fixture.detectChanges();
+
+        expect(component.sortKey()).toBe('age');
+        expect(component.direction()).toBe(TuiSortDirection.Asc);
+
+        component.changeCount = 0;
+
+        component.sortKey.set('age');
+        component.direction.set(TuiSortDirection.Desc);
+        fixture.detectChanges();
+
+        expect(component.changeCount).toBeLessThan(10);
+        expect(component.sortKey()).toBe('age');
+        expect(component.direction()).toBe(TuiSortDirection.Desc);
+    });
+
+    it('does not loop on simultaneous change when requiredSort is disabled', () => {
+        component.requiredSort.set(false);
+        fixture.detectChanges();
+
+        const [, ageHeader] = headers();
+
+        expect(ageHeader).toBeDefined();
+
+        ageHeader?.click();
+        fixture.detectChanges();
+
+        expect(component.sortKey()).toBe('age');
+
+        component.changeCount = 0;
+
+        component.sortKey.set('name');
+        component.direction.update((direction) =>
+            direction === TuiSortDirection.Asc
+                ? TuiSortDirection.Desc
+                : TuiSortDirection.Asc,
+        );
+        fixture.detectChanges();
+
+        expect(component.changeCount).toBeLessThan(10);
+        expect(component.sortKey()).toBe('name');
+        expect(component.direction()).toBe(TuiSortDirection.Desc);
+    });
+});


### PR DESCRIPTION
Closes #14800

Changing `tuiSortBy` and `direction` at the same time (e.g. a filter preset) sent `tuiSortChange` into an infinite loop — the key kept flipping `age → name → age` until `NG0103`. Worked in v4, blocked v5 migration.

**Cause:** the table comparator was synced from `tuiSortBy` by one effect per column, and on a simultaneous change these raced across CD passes, so the emitted key disagreed with the input. `updateSorter` also reset direction to `Asc`, fighting the `direction` input. (v4 masked this with `debounceTime(0)`, lost in the signals refactor.)

**Fix:** a single effect in `sort-by.directive` resolves the active column directly from `tuiSortBy` (no race), and syncs via `sorter.set()` so direction stays owned by its input. Header-click sorting is untouched.

**Tests:** `directives/test/sort.spec.ts` — reproduces the loop (fails before, converges to `{name, Desc}` after) plus guards for header click, direction-only, same-key preset, and `requiredSort=false`. Also verified live in the demo (before: 100 emits + `NG0103`; after: 1 emit, clean).