### PR TITLE
fix(core): increase hint max width

### DIFF
--- a/projects/core/directives/hint/hint.style.less
+++ b/projects/core/directives/hint/hint.style.less
@@ -2,7 +2,7 @@
 
 :host {
     position: absolute;
-    max-inline-size: ~'min(18rem, calc(100% - 1rem))';
+    max-inline-size: ~'min(20rem, calc(100% - 1rem))';
     padding: 0.75rem 1rem;
     background: var(--tui-background-accent-1);
     border-radius: var(--tui-radius-l);


### PR DESCRIPTION
## Summary

- increase `tuiHint` maximum width from `18rem` (288px) to `20rem` (320px)
- align v4 behavior with the v5 specification

## Reference

https://taiga-ui.dev/v4/directives/hint/API