### PR TITLE
feat(core): allow content-sized dialogs

### DIFF
--- a/projects/core/portals/dialog/dialog.options.ts
+++ b/projects/core/portals/dialog/dialog.options.ts
@@ -12,7 +12,7 @@ import {type Observable} from 'rxjs';
  * dismissible - close dialog by Esc button or click on overlay (true by default)
  * label - string title for the dialog ('' by default)
  * required - dismissing or closing dialog by X button throws (false by default)
- * size - size of the dialog ('m' by default)
+ * size - size of the dialog ('m' by default, empty string for content width)
  */
 export interface TuiDialogOptions<I> {
     readonly appearance: string;
@@ -21,7 +21,7 @@ export interface TuiDialogOptions<I> {
     readonly dismissible: Observable<boolean> | boolean;
     readonly label: string;
     readonly required: boolean;
-    readonly size: TuiSizeL | TuiSizeS;
+    readonly size: '' | TuiSizeL | TuiSizeS;
 }
 
 export type TuiDialogContext<O = void, I = undefined> = TuiPortalContext<

--- a/projects/core/portals/dialog/dialog.options.ts
+++ b/projects/core/portals/dialog/dialog.options.ts
@@ -21,7 +21,7 @@ export interface TuiDialogOptions<I> {
     readonly dismissible: Observable<boolean> | boolean;
     readonly label: string;
     readonly required: boolean;
-    readonly size: null | TuiSizeL | TuiSizeS;
+    readonly size: TuiSizeL | TuiSizeS | null;
 }
 
 export type TuiDialogContext<O = void, I = undefined> = TuiPortalContext<

--- a/projects/core/portals/dialog/dialog.options.ts
+++ b/projects/core/portals/dialog/dialog.options.ts
@@ -12,7 +12,7 @@ import {type Observable} from 'rxjs';
  * dismissible - close dialog by Esc button or click on overlay (true by default)
  * label - string title for the dialog ('' by default)
  * required - dismissing or closing dialog by X button throws (false by default)
- * size - size of the dialog ('m' by default, empty string for content width)
+ * size - size of the dialog ('m' by default, null for content width)
  */
 export interface TuiDialogOptions<I> {
     readonly appearance: string;
@@ -21,7 +21,7 @@ export interface TuiDialogOptions<I> {
     readonly dismissible: Observable<boolean> | boolean;
     readonly label: string;
     readonly required: boolean;
-    readonly size: '' | TuiSizeL | TuiSizeS;
+    readonly size: null | TuiSizeL | TuiSizeS;
 }
 
 export type TuiDialogContext<O = void, I = undefined> = TuiPortalContext<

--- a/projects/core/portals/dialog/test/dialog.component.spec.ts
+++ b/projects/core/portals/dialog/test/dialog.component.spec.ts
@@ -62,6 +62,17 @@ describe('Dialogs', () => {
         });
     });
 
+    describe('size', () => {
+        it('supports content-driven width', () => {
+            service.open('Test', {size: ''}).subscribe();
+            fixture.detectChanges();
+
+            const dialog = fixture.debugElement.query(By.css('tui-dialog'));
+
+            expect(dialog.nativeElement.getAttribute('data-size')).toBe('');
+        });
+    });
+
     describe('active zone', () => {
         it('stays true when dialog is activated', () => {
             const button = fixture.debugElement.query(By.css('button'));

--- a/projects/core/portals/dialog/test/dialog.component.spec.ts
+++ b/projects/core/portals/dialog/test/dialog.component.spec.ts
@@ -64,12 +64,12 @@ describe('Dialogs', () => {
 
     describe('size', () => {
         it('supports content-driven width', () => {
-            service.open('Test', {size: ''}).subscribe();
+            service.open('Test', {size: null}).subscribe();
             fixture.detectChanges();
 
             const dialog = fixture.debugElement.query(By.css('tui-dialog'));
 
-            expect(dialog.nativeElement.getAttribute('data-size')).toBe('');
+            expect(dialog.nativeElement.getAttribute('data-size')).toBeNull();
         });
     });
 

--- a/projects/demo/src/pages/components/dialog/examples/8/index.html
+++ b/projects/demo/src/pages/components/dialog/examples/8/index.html
@@ -1,0 +1,7 @@
+<button
+    tuiButton
+    type="button"
+    (click)="show()"
+>
+    Show content-sized dialog
+</button>

--- a/projects/demo/src/pages/components/dialog/examples/8/index.ts
+++ b/projects/demo/src/pages/components/dialog/examples/8/index.ts
@@ -1,0 +1,21 @@
+import {Component, inject} from '@angular/core';
+import {changeDetection} from '@demo/emulate/change-detection';
+import {TuiButton, TuiDialogService} from '@taiga-ui/core';
+
+@Component({
+    imports: [TuiButton],
+    templateUrl: './index.html',
+    changeDetection,
+})
+export default class Example {
+    private readonly dialogs = inject(TuiDialogService);
+
+    protected show(): void {
+        this.dialogs
+            .open('The width of this dialog is defined by its content.', {
+                label: 'Content-sized dialog',
+                size: null,
+            })
+            .subscribe();
+    }
+}

--- a/projects/demo/src/pages/components/dialog/index.html
+++ b/projects/demo/src/pages/components/dialog/index.html
@@ -40,6 +40,11 @@
                             Customizing look and animations of dialogs by augmenting built-in appearance or completely
                             overriding it.
                         }
+                        @case (7) {
+                            Passing
+                            <code>null</code>
+                            as size lets the dialog width be determined by its content.
+                        }
                     }
                 </ng-template>
             </tui-doc-example>
@@ -161,11 +166,13 @@
             <tr
                 name="[size]"
                 tuiDocAPIItem
-                type="'' | TuiSizeS | TuiSizeL"
+                type="null | TuiSizeS | TuiSizeL"
                 [items]="sizes"
                 [(value)]="size"
             >
-                Pass an empty string to make the dialog width fit its content.
+                Pass
+                <code>null</code>
+                to make the dialog width fit its content.
             </tr>
         </table>
     </ng-template>

--- a/projects/demo/src/pages/components/dialog/index.html
+++ b/projects/demo/src/pages/components/dialog/index.html
@@ -161,10 +161,12 @@
             <tr
                 name="[size]"
                 tuiDocAPIItem
-                type="TuiSizeS | TuiSizeL"
+                type="'' | TuiSizeS | TuiSizeL"
                 [items]="sizes"
                 [(value)]="size"
-            ></tr>
+            >
+                Pass an empty string to make the dialog width fit its content.
+            </tr>
         </table>
     </ng-template>
 </tui-doc-page>

--- a/projects/demo/src/pages/components/dialog/index.ts
+++ b/projects/demo/src/pages/components/dialog/index.ts
@@ -34,6 +34,7 @@ export default class Page extends Array {
         'Closing',
         'Fullscreen',
         'Customization',
+        'Content width',
     ];
 
     protected readonly [2] = {


### PR DESCRIPTION
## Changes

* allow an empty dialog `size`
* let the dialog width be controlled by its content when `size === ''`
* keep existing `s`, `m`, and `l` width presets unchanged
* keep vertical scrolling behavior unchanged
* add regression coverage for the empty size

This uses the existing dialog layout: fixed widths are only applied to the `s`, `m`, and `l` presets, while the base dialog already keeps the viewport margins via `max-inline-size`.

Fixes #14836
