### PR TITLE
fix(cdk): `AutoFocus` defer iOS focus until entrance animation ends to prevent dialog jump

### DIFF
--- a/projects/cdk/directives/auto-focus/handlers/ios.handler.ts
+++ b/projects/cdk/directives/auto-focus/handlers/ios.handler.ts
@@ -1,4 +1,5 @@
 import {type ElementRef, type NgZone, type Renderer2} from '@angular/core';
+import {TUI_ANIMATED} from '@taiga-ui/cdk/directives/animated';
 import {tuiIsPresent, tuiPx} from '@taiga-ui/cdk/utils/miscellaneous';
 
 import {type TuiAutofocusOptions} from '../autofocus.options';
@@ -32,7 +33,13 @@ export class TuiIosAutofocusHandler extends AbstractTuiAutofocusHandler {
         if (this.isTextFieldElement) {
             this.zone.runOutsideAngular(() => this.iosWebkitAutofocus());
         } else {
-            this.element.focus({preventScroll: true});
+            // iOS scrolls to the focused element mid-animation despite preventScroll, jumping the dialog
+            void Promise.allSettled(
+                this.element
+                    .closest(`.${TUI_ANIMATED}`)
+                    ?.getAnimations?.()
+                    .map(async ({finished}) => finished) ?? [],
+            ).then(() => this.element.focus({preventScroll: true}));
         }
     }
 

--- a/projects/cdk/directives/auto-focus/test/auto-focus.directive.spec.ts
+++ b/projects/cdk/directives/auto-focus/test/auto-focus.directive.spec.ts
@@ -8,6 +8,7 @@ import {
 } from '@angular/core';
 import {type ComponentFixture, fakeAsync, TestBed, tick} from '@angular/core/testing';
 import {WA_WINDOW} from '@ng-web-apis/common';
+import {WA_IS_IOS} from '@ng-web-apis/platform';
 import {
     TUI_AUTOFOCUS_HANDLER,
     TUI_AUTOFOCUS_OPTIONS,
@@ -106,6 +107,63 @@ describe('TuiAutoFocus directive', () => {
 
         it('focuses', fakeAsync(() => {
             fixture.detectChanges();
+            tick(100);
+
+            expect(tuiIsFocused(testComponent.element().nativeElement)).toBe(true);
+        }));
+    });
+
+    describe('iOS defers focus of non-text-field until the entrance animation finishes', () => {
+        @Component({
+            imports: [TuiAutoFocus],
+            template: `
+                <div class="tui-animated">
+                    <button
+                        tuiAutoFocus
+                        type="button"
+                    >
+                        Ok
+                    </button>
+                </div>
+            `,
+            changeDetection: ChangeDetectionStrategy.OnPush,
+        })
+        class TestIosButton {
+            public readonly element = viewChild.required(TuiAutoFocus, {
+                read: ElementRef,
+            });
+        }
+
+        let fixture: ComponentFixture<TestIosButton>;
+        let testComponent: TestIosButton;
+        let finishAnimation!: () => void;
+
+        beforeEach(async () => {
+            TestBed.configureTestingModule({
+                imports: [TestIosButton],
+                providers: [provideTaiga(), {provide: WA_IS_IOS, useValue: true}],
+            });
+            await TestBed.compileComponents();
+            fixture = TestBed.createComponent(TestIosButton);
+            testComponent = fixture.componentInstance;
+
+            const animated: HTMLElement =
+                fixture.nativeElement.querySelector('.tui-animated');
+
+            const finished = new Promise<void>((resolve) => {
+                finishAnimation = resolve;
+            });
+
+            animated.getAnimations = () => [{finished} as unknown as Animation];
+        });
+
+        it('does not focus while the animation is running', fakeAsync(() => {
+            fixture.detectChanges();
+            tick(100);
+
+            expect(tuiIsFocused(testComponent.element().nativeElement)).toBe(false);
+
+            finishAnimation();
             tick(100);
 
             expect(tuiIsFocused(testComponent.element().nativeElement)).toBe(true);


### PR DESCRIPTION
Closes #14665

On iOS the confirm dialog jumped during the opening animation: `TuiConfirm` autofocuses its button, and iOS `focus()` scrolls it into view even with `{preventScroll: true}` when called mid-animation inside a scrollable sheet/dialog.

Now non-text-field elements are focused only after the surrounding `.tui-animated` entrance animation finishes. Autofocus is preserved (it just lands after the dialog settles), with immediate focus as a fallback when there is no animation.