### PR TITLE
fix(cdk): `tuiControlValue` utility supports `NgControl` from signal forms

### DIFF
--- a/projects/addon-commerce/components/input-card/input-card-content.component.ts
+++ b/projects/addon-commerce/components/input-card/input-card-content.component.ts
@@ -3,6 +3,7 @@ import {
     Component,
     computed,
     inject,
+    INJECTOR,
     ViewEncapsulation,
 } from '@angular/core';
 import {toSignal} from '@angular/core/rxjs-interop';
@@ -36,11 +37,14 @@ import {switchMap, timer} from 'rxjs';
     host: {'data-tui-version': TUI_VERSION},
 })
 export class TuiInputCardContent {
+    private readonly injector = inject(INJECTOR);
     private readonly icons = inject(TUI_PAYMENT_SYSTEM_ICONS);
     private readonly control = inject(NgControl);
 
     private readonly value = toSignal(
-        timer(0).pipe(switchMap(() => tuiControlValue<string>(this.control))),
+        timer(0).pipe(
+            switchMap(() => tuiControlValue<string>(this.control, this.injector)),
+        ),
         {initialValue: ''},
     );
 

--- a/projects/addon-commerce/components/input-card/input-card.component.ts
+++ b/projects/addon-commerce/components/input-card/input-card.component.ts
@@ -1,4 +1,4 @@
-import {Directive, inject, type OnInit} from '@angular/core';
+import {Directive, inject, INJECTOR, type OnInit} from '@angular/core';
 import {outputFromObservable} from '@angular/core/rxjs-interop';
 import {DefaultValueAccessor, NgControl} from '@angular/forms';
 import {MaskitoDirective} from '@maskito/angular';
@@ -27,6 +27,7 @@ import {TuiInputCardContent} from './input-card-content.component';
 })
 // TODO(v6): rename to TuiInputCardDirective
 export class TuiInputCardComponent implements OnInit {
+    private readonly injector = inject(INJECTOR);
     private readonly control = inject(NgControl);
 
     private readonly accessor = inject(DefaultValueAccessor, {
@@ -38,7 +39,7 @@ export class TuiInputCardComponent implements OnInit {
 
     public readonly binChange = outputFromObservable(
         timer(0).pipe(
-            switchMap(() => tuiControlValue<string>(this.control)),
+            switchMap(() => tuiControlValue<string>(this.control, this.injector)),
             map((v) => (v.length < 6 ? null : v.replace(' ', '').slice(0, 6))),
             startWith(null),
             distinctUntilChanged(),

--- a/projects/addon-mobile/components/mobile-calendar/calendar-date-stream.ts
+++ b/projects/addon-mobile/components/mobile-calendar/calendar-date-stream.ts
@@ -1,7 +1,4 @@
-import {
-    inject,
-    InjectionToken, INJECTOR, type Provider
-} from '@angular/core';
+import {inject, InjectionToken, INJECTOR, type Provider} from '@angular/core';
 import {NgControl} from '@angular/forms';
 import {type TuiValueTransformer} from '@taiga-ui/cdk/classes';
 import {type TuiDay, type TuiDayRange, type TuiTime} from '@taiga-ui/cdk/date-time';
@@ -23,10 +20,12 @@ export function tuiDateStreamWithTransformer(
 
             return control
                 ? tuiControlValue(control, inject(INJECTOR)).pipe(
-                    map((value) =>
-                        transformer ? transformer?.fromControlValue(value) : (value as T),
-                    ),
-                )
+                      map((value) =>
+                          transformer
+                              ? transformer?.fromControlValue(value)
+                              : (value as T),
+                      ),
+                  )
                 : of(null);
         },
     };

--- a/projects/addon-mobile/components/mobile-calendar/calendar-date-stream.ts
+++ b/projects/addon-mobile/components/mobile-calendar/calendar-date-stream.ts
@@ -1,4 +1,7 @@
-import {InjectionToken, Optional, type Provider, Self} from '@angular/core';
+import {
+    inject,
+    InjectionToken, INJECTOR, type Provider
+} from '@angular/core';
 import {NgControl} from '@angular/forms';
 import {type TuiValueTransformer} from '@taiga-ui/cdk/classes';
 import {type TuiDay, type TuiDayRange, type TuiTime} from '@taiga-ui/cdk/date-time';
@@ -10,29 +13,21 @@ export const TUI_CALENDAR_DATE_STREAM = new InjectionToken<
 >(ngDevMode ? 'TUI_CALENDAR_DATE_STREAM' : '');
 
 export function tuiDateStreamWithTransformer(
-    transformer: InjectionToken<TuiValueTransformer<any>>,
+    transformerToken: InjectionToken<TuiValueTransformer<any>>,
 ): Provider {
     return {
         provide: TUI_CALENDAR_DATE_STREAM,
-        deps: [
-            [new Optional(), new Self(), NgControl],
-            [new Optional(), transformer],
-        ],
-        useFactory: tuiControlValueFactory,
-    };
-}
+        useFactory: <T extends TuiDay | TuiDayRange | [TuiDay, TuiTime | null]>() => {
+            const control = inject(NgControl, {optional: true, self: true});
+            const transformer = inject(transformerToken, {optional: true});
 
-function tuiControlValueFactory<
-    T extends TuiDay | TuiDayRange | [TuiDay, TuiTime | null],
->(
-    control: NgControl | null,
-    transformer?: TuiValueTransformer<T> | null,
-): Observable<T | null> | null {
-    return control
-        ? tuiControlValue(control).pipe(
-              map((value) =>
-                  transformer ? transformer?.fromControlValue(value) : (value as T),
-              ),
-          )
-        : of(null);
+            return control
+                ? tuiControlValue(control, inject(INJECTOR)).pipe(
+                    map((value) =>
+                        transformer ? transformer?.fromControlValue(value) : (value as T),
+                    ),
+                )
+                : of(null);
+        },
+    };
 }

--- a/projects/cdk/directives/value-changes/value-changes.directive.ts
+++ b/projects/cdk/directives/value-changes/value-changes.directive.ts
@@ -1,4 +1,4 @@
-import {Directive, type DoCheck, inject} from '@angular/core';
+import {Directive, type DoCheck, inject, INJECTOR} from '@angular/core';
 import {outputFromObservable} from '@angular/core/rxjs-interop';
 import {ControlContainer, NgControl} from '@angular/forms';
 import {tuiControlValue} from '@taiga-ui/cdk/observables';
@@ -6,13 +6,14 @@ import {distinctUntilChanged, skip, Subject, switchMap} from 'rxjs';
 
 @Directive({selector: '[tuiValueChanges]'})
 export class TuiValueChanges<T> implements DoCheck {
+    private readonly injector = inject(INJECTOR);
     private readonly container = inject(ControlContainer, {optional: true});
     private readonly control = inject(NgControl, {optional: true});
     private readonly control$ = new Subject<ControlContainer | NgControl | null>();
 
     private readonly tuiValueChanges$ = this.control$.pipe(
         distinctUntilChanged(),
-        switchMap(tuiControlValue<T>),
+        switchMap((control) => tuiControlValue<T>(control, this.injector)),
         distinctUntilChanged(),
         skip(1),
     );

--- a/projects/cdk/observables/control-value.ts
+++ b/projects/cdk/observables/control-value.ts
@@ -5,6 +5,7 @@ import {distinctUntilChanged, Observable, startWith} from 'rxjs';
 
 /**
  * Turns form control value changes into ReplaySubject(1)
+ * TODO(v6): refactor it after signal forms are fully supported (Angular >= 22)
  */
 export function tuiControlValue<T>(
     control?: AbstractControl | AbstractControlDirective | null, // TODO: add `InteropNgControl` as possible type after update to Angular 21+

--- a/projects/cdk/observables/control-value.ts
+++ b/projects/cdk/observables/control-value.ts
@@ -1,13 +1,26 @@
+import {computed, type Injector, untracked} from '@angular/core';
+import {toObservable} from '@angular/core/rxjs-interop';
 import {type AbstractControl, type AbstractControlDirective} from '@angular/forms';
-import {Observable, startWith} from 'rxjs';
+import {distinctUntilChanged, Observable, startWith} from 'rxjs';
 
 /**
- * Turns AbstractControl/Abstract-control-directive valueChanges into ReplaySubject(1)
+ * Turns form control value changes into ReplaySubject(1)
  */
 export function tuiControlValue<T>(
-    control?: AbstractControl | AbstractControlDirective | null,
+    control?: AbstractControl | AbstractControlDirective | null, // TODO: add `InteropNgControl` as possible type after update to Angular 21+
+    injector?: Injector,
 ): Observable<T> {
-    return new Observable((subscriber) =>
-        control?.valueChanges?.pipe(startWith(control.value)).subscribe(subscriber),
-    );
+    return new Observable((subscriber) => {
+        const value = computed(() => control?.value as T);
+        const valueChanges$ =
+            control?.valueChanges ?? // reactive forms
+            (control && injector && toObservable(value, {injector})); // signal forms
+
+        return valueChanges$
+            ?.pipe(
+                startWith(untracked(value)),
+                distinctUntilChanged(),
+            )
+            .subscribe(subscriber);
+    });
 }

--- a/projects/cdk/observables/control-value.ts
+++ b/projects/cdk/observables/control-value.ts
@@ -1,4 +1,4 @@
-import {computed, type Injector, untracked} from '@angular/core';
+import {computed, type Injector} from '@angular/core';
 import {toObservable} from '@angular/core/rxjs-interop';
 import {type AbstractControl, type AbstractControlDirective} from '@angular/forms';
 import {distinctUntilChanged, Observable, startWith} from 'rxjs';
@@ -11,16 +11,19 @@ export function tuiControlValue<T>(
     injector?: Injector,
 ): Observable<T> {
     return new Observable((subscriber) => {
-        const value = computed(() => control?.value as T);
+        const value = control?.value as T;
         const valueChanges$ =
             control?.valueChanges ?? // reactive forms
-            (control && injector && toObservable(value, {injector})); // signal forms
+            // signal forms
+            (control &&
+                injector &&
+                toObservable(
+                    computed(() => control?.value as T),
+                    {injector},
+                ));
 
         return valueChanges$
-            ?.pipe(
-                startWith(untracked(value)),
-                distinctUntilChanged(),
-            )
+            ?.pipe(startWith(value), distinctUntilChanged())
             .subscribe(subscriber);
     });
 }

--- a/projects/cdk/observables/test/control-value.spec.ts
+++ b/projects/cdk/observables/test/control-value.spec.ts
@@ -1,5 +1,6 @@
-import {fakeAsync} from '@angular/core/testing';
-import {FormControl} from '@angular/forms';
+import {Injector, signal, type WritableSignal} from '@angular/core';
+import {fakeAsync, TestBed, tick} from '@angular/core/testing';
+import {type AbstractControlDirective, FormControl} from '@angular/forms';
 import {tuiControlValue} from '@taiga-ui/cdk';
 import {skip} from 'rxjs';
 
@@ -29,4 +30,61 @@ describe('tuiControlValue', () => {
 
         expect(actual).toBe('test');
     }));
+
+    describe('control without valueChanges (InteropNgControl from signal forms)', () => {
+        /**
+         * `InteropNgControl` (from `@angular/forms/signals`) 
+         * has no observables, only getters over the field state signals
+         */
+        function fakeInteropNgControl(
+            value: WritableSignal<string>,
+        ): AbstractControlDirective {
+            return {
+                get value() {
+                    return value();
+                },
+            } as unknown as AbstractControlDirective;
+        }
+
+        it('starts with the current value synchronously', () => {
+            let actual = '';
+            const value = signal('hello');
+
+            tuiControlValue<string>(
+                fakeInteropNgControl(value),
+                TestBed.inject(Injector),
+            ).subscribe((current) => {
+                actual = current;
+            });
+
+            expect(actual).toBe('hello');
+        });
+
+        it('emits when the underlying signal changes', fakeAsync(() => {
+            let actual = '';
+            const value = signal('hello');
+
+            tuiControlValue<string>(fakeInteropNgControl(value), TestBed.inject(Injector))
+                .pipe(skip(1))
+                .subscribe((current) => {
+                    actual = current;
+                });
+
+            value.set('test');
+            tick(); // `toObservable` watches the signal with an effect, which is asynchronous
+
+            expect(actual).toBe('test');
+        }));
+
+        it('emits nothing without an injector', () => {
+            let calls = 0;
+            const value = signal('hello');
+
+            tuiControlValue<string>(fakeInteropNgControl(value)).subscribe(() => {
+                calls++;
+            });
+
+            expect(calls).toBe(0);
+        });
+    });
 });

--- a/projects/cdk/observables/test/control-value.spec.ts
+++ b/projects/cdk/observables/test/control-value.spec.ts
@@ -33,7 +33,7 @@ describe('tuiControlValue', () => {
 
     describe('control without valueChanges (InteropNgControl from signal forms)', () => {
         /**
-         * `InteropNgControl` (from `@angular/forms/signals`) 
+         * `InteropNgControl` (from `@angular/forms/signals`)
          * has no observables, only getters over the field state signals
          */
         function fakeInteropNgControl(

--- a/projects/core/components/radio/radio.component.ts
+++ b/projects/core/components/radio/radio.component.ts
@@ -4,6 +4,7 @@ import {
     DestroyRef,
     type DoCheck,
     inject,
+    INJECTOR,
     input,
     type OnInit,
     ViewEncapsulation,
@@ -44,6 +45,7 @@ import {TUI_RADIO_OPTIONS, type TuiRadioOptions} from './radio.options';
 })
 export class TuiRadioComponent<T extends TuiRadioOptions> implements DoCheck, OnInit {
     private readonly destroyRef = inject(DestroyRef);
+    private readonly injector = inject(INJECTOR);
 
     protected readonly el = tuiInjectElement<HTMLInputElement>();
     protected readonly options = inject<T>(TUI_RADIO_OPTIONS);
@@ -53,7 +55,7 @@ export class TuiRadioComponent<T extends TuiRadioOptions> implements DoCheck, On
     public readonly size = input(this.options.size);
 
     public ngOnInit(): void {
-        tuiControlValue(this.control)
+        tuiControlValue(this.control, this.injector)
             .pipe(distinctUntilChanged(), takeUntilDestroyed(this.destroyRef))
             .subscribe((value) => {
                 // https://github.com/angular/angular/issues/14988

--- a/projects/core/components/slider/helpers/slider-key-steps.directive.ts
+++ b/projects/core/components/slider/helpers/slider-key-steps.directive.ts
@@ -58,7 +58,7 @@ export class TuiSliderKeyStepsBase implements OnInit {
 
     public controlValue = toSignal(
         timer(0) // https://github.com/angular/angular/issues/54418
-            .pipe(switchMap(() => tuiControlValue<number>(this.control))),
+            .pipe(switchMap(() => tuiControlValue<number>(this.control, this.injector))),
     );
 
     public readonly totalSteps = computed(() =>

--- a/projects/core/components/slider/helpers/slider-thumb-label.component.ts
+++ b/projects/core/components/slider/helpers/slider-thumb-label.component.ts
@@ -4,9 +4,14 @@ import {
     ChangeDetectionStrategy,
     Component,
     contentChild,
+    inject,
+    INJECTOR,
 } from '@angular/core';
+import {toObservable} from '@angular/core/rxjs-interop';
 import {NgControl} from '@angular/forms';
+import {tuiControlValue} from '@taiga-ui/cdk/observables';
 import {tuiHintOptionsProvider} from '@taiga-ui/core/portals/hint';
+import {switchMap} from 'rxjs';
 
 import {TuiSliderComponent} from '../slider.component';
 
@@ -19,14 +24,20 @@ import {TuiSliderComponent} from '../slider.component';
     providers: [tuiHintOptionsProvider({direction: 'top', appearance: 'floating'})],
 })
 export class TuiSliderThumbLabel implements AfterContentInit {
+    private readonly injector = inject(INJECTOR);
+
     protected readonly slider = contentChild(TuiSliderComponent);
     protected readonly control = contentChild(NgControl);
+
+    protected readonly valueChanges$ = toObservable(this.control).pipe(
+        switchMap((control) => tuiControlValue(control, this.injector)),
+    );
 
     public ngAfterContentInit(): void {
         ngDevMode &&
             console.assert(
-                Boolean(this.control()?.valueChanges),
-                '\n[tuiSliderThumbLabel] expected <input tuiSlider type="range" /> to use Angular Forms.\nUse [(ngModel)] or [formControl] or formControlName for correct work.',
+                Boolean(this.control()),
+                '\n[tuiSliderThumbLabel] expected <input tuiSlider type="range" /> to use Angular Forms.\nUse [(ngModel)] or [formControl] or formControlName or [formField] for correct work.',
             );
     }
 

--- a/projects/core/components/slider/helpers/slider-thumb-label.template.html
+++ b/projects/core/components/slider/helpers/slider-thumb-label.template.html
@@ -1,4 +1,4 @@
-@if (control()?.valueChanges | async) {}
+@if (valueChanges$ | async) {}
 
 <div
     class="t-ghost"

--- a/projects/kit/components/files/input-files/input-files.directive.ts
+++ b/projects/kit/components/files/input-files/input-files.directive.ts
@@ -1,5 +1,5 @@
 import {coerceArray} from '@angular/cdk/coercion';
-import {Directive} from '@angular/core';
+import {Directive, inject, INJECTOR} from '@angular/core';
 import {outputFromObservable} from '@angular/core/rxjs-interop';
 import {tuiAsControl, TuiControl} from '@taiga-ui/cdk/classes';
 import {TuiNativeValidator} from '@taiga-ui/cdk/directives/native-validator';
@@ -42,13 +42,15 @@ import {TuiInputFilesValidator} from './input-files-validator.directive';
 export class TuiInputFilesDirective extends TuiControl<
     TuiFileLike | readonly TuiFileLike[]
 > {
+    private readonly injector = inject(INJECTOR);
+
     protected readonly m = tuiAppearanceMode(this.mode);
 
     public readonly el = tuiInjectElement<HTMLInputElement>();
 
     public readonly reject = outputFromObservable(
         timer(0, tuiZonefreeScheduler()).pipe(
-            switchMap(() => tuiControlValue(this.control.control)),
+            switchMap(() => tuiControlValue(this.control.control, this.injector)),
             map(() => tuiFilesRejected(this.control.control)),
             filter(({length}) => !!length),
         ),

--- a/projects/kit/components/segmented/segmented.directive.ts
+++ b/projects/kit/components/segmented/segmented.directive.ts
@@ -6,6 +6,7 @@ import {
     Directive,
     ElementRef,
     inject,
+    INJECTOR,
 } from '@angular/core';
 import {takeUntilDestroyed, toObservable} from '@angular/core/rxjs-interop';
 import {NgControl, RadioControlValueAccessor} from '@angular/forms';
@@ -19,6 +20,7 @@ import {TuiSegmented} from './segmented.component';
 @Directive({host: {'(click)': 'update($event.target)'}})
 export class TuiSegmentedDirective implements AfterContentChecked, AfterContentInit {
     private readonly destroyRef = inject(DestroyRef);
+    private readonly injector = inject(INJECTOR);
     private readonly component = inject(TuiSegmented);
     private readonly el = tuiInjectElement();
     private readonly links = contentChildren(RouterLinkActive);
@@ -33,7 +35,9 @@ export class TuiSegmentedDirective implements AfterContentChecked, AfterContentI
     public ngAfterContentInit(): void {
         this.controls$
             .pipe(
-                switchMap(([control]) => (control ? tuiControlValue(control) : EMPTY)),
+                switchMap(([control]) =>
+                    control ? tuiControlValue(control, this.injector) : EMPTY,
+                ),
                 map((value) => this.radios().findIndex((c) => c.value === value)),
                 takeUntilDestroyed(this.destroyRef),
             )

--- a/projects/kit/utils/inject-value.ts
+++ b/projects/kit/utils/inject-value.ts
@@ -1,4 +1,4 @@
-import {computed, inject, type Signal} from '@angular/core';
+import {computed, inject, INJECTOR, type Signal} from '@angular/core';
 import {toSignal} from '@angular/core/rxjs-interop';
 import {NgControl} from '@angular/forms';
 import {tuiControlValue} from '@taiga-ui/cdk/observables';
@@ -7,7 +7,9 @@ import {TuiTextfieldComponent} from '@taiga-ui/core/components/textfield';
 export function tuiInjectValue<T>(): Signal<T> {
     const textfield = inject(TuiTextfieldComponent, {optional: true});
     const control = textfield?.control() || inject(NgControl, {optional: true});
-    const fallback = toSignal<T>(tuiControlValue(control), {requireSync: true});
+    const fallback = toSignal<T>(tuiControlValue(control, inject(INJECTOR)), {
+        requireSync: true,
+    });
 
     return computed(() => {
         const cva = textfield?.child();


### PR DESCRIPTION
Relates:
- https://github.com/taiga-family/taiga-ui/issues/14341

### Problem
```html
<tui-textfield tuiChevron>
  <input
    tuiSelect
    [formField]="f.select"
  />

  <tui-data-list-wrapper
    *tuiDropdown
    [items]="items"
  />
</tui-textfield>
```

throws error on attempt to open dropdown

```
ERROR RuntimeError: 
NG0601: `toSignal()` called with `requireSync` but `Observable` did not emit synchronously.
    at toSignal (rxjs-interop.mjs:143:11)
    at tuiInjectValue (inject-value.ts:10:22)
    at <instance_members_initializer> (select-option.component.ts:44:30
    at new _TuiSelectOption (select-option.component.ts:42:7
    at NodeInjectorFactory.TuiSelectOption_Factory [as factory] (select-option.component.ts:59:22)
```

(same issue for other controls with datalist suggestions: `ComboBox`, `InputChip` etc.)

### Why
Signal forms provide a fake `NgControl` which is not an `AbstractControl` and has no
observable `valueChanges` — its value is exposed as a signal, so reading it inside `computed`
subscribes to it. 