### PR TITLE
fix(cdk): `TuiControl` should ignore `[invalid]` input hijacked by signal forms

### DIFF
--- a/projects/cdk/classes/control.ts
+++ b/projects/cdk/classes/control.ts
@@ -21,7 +21,7 @@ import {
 } from '@angular/forms';
 import {EMPTY_FUNCTION} from '@taiga-ui/cdk/constants';
 import {TUI_FALLBACK_VALUE} from '@taiga-ui/cdk/tokens';
-import {tuiProvide} from '@taiga-ui/cdk/utils/di';
+import {tuiInjectFormField, tuiProvide} from '@taiga-ui/cdk/utils/di';
 import {
     delay,
     distinctUntilChanged,
@@ -84,6 +84,7 @@ export abstract class TuiControl<T> implements ControlValueAccessor {
 
     protected readonly control = inject(NgControl, {self: true});
     protected readonly cdr = inject(ChangeDetectorRef);
+    protected readonly field = tuiInjectFormField(FLAGS);
 
     protected transformer =
         inject(TuiValueTransformer, FLAGS) ?? TUI_IDENTITY_VALUE_TRANSFORMER;
@@ -105,13 +106,19 @@ export abstract class TuiControl<T> implements ControlValueAccessor {
      * TODO(v6): delete
      */
     public readonly pseudoInvalid = input<boolean | null>(undefined, {alias: 'invalid'});
+    /**
+     * @deprecated internal purpose only
+     * TODO(v6): delete when `TuiControl[pseudoInvalid]` is deleted
+     */
+    public readonly externalInvalid = signal<boolean | null>(null);
     public readonly touched = signal(false);
     public readonly status = signal<FormControlStatus | undefined>(undefined);
     public readonly disabled = computed(() => this.status() === 'DISABLED');
     public readonly interactive = computed(() => !this.disabled() && !this.readOnly());
 
     public readonly invalid = computed(() => {
-        const pseudoInvalid = this.pseudoInvalid();
+        const pseudoInvalid =
+            this.externalInvalid() ?? (this.field() ? null : this.pseudoInvalid());
 
         return pseudoInvalid == null
             ? this.interactive() && this.touched() && this.status() === 'INVALID'

--- a/projects/core/components/input/input.directive.ts
+++ b/projects/core/components/input/input.directive.ts
@@ -5,7 +5,6 @@ import {TuiId} from '@taiga-ui/cdk/directives/id';
 import {TuiNativeValidator} from '@taiga-ui/cdk/directives/native-validator';
 import {tuiInjectFormField} from '@taiga-ui/cdk/utils/di';
 import {tuiInjectElement, tuiValue} from '@taiga-ui/cdk/utils/dom';
-import {tuiSetSignal} from '@taiga-ui/cdk/utils/miscellaneous';
 import {
     TUI_TEXTFIELD_OPTIONS,
     tuiAsTextfieldAccessor,
@@ -110,7 +109,7 @@ export class TuiInputDirective<T> implements TuiTextfieldAccessor<T> {
     });
 
     /**
-     * Temporary workaround until TuiControl has deprecated `pseudoInvalid` property
+     * Temporary workaround until TuiControl has deprecated `pseudoInvalid = input(..., {alias: 'invalid'})` property
      * We cannot inject `TuiTextfieldComponent` (@taiga-ui/core) inside `TuiControl` (`@taiga-ui/cdk`)
      * TODO(v6): remove all logic inside constructor
      */
@@ -120,9 +119,7 @@ export class TuiInputDirective<T> implements TuiTextfieldAccessor<T> {
         effect(() => {
             const control = injector.get(TuiControl, null, {self: true});
 
-            if (control) {
-                tuiSetSignal(control.pseudoInvalid, this.computedInvalid());
-            }
+            control?.externalInvalid.set(this.textfield.invalid());
         });
     }
 

--- a/projects/demo-cypress/cypress.config.ts
+++ b/projects/demo-cypress/cypress.config.ts
@@ -88,6 +88,7 @@ export default defineConfig({
                             'projects/styles/components/switch.less',
                             'projects/styles/components/toast.less',
                             'projects/kit/components/accordion/accordion.style.less',
+                            'projects/kit/components/files/input-files/input-files.style.less',
                             'projects/kit/components/input-date/input-date.style.less',
                             'projects/kit/components/input-number/step/input-number-step.style.less',
                             'projects/kit/components/input-phone-international/input-phone-international.style.less',

--- a/projects/demo-cypress/src/tests/input-files/signal-forms.cy.ts
+++ b/projects/demo-cypress/src/tests/input-files/signal-forms.cy.ts
@@ -1,0 +1,105 @@
+/*
+// TODO: Uncomment the whole file when the `@angular/forms/signals` entry point becomes available,
+// when Taiga UI drops support of Angular below 22 (stable API for signal forms appeared in Angular 22)
+import {ChangeDetectionStrategy, Component, signal} from '@angular/core';
+import {form, FormField, requiredError, validate} from '@angular/forms/signals';
+import {TuiRoot} from '@taiga-ui/core';
+import {type TuiFileLike, TuiFiles} from '@taiga-ui/kit';
+
+const FILE: TuiFileLike = {name: 'report.pdf', size: 1024, type: 'application/pdf'};
+
+@Component({
+    imports: [FormField, TuiFiles, TuiRoot],
+    template: `
+        <tui-root>
+            <label
+                style="inline-size: 15rem"
+                tuiInputFiles
+            >
+                <input
+                    multiple
+                    tuiInputFiles
+                    [formField]="$any(f.files)"
+                />
+            </label>
+
+            <div style="margin-block-start: 1rem">
+                <output id="touched">{{ f.files().touched() }}</output>
+                <output id="invalid">{{ f.files().invalid() }}</output>
+
+                <button
+                    id="mark-touched"
+                    type="button"
+                    (click)="f().markAsTouched()"
+                >
+                    Mark as touched
+                </button>
+
+                <button
+                    id="set-valid"
+                    type="button"
+                    (click)="f.files().value.set([file])"
+                >
+                    Set valid value
+                </button>
+            </div>
+
+        </tui-root>
+    `,
+    changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class Sandbox {
+    public readonly file = FILE;
+    public readonly model = signal<{files: readonly TuiFileLike[]}>({files: []});
+
+    public readonly f = form(this.model, (path) => {
+        validate(path.files, ({value}) => (value().length ? null : requiredError()));
+    });
+}
+
+function snapshot(name: string): void {
+    cy.get('label[tuiInputFiles]').compareSnapshot({
+        name: `tuiInputFiles-${name}`,
+        cypressScreenshotOptions: {padding: 8},
+    });
+}
+
+describe('tuiInputFiles + signal forms', () => {
+    beforeEach(() => {
+        cy.viewport(400, 200);
+        cy.mount(Sandbox);
+        cy.get('input[tuiInputFiles]').as('input');
+    });
+
+    it('invalid but untouched => no invalid decoration', () => {
+        cy.get('#invalid').should('have.text', 'true');
+        cy.get('#touched').should('have.text', 'false');
+
+        cy.get('@input').should('not.have.attr', 'data-mode', 'invalid');
+
+        snapshot('untouched-invalid');
+    });
+
+    it('external markAsTouched() => invalid decoration appears', () => {
+        cy.get('#mark-touched').click();
+
+        cy.get('#touched').should('have.text', 'true');
+        cy.get('@input').should('have.attr', 'data-mode', 'invalid');
+
+        snapshot('touched-invalid');
+    });
+
+    it('valid value => decoration is dropped again', () => {
+        cy.get('#mark-touched').click();
+        cy.get('@input').should('have.attr', 'data-mode', 'invalid');
+
+        cy.get('#set-valid').click();
+
+        cy.get('#invalid').should('have.text', 'false');
+        cy.get('@input').should('not.have.attr', 'data-mode', 'invalid');
+
+        snapshot('valid-again');
+    });
+});
+*/
+// eslint-disable-next-line unicorn/no-empty-file

--- a/projects/demo-cypress/src/tests/input-phone-international/signal-forms.cy.ts
+++ b/projects/demo-cypress/src/tests/input-phone-international/signal-forms.cy.ts
@@ -1,0 +1,143 @@
+/*
+// TODO: Uncomment the whole file when the `@angular/forms/signals` entry point becomes available,
+// when Taiga UI drops support of Angular below 22 (stable API for signal forms appeared in Angular 22)
+import {ChangeDetectionStrategy, Component, signal} from '@angular/core';
+import {form, FormField, minLengthError, validate} from '@angular/forms/signals';
+import {TuiRoot} from '@taiga-ui/core';
+import {type TuiCountryIsoCode} from '@taiga-ui/i18n';
+import {
+    TuiInputPhoneInternational,
+    tuiInputPhoneInternationalOptionsProvider,
+} from '@taiga-ui/kit';
+
+@Component({
+    imports: [FormField, TuiInputPhoneInternational, TuiRoot],
+    template: `
+        <tui-root>
+            <tui-textfield>
+                <input
+                    tuiInputPhoneInternational
+                    [countries]="countries"
+                    [formField]="f.phone"
+                    [(countryIsoCode)]="countryIsoCode"
+                />
+            </tui-textfield>
+
+            <div style="margin-block-start: 1rem">
+                <output id="touched">{{ f.phone().touched() }}</output>
+                <output id="invalid">{{ f.phone().invalid() }}</output>
+
+                <button
+                    id="mark-touched"
+                    type="button"
+                    (click)="f().markAsTouched()"
+                >
+                    Mark as touched
+                </button>
+
+                <button
+                    id="strict"
+                    type="button"
+                    (click)="strict.set(!strict())"
+                >
+                    Toggle strict
+                </button>
+            </div>
+
+        </tui-root>
+    `,
+    changeDetection: ChangeDetectionStrategy.OnPush,
+    providers: [
+        tuiInputPhoneInternationalOptionsProvider({
+            metadata: import('libphonenumber-js/min/metadata').then((m) => m.default),
+        }),
+    ],
+})
+export class Sandbox {
+    public readonly countries: readonly TuiCountryIsoCode[] = ['RU', 'US'];
+    public readonly countryIsoCode = signal<TuiCountryIsoCode>('RU');
+    public readonly strict = signal(true);
+    public readonly model = signal<{phone: string}>({phone: ''});
+
+    public readonly f = form(this.model, (path) => {
+        validate(path.phone, ({value}) =>
+            this.strict() && value().length < 12 ? minLengthError(12) : null,
+        );
+    });
+}
+
+function snapshot(name: string): void {
+    cy.get('tui-textfield').compareSnapshot({
+        name: `tuiInputPhoneInternational-${name}`,
+        cypressScreenshotOptions: {padding: 8},
+    });
+}
+
+describe('tuiInputPhoneInternational + signal forms', () => {
+    beforeEach(() => {
+        cy.viewport(400, 300);
+        cy.mount(Sandbox);
+        cy.get('input[tuiInputPhoneInternational]').as('input');
+        cy.get('tui-textfield button[tuiChevron]').as('select');
+    });
+
+    it('invalid but untouched => nothing is painted', () => {
+        cy.get('#invalid').should('have.text', 'true');
+        cy.get('#touched').should('have.text', 'false');
+
+        cy.get('tui-textfield').should('not.have.class', 'tui-invalid');
+        cy.get('@input').should('have.attr', 'aria-invalid', 'false');
+        cy.get('@select').should('not.have.attr', 'data-mode', 'invalid');
+
+        snapshot('untouched-invalid');
+    });
+
+    it('blur => invalid decoration appears', () => {
+        cy.get('@input').focus().blur();
+
+        cy.get('#touched').should('have.text', 'true');
+
+        cy.get('tui-textfield').should('have.class', 'tui-invalid');
+        cy.get('@input').should('have.attr', 'aria-invalid', 'true');
+        cy.get('@select').should('have.attr', 'data-mode', 'invalid');
+
+        snapshot('blurred-invalid');
+    });
+
+    it('external markAsTouched() => invalid decoration appears', () => {
+        cy.get('#mark-touched').click();
+
+        cy.get('tui-textfield').should('have.class', 'tui-invalid');
+        cy.get('@input').should('have.attr', 'aria-invalid', 'true');
+        cy.get('@select').should('have.attr', 'data-mode', 'invalid');
+    });
+
+    it('field state flip leaves the untouched field unpainted', () => {
+        cy.get('#strict').click();
+        cy.get('#invalid').should('have.text', 'false');
+
+        cy.get('#strict').click();
+
+        cy.get('#invalid').should('have.text', 'true');
+        cy.get('#touched').should('have.text', 'false');
+
+        cy.get('tui-textfield').should('not.have.class', 'tui-invalid');
+        cy.get('@input').should('have.attr', 'aria-invalid', 'false');
+        cy.get('@select').should('not.have.attr', 'data-mode', 'invalid');
+
+        snapshot('flip-untouched');
+    });
+
+    it('valid value of a touched field => decoration disappears', () => {
+        cy.get('#mark-touched').click();
+        cy.get('@input').type('9123456789');
+
+        cy.get('#invalid').should('have.text', 'false');
+
+        cy.get('tui-textfield').should('not.have.class', 'tui-invalid');
+        cy.get('@input').should('have.attr', 'aria-invalid', 'false');
+        cy.get('@select').should('not.have.attr', 'data-mode', 'invalid');
+    });
+});
+*/
+// eslint-disable-next-line unicorn/no-empty-file

--- a/projects/demo-cypress/src/tests/input-range/signal-forms.cy.ts
+++ b/projects/demo-cypress/src/tests/input-range/signal-forms.cy.ts
@@ -1,0 +1,99 @@
+/*
+// TODO: Uncomment the whole file when the `@angular/forms/signals` entry point becomes available,
+// when Taiga UI drops support of Angular below 22 (stable API for signal forms appeared in Angular 22)
+import {ChangeDetectionStrategy, Component, signal} from '@angular/core';
+import {form, FormField, minError, validate} from '@angular/forms/signals';
+import {TuiRoot} from '@taiga-ui/core';
+import {TuiInputRange} from '@taiga-ui/kit';
+
+@Component({
+    imports: [FormField, TuiInputRange, TuiRoot],
+    template: `
+        <tui-root>
+            <tui-input-range
+                [formField]="$any(f.range)"
+                [max]="100"
+                [min]="0"
+            >
+                Range
+            </tui-input-range>
+
+            <div style="margin-block-start: 1rem">
+                <output id="touched">{{ f.range().touched() }}</output>
+                <output id="invalid">{{ f.range().invalid() }}</output>
+
+                <button
+                    id="mark-touched"
+                    type="button"
+                    (click)="f().markAsTouched()"
+                >
+                    Mark as touched
+                </button>
+
+                <button
+                    id="set-valid"
+                    type="button"
+                    (click)="f.range().value.set([0, 60])"
+                >
+                    Set valid value
+                </button>
+            </div>
+
+        </tui-root>
+    `,
+    changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class Sandbox {
+    public readonly model = signal<{range: readonly [number, number]}>({range: [0, 0]});
+
+    public readonly f = form(this.model, (path) => {
+        validate(path.range, ({value}) => (value()[1] < 50 ? minError(50) : null));
+    });
+}
+
+function snapshot(name: string): void {
+    cy.get('tui-input-range').compareSnapshot({
+        name: `tuiInputRange-${name}`,
+        cypressScreenshotOptions: {padding: 8},
+    });
+}
+
+describe('tuiInputRange + signal forms', () => {
+    beforeEach(() => {
+        cy.viewport(400, 200);
+        cy.mount(Sandbox);
+        cy.get('tui-input-range tui-textfield').as('textfield');
+    });
+
+    it('invalid but untouched => no invalid decoration', () => {
+        cy.get('#invalid').should('have.text', 'true');
+        cy.get('#touched').should('have.text', 'false');
+
+        cy.get('@textfield').should('not.have.attr', 'data-mode', 'invalid');
+
+        snapshot('untouched-invalid');
+    });
+
+    it('external markAsTouched() => invalid decoration appears', () => {
+        cy.get('#mark-touched').click();
+
+        cy.get('#touched').should('have.text', 'true');
+        cy.get('@textfield').should('have.attr', 'data-mode', 'invalid');
+
+        snapshot('touched-invalid');
+    });
+
+    it('valid value => decoration is dropped again', () => {
+        cy.get('#mark-touched').click();
+        cy.get('@textfield').should('have.attr', 'data-mode', 'invalid');
+
+        cy.get('#set-valid').click();
+
+        cy.get('#invalid').should('have.text', 'false');
+        cy.get('@textfield').should('not.have.attr', 'data-mode', 'invalid');
+
+        snapshot('valid-again');
+    });
+});
+*/
+// eslint-disable-next-line unicorn/no-empty-file

--- a/projects/demo-cypress/src/tests/pincode/signal-forms.cy.ts
+++ b/projects/demo-cypress/src/tests/pincode/signal-forms.cy.ts
@@ -1,0 +1,151 @@
+/*
+// TODO: Uncomment the whole file when the `@angular/forms/signals` entry point becomes available,
+// when Taiga UI drops support of Angular below 22 (stable API for signal forms appeared in Angular 22)
+import {ChangeDetectionStrategy, Component, signal} from '@angular/core';
+import {form, FormField, patternError, validate} from '@angular/forms/signals';
+import {TuiRoot} from '@taiga-ui/core';
+import {TuiPincode} from '@taiga-ui/kit';
+
+const PIN = /^4321$/;
+
+@Component({
+    imports: [FormField, TuiPincode, TuiRoot],
+    template: `
+        <tui-root>
+            <tui-textfield
+                style="inline-size: 10rem"
+                [invalid]="override()"
+            >
+                <input
+                    tuiPincode
+                    [formField]="$any(f.pin)"
+                />
+            </tui-textfield>
+
+            <div style="margin-block-start: 1rem">
+                <output id="touched">{{ f.pin().touched() }}</output>
+                <output id="invalid">{{ f.pin().invalid() }}</output>
+
+                <button
+                    id="mark-touched"
+                    type="button"
+                    (click)="f().markAsTouched()"
+                >
+                    Mark as touched
+                </button>
+
+                <button
+                    id="override-true"
+                    type="button"
+                    (click)="override.set(true)"
+                >
+                    Wrong pin
+                </button>
+
+                <button
+                    id="override-false"
+                    type="button"
+                    (click)="override.set(false)"
+                >
+                    Correct pin
+                </button>
+
+                <button
+                    id="override-null"
+                    type="button"
+                    (click)="override.set(null)"
+                >
+                    Drop override
+                </button>
+            </div>
+
+        </tui-root>
+    `,
+    changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class Sandbox {
+    public readonly override = signal<boolean | null>(null);
+    public readonly model = signal<{pin: string}>({pin: ''});
+
+    public readonly f = form(this.model, (path) => {
+        validate(path.pin, ({value}) => (PIN.test(value()) ? null : patternError(PIN)));
+    });
+}
+
+function snapshot(name: string): void {
+    cy.get('tui-textfield').compareSnapshot({
+        name: `tuiPincode-${name}`,
+        cypressScreenshotOptions: {padding: 8},
+    });
+}
+
+describe('tuiPincode + signal forms', () => {
+    beforeEach(() => {
+        cy.viewport(250, 150);
+        cy.mount(Sandbox);
+        cy.get('input[tuiPincode]').as('input');
+    });
+
+    describe('Field state never reaches the animation', () => {
+        it('invalid but untouched => no state', () => {
+            cy.get('#invalid').should('have.text', 'true');
+
+            cy.get('@input').should('not.have.attr', 'data-state');
+
+            snapshot('untouched-invalid');
+        });
+
+        it('invalid and touched => still no state', () => {
+            cy.get('#mark-touched').click();
+
+            cy.get('#touched').should('have.text', 'true');
+            cy.get('@input').should('not.have.attr', 'data-state');
+
+            snapshot('touched-invalid');
+        });
+
+        it('complete but invalid value => pending, not invalid', () => {
+            cy.get('@input').type('1234');
+
+            cy.get('#invalid').should('have.text', 'true');
+            cy.get('@input').should('have.attr', 'data-state', 'pending');
+
+            snapshot('pending');
+        });
+    });
+
+    describe('`tui-textfield[invalid]` is the override channel', () => {
+        it('[invalid]=true => invalid state', () => {
+            cy.get('#override-true').click();
+
+            cy.get('@input').should('have.attr', 'data-state', 'invalid');
+        });
+
+        it('[invalid]=false => success state', () => {
+            cy.get('#override-false').click();
+
+            cy.get('@input').should('have.attr', 'data-state', 'success');
+        });
+
+        it('[invalid]=null => the animation is dropped', () => {
+            cy.get('#override-true').click();
+            cy.get('@input').should('have.attr', 'data-state', 'invalid');
+
+            cy.get('#override-null').click();
+            cy.get('@input').should('not.have.attr', 'data-state');
+        });
+
+        it('override survives field state changes', () => {
+            cy.get('#override-false').click();
+            cy.get('@input').should('have.attr', 'data-state', 'success');
+
+            cy.get('#mark-touched').click();
+            cy.get('@input').type('1234');
+
+            cy.get('#invalid').should('have.text', 'true');
+            cy.get('@input').should('have.attr', 'data-state', 'success');
+        });
+    });
+});
+*/
+// eslint-disable-next-line unicorn/no-empty-file

--- a/projects/demo-cypress/src/tests/pincode/signal-forms.cy.ts
+++ b/projects/demo-cypress/src/tests/pincode/signal-forms.cy.ts
@@ -72,13 +72,6 @@ export class Sandbox {
     });
 }
 
-function snapshot(name: string): void {
-    cy.get('tui-textfield').compareSnapshot({
-        name: `tuiPincode-${name}`,
-        cypressScreenshotOptions: {padding: 8},
-    });
-}
-
 describe('tuiPincode + signal forms', () => {
     beforeEach(() => {
         cy.viewport(250, 150);
@@ -91,8 +84,6 @@ describe('tuiPincode + signal forms', () => {
             cy.get('#invalid').should('have.text', 'true');
 
             cy.get('@input').should('not.have.attr', 'data-state');
-
-            snapshot('untouched-invalid');
         });
 
         it('invalid and touched => still no state', () => {
@@ -100,8 +91,6 @@ describe('tuiPincode + signal forms', () => {
 
             cy.get('#touched').should('have.text', 'true');
             cy.get('@input').should('not.have.attr', 'data-state');
-
-            snapshot('touched-invalid');
         });
 
         it('complete but invalid value => pending, not invalid', () => {
@@ -109,8 +98,6 @@ describe('tuiPincode + signal forms', () => {
 
             cy.get('#invalid').should('have.text', 'true');
             cy.get('@input').should('have.attr', 'data-state', 'pending');
-
-            snapshot('pending');
         });
     });
 

--- a/projects/demo-cypress/src/tests/radio-list/signal-forms.cy.ts
+++ b/projects/demo-cypress/src/tests/radio-list/signal-forms.cy.ts
@@ -1,0 +1,78 @@
+/*
+// TODO: Uncomment the whole file when the `@angular/forms/signals` entry point becomes available,
+// when Taiga UI drops support of Angular below 22 (stable API for signal forms appeared in Angular 22)
+import {ChangeDetectionStrategy, Component, signal} from '@angular/core';
+import {form, FormField, required} from '@angular/forms/signals';
+import {TuiRoot} from '@taiga-ui/core';
+import {TuiRadioList} from '@taiga-ui/kit';
+
+@Component({
+    imports: [FormField, TuiRadioList, TuiRoot],
+    template: `
+        <tui-root>
+            <tui-radio-list
+                [formField]="f.pick"
+                [items]="items"
+            />
+
+            <output id="touched">{{ f.pick().touched() }}</output>
+            <output id="invalid">{{ f.pick().invalid() }}</output>
+
+            <button
+                id="mark-touched"
+                type="button"
+                (click)="f().markAsTouched()"
+            >
+                Mark as touched
+            </button>
+        </tui-root>
+    `,
+    changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class Sandbox {
+    public readonly items = ['one', 'two'];
+    public readonly model = signal<{pick: string}>({pick: ''});
+
+    public readonly f = form(this.model, (path) => {
+        required(path.pick);
+    });
+}
+
+describe('tuiRadioList + signal forms', () => {
+    beforeEach(() => {
+        cy.mount(Sandbox);
+        cy.get('tui-radio-list input[tuiRadio]').as('radios');
+    });
+
+    it('invalid but untouched => inner controls stay valid', () => {
+        cy.get('#invalid').should('have.text', 'true');
+        cy.get('#touched').should('have.text', 'false');
+
+        cy.get('@radios').each(($radio) => {
+            cy.wrap($radio).should('have.class', 'ng-valid');
+        });
+    });
+
+    it('external markAsTouched() => inner controls become invalid', () => {
+        cy.get('#mark-touched').click();
+
+        cy.get('#touched').should('have.text', 'true');
+
+        cy.get('@radios').each(($radio) => {
+            cy.wrap($radio).should('have.class', 'ng-invalid');
+        });
+    });
+
+    it('picking an item makes everything valid again', () => {
+        cy.get('#mark-touched').click();
+        cy.get('@radios').first().click();
+
+        cy.get('#invalid').should('have.text', 'false');
+
+        cy.get('@radios').each(($radio) => {
+            cy.wrap($radio).should('have.class', 'ng-valid');
+        });
+    });
+});
+*/
+// eslint-disable-next-line unicorn/no-empty-file

--- a/projects/kit/components/pincode/pincode.component.ts
+++ b/projects/kit/components/pincode/pincode.component.ts
@@ -1,4 +1,4 @@
-import {computed, Directive, effect, input, output, signal} from '@angular/core';
+import {computed, Directive, effect, inject, input, output, signal} from '@angular/core';
 import {MaskitoDirective} from '@maskito/angular';
 import {maskitoCaretGuard} from '@maskito/kit';
 import {TuiControl} from '@taiga-ui/cdk/classes';
@@ -8,6 +8,7 @@ import {tuiFocusedIn} from '@taiga-ui/cdk/utils/focus';
 import {tuiIsPresent} from '@taiga-ui/cdk/utils/miscellaneous';
 import {
     tuiAsTextfieldContent,
+    TuiTextfieldComponent,
     TuiTextfieldContent,
 } from '@taiga-ui/core/components/textfield';
 import {tuiMaskito} from '@taiga-ui/kit/utils';
@@ -39,8 +40,15 @@ const ANIMATION = {
     },
 })
 export class TuiPincodeComponent extends TuiControl<string> {
+    private readonly textfield = inject(TuiTextfieldComponent);
+
     private phase = 0;
     private bounced = false;
+
+    // TODO(v6): use only `this.textfield.invalid()`
+    private readonly manualInvalid = computed(
+        () => this.textfield.invalid() ?? (this.field() ? null : this.pseudoInvalid()),
+    );
 
     public readonly el = tuiInjectElement<HTMLInputElement>();
     public readonly paste = signal(false);
@@ -58,8 +66,8 @@ export class TuiPincodeComponent extends TuiControl<string> {
     public readonly finished = output();
 
     protected readonly state = computed<'invalid' | 'pending' | 'success' | null>(() => {
-        if (tuiIsPresent(this.pseudoInvalid())) {
-            return this.pseudoInvalid() ? 'invalid' : 'success';
+        if (tuiIsPresent(this.manualInvalid())) {
+            return this.manualInvalid() ? 'invalid' : 'success';
         }
 
         return this.value().length === this.maxLength() ? 'pending' : null;
@@ -67,7 +75,7 @@ export class TuiPincodeComponent extends TuiControl<string> {
 
     protected readonly effect = effect(() => {
         this.bounced = false;
-        this.phase = tuiIsPresent(this.pseudoInvalid()) ? this.value().length : 0;
+        this.phase = tuiIsPresent(this.manualInvalid()) ? this.value().length : 0;
     });
 
     public onAnimationStart({animationName}: AnimationEvent): void {

--- a/projects/kit/components/pincode/pincode.component.ts
+++ b/projects/kit/components/pincode/pincode.component.ts
@@ -41,7 +41,6 @@ const ANIMATION = {
 })
 export class TuiPincodeComponent extends TuiControl<string> {
     private readonly textfield = inject(TuiTextfieldComponent);
-
     private phase = 0;
     private bounced = false;
 


### PR DESCRIPTION
### Problem

`FormField` writes field state into directive inputs **by name**, and `invalid` is one of those names — so signal forms silently take over `TuiControl.pseudoInvalid`, which is the deprecated manual appearance override. As soon as it is not `null`, `TuiControl.invalid()` stops respecting `touched()`, and an untouched field reports itself as invalid.

https://github.com/taiga-family/taiga-ui/blob/3cc8130dd8643e94616008482c7bceac2edadba4/projects/cdk/classes/control.ts#L103-L107

### Untouched invalid `InputRange`
<img height="100" alt="Image" src="https://github.com/user-attachments/assets/9a33109a-b7b7-4fe7-8557-fdf3634a7f1d" />

<p align="center">⬇️ </p>

<img height="100" alt="Image" src="https://github.com/user-attachments/assets/d755e635-0ee3-49bf-ba77-439b23af5bd5" />

### Untouched invalid `InputFiles`
<img width="512" height="144" alt="Image" src="https://github.com/user-attachments/assets/273a8b41-dcb8-41a2-bbfb-ca9b25e5e361" />

<p align="center">⬇️ </p>

<img width="512" height="144" alt="Image" src="https://github.com/user-attachments/assets/a621b454-47ca-4c1d-95d8-53f5a1f37aa5" />

### Untouched invalid `InputPhoneInternational`
<img height="100" alt="Image" src="https://github.com/user-attachments/assets/624feb04-6427-4c2c-bfd3-fa455ce1c28b" />

<p align="center">⬇️ </p>

<img height="100" alt="Image" src="https://github.com/user-attachments/assets/e25ad493-69a4-4675-8a58-8a5260c8ce44" />

Relates:
- https://github.com/taiga-family/taiga-ui/issues/14341