### PR TITLE
chore(demo): `FloatingContainer` compact example no longer produces horizontal scroll

### DIFF
--- a/projects/demo-playwright/tests/layout/floating-container.pw.spec.ts
+++ b/projects/demo-playwright/tests/layout/floating-container.pw.spec.ts
@@ -18,4 +18,27 @@ test.describe('FloatingContainer', () => {
             .soft(example.locator('[tuiFloatingContainer]'))
             .toHaveScreenshot('01-floating-container.png');
     });
+
+    test('compact example does not produce horizontal scroll', async ({page}) => {
+        await tuiGoto(page, DemoRoute.FloatingContainer);
+
+        const example = new TuiDocumentationPagePO(page).getExample('#compact');
+
+        await example.scrollIntoViewIfNeeded();
+
+        const content = example.locator('.content');
+
+        await expect(content).toBeVisible();
+
+        // Retry until the lazily-rendered example settles: on the production build its
+        // component styles stream in after the DOM, briefly leaving the footer full-width.
+        await expect(async () => {
+            const {scrollWidth, clientWidth} = await content.evaluate((el) => ({
+                scrollWidth: el.scrollWidth,
+                clientWidth: el.clientWidth,
+            }));
+
+            expect(scrollWidth).toBeLessThanOrEqual(clientWidth);
+        }).toPass({timeout: 15_000});
+    });
 });

--- a/projects/demo/src/pages/components/floating-container/examples/7/index.less
+++ b/projects/demo/src/pages/components/floating-container/examples/7/index.less
@@ -8,6 +8,11 @@
     background: var(--tui-background-elevation-1);
 }
 
+footer {
+    // inset the footer so the container's bleeding background stays within the scroll area
+    margin-inline: 1rem;
+}
+
 .field {
     margin: 1rem 1rem 0;
 }
@@ -15,5 +20,4 @@
 .action {
     // shrink the single action to its content and pin it to the trailing edge
     justify-self: end;
-    margin-inline: 1rem;
 }


### PR DESCRIPTION
The **Compact** example on the `FloatingContainer` page had an unexpected horizontal scroll. `[tuiFloatingContainer]` draws a `::before` background that intentionally bleeds `-1rem` past both horizontal edges, so it expects the footer to be inset by `1rem`. Every other example does this via `footer { margin-inline: 1rem; }`, but here the inline margin was put on the inner `.action` button instead, leaving the footer full-width — so the background overflowed the container by `1rem`.

Moved the `1rem` inline inset from `.action` onto the `footer` to match the sibling examples; the single action still shrinks and pins to the trailing edge via `justify-self: end`. Also added an e2e test asserting the demo container has no horizontal overflow.
