### PR TITLE
fix(layout): `FloatingContainer` fix width of actions nested in `tui-expand`

### DIFF
--- a/projects/demo-playwright/tests/layout/floating-container.pw.spec.ts
+++ b/projects/demo-playwright/tests/layout/floating-container.pw.spec.ts
@@ -1,0 +1,21 @@
+import {DemoRoute} from '@demo/routes';
+import {TuiDocumentationPagePO, tuiGoto} from '@demo-playwright/utils';
+import {expect, test} from '@playwright/test';
+
+test.describe('FloatingContainer', () => {
+    test('stretches secondary action nested in tui-expand to full width', async ({
+        page,
+    }) => {
+        await tuiGoto(page, DemoRoute.FloatingContainer);
+
+        const example = new TuiDocumentationPagePO(page).getExample('#basic');
+
+        await example.scrollIntoViewIfNeeded();
+        await example.getByLabel('Floating visibility').check();
+        await example.getByLabel('Second action visibility').check();
+
+        await expect
+            .soft(example.locator('[tuiFloatingContainer]'))
+            .toHaveScreenshot('01-floating-container.png');
+    });
+});

--- a/projects/layout/components/floating-container/floating-container.style.less
+++ b/projects/layout/components/floating-container/floating-container.style.less
@@ -48,6 +48,12 @@
         }
     }
 
+    // grid stretches direct children only; stretch wrapped content too
+    > tui-expand > .t-wrapper > *,
+    > tui-elastic-container > .t-wrapper > * {
+        inline-size: 100%;
+    }
+
     &::before {
         .fullsize(absolute, inset);
         .transition(background);


### PR DESCRIPTION
Actions nested inside `tui-expand` / `tui-elastic-container` stopped stretching to full width — only the first, direct button did.

The `flex → grid` refactor (#12688) dropped the `inline-size: 100%` rule for wrapped content. Grid stretches only **direct** children, so a button living in `tui-expand > .t-wrapper` collapsed to its content width.

Restore explicit full-width stretching for content nested in the wrapper. Grid still handles direct children.