### PR TITLE
fix(core): `tuiDropdownHover` no longer opens when obscured by a dialog

### DIFF
--- a/projects/core/directives/dropdown/dropdown-hover.directive.ts
+++ b/projects/core/directives/dropdown/dropdown-hover.directive.ts
@@ -106,8 +106,7 @@ export class TuiDropdownHover extends TuiDriver {
 
     private isHovered(element: Element): boolean {
         const host = this.dropdownHost?.nativeElement || this.el;
-        // Only the dropdown's own content counts as a hovered area, not sibling
-        // overlays (e.g. a dialog) that attach to the same active zone as the host.
+        // Match the dropdown's own content zone, not the host's, so overlays (e.g. a dialog) don't count as hovered
         const zone = this.directive.ref()?.injector.get(TuiActiveZone, null);
         const hovered = host.contains(element);
         const child = !this.el.contains(element) && !!zone?.contains(element);

--- a/projects/core/directives/dropdown/dropdown-hover.directive.ts
+++ b/projects/core/directives/dropdown/dropdown-hover.directive.ts
@@ -41,18 +41,18 @@ export class TuiDropdownHover extends TuiDriver {
     @ContentChild('tuiDropdownHost', {descendants: true, read: ElementRef})
     private readonly dropdownHost?: ElementRef<HTMLElement>;
 
+    private readonly directive = inject(TuiDropdownDirective);
     private readonly el = tuiInjectElement();
     private readonly doc = inject(DOCUMENT);
     private readonly options = inject(TUI_DROPDOWN_HOVER_OPTIONS);
-    private readonly activeZone = inject(TuiActiveZone);
     private readonly open = inject(TuiDropdownOpen, {optional: true});
     /**
      * Dropdown can be removed not only via click/touch –
      * swipe on mobile devices removes dropdown sheet without triggering new mouseover / mouseout events.
      */
-    private readonly dropdownExternalRemoval$ = toObservable(
-        inject(TuiDropdownDirective).ref,
-    ).pipe(filter((x) => !x && this.hovered));
+    private readonly dropdownExternalRemoval$ = toObservable(this.directive.ref).pipe(
+        filter((x) => !x && this.hovered),
+    );
 
     private readonly stream$ = merge(
         this.dropdownExternalRemoval$.pipe(
@@ -106,8 +106,11 @@ export class TuiDropdownHover extends TuiDriver {
 
     private isHovered(element: Element): boolean {
         const host = this.dropdownHost?.nativeElement || this.el;
+        // Only the dropdown's own content counts as a hovered area, not sibling
+        // overlays (e.g. a dialog) that attach to the same active zone as the host.
+        const zone = this.directive.ref()?.injector.get(TuiActiveZone, null);
         const hovered = host.contains(element);
-        const child = !this.el.contains(element) && this.activeZone.contains(element);
+        const child = !this.el.contains(element) && !!zone?.contains(element);
 
         return hovered || child;
     }

--- a/projects/core/directives/dropdown/test/dropdown-hover.directive.spec.ts
+++ b/projects/core/directives/dropdown/test/dropdown-hover.directive.spec.ts
@@ -1,0 +1,94 @@
+import {ChangeDetectionStrategy, Component, inject} from '@angular/core';
+import {
+    type ComponentFixture,
+    fakeAsync,
+    flush,
+    TestBed,
+    tick,
+} from '@angular/core/testing';
+import {By} from '@angular/platform-browser';
+import {
+    TuiDialogService,
+    TuiDropdown,
+    tuiDropdownHoverOptionsProvider,
+    TuiDropdownHover,
+    TuiRoot,
+} from '@taiga-ui/core';
+import {NG_EVENT_PLUGINS} from '@taiga-ui/event-plugins';
+
+describe('TuiDropdownHover', () => {
+    @Component({
+        standalone: true,
+        imports: [TuiDropdown, TuiRoot],
+        template: `
+            <tui-root>
+                <button
+                    tuiDropdown="Dropdown content"
+                    tuiDropdownHover
+                    type="button"
+                    (click)="dialogs.open('Dialog').subscribe()"
+                >
+                    Hover me
+                </button>
+            </tui-root>
+        `,
+        changeDetection: ChangeDetectionStrategy.OnPush,
+    })
+    class Test {
+        public readonly dialogs = inject(TuiDialogService);
+    }
+
+    let fixture: ComponentFixture<Test>;
+
+    beforeEach(async () => {
+        TestBed.configureTestingModule({
+            imports: [Test],
+            providers: [
+                NG_EVENT_PLUGINS,
+                tuiDropdownHoverOptionsProvider({showDelay: 0, hideDelay: 0}),
+            ],
+        });
+        await TestBed.compileComponents();
+        fixture = TestBed.createComponent(Test);
+        fixture.detectChanges();
+    });
+
+    function getHover(): TuiDropdownHover {
+        return fixture.debugElement
+            .query(By.directive(TuiDropdownHover))
+            .injector.get(TuiDropdownHover);
+    }
+
+    function mouseover(element: Element): void {
+        element.dispatchEvent(new MouseEvent('mouseover', {bubbles: true}));
+    }
+
+    it('is not hovered when the pointer is over a dialog obscuring the dropdown', fakeAsync(() => {
+        const button = fixture.debugElement.query(By.css('button')).nativeElement;
+
+        button.focus();
+        mouseover(button);
+        tick();
+        fixture.detectChanges();
+
+        expect(getHover().hovered).toBe(true);
+        expect(fixture.nativeElement.querySelector('tui-dropdown')).not.toBeNull();
+
+        button.click();
+        fixture.detectChanges();
+        tick();
+
+        const dialog = fixture.nativeElement.querySelector('tui-dialog');
+
+        expect(dialog).not.toBeNull();
+
+        mouseover(dialog);
+        tick();
+        fixture.detectChanges();
+
+        expect(getHover().hovered).toBe(false);
+
+        fixture.destroy();
+        flush();
+    }));
+});


### PR DESCRIPTION
Closes #14118

`tuiDropdownHover` now checks the dropdown's own content active zone instead of the host's, so a dialog opened from the trigger is no longer treated as a hovered area. Nested-portal content still keeps the dropdown open.

Before (dropdown shows through the dialog):
<img width="2560" height="1600" alt="v4-BEFORE-bug-dropdown-over-dialog" src="https://github.com/user-attachments/assets/d86b0037-ec4e-4038-8448-d8f67eef7c64" />


After (dropdown stays closed):
<img width="2560" height="1600" alt="v4-AFTER-fix-no-dropdown" src="https://github.com/user-attachments/assets/1a836cef-ee86-48b6-96e7-ab48dd8bb4a5" />