### PR TITLE
fix(addon-mobile): mobile dropdown sheet reliably reopens after dismiss

### DIFF
--- a/projects/addon-mobile/directives/dropdown-sheet/dropdown-sheet.component.ts
+++ b/projects/addon-mobile/directives/dropdown-sheet/dropdown-sheet.component.ts
@@ -10,6 +10,7 @@ import {TuiSheetDialogService} from '@taiga-ui/addon-mobile/components/sheet-dia
 import {tuiIfMap} from '@taiga-ui/cdk/observables';
 import {TuiDropdownDirective} from '@taiga-ui/core/portals/dropdown';
 import {PolymorpheusOutlet} from '@taiga-ui/polymorpheus';
+import {finalize} from 'rxjs';
 
 import {TuiDropdownSheet} from './dropdown-sheet.directive';
 
@@ -37,9 +38,13 @@ export class TuiDropdownSheetComponent {
     protected readonly sub = toObservable(this.content)
         .pipe(
             tuiIfMap((content) =>
-                this.dialogs.open(content, this.directive.tuiDropdownSheet()),
+                this.dialogs.open(content, this.directive.tuiDropdownSheet()).pipe(
+                    // A dismissed sheet completes the dialog but leaves the dropdown open;
+                    // close it here so it reliably reopens on the next tap.
+                    finalize(() => this.dropdown.toggle(false)),
+                ),
             ),
             takeUntilDestroyed(),
         )
-        .subscribe({complete: () => this.dropdown.toggle(false)});
+        .subscribe();
 }

--- a/projects/addon-mobile/directives/dropdown-sheet/test/dropdown-sheet.component.spec.ts
+++ b/projects/addon-mobile/directives/dropdown-sheet/test/dropdown-sheet.component.spec.ts
@@ -1,0 +1,81 @@
+import {ChangeDetectionStrategy, Component} from '@angular/core';
+import {type ComponentFixture, fakeAsync, TestBed, tick} from '@angular/core/testing';
+import {By} from '@angular/platform-browser';
+import {WA_IS_MOBILE} from '@ng-web-apis/platform';
+import {TuiDropdownSheet} from '@taiga-ui/addon-mobile';
+import {
+    provideTaiga,
+    TuiDropdown,
+    TuiDropdownHover,
+    tuiDropdownHoverOptionsProvider,
+    TuiRoot,
+} from '@taiga-ui/core';
+
+describe('TuiDropdownSheet', () => {
+    @Component({
+        imports: [TuiDropdown, TuiDropdownHover, TuiDropdownSheet, TuiRoot],
+        template: `
+            <tui-root>
+                <button
+                    tuiDropdown="Content"
+                    tuiDropdownHover
+                    tuiDropdownSheet
+                    type="button"
+                >
+                    Open
+                </button>
+            </tui-root>
+        `,
+        changeDetection: ChangeDetectionStrategy.OnPush,
+    })
+    class Test {}
+
+    let fixture: ComponentFixture<Test>;
+
+    beforeEach(async () => {
+        TestBed.configureTestingModule({
+            imports: [Test],
+            providers: [
+                provideTaiga(),
+                {provide: WA_IS_MOBILE, useValue: true},
+                tuiDropdownHoverOptionsProvider({showDelay: 0, hideDelay: 0}),
+            ],
+        });
+        await TestBed.compileComponents();
+        fixture = TestBed.createComponent(Test);
+        fixture.detectChanges();
+    });
+
+    function button(): HTMLElement {
+        return fixture.debugElement.query(By.css('button')).nativeElement;
+    }
+
+    function sheet(): Element | null {
+        return fixture.nativeElement.querySelector('tui-sheet-dialog');
+    }
+
+    function hover(): void {
+        button().dispatchEvent(new MouseEvent('mouseover', {bubbles: true}));
+        tick();
+        fixture.detectChanges();
+        tick();
+    }
+
+    it('reopens on the next hover after the sheet is dismissed', fakeAsync(() => {
+        hover();
+        expect(sheet()).not.toBeNull();
+
+        // Dismiss via the backdrop (click.self on the sheet host) without a
+        // hover reset — the case that used to leave the dropdown stuck open.
+        sheet()!.dispatchEvent(new MouseEvent('click', {bubbles: true}));
+        tick();
+        fixture.detectChanges();
+        tick();
+        expect(sheet()).toBeNull();
+
+        hover();
+        expect(sheet()).not.toBeNull();
+
+        fixture.destroy();
+    }));
+});


### PR DESCRIPTION
Mobile `tuiDropdownHover` renders as a sheet dialog. Dismissing the sheet completes the dialog but not the launcher's stream (`tuiIfMap` swallows it), so the dropdown itself wasn't closed — it relied on the mobile hover-reset (`mouseover(backdrop)` → `isHovered=false`), whose event ordering is browser-dependent. In Chrome this wedged after a few open/close cycles and the sheet stopped reopening. Safari was fine.

Fix: close the dropdown when the sheet dialog completes, so `ref` clears and the hover state resets, letting it reopen reliably on the next tap. Scoped to the mobile launcher `TuiDropdownSheetComponent`; where the hover-reset already worked the extra `toggle(false)` is a no-op, so desktop and Safari are unchanged.

Verified on real Chrome and Safari.
