### PR TITLE
feat(core): support labels for buttons

### DIFF
--- a/projects/core/components/button/button.directive.ts
+++ b/projects/core/components/button/button.directive.ts
@@ -30,7 +30,8 @@ import {TUI_BUTTON_OPTIONS} from './button.options';
 class Styles {}
 
 @Directive({
-    selector: 'a[tuiButton],button[tuiButton],a[tuiIconButton],button[tuiIconButton]',
+    selector:
+        'a[tuiButton],button[tuiButton],label[tuiButton],a[tuiIconButton],button[tuiIconButton],label[tuiIconButton]',
     providers: [tuiAppearanceOptionsProvider(TUI_BUTTON_OPTIONS)],
     hostDirectives: [TuiWithAppearance, TuiWithIcons],
     host: {'[attr.data-size]': 'size()'},

--- a/projects/core/components/button/test/button.directive.spec.ts
+++ b/projects/core/components/button/test/button.directive.spec.ts
@@ -53,28 +53,6 @@ describe('ButtonDirective', () => {
             >
                 Extra small
             </button>
-
-            <label
-                id="label-button"
-                tuiButton
-                for="file"
-            >
-                Label
-            </label>
-
-            <label
-                id="label-icon-button"
-                tuiIconButton
-                for="file"
-            >
-                Label icon
-            </label>
-
-            <input
-                id="file"
-                type="file"
-                hidden
-            />
         `,
         changeDetection: ChangeDetectionStrategy.OnPush,
     })
@@ -141,24 +119,6 @@ describe('ButtonDirective', () => {
             const size = await harness.getSize();
 
             expect(size).toBe('xs');
-        });
-    });
-
-    describe('label:', () => {
-        it('supports tuiButton', async () => {
-            const harness = await loader.getHarness(
-                TuiButtonHarness.with({selector: '#label-button'}),
-            );
-
-            expect(await harness.getSize()).toBe('l');
-        });
-
-        it('supports tuiIconButton', async () => {
-            const harness = await loader.getHarness(
-                TuiButtonHarness.with({selector: '#label-icon-button'}),
-            );
-
-            expect(await harness.getSize()).toBe('l');
         });
     });
 });

--- a/projects/core/components/button/test/button.directive.spec.ts
+++ b/projects/core/components/button/test/button.directive.spec.ts
@@ -53,6 +53,28 @@ describe('ButtonDirective', () => {
             >
                 Extra small
             </button>
+
+            <label
+                id="label-button"
+                tuiButton
+                for="file"
+            >
+                Label
+            </label>
+
+            <label
+                id="label-icon-button"
+                tuiIconButton
+                for="file"
+            >
+                Label icon
+            </label>
+
+            <input
+                id="file"
+                type="file"
+                hidden
+            />
         `,
         changeDetection: ChangeDetectionStrategy.OnPush,
     })
@@ -119,6 +141,24 @@ describe('ButtonDirective', () => {
             const size = await harness.getSize();
 
             expect(size).toBe('xs');
+        });
+    });
+
+    describe('label:', () => {
+        it('supports tuiButton', async () => {
+            const harness = await loader.getHarness(
+                TuiButtonHarness.with({selector: '#label-button'}),
+            );
+
+            expect(await harness.getSize()).toBe('l');
+        });
+
+        it('supports tuiIconButton', async () => {
+            const harness = await loader.getHarness(
+                TuiButtonHarness.with({selector: '#label-icon-button'}),
+            );
+
+            expect(await harness.getSize()).toBe('l');
         });
     });
 });

--- a/projects/demo/src/pages/components/button/examples/9/index.html
+++ b/projects/demo/src/pages/components/button/examples/9/index.html
@@ -1,0 +1,12 @@
+<label
+    tuiButton
+    for="file"
+>
+    Upload file
+</label>
+
+<input
+    id="file"
+    type="file"
+    hidden
+/>

--- a/projects/demo/src/pages/components/button/examples/9/index.html
+++ b/projects/demo/src/pages/components/button/examples/9/index.html
@@ -1,12 +1,12 @@
 <label
-    tuiButton
     for="file"
+    tuiButton
 >
     Upload file
 </label>
 
 <input
     id="file"
-    type="file"
     hidden
+    type="file"
 />

--- a/projects/demo/src/pages/components/button/examples/9/index.html
+++ b/projects/demo/src/pages/components/button/examples/9/index.html
@@ -1,12 +1,5 @@
-<label
-    for="file"
-    tuiButton
->
+<label tuiButton>
     Upload file
-</label>
 
-<input
-    id="file"
-    hidden
-    type="file"
-/>
+    <input type="file" />
+</label>

--- a/projects/demo/src/pages/components/button/examples/9/index.less
+++ b/projects/demo/src/pages/components/button/examples/9/index.less
@@ -1,0 +1,4 @@
+:host {
+    display: flex;
+    gap: 1rem;
+}

--- a/projects/demo/src/pages/components/button/examples/9/index.less
+++ b/projects/demo/src/pages/components/button/examples/9/index.less
@@ -2,3 +2,16 @@
     display: flex;
     gap: 1rem;
 }
+
+label:has(input:focus-visible) {
+    outline-color: var(--tui-border-focus);
+}
+
+input {
+    position: absolute;
+    inset: 0;
+    block-size: 100%;
+    inline-size: 100%;
+    cursor: pointer;
+    opacity: 0;
+}

--- a/projects/demo/src/pages/components/button/examples/9/index.ts
+++ b/projects/demo/src/pages/components/button/examples/9/index.ts
@@ -1,0 +1,13 @@
+import {Component} from '@angular/core';
+import {changeDetection} from '@demo/emulate/change-detection';
+import {encapsulation} from '@demo/emulate/encapsulation';
+import {TuiButton} from '@taiga-ui/core';
+
+@Component({
+    imports: [TuiButton],
+    templateUrl: './index.html',
+    styleUrl: './index.less',
+    encapsulation,
+    changeDetection,
+})
+export default class Example {}

--- a/projects/demo/src/pages/components/button/index.html
+++ b/projects/demo/src/pages/components/button/index.html
@@ -8,8 +8,10 @@
             Button is a basic component used for both icon buttons and regular buttons with optional icons on either
             side. It can be applied to
             <code>button</code>
-            and
+            ,
             <code>a</code>
+            and
+            <code>label</code>
             tags. When used as
             <code>tuiIconButton</code>
             don't forget to still put text label within the tag for accessibility.
@@ -69,6 +71,14 @@
                         <code>&lt;a&gt;</code>
                         element preserves native link semantics — right-click, open in new tab, and URL preview all work
                         as expected.
+                    }
+                    @case (8) {
+                        Using
+                        <code>tuiButton</code>
+                        on a
+                        <code>&lt;label&gt;</code>
+                        element preserves native label semantics and can trigger associated controls, such as hidden
+                        file inputs.
                     }
                 }
             </ng-template>

--- a/projects/demo/src/pages/components/button/index.ts
+++ b/projects/demo/src/pages/components/button/index.ts
@@ -22,6 +22,7 @@ export default class Page {
         'Vertical',
         'Two labels',
         'Link',
+        'Label',
     ];
 
     protected readonly sizes: ReadonlyArray<TuiSizeL | TuiSizeXS> = ['xs', 's', 'm', 'l'];

--- a/projects/testing/core/button.harness.ts
+++ b/projects/testing/core/button.harness.ts
@@ -4,7 +4,7 @@ import {TuiLoaderHarness} from './loader.harness';
 
 export class TuiButtonHarness extends TuiComponentHarness {
     public static hostSelector =
-        'button[tuiButton], button[tuiIconButton], a[tuiButton], a[tuiIconButton]';
+        'button[tuiButton], button[tuiIconButton], a[tuiButton], a[tuiIconButton], label[tuiButton], label[tuiIconButton]';
 
     private readonly loader = this.locatorForOptional(TuiLoaderHarness);
 


### PR DESCRIPTION
## Motivation

`TuiButton` can currently be applied only to `button` and `a` elements.

Using `label` as a button is useful for native controls such as hidden file inputs:

```html
<label
    tuiButton
    for="file"
>
    Upload file
</label>

<input
    id="file"
    type="file"
    hidden
/>
```

This allows opening the native file picker without manually triggering the input with JavaScript.