### PR TITLE
fix(addon-mobile): `MobileCalendar` closes only its own dropdown, not the enclosing dialog

### DIFF
--- a/projects/addon-mobile/components/mobile-calendar-dropdown/mobile-calendar-dropdown.component.ts
+++ b/projects/addon-mobile/components/mobile-calendar-dropdown/mobile-calendar-dropdown.component.ts
@@ -44,7 +44,12 @@ export class TuiMobileCalendarDropdownComponent {
     // TODO: Rework to use TuiDropdownOpenDirective so the focus returns to the field on closing
     private readonly dropdown = inject(TuiDropdownDirective, {optional: true});
     private readonly keyboard = inject(TuiKeyboardService);
-    private readonly context = injectContext<Record<string, any>>({optional: true});
+    // As a dropdown, ignore the ambient context: `injectContext` would otherwise resolve
+    // to an enclosing dialog/sheet and `observer.complete()` on close would shut it too.
+    private readonly context = this.dropdown
+        ? null
+        : injectContext<Record<string, any>>({optional: true});
+
     private readonly observer?: Observer<unknown> = this.context?.$implicit;
     private readonly data: TuiMobileCalendarData = this.context?.data || {};
 

--- a/projects/addon-mobile/components/mobile-calendar-dropdown/mobile-calendar-dropdown.component.ts
+++ b/projects/addon-mobile/components/mobile-calendar-dropdown/mobile-calendar-dropdown.component.ts
@@ -44,8 +44,7 @@ export class TuiMobileCalendarDropdownComponent {
     // TODO: Rework to use TuiDropdownOpenDirective so the focus returns to the field on closing
     private readonly dropdown = inject(TuiDropdownDirective, {optional: true});
     private readonly keyboard = inject(TuiKeyboardService);
-    // As a dropdown, ignore the ambient context: `injectContext` would otherwise resolve
-    // to an enclosing dialog/sheet and `observer.complete()` on close would shut it too.
+    // As a dropdown we own no context — the ambient one belongs to the enclosing dialog
     private readonly context = this.dropdown
         ? null
         : injectContext<Record<string, any>>({optional: true});

--- a/projects/addon-mobile/components/mobile-calendar-dropdown/test/mobile-calendar-dropdown.component.spec.ts
+++ b/projects/addon-mobile/components/mobile-calendar-dropdown/test/mobile-calendar-dropdown.component.spec.ts
@@ -79,7 +79,7 @@ describe('TuiMobileCalendarDropdown as a dropdown inside a dialog', () => {
 
         // Simulates pressing "Done"/"Cancel": the calendar closes itself.
         // Regression (#14561): it must not complete the dialog's observer too.
-        (dropdown.ref()?.instance as {close: () => void}).close();
+        (dropdown.ref()?.instance as {close(): void}).close();
         fixture.detectChanges();
 
         expect(fixture.componentInstance.open()).toBe(true);

--- a/projects/addon-mobile/components/mobile-calendar-dropdown/test/mobile-calendar-dropdown.component.spec.ts
+++ b/projects/addon-mobile/components/mobile-calendar-dropdown/test/mobile-calendar-dropdown.component.spec.ts
@@ -1,0 +1,87 @@
+import {ChangeDetectionStrategy, Component, signal} from '@angular/core';
+import {type ComponentFixture, TestBed} from '@angular/core/testing';
+import {FormsModule} from '@angular/forms';
+import {By} from '@angular/platform-browser';
+import {WA_IS_MOBILE} from '@ng-web-apis/platform';
+import {TuiMobileCalendarDropdown} from '@taiga-ui/addon-mobile';
+import {type TuiDay} from '@taiga-ui/cdk';
+import {provideTaiga, TuiDialog, TuiDropdownDirective, TuiRoot} from '@taiga-ui/core';
+import {TuiInputDate} from '@taiga-ui/kit';
+
+describe('TuiMobileCalendarDropdown as a dropdown inside a dialog', () => {
+    @Component({
+        imports: [
+            FormsModule,
+            TuiDialog,
+            TuiInputDate,
+            TuiMobileCalendarDropdown,
+            TuiRoot,
+        ],
+        template: `
+            <tui-root>
+                <ng-template
+                    [tuiDialogOptions]="{appearance: 'fullscreen'}"
+                    [(tuiDialog)]="open"
+                >
+                    <tui-textfield tuiMobileCalendar>
+                        <input
+                            tuiInputDate
+                            [(ngModel)]="value"
+                        />
+                        <tui-calendar *tuiDropdown />
+                    </tui-textfield>
+                </ng-template>
+            </tui-root>
+        `,
+        changeDetection: ChangeDetectionStrategy.OnPush,
+    })
+    class Test {
+        public readonly open = signal(false);
+        public value: TuiDay | null = null;
+    }
+
+    let fixture: ComponentFixture<Test>;
+
+    beforeEach(async () => {
+        TestBed.configureTestingModule({
+            imports: [Test],
+            providers: [provideTaiga(), {provide: WA_IS_MOBILE, useValue: true}],
+        });
+        await TestBed.compileComponents();
+        fixture = TestBed.createComponent(Test);
+        fixture.detectChanges();
+        fixture.componentInstance.open.set(true);
+        fixture.detectChanges();
+        await fixture.whenStable();
+        fixture.detectChanges();
+    });
+
+    function openCalendar(): TuiDropdownDirective {
+        const dropdown = fixture.debugElement
+            .query(By.css('tui-textfield'))
+            .injector.get(TuiDropdownDirective);
+
+        dropdown.toggle(true);
+        fixture.detectChanges();
+
+        return dropdown;
+    }
+
+    it('opens the mobile calendar as its dropdown, not the enclosing dialog', () => {
+        const dropdown = openCalendar();
+
+        expect(dropdown.ref()).not.toBeNull();
+        expect(fixture.componentInstance.open()).toBe(true);
+    });
+
+    it('leaves the enclosing dialog open when the calendar is closed', () => {
+        const dropdown = openCalendar();
+
+        // Simulates pressing "Done"/"Cancel": the calendar closes itself.
+        // Regression (#14561): it must not complete the dialog's observer too.
+        (dropdown.ref()?.instance as {close: () => void}).close();
+        fixture.detectChanges();
+
+        expect(fixture.componentInstance.open()).toBe(true);
+    });
+});


### PR DESCRIPTION
Closes #14561

Inside a dialog, `tuiMobileCalendar` renders as a dropdown but resolved the enclosing dialog's `POLYMORPHEUS_CONTEXT` via `injectContext`, so closing the calendar completed that dialog's observer and shut it. Now the ambient context is ignored when the component acts as a dropdown.
