### PR TITLE
chore(demo): add scroll-driven carousel example

### DIFF
--- a/projects/demo/src/pages/components/carousel/examples/6/index.html
+++ b/projects/demo/src/pages/components/carousel/examples/6/index.html
@@ -1,0 +1,33 @@
+<button
+    appearance="action"
+    iconStart="@tui.chevron-left"
+    tuiIconButton
+    type="button"
+    [disabled]="index() === 0"
+    (click)="carousel.prev()"
+>
+    Previous
+</button>
+<tui-carousel
+    #carousel
+    [max]="5"
+    [min]="0"
+    [(index)]="index"
+>
+    <section
+        *tuiItem="let index"
+        class="item"
+    >
+        {{ index + 1 }}
+    </section>
+</tui-carousel>
+<button
+    appearance="action"
+    iconStart="@tui.chevron-right"
+    tuiIconButton
+    type="button"
+    [disabled]="index() === 5"
+    (click)="carousel.next()"
+>
+    Next
+</button>

--- a/projects/demo/src/pages/components/carousel/examples/6/index.less
+++ b/projects/demo/src/pages/components/carousel/examples/6/index.less
@@ -1,0 +1,44 @@
+:host {
+    display: grid;
+    gap: 1rem;
+    grid-template-columns: min-content 1fr min-content;
+    align-items: center;
+    font: var(--tui-typography-heading-h3);
+}
+
+.item {
+    display: flex;
+    inline-size: 100%;
+    block-size: 10rem;
+    align-items: center;
+    justify-content: center;
+    border-radius: 1rem;
+    background: var(--tui-background-neutral-1);
+    // Keep the name outside conditional rules so Angular scopes it in minified CSS.
+    animation-name: carousel-item;
+}
+
+@media (prefers-reduced-motion: no-preference) {
+    @supports (animation-timeline: view(inline)) {
+        .item {
+            animation-duration: 1ms;
+            animation-timing-function: linear;
+            animation-fill-mode: both;
+            animation-timeline: view(inline);
+            animation-range: cover;
+        }
+    }
+}
+
+@keyframes carousel-item {
+    0%,
+    100% {
+        transform: scale(0.85);
+        opacity: 0.5;
+    }
+
+    50% {
+        transform: scale(1);
+        opacity: 1;
+    }
+}

--- a/projects/demo/src/pages/components/carousel/examples/6/index.ts
+++ b/projects/demo/src/pages/components/carousel/examples/6/index.ts
@@ -1,0 +1,15 @@
+import {Component, signal} from '@angular/core';
+import {changeDetection} from '@demo/emulate/change-detection';
+import {encapsulation} from '@demo/emulate/encapsulation';
+import {TuiButton, TuiCarousel} from '@taiga-ui/core';
+
+@Component({
+    imports: [TuiButton, TuiCarousel],
+    templateUrl: './index.html',
+    styleUrl: './index.less',
+    encapsulation,
+    changeDetection,
+})
+export default class Example {
+    protected readonly index = signal(0);
+}

--- a/projects/demo/src/pages/components/carousel/index.html
+++ b/projects/demo/src/pages/components/carousel/index.html
@@ -30,6 +30,9 @@
                     @case (4) {
                         Multiple items per slide.
                     }
+                    @case (5) {
+                        Custom scroll-driven animation with CSS.
+                    }
                 }
             </ng-template>
         }

--- a/projects/demo/src/pages/components/carousel/index.ts
+++ b/projects/demo/src/pages/components/carousel/index.ts
@@ -15,5 +15,6 @@ export default class Page {
         'Automatic',
         'Dynamic height',
         'Multiple',
+        'Scroll-driven animation',
     ];
 }


### PR DESCRIPTION
## Changes

* add a subtle scroll-driven microinteraction for `Carousel` items
* scale and fade items based on their position in the carousel viewport
* keep the currently centered item visually emphasized
* respect `prefers-reduced-motion`
* keep existing scroll snap and `IntersectionObserver` behavior unchanged

## Motivation

The microinteraction makes carousel navigation feel more responsive and helps visually distinguish the currently focused item while scrolling.

The animation is driven entirely by CSS scroll-driven animations, so it does not require additional JavaScript or scroll event listeners.

This is implemented as progressive enhancement: browsers without `animation-timeline` support keep the existing carousel behavior unchanged.

No public API changes.
