### PR TITLE
fix(addon-mobile): `SheetDialog` opens at the top with async content

### DIFF
--- a/projects/addon-mobile/components/sheet-dialog/sheet-dialog.component.ts
+++ b/projects/addon-mobile/components/sheet-dialog/sheet-dialog.component.ts
@@ -78,7 +78,7 @@ export class TuiSheetDialogComponent<I> implements AfterViewInit {
         .subscribe(() => this.close());
 
     public ngAfterViewInit(): void {
-        this.el.scrollTop = this.initial || 0;
+        this.onResize();
     }
 
     // Re-pin async content to the initial snap; mandatory scroll-snap jumps to the bottom otherwise.

--- a/projects/addon-mobile/components/sheet-dialog/sheet-dialog.component.ts
+++ b/projects/addon-mobile/components/sheet-dialog/sheet-dialog.component.ts
@@ -53,7 +53,6 @@ export class TuiSheetDialogComponent<I> implements AfterViewInit {
 
     protected readonly close$ = new Subject<void>();
 
-    // Set on the first user gesture; disables the re-pin so it never fights manual scrolling.
     protected interacted = false;
 
     protected readonly $ = merge(

--- a/projects/addon-mobile/components/sheet-dialog/sheet-dialog.component.ts
+++ b/projects/addon-mobile/components/sheet-dialog/sheet-dialog.component.ts
@@ -4,6 +4,8 @@ import {
     Component,
     ElementRef,
     inject,
+    type OnDestroy,
+    viewChild,
     viewChildren,
 } from '@angular/core';
 import {takeUntilDestroyed} from '@angular/core/rxjs-interop';
@@ -39,17 +41,28 @@ const REQUIRED_ERROR = new Error(ngDevMode ? 'Required dialog was dismissed' : '
         '(document:touchend.zoneless)': 'onPointerChange(-1)',
         '(document:touchstart.passive.zoneless)': 'onPointerChange(1)',
         '(scroll.zoneless)': 'onPointerChange(0)',
+        '(wheel.passive.zoneless)': 'interacted = true',
     },
 })
-export class TuiSheetDialogComponent<I> implements AfterViewInit {
+export class TuiSheetDialogComponent<I> implements AfterViewInit, OnDestroy {
     private readonly stops = viewChildren('stops', {read: ElementRef});
+    private readonly sheet = viewChild<ElementRef<HTMLElement>>('sheet');
     private readonly el = tuiInjectElement();
     private pointers = 0;
+    // Re-pin async content to the initial snap; mandatory scroll-snap jumps to the bottom otherwise.
+    private readonly observer = new ResizeObserver(() => {
+        if (!this.interacted) {
+            this.el.scrollTop = this.initial || 0;
+        }
+    });
 
     protected readonly context =
         injectContext<TuiPortalContext<TuiSheetDialogOptions<I>, any>>();
 
     protected readonly close$ = new Subject<void>();
+
+    // Set on the first user gesture; disables the re-pin so it never fights manual scrolling.
+    protected interacted = false;
 
     protected readonly $ = merge(
         this.close$,
@@ -76,9 +89,23 @@ export class TuiSheetDialogComponent<I> implements AfterViewInit {
 
     public ngAfterViewInit(): void {
         this.el.scrollTop = this.initial || 0;
+
+        const sheet = this.sheet()?.nativeElement;
+
+        if (sheet) {
+            this.observer.observe(sheet);
+        }
+    }
+
+    public ngOnDestroy(): void {
+        this.observer.disconnect();
     }
 
     protected onPointerChange(delta: number): void {
+        if (delta > 0) {
+            this.interacted = true;
+        }
+
         this.pointers = Math.max(this.pointers + delta, 0);
 
         if (!this.pointers && this.el.scrollTop <= 0) {

--- a/projects/addon-mobile/components/sheet-dialog/sheet-dialog.component.ts
+++ b/projects/addon-mobile/components/sheet-dialog/sheet-dialog.component.ts
@@ -4,11 +4,10 @@ import {
     Component,
     ElementRef,
     inject,
-    type OnDestroy,
-    viewChild,
     viewChildren,
 } from '@angular/core';
 import {takeUntilDestroyed} from '@angular/core/rxjs-interop';
+import {WaResizeObserver} from '@ng-web-apis/resize-observer';
 import {TUI_TRUE_HANDLER} from '@taiga-ui/cdk/constants';
 import {TuiAnimated} from '@taiga-ui/cdk/directives/animated';
 import {tuiCloseWatcher, tuiZonefull} from '@taiga-ui/cdk/observables';
@@ -26,7 +25,7 @@ const REQUIRED_ERROR = new Error(ngDevMode ? 'Required dialog was dismissed' : '
 
 @Component({
     selector: 'tui-sheet-dialog',
-    imports: [PolymorpheusOutlet, TuiButton],
+    imports: [PolymorpheusOutlet, TuiButton, WaResizeObserver],
     templateUrl: './sheet-dialog.template.html',
     styleUrl: './sheet-dialog.style.less',
     changeDetection: ChangeDetectionStrategy.OnPush,
@@ -44,17 +43,10 @@ const REQUIRED_ERROR = new Error(ngDevMode ? 'Required dialog was dismissed' : '
         '(wheel.passive.zoneless)': 'interacted = true',
     },
 })
-export class TuiSheetDialogComponent<I> implements AfterViewInit, OnDestroy {
+export class TuiSheetDialogComponent<I> implements AfterViewInit {
     private readonly stops = viewChildren('stops', {read: ElementRef});
-    private readonly sheet = viewChild<ElementRef<HTMLElement>>('sheet');
     private readonly el = tuiInjectElement();
     private pointers = 0;
-    // Re-pin async content to the initial snap; mandatory scroll-snap jumps to the bottom otherwise.
-    private readonly observer = new ResizeObserver(() => {
-        if (!this.interacted) {
-            this.el.scrollTop = this.initial || 0;
-        }
-    });
 
     protected readonly context =
         injectContext<TuiPortalContext<TuiSheetDialogOptions<I>, any>>();
@@ -89,20 +81,17 @@ export class TuiSheetDialogComponent<I> implements AfterViewInit, OnDestroy {
 
     public ngAfterViewInit(): void {
         this.el.scrollTop = this.initial || 0;
+    }
 
-        const sheet = this.sheet()?.nativeElement;
-
-        if (sheet) {
-            this.observer.observe(sheet);
+    // Re-pin async content to the initial snap; mandatory scroll-snap jumps to the bottom otherwise.
+    protected onResize(): void {
+        if (!this.interacted) {
+            this.el.scrollTop = this.initial || 0;
         }
     }
 
-    public ngOnDestroy(): void {
-        this.observer.disconnect();
-    }
-
     protected onPointerChange(delta: number): void {
-        if (delta > 0) {
+        if (delta) {
             this.interacted = true;
         }
 

--- a/projects/addon-mobile/components/sheet-dialog/sheet-dialog.component.ts
+++ b/projects/addon-mobile/components/sheet-dialog/sheet-dialog.component.ts
@@ -52,7 +52,6 @@ export class TuiSheetDialogComponent<I> implements AfterViewInit {
         injectContext<TuiPortalContext<TuiSheetDialogOptions<I>, any>>();
 
     protected readonly close$ = new Subject<void>();
-
     protected interacted = false;
 
     protected readonly $ = merge(

--- a/projects/addon-mobile/components/sheet-dialog/sheet-dialog.component.ts
+++ b/projects/addon-mobile/components/sheet-dialog/sheet-dialog.component.ts
@@ -1,5 +1,5 @@
 import {
-    type AfterViewInit,
+    afterNextRender,
     ChangeDetectionStrategy,
     Component,
     ElementRef,
@@ -43,7 +43,7 @@ const REQUIRED_ERROR = new Error(ngDevMode ? 'Required dialog was dismissed' : '
         '(wheel.passive.zoneless)': 'interacted = true',
     },
 })
-export class TuiSheetDialogComponent<I> implements AfterViewInit {
+export class TuiSheetDialogComponent<I> {
     private readonly stops = viewChildren('stops', {read: ElementRef});
     private readonly el = tuiInjectElement();
     private pointers = 0;
@@ -77,8 +77,8 @@ export class TuiSheetDialogComponent<I> implements AfterViewInit {
         )
         .subscribe(() => this.close());
 
-    public ngAfterViewInit(): void {
-        this.onResize();
+    constructor() {
+        afterNextRender(() => this.onResize());
     }
 
     // Re-pin async content to the initial snap; mandatory scroll-snap jumps to the bottom otherwise.

--- a/projects/addon-mobile/components/sheet-dialog/sheet-dialog.component.ts
+++ b/projects/addon-mobile/components/sheet-dialog/sheet-dialog.component.ts
@@ -89,10 +89,7 @@ export class TuiSheetDialogComponent<I> {
     }
 
     protected onPointerChange(delta: number): void {
-        if (delta) {
-            this.interacted = true;
-        }
-
+        this.interacted = this.interacted || !!delta;
         this.pointers = Math.max(this.pointers + delta, 0);
 
         if (!this.pointers && this.el.scrollTop <= 0) {

--- a/projects/addon-mobile/components/sheet-dialog/sheet-dialog.template.html
+++ b/projects/addon-mobile/components/sheet-dialog/sheet-dialog.template.html
@@ -8,8 +8,8 @@
     }
 </div>
 <div
-    #sheet
     class="t-sheet"
+    (waResizeObserver)="onResize()"
 >
     <div class="t-bar"></div>
     <div class="t-content">

--- a/projects/addon-mobile/components/sheet-dialog/sheet-dialog.template.html
+++ b/projects/addon-mobile/components/sheet-dialog/sheet-dialog.template.html
@@ -7,7 +7,10 @@
         ></div>
     }
 </div>
-<div class="t-sheet">
+<div
+    #sheet
+    class="t-sheet"
+>
     <div class="t-bar"></div>
     <div class="t-content">
         @if (context.label) {

--- a/projects/addon-mobile/package.json
+++ b/projects/addon-mobile/package.json
@@ -36,6 +36,7 @@
         "@angular/core": ">=19.0.0",
         "@ng-web-apis/common": "^5.3.0",
         "@ng-web-apis/platform": "^5.3.0",
+        "@ng-web-apis/resize-observer": "^5.3.0",
         "@taiga-ui/cdk": "5.21.0",
         "@taiga-ui/core": "5.21.0",
         "@taiga-ui/kit": "5.21.0",

--- a/projects/demo-cypress/src/tests/sheet-dialog.cy.ts
+++ b/projects/demo-cypress/src/tests/sheet-dialog.cy.ts
@@ -1,3 +1,4 @@
+import {AsyncPipe} from '@angular/common';
 import {ChangeDetectionStrategy, Component, inject} from '@angular/core';
 import {
     TuiSheetDialog,
@@ -5,6 +6,7 @@ import {
     TuiThemeColorService,
 } from '@taiga-ui/addon-mobile';
 import {TuiButton, TuiRoot} from '@taiga-ui/core';
+import {BehaviorSubject, delay} from 'rxjs';
 
 describe('TuiSheetDialog', () => {
     @Component({
@@ -58,6 +60,58 @@ describe('TuiSheetDialog', () => {
             });
 
         cy.get('tui-sheet-dialog').compareSnapshot('tui-sheet-dialog__1');
+    });
+});
+
+describe('TuiSheetDialog with async content', () => {
+    @Component({
+        imports: [AsyncPipe, TuiButton, TuiRoot, TuiSheetDialog],
+        template: `
+            <tui-root>
+                <button
+                    tuiButton
+                    type="button"
+                    (click)="open = true"
+                >
+                    Show
+                </button>
+                <ng-template
+                    [tuiSheetDialogOptions]="{closable: true, bar: false}"
+                    [(tuiSheetDialog)]="open"
+                >
+                    @for (item of content$ | async; track item) {
+                        <div class="async-item">{{ item }}</div>
+                    }
+                </ng-template>
+            </tui-root>
+        `,
+        changeDetection: ChangeDetectionStrategy.OnPush,
+    })
+    class Test {
+        protected open = false;
+
+        // Streams in after `ngAfterViewInit`, reproducing the reported scenario.
+        protected readonly content$ = new BehaviorSubject(
+            Array.from({length: 100}, (_, i) => i),
+        ).pipe(delay(500));
+    }
+
+    beforeEach(() => cy.mount(Test));
+
+    it('opens at the top of the sheet, not scrolled to the bottom', () => {
+        cy.get('button').click();
+        cy.get('.async-item').should('have.length', 100);
+
+        cy.get('tui-sheet-dialog').should(($el) => {
+            const el = $el[0]!;
+            const max = el.scrollHeight - el.clientHeight;
+
+            expect(max, 'content overflows and is scrollable').to.be.greaterThan(0);
+            expect(
+                el.scrollTop,
+                'sheet opens near the top, not snapped to the bottom',
+            ).to.be.lessThan(max / 2);
+        });
     });
 });
 


### PR DESCRIPTION
Closes #10912

With async content the sheet opened scrolled to the bottom (Chrome/Safari): the initial scroll was applied before the content arrived, and `scroll-snap-type: y mandatory` then re-snapped the grown content to the bottom `scroll-snap-align: end` anchor.

Fix: pin the sheet to its initial snap via `afterNextRender`, and re-pin on content resize with `waResizeObserver` — until the first user gesture (touch/wheel). Snap/drag/close/stops behavior is unchanged. Cypress spec added.
