### PR TITLE
fix(schematics): warn about removed TUI_DIALOGS token (v5)

### DIFF
--- a/projects/cdk/schematics/ng-update/v5/steps/constants/migration-warnings.ts
+++ b/projects/cdk/schematics/ng-update/v5/steps/constants/migration-warnings.ts
@@ -814,4 +814,10 @@ export const MIGRATION_WARNINGS: MigrationWarning[] = [
         message:
             'TuiTableBarsHostComponent (<tui-table-bars-host>) has been removed. Use TuiActionBar (<tui-action-bar>) from @taiga-ui/kit instead — it has a different API and no host container is required. See https://taiga-ui.dev/components/actions-bar',
     },
+    {
+        name: 'TUI_DIALOGS',
+        moduleSpecifier: '@taiga-ui/core',
+        message:
+            'TUI_DIALOGS removed. Track each dialog via the stream returned by TuiDialogService/TuiAlertService.open() and unsubscribe to close it, instead of reading a global registry.',
+    },
 ];

--- a/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-dialogs-warning.spec.ts.snap
+++ b/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-dialogs-warning.spec.ts.snap
@@ -1,0 +1,25 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ng-update TUI_DIALOGS removal warning adds TODO comment when TUI_DIALOGS is injected: test.ts 1`] = `
+{
+  "0. Before": "
+                import {Component, inject} from '@angular/core';
+                import {TUI_DIALOGS} from '@taiga-ui/core';
+
+                @Component({})
+                export class TestComponent {
+                    protected readonly dialogs = inject(TUI_DIALOGS);
+                }
+            ",
+  "1. After": "
+                import {Component, inject} from '@angular/core';
+// TODO: (Taiga UI migration) TUI_DIALOGS removed. Track each dialog via the stream returned by TuiDialogService/TuiAlertService.open() and unsubscribe to close it, instead of reading a global registry.
+                import {TUI_DIALOGS} from '@taiga-ui/core';
+
+                @Component({})
+                export class TestComponent {
+                    protected readonly dialogs = inject(TUI_DIALOGS);
+                }
+            ",
+}
+`;

--- a/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-popover.spec.ts.snap
+++ b/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-popover.spec.ts.snap
@@ -169,6 +169,7 @@ exports[`ng-update TuiPopover migration TuiPopoverService → TuiPortal + warnin
 import { TuiPortal } from "@taiga-ui/cdk";
 
                     import {inject, Injectable} from '@angular/core';
+// TODO: (Taiga UI migration) TUI_DIALOGS removed. Track each dialog via the stream returned by TuiDialogService/TuiAlertService.open() and unsubscribe to close it, instead of reading a global registry.
                     import {TUI_DIALOGS} from '@taiga-ui/core';
 
                     import {PromptComponent} from './prompt.component';

--- a/projects/cdk/schematics/ng-update/v5/tests/schematic-migrate-dialogs-warning.spec.ts
+++ b/projects/cdk/schematics/ng-update/v5/tests/schematic-migrate-dialogs-warning.spec.ts
@@ -1,0 +1,28 @@
+import {join} from 'node:path';
+
+import {resetActiveProject} from 'ng-morph';
+
+import {createMigration} from '../../../utils/run-migration';
+
+describe('ng-update TUI_DIALOGS removal warning', () => {
+    const migrate = createMigration({
+        collection: join(__dirname, '../../../migration.json'),
+    });
+
+    it(
+        'adds TODO comment when TUI_DIALOGS is injected',
+        migrate({
+            component: /* TypeScript */ `
+                import {Component, inject} from '@angular/core';
+                import {TUI_DIALOGS} from '@taiga-ui/core';
+
+                @Component({})
+                export class TestComponent {
+                    protected readonly dialogs = inject(TUI_DIALOGS);
+                }
+            `,
+        }),
+    );
+
+    afterEach(() => resetActiveProject());
+});


### PR DESCRIPTION
`TUI_DIALOGS` was removed from `@taiga-ui/core` in v5, but the v5 `ng update` had neither a codemod nor a warning for it. Code that read the registry (`inject(TUI_DIALOGS)`) keeps a dangling import and only breaks later at build time with `TS2724: '"@taiga-ui/core"' has no exported member named 'TUI_DIALOGS'`.

This adds a warning keyed on `TUI_DIALOGS` (reusing the existing `showWarnings` step): a `// TODO: (Taiga UI migration)` above the import explaining there is no drop-in replacement — track each dialog through the stream returned by the service that opened it (`TuiDialogService`/`TuiAlertService.open()`) and unsubscribe to close it, instead of reading a global registry. Warning only, since there is no 1:1 replacement. Covered by a new spec; the `migrate-popover` snapshot picks up the same TODO where its fixture imports `TUI_DIALOGS`. Found while migrating a large project from Taiga v4 to v5.