### PR TITLE
ci: squash history of generated gh-pages and next snapshot branches

### DIFF
--- a/.github/workflows/deploy-gh-pages.yml
+++ b/.github/workflows/deploy-gh-pages.yml
@@ -75,6 +75,7 @@ jobs:
           github_token: ${{ secrets.TAIGA_FAMILY_BOT_PAT }}
           publish_dir: ${{ env.DIST }}
           cname: taiga-ui.dev
+          force_orphan: true
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/snapshots.yml
+++ b/.github/workflows/snapshots.yml
@@ -34,6 +34,7 @@ jobs:
           FOLDER: ${{ env.DIST }}
           BRANCH: snapshots/demo/next/${{ github.head_ref || github.ref_name }}
           GITHUB_TOKEN: ${{ secrets.TAIGA_FAMILY_BOT_PAT }}
+          SQUASH_HISTORY: true
 
   production-snapshot:
     name: Push production snapshot


### PR DESCRIPTION
  ## What                                                                                                                                                                       
                                                                                                                                                                                
  - `force_orphan: true` for `peaceiris/actions-gh-pages` in `deploy-gh-pages.yml`                                                                                              
  - `SQUASH_HISTORY: true` for `s0/git-publish-subdir-action` in the `next-snapshot` job of `snapshots.yml`                                                                     
                                                                                                                                                                                
  ## Why                                                                                                                                                                        
                                                                                                                                                                                
  `git clone` of this repository currently downloads ~5 GB, and ~90% of that is                                                                                                 
  accumulated build history of branches whose content is fully generated
