### PR TITLE
fix(core): `tuiDropdownHover` no longer opens when obscured by a dialog

### DIFF
--- a/projects/core/portals/dropdown/dropdown-hover.directive.ts
+++ b/projects/core/portals/dropdown/dropdown-hover.directive.ts
@@ -49,10 +49,10 @@ export class TuiDropdownHover extends TuiDriver {
         read: ElementRef,
     });
 
+    private readonly directive = inject(TuiDropdownDirective);
     private readonly el = tuiInjectElement();
     private readonly doc = inject(DOCUMENT);
     private readonly options = inject(TUI_DROPDOWN_HOVER_OPTIONS);
-    private readonly activeZone = inject(TuiActiveZone);
     private readonly open = inject(TuiDropdownOpen, {optional: true});
 
     private readonly stream$ = merge(
@@ -60,7 +60,7 @@ export class TuiDropdownHover extends TuiDriver {
          * Dropdown can be removed not only via click/touch –
          * swipe on mobile devices removes dropdown sheet without triggering new mouseover / mouseout events.
          */
-        toObservable(inject(TuiDropdownDirective).ref).pipe(
+        toObservable(this.directive.ref).pipe(
             filter((x) => !x && this.hovered()),
             switchMap(() =>
                 tuiTypedFromEvent(this.doc, 'pointerdown').pipe(
@@ -107,8 +107,11 @@ export class TuiDropdownHover extends TuiDriver {
 
     private isHovered(element: Element): boolean {
         const host = this.dropdownHost()?.nativeElement || this.el;
+        // Only the dropdown's own content counts as a hovered area, not sibling
+        // overlays (e.g. a dialog) that attach to the same active zone as the host.
+        const zone = this.directive.ref()?.injector.get(TuiActiveZone, null);
         const hovered = host.contains(element);
-        const child = !this.el.contains(element) && this.activeZone.contains(element);
+        const child = !this.el.contains(element) && !!zone?.contains(element);
 
         return hovered || child;
     }

--- a/projects/core/portals/dropdown/dropdown-hover.directive.ts
+++ b/projects/core/portals/dropdown/dropdown-hover.directive.ts
@@ -107,8 +107,7 @@ export class TuiDropdownHover extends TuiDriver {
 
     private isHovered(element: Element): boolean {
         const host = this.dropdownHost()?.nativeElement || this.el;
-        // Only the dropdown's own content counts as a hovered area, not sibling
-        // overlays (e.g. a dialog) that attach to the same active zone as the host.
+        // Match the dropdown's own content zone, not the host's, so overlays (e.g. a dialog) don't count as hovered
         const zone = this.directive.ref()?.injector.get(TuiActiveZone, null);
         const hovered = host.contains(element);
         const child = !this.el.contains(element) && !!zone?.contains(element);

--- a/projects/core/portals/dropdown/test/dropdown-hover.directive.spec.ts
+++ b/projects/core/portals/dropdown/test/dropdown-hover.directive.spec.ts
@@ -1,0 +1,86 @@
+import {ChangeDetectionStrategy, Component, inject} from '@angular/core';
+import {type ComponentFixture, fakeAsync, TestBed, tick} from '@angular/core/testing';
+import {By} from '@angular/platform-browser';
+import {
+    provideTaiga,
+    TuiDialogService,
+    TuiDropdown,
+    TuiDropdownHover,
+    tuiDropdownHoverOptionsProvider,
+    TuiRoot,
+} from '@taiga-ui/core';
+
+describe('TuiDropdownHover', () => {
+    @Component({
+        imports: [TuiDropdown, TuiRoot],
+        template: `
+            <tui-root>
+                <button
+                    tuiDropdown="Dropdown content"
+                    tuiDropdownHover
+                    type="button"
+                    (click)="dialogs.open('Dialog').subscribe()"
+                >
+                    Hover me
+                </button>
+            </tui-root>
+        `,
+        changeDetection: ChangeDetectionStrategy.OnPush,
+    })
+    class Test {
+        public readonly dialogs = inject(TuiDialogService);
+    }
+
+    let fixture: ComponentFixture<Test>;
+
+    beforeEach(async () => {
+        TestBed.configureTestingModule({
+            imports: [Test],
+            providers: [
+                provideTaiga(),
+                tuiDropdownHoverOptionsProvider({showDelay: 0, hideDelay: 0}),
+            ],
+        });
+        await TestBed.compileComponents();
+        fixture = TestBed.createComponent(Test);
+        fixture.detectChanges();
+    });
+
+    function getHover(): TuiDropdownHover {
+        return fixture.debugElement
+            .query(By.directive(TuiDropdownHover))
+            .injector.get(TuiDropdownHover);
+    }
+
+    function mouseover(element: Element): void {
+        element.dispatchEvent(new MouseEvent('mouseover', {bubbles: true}));
+    }
+
+    it('is not hovered when the pointer is over a dialog obscuring the dropdown', fakeAsync(() => {
+        const button = fixture.debugElement.query(By.css('button')).nativeElement;
+
+        button.focus();
+        mouseover(button);
+        tick();
+        fixture.detectChanges();
+
+        expect(getHover().hovered()).toBe(true);
+        expect(fixture.nativeElement.querySelector('tui-dropdown')).not.toBeNull();
+
+        button.click();
+        fixture.detectChanges();
+        tick();
+
+        const dialog = fixture.nativeElement.querySelector('tui-dialog');
+
+        expect(dialog).not.toBeNull();
+
+        mouseover(dialog);
+        tick();
+        fixture.detectChanges();
+
+        expect(getHover().hovered()).toBe(false);
+
+        fixture.destroy();
+    }));
+});


### PR DESCRIPTION
Closes #14118

`tuiDropdownHover` now checks the dropdown's own content active zone instead of the host's, so a dialog opened from the trigger is no longer treated as a hovered area. Nested-portal content still keeps the dropdown open.

Before (dropdown shows through the dialog):
<img width="2560" height="1600" alt="v5-BEFORE-bug-dropdown-over-dialog" src="https://github.com/user-attachments/assets/f66f917b-8f43-452c-86bb-d484c6994318" />


After (dropdown stays closed):
<img width="2560" height="1600" alt="v5-AFTER-fix-no-dropdown" src="https://github.com/user-attachments/assets/2a8fc514-1ded-4dcd-b388-632e83035c06" />
