### PR TITLE
fix(addon-mobile): `SheetDialog` opens at the top with async content

### DIFF
--- a/projects/addon-mobile/components/sheet-dialog/sheet-dialog.component.ts
+++ b/projects/addon-mobile/components/sheet-dialog/sheet-dialog.component.ts
@@ -60,7 +60,6 @@ export class TuiSheetDialogComponent<I> implements AfterViewInit {
 
     protected readonly close$ = new Subject<void>();
 
-    // Set on the first user gesture; disables the re-pin so it never fights manual scrolling.
     protected interacted = false;
 
     protected readonly $ = merge(

--- a/projects/addon-mobile/components/sheet-dialog/sheet-dialog.component.ts
+++ b/projects/addon-mobile/components/sheet-dialog/sheet-dialog.component.ts
@@ -5,12 +5,11 @@ import {
     Component,
     ElementRef,
     inject,
-    type OnDestroy,
     type QueryList,
-    ViewChild,
     ViewChildren,
 } from '@angular/core';
 import {takeUntilDestroyed} from '@angular/core/rxjs-interop';
+import {WaResizeObserver} from '@ng-web-apis/resize-observer';
 import {EMPTY_QUERY, TUI_TRUE_HANDLER} from '@taiga-ui/cdk/constants';
 import {TuiAnimated} from '@taiga-ui/cdk/directives/animated';
 import {tuiCloseWatcher, tuiZonefull} from '@taiga-ui/cdk/observables';
@@ -30,7 +29,7 @@ const REQUIRED_ERROR = new Error(ngDevMode ? 'Required dialog was dismissed' : '
 @Component({
     standalone: true,
     selector: 'tui-sheet-dialog',
-    imports: [NgForOf, NgIf, PolymorpheusOutlet, TuiButton],
+    imports: [NgForOf, NgIf, PolymorpheusOutlet, TuiButton, WaResizeObserver],
     templateUrl: './sheet-dialog.template.html',
     styleUrls: ['./sheet-dialog.style.less'],
     changeDetection: ChangeDetectionStrategy.OnPush,
@@ -49,21 +48,12 @@ const REQUIRED_ERROR = new Error(ngDevMode ? 'Required dialog was dismissed' : '
         '(click.self)': 'close$.next()',
     },
 })
-export class TuiSheetDialogComponent<I> implements AfterViewInit, OnDestroy {
+export class TuiSheetDialogComponent<I> implements AfterViewInit {
     @ViewChildren('stops')
     private readonly stops: QueryList<ElementRef<HTMLElement>> = EMPTY_QUERY;
 
-    @ViewChild('sheet')
-    private readonly sheet?: ElementRef<HTMLElement>;
-
     private readonly el = tuiInjectElement();
     private pointers = 0;
-    // Re-pin async content to the initial snap; mandatory scroll-snap jumps to the bottom otherwise.
-    private readonly observer = new ResizeObserver(() => {
-        if (!this.interacted) {
-            this.el.scrollTop = this.initial;
-        }
-    });
 
     protected readonly context =
         injectContext<TuiPopover<TuiSheetDialogOptions<I>, any>>();
@@ -98,18 +88,17 @@ export class TuiSheetDialogComponent<I> implements AfterViewInit, OnDestroy {
 
     public ngAfterViewInit(): void {
         this.el.scrollTop = this.initial;
+    }
 
-        if (this.sheet) {
-            this.observer.observe(this.sheet.nativeElement);
+    // Re-pin async content to the initial snap; mandatory scroll-snap jumps to the bottom otherwise.
+    protected onResize(): void {
+        if (!this.interacted) {
+            this.el.scrollTop = this.initial;
         }
     }
 
-    public ngOnDestroy(): void {
-        this.observer.disconnect();
-    }
-
     protected onPointerChange(delta: number): void {
-        if (delta > 0) {
+        if (delta) {
             this.interacted = true;
         }
 

--- a/projects/addon-mobile/components/sheet-dialog/sheet-dialog.component.ts
+++ b/projects/addon-mobile/components/sheet-dialog/sheet-dialog.component.ts
@@ -1,6 +1,6 @@
 import {NgForOf, NgIf} from '@angular/common';
 import {
-    type AfterViewInit,
+    afterNextRender,
     ChangeDetectionStrategy,
     Component,
     ElementRef,
@@ -48,7 +48,7 @@ const REQUIRED_ERROR = new Error(ngDevMode ? 'Required dialog was dismissed' : '
         '(click.self)': 'close$.next()',
     },
 })
-export class TuiSheetDialogComponent<I> implements AfterViewInit {
+export class TuiSheetDialogComponent<I> {
     @ViewChildren('stops')
     private readonly stops: QueryList<ElementRef<HTMLElement>> = EMPTY_QUERY;
 
@@ -84,8 +84,8 @@ export class TuiSheetDialogComponent<I> implements AfterViewInit {
         )
         .subscribe(() => this.close());
 
-    public ngAfterViewInit(): void {
-        this.onResize();
+    constructor() {
+        afterNextRender(() => this.onResize());
     }
 
     // Re-pin async content to the initial snap; mandatory scroll-snap jumps to the bottom otherwise.

--- a/projects/addon-mobile/components/sheet-dialog/sheet-dialog.component.ts
+++ b/projects/addon-mobile/components/sheet-dialog/sheet-dialog.component.ts
@@ -59,7 +59,6 @@ export class TuiSheetDialogComponent<I> implements AfterViewInit {
         injectContext<TuiPopover<TuiSheetDialogOptions<I>, any>>();
 
     protected readonly close$ = new Subject<void>();
-
     protected interacted = false;
 
     protected readonly $ = merge(
@@ -86,7 +85,7 @@ export class TuiSheetDialogComponent<I> implements AfterViewInit {
         .subscribe(() => this.close());
 
     public ngAfterViewInit(): void {
-        this.el.scrollTop = this.initial;
+        this.onResize();
     }
 
     // Re-pin async content to the initial snap; mandatory scroll-snap jumps to the bottom otherwise.

--- a/projects/addon-mobile/components/sheet-dialog/sheet-dialog.component.ts
+++ b/projects/addon-mobile/components/sheet-dialog/sheet-dialog.component.ts
@@ -5,7 +5,9 @@ import {
     Component,
     ElementRef,
     inject,
+    type OnDestroy,
     type QueryList,
+    ViewChild,
     ViewChildren,
 } from '@angular/core';
 import {takeUntilDestroyed} from '@angular/core/rxjs-interop';
@@ -43,20 +45,34 @@ const REQUIRED_ERROR = new Error(ngDevMode ? 'Required dialog was dismissed' : '
         '(document:touchend.zoneless)': 'onPointerChange(-1)',
         '(document:touchcancel.zoneless)': 'onPointerChange(-1)',
         '(scroll.zoneless)': 'onPointerChange(0)',
+        '(wheel.passive.zoneless)': 'interacted = true',
         '(click.self)': 'close$.next()',
     },
 })
-export class TuiSheetDialogComponent<I> implements AfterViewInit {
+export class TuiSheetDialogComponent<I> implements AfterViewInit, OnDestroy {
     @ViewChildren('stops')
     private readonly stops: QueryList<ElementRef<HTMLElement>> = EMPTY_QUERY;
 
+    @ViewChild('sheet')
+    private readonly sheet?: ElementRef<HTMLElement>;
+
     private readonly el = tuiInjectElement();
     private pointers = 0;
+    // Re-pin async content to the initial snap; mandatory scroll-snap jumps to the bottom otherwise.
+    private readonly observer = new ResizeObserver(() => {
+        if (!this.interacted) {
+            this.el.scrollTop = this.initial;
+        }
+    });
 
     protected readonly context =
         injectContext<TuiPopover<TuiSheetDialogOptions<I>, any>>();
 
     protected readonly close$ = new Subject<void>();
+
+    // Set on the first user gesture; disables the re-pin so it never fights manual scrolling.
+    protected interacted = false;
+
     protected readonly $ = merge(
         this.close$,
         tuiCloseWatcher(),
@@ -82,9 +98,21 @@ export class TuiSheetDialogComponent<I> implements AfterViewInit {
 
     public ngAfterViewInit(): void {
         this.el.scrollTop = this.initial;
+
+        if (this.sheet) {
+            this.observer.observe(this.sheet.nativeElement);
+        }
+    }
+
+    public ngOnDestroy(): void {
+        this.observer.disconnect();
     }
 
     protected onPointerChange(delta: number): void {
+        if (delta > 0) {
+            this.interacted = true;
+        }
+
         this.pointers = Math.max(this.pointers + delta, 0);
 
         if (!this.pointers && this.el.scrollTop <= 0) {

--- a/projects/addon-mobile/components/sheet-dialog/sheet-dialog.component.ts
+++ b/projects/addon-mobile/components/sheet-dialog/sheet-dialog.component.ts
@@ -96,10 +96,7 @@ export class TuiSheetDialogComponent<I> {
     }
 
     protected onPointerChange(delta: number): void {
-        if (delta) {
-            this.interacted = true;
-        }
-
+        this.interacted = this.interacted || !!delta;
         this.pointers = Math.max(this.pointers + delta, 0);
 
         if (!this.pointers && this.el.scrollTop <= 0) {

--- a/projects/addon-mobile/components/sheet-dialog/sheet-dialog.template.html
+++ b/projects/addon-mobile/components/sheet-dialog/sheet-dialog.template.html
@@ -6,7 +6,10 @@
         [style.margin-top]="stop"
     ></div>
 </div>
-<div class="t-sheet">
+<div
+    #sheet
+    class="t-sheet"
+>
     <div
         *ngIf="context.bar"
         class="t-top"

--- a/projects/addon-mobile/components/sheet-dialog/sheet-dialog.template.html
+++ b/projects/addon-mobile/components/sheet-dialog/sheet-dialog.template.html
@@ -7,8 +7,8 @@
     ></div>
 </div>
 <div
-    #sheet
     class="t-sheet"
+    (waResizeObserver)="onResize()"
 >
     <div
         *ngIf="context.bar"

--- a/projects/addon-mobile/package.json
+++ b/projects/addon-mobile/package.json
@@ -18,6 +18,7 @@
         "@angular/common": ">=16.0.0",
         "@angular/core": ">=16.0.0",
         "@ng-web-apis/common": "^4.14.0",
+        "@ng-web-apis/resize-observer": "^4.14.0",
         "@taiga-ui/cdk": "4.96.0",
         "@taiga-ui/core": "4.96.0",
         "@taiga-ui/kit": "4.96.0",

--- a/projects/demo-cypress/src/tests/sheet-dialog.cy.ts
+++ b/projects/demo-cypress/src/tests/sheet-dialog.cy.ts
@@ -1,7 +1,9 @@
+import {AsyncPipe, NgForOf} from '@angular/common';
 import {ChangeDetectionStrategy, Component} from '@angular/core';
 import {TuiSheetDialog, type TuiSheetDialogOptions} from '@taiga-ui/addon-mobile';
 import {TuiRepeatTimes} from '@taiga-ui/cdk';
 import {TuiButton, TuiRoot} from '@taiga-ui/core';
+import {BehaviorSubject, delay} from 'rxjs';
 
 describe('TuiSheetDialog', () => {
     @Component({
@@ -57,5 +59,61 @@ describe('TuiSheetDialog', () => {
             });
 
         cy.get('tui-sheet-dialog').compareSnapshot('tui-sheet-dialog__1');
+    });
+});
+
+describe('TuiSheetDialog with async content', () => {
+    @Component({
+        standalone: true,
+        imports: [AsyncPipe, NgForOf, TuiButton, TuiRoot, TuiSheetDialog],
+        template: `
+            <tui-root>
+                <button
+                    tuiButton
+                    type="button"
+                    (click)="open = true"
+                >
+                    Show
+                </button>
+                <ng-template
+                    [tuiSheetDialogOptions]="{closeable: true, bar: false}"
+                    [(tuiSheetDialog)]="open"
+                >
+                    <div
+                        *ngFor="let item of content$ | async"
+                        class="async-item"
+                    >
+                        {{ item }}
+                    </div>
+                </ng-template>
+            </tui-root>
+        `,
+        changeDetection: ChangeDetectionStrategy.OnPush,
+    })
+    class Test {
+        protected open = false;
+
+        // Streams in after `ngAfterViewInit`, reproducing the reported scenario.
+        protected readonly content$ = new BehaviorSubject(
+            Array.from({length: 100}, (_, i) => i),
+        ).pipe(delay(500));
+    }
+
+    beforeEach(() => cy.mount(Test));
+
+    it('opens at the top of the sheet, not scrolled to the bottom', () => {
+        cy.get('button').click();
+        cy.get('.async-item').should('have.length', 100);
+
+        cy.get('tui-sheet-dialog').should(($el) => {
+            const el = $el[0]!;
+            const max = el.scrollHeight - el.clientHeight;
+
+            expect(max, 'content overflows and is scrollable').to.be.greaterThan(0);
+            expect(
+                el.scrollTop,
+                'sheet opens near the top, not snapped to the bottom',
+            ).to.be.lessThan(max / 2);
+        });
     });
 });


### PR DESCRIPTION
Closes #10912

Backport of #14859 to `v4.x`.

With async content the sheet opened scrolled to the bottom (Chrome/Safari): the initial scroll was applied before the content arrived, and `scroll-snap-type: y mandatory` then re-snapped the grown content to the bottom `scroll-snap-align: end` anchor.

Fix: pin the sheet to its initial snap via `afterNextRender`, and re-pin on content resize with `waResizeObserver` — until the first user gesture (touch/wheel). Snap/drag/close/stops behavior is unchanged. Cypress spec added.
