### PR TITLE
fix(kit): `InputFiles` support `accept` / `maxFileSize` validation with signal forms

### DIFF
--- a/projects/demo-cypress/src/tests/input-files/signal-forms.cy.ts
+++ b/projects/demo-cypress/src/tests/input-files/signal-forms.cy.ts
@@ -1,104 +1,296 @@
 /*
 // TODO: Uncomment the whole file when the `@angular/forms/signals` entry point becomes available,
 // when Taiga UI drops support of Angular below 22 (stable API for signal forms appeared in Angular 22)
-import {ChangeDetectionStrategy, Component, signal} from '@angular/core';
+import {
+    ChangeDetectionStrategy,
+    Component,
+    computed,
+    Directive,
+    signal,
+    type Type,
+} from '@angular/core';
+import {toSignal} from '@angular/core/rxjs-interop';
+import {FormControl, ReactiveFormsModule} from '@angular/forms';
 import {form, FormField, requiredError, validate} from '@angular/forms/signals';
 import {TuiRoot} from '@taiga-ui/core';
 import {type TuiFileLike, TuiFiles} from '@taiga-ui/kit';
 
-const FILE: TuiFileLike = {name: 'report.pdf', size: 1024, type: 'application/pdf'};
-
-@Component({
-    imports: [FormField, TuiFiles, TuiRoot],
-    template: `
-        <tui-root>
-            <label
-                style="inline-size: 15rem"
-                tuiInputFiles
-            >
-                <input
-                    multiple
-                    tuiInputFiles
-                    [formField]="$any(f.files)"
-                />
-            </label>
-
-            <div style="margin-block-start: 1rem">
-                <output id="touched">{{ f.files().touched() }}</output>
-                <output id="invalid">{{ f.files().invalid() }}</output>
-
-                <button
-                    id="mark-touched"
-                    type="button"
-                    (click)="f().markAsTouched()"
-                >
-                    Mark as touched
-                </button>
-
-                <button
-                    id="set-valid"
-                    type="button"
-                    (click)="f.files().value.set([file])"
-                >
-                    Set valid value
-                </button>
-            </div>
-
-        </tui-root>
-    `,
-    changeDetection: ChangeDetectionStrategy.OnPush,
-})
-export class Sandbox {
-    public readonly file = FILE;
-    public readonly model = signal<{files: readonly TuiFileLike[]}>({files: []});
-
-    public readonly f = form(this.model, (path) => {
-        validate(path.files, ({value}) => (value().length ? null : requiredError()));
-    });
-}
-
-function snapshot(name: string): void {
-    cy.get('label[tuiInputFiles]').compareSnapshot({
-        name: `tuiInputFiles-${name}`,
-        cypressScreenshotOptions: {padding: 8},
-    });
-}
-
 describe('tuiInputFiles + signal forms', () => {
-    beforeEach(() => {
-        cy.viewport(400, 200);
-        cy.mount(Sandbox);
-        cy.get('input[tuiInputFiles]').as('input');
+    describe('invalid decoration', () => {
+        const FILE: TuiFileLike = {
+            name: 'report.pdf',
+            size: 1024,
+            type: 'application/pdf',
+        };
+
+        @Component({
+            imports: [FormField, TuiFiles, TuiRoot],
+            template: `
+                <tui-root>
+                    <label
+                        style="inline-size: 15rem"
+                        tuiInputFiles
+                    >
+                        <input
+                            multiple
+                            tuiInputFiles
+                            [formField]="$any(f.files)"
+                        />
+                    </label>
+
+                    <div style="margin-block-start: 1rem">
+                        <output id="touched">{{ f.files().touched() }}</output>
+                        <output id="invalid">{{ f.files().invalid() }}</output>
+
+                        <button
+                            id="mark-touched"
+                            type="button"
+                            (click)="f().markAsTouched()"
+                        >
+                            Mark as touched
+                        </button>
+
+                        <button
+                            id="set-valid"
+                            type="button"
+                            (click)="f.files().value.set([file])"
+                        >
+                            Set valid value
+                        </button>
+                    </div>
+                </tui-root>
+            `,
+            changeDetection: ChangeDetectionStrategy.OnPush,
+        })
+        class Sandbox {
+            public readonly file = FILE;
+            public readonly model = signal<{files: readonly TuiFileLike[]}>({files: []});
+
+            public readonly f = form(this.model, (path) => {
+                validate(path.files, ({value}) =>
+                    value().length ? null : requiredError(),
+                );
+            });
+        }
+
+        function snapshot(name: string): void {
+            cy.get('label[tuiInputFiles]').compareSnapshot({
+                name: `tuiInputFiles-${name}`,
+                cypressScreenshotOptions: {padding: 8},
+            });
+        }
+
+        beforeEach(() => {
+            cy.viewport(400, 200);
+            cy.mount(Sandbox);
+            cy.get('input[tuiInputFiles]').as('input');
+        });
+
+        it('invalid but untouched => no invalid decoration', () => {
+            cy.get('#invalid').should('have.text', 'true');
+            cy.get('#touched').should('have.text', 'false');
+
+            cy.get('@input').should('not.have.attr', 'data-mode', 'invalid');
+
+            snapshot('untouched-invalid');
+        });
+
+        it('external markAsTouched() => invalid decoration appears', () => {
+            cy.get('#mark-touched').click();
+
+            cy.get('#touched').should('have.text', 'true');
+            cy.get('@input').should('have.attr', 'data-mode', 'invalid');
+
+            snapshot('touched-invalid');
+        });
+
+        it('valid value => decoration is dropped again', () => {
+            cy.get('#mark-touched').click();
+            cy.get('@input').should('have.attr', 'data-mode', 'invalid');
+
+            cy.get('#set-valid').click();
+
+            cy.get('#invalid').should('have.text', 'false');
+            cy.get('@input').should('not.have.attr', 'data-mode', 'invalid');
+
+            snapshot('valid-again');
+        });
     });
 
-    it('invalid but untouched => no invalid decoration', () => {
-        cy.get('#invalid').should('have.text', 'true');
-        cy.get('#touched').should('have.text', 'false');
+    describe('(reject)', () => {
+        const MAX_FILE_SIZE = 1024;
 
-        cy.get('@input').should('not.have.attr', 'data-mode', 'invalid');
+        const NOT_AN_IMAGE = {
+            contents: new Uint8Array(3),
+            fileName: 'notes.txt',
+            mimeType: 'text/plain',
+        };
 
-        snapshot('untouched-invalid');
-    });
+        const SMALL_IMAGE = {
+            contents: new Uint8Array(3),
+            fileName: 'avatar.png',
+            mimeType: 'image/png',
+        };
 
-    it('external markAsTouched() => invalid decoration appears', () => {
-        cy.get('#mark-touched').click();
+        const HUGE_IMAGE = {
+            contents: new Uint8Array(MAX_FILE_SIZE * 2),
+            fileName: 'poster.png',
+            mimeType: 'image/png',
+        };
 
-        cy.get('#touched').should('have.text', 'true');
-        cy.get('@input').should('have.attr', 'data-mode', 'invalid');
+        @Directive()
+        abstract class RejectSandbox {
+            public readonly maxFileSize = MAX_FILE_SIZE;
+            public readonly rejected = signal<readonly TuiFileLike[]>([]);
 
-        snapshot('touched-invalid');
-    });
+            public abstract readonly accepted: () => readonly TuiFileLike[];
 
-    it('valid value => decoration is dropped again', () => {
-        cy.get('#mark-touched').click();
-        cy.get('@input').should('have.attr', 'data-mode', 'invalid');
+            protected keepAccepted(
+                files: readonly TuiFileLike[],
+            ): readonly TuiFileLike[] {
+                return files.filter((file) => !this.rejected().includes(file));
+            }
+        }
 
-        cy.get('#set-valid').click();
+        @Component({
+            imports: [FormField, TuiFiles, TuiRoot],
+            template: `
+                <tui-root>
+                    <label
+                        style="inline-size: 15rem"
+                        tuiInputFiles
+                    >
+                        <input
+                            accept="image/*"
+                            multiple
+                            tuiInputFiles
+                            [formField]="$any(f.files)"
+                            [maxFileSize]="maxFileSize"
+                            (reject)="rejected.set($event)"
+                        />
+                    </label>
 
-        cy.get('#invalid').should('have.text', 'false');
-        cy.get('@input').should('not.have.attr', 'data-mode', 'invalid');
+                    <tui-files id="accepted">
+                        @for (file of accepted(); track file.name) {
+                            <tui-file [file]="file" />
+                        }
+                    </tui-files>
 
-        snapshot('valid-again');
+                    <tui-files id="rejected">
+                        @for (file of rejected(); track file.name) {
+                            <tui-file
+                                state="error"
+                                [file]="file"
+                            />
+                        }
+                    </tui-files>
+                </tui-root>
+            `,
+            changeDetection: ChangeDetectionStrategy.OnPush,
+        })
+        class RejectSignalFormsSandbox extends RejectSandbox {
+            public readonly model = signal<{files: readonly TuiFileLike[]}>({files: []});
+            public readonly f = form(this.model);
+
+            public readonly accepted = computed(() =>
+                this.keepAccepted(this.model().files),
+            );
+        }
+
+        @Component({
+            imports: [ReactiveFormsModule, TuiFiles, TuiRoot],
+            template: `
+                <tui-root>
+                    <label
+                        style="inline-size: 15rem"
+                        tuiInputFiles
+                    >
+                        <input
+                            accept="image/*"
+                            multiple
+                            tuiInputFiles
+                            [formControl]="control"
+                            [maxFileSize]="maxFileSize"
+                            (reject)="rejected.set($event)"
+                        />
+                    </label>
+
+                    <tui-files id="accepted">
+                        @for (file of accepted(); track file.name) {
+                            <tui-file [file]="file" />
+                        }
+                    </tui-files>
+
+                    <tui-files id="rejected">
+                        @for (file of rejected(); track file.name) {
+                            <tui-file
+                                state="error"
+                                [file]="file"
+                            />
+                        }
+                    </tui-files>
+                </tui-root>
+            `,
+            changeDetection: ChangeDetectionStrategy.OnPush,
+        })
+        class RejectReactiveFormsSandbox extends RejectSandbox {
+            public readonly control = new FormControl<readonly TuiFileLike[]>([], {
+                nonNullable: true,
+            });
+
+            private readonly value = toSignal(this.control.valueChanges, {
+                initialValue: this.control.value,
+            });
+
+            public readonly accepted = computed(() => this.keepAccepted(this.value()));
+        }
+
+        const SANDBOXES: ReadonlyArray<{
+            readonly component: Type<RejectSandbox>;
+            readonly title: string;
+        }> = [
+            {component: RejectSignalFormsSandbox, title: '[formField] (signal forms)'},
+            {component: RejectReactiveFormsSandbox, title: '[formControl] (reactive forms)'},
+        ];
+
+        SANDBOXES.forEach(({component, title}) => {
+            describe(title, () => {
+                beforeEach(() => {
+                    cy.viewport(400, 300);
+                    cy.mount(component);
+                    cy.get('input[tuiInputFiles]').as('input');
+                });
+
+                it('a file of the wrong format is shown as rejected, not as accepted', () => {
+                    cy.get('@input').selectFile(NOT_AN_IMAGE, {force: true});
+
+                    cy.get('#rejected tui-file').should('have.length', 1);
+                    cy.get('#rejected tui-file').should('contain.text', 'notes');
+                    cy.get('#accepted tui-file').should('have.length', 0);
+                });
+
+                it('a file over the size limit is shown as rejected, not as accepted', () => {
+                    cy.get('@input').selectFile(HUGE_IMAGE, {force: true});
+
+                    cy.get('#rejected tui-file').should('have.length', 1);
+                    cy.get('#rejected tui-file').should('contain.text', 'poster');
+                    cy.get('#accepted tui-file').should('have.length', 0);
+                });
+
+                it('a bad file picked after a good one does not join the accepted list', () => {
+                    cy.get('@input').selectFile(SMALL_IMAGE, {force: true});
+
+                    cy.get('#accepted tui-file').should('have.length', 1);
+                    cy.get('#rejected tui-file').should('have.length', 0);
+
+                    cy.get('@input').selectFile(NOT_AN_IMAGE, {force: true});
+
+                    cy.get('#rejected tui-file').should('have.length', 1);
+                    cy.get('#accepted tui-file').should('have.length', 1);
+                    cy.get('#accepted tui-file').should('contain.text', 'avatar');
+                });
+            });
+        });
     });
 });
 */

--- a/projects/kit/components/files/files.utils.ts
+++ b/projects/kit/components/files/files.utils.ts
@@ -17,8 +17,8 @@ const BYTES_PER_MIB = 1024 * BYTES_PER_KIB;
  */
 function getRejected(control: AbstractControl | null | undefined, key: string): File[] {
     /**
-     * `getError(key)` is not an option: 
-     * the fake `NgControl` signal forms provide has only the `errors` getter, 
+     * `getError(key)` is not an option:
+     * the fake `NgControl` signal forms provide has only the `errors` getter,
      * and calling the missing method throws
      */
     const error = control?.errors?.[key];

--- a/projects/kit/components/files/files.utils.ts
+++ b/projects/kit/components/files/files.utils.ts
@@ -7,9 +7,28 @@ import {TUI_FORMAT_ERROR, TUI_SIZE_ERROR} from './files.validators';
 const BYTES_PER_KIB = 1024;
 const BYTES_PER_MIB = 1024 * BYTES_PER_KIB;
 
+/**
+ * Reads the files a rejection error carries, for both kinds of form.
+ *
+ * Signal forms wrap a reactive error into `CompatValidationError`
+ * https://github.com/angular/angular/blob/f44bf0fe221288d03107cc78acfbe333a9a9b7b5/packages/forms/signals/src/compat/validation_errors.ts#L55-L65
+ *
+ * TODO(v6): drop the `context` branch after signal forms are fully supported (Angular >= 22)
+ */
+function getRejected(control: AbstractControl | null | undefined, key: string): File[] {
+    /**
+     * `getError(key)` is not an option: 
+     * the fake `NgControl` signal forms provide has only the `errors` getter, 
+     * and calling the missing method throws
+     */
+    const error = control?.errors?.[key];
+
+    return error?.$implicit || error?.context?.$implicit || [];
+}
+
 export function tuiFilesRejected(control?: AbstractControl | null): File[] {
-    const format: File[] = control?.getError(TUI_FORMAT_ERROR)?.$implicit || [];
-    const size: File[] = control?.getError(TUI_SIZE_ERROR)?.$implicit || [];
+    const format = getRejected(control, TUI_FORMAT_ERROR);
+    const size = getRejected(control, TUI_SIZE_ERROR);
 
     return Array.from(new Set([...format, ...size]));
 }
@@ -17,8 +36,8 @@ export function tuiFilesRejected(control?: AbstractControl | null): File[] {
 export function tuiFilesAccepted(control?: AbstractControl | null): File[] {
     const value = control?.value || [];
     const files: File[] = coerceArray(value);
-    const size: File[] = control?.getError(TUI_SIZE_ERROR)?.$implicit || [];
-    const format: File[] = control?.getError(TUI_FORMAT_ERROR)?.$implicit || [];
+    const size = getRejected(control, TUI_SIZE_ERROR);
+    const format = getRejected(control, TUI_FORMAT_ERROR);
 
     return files.filter((file) => !size.includes(file) && !format.includes(file));
 }

--- a/projects/kit/components/files/files.utils.ts
+++ b/projects/kit/components/files/files.utils.ts
@@ -7,14 +7,6 @@ import {TUI_FORMAT_ERROR, TUI_SIZE_ERROR} from './files.validators';
 const BYTES_PER_KIB = 1024;
 const BYTES_PER_MIB = 1024 * BYTES_PER_KIB;
 
-/**
- * Reads the files a rejection error carries, for both kinds of form.
- *
- * Signal forms wrap a reactive error into `CompatValidationError`
- * https://github.com/angular/angular/blob/f44bf0fe221288d03107cc78acfbe333a9a9b7b5/packages/forms/signals/src/compat/validation_errors.ts#L55-L65
- *
- * TODO(v6): drop the `context` branch after signal forms are fully supported (Angular >= 22)
- */
 function getRejected(control: AbstractControl | null | undefined, key: string): File[] {
     /**
      * `getError(key)` is not an option:
@@ -23,7 +15,17 @@ function getRejected(control: AbstractControl | null | undefined, key: string): 
      */
     const error = control?.errors?.[key];
 
-    return error?.$implicit || error?.context?.$implicit || [];
+    return (
+        error?.$implicit ||
+        /**
+         * Signal forms wrap a reactive error into `CompatValidationError`
+         * https://github.com/angular/angular/blob/f44bf0fe221288d03107cc78acfbe333a9a9b7b5/packages/forms/signals/src/compat/validation_errors.ts#L55-L65
+         *
+         * TODO(v6): drop the `context` branch after signal forms are fully supported (Angular >= 22)
+         */
+        error?.context?.$implicit ||
+        []
+    );
 }
 
 export function tuiFilesRejected(control?: AbstractControl | null): File[] {

--- a/projects/kit/components/files/input-files/input-files-validator.directive.ts
+++ b/projects/kit/components/files/input-files/input-files-validator.directive.ts
@@ -1,9 +1,10 @@
 import {Directive, inject, type OnChanges, type OnInit} from '@angular/core';
 import {
-    AbstractControl, NG_VALIDATORS,
+    type AbstractControl,
+    NG_VALIDATORS,
     type ValidationErrors,
     type ValidatorFn,
-    Validators
+    Validators,
 } from '@angular/forms';
 import {TuiValidator} from '@taiga-ui/cdk/directives/validator';
 import {tuiProvide} from '@taiga-ui/cdk/utils/di';
@@ -27,8 +28,8 @@ export class TuiInputFilesValidator extends TuiValidator implements OnInit, OnCh
     public accept = this.options.accept;
     public maxFileSize = this.options.maxFileSize;
 
-    public override validate = 
-        (control: AbstractControl): ValidationErrors | null => this.validator(control);
+    public override validate = (control: AbstractControl): ValidationErrors | null =>
+        this.validator(control);
 
     public override ngOnChanges(): void {
         this.update();

--- a/projects/kit/components/files/input-files/input-files-validator.directive.ts
+++ b/projects/kit/components/files/input-files/input-files-validator.directive.ts
@@ -1,5 +1,10 @@
 import {Directive, inject, type OnChanges, type OnInit} from '@angular/core';
-import {NG_VALIDATORS, Validators} from '@angular/forms';
+import {
+    AbstractControl, NG_VALIDATORS,
+    type ValidationErrors,
+    type ValidatorFn,
+    Validators
+} from '@angular/forms';
 import {TuiValidator} from '@taiga-ui/cdk/directives/validator';
 import {tuiProvide} from '@taiga-ui/cdk/utils/di';
 
@@ -17,9 +22,13 @@ import {TUI_INPUT_FILES_OPTIONS} from './input-files.options';
 })
 export class TuiInputFilesValidator extends TuiValidator implements OnInit, OnChanges {
     private readonly options = inject(TUI_INPUT_FILES_OPTIONS);
+    private validator: ValidatorFn = Validators.nullValidator;
 
     public accept = this.options.accept;
     public maxFileSize = this.options.maxFileSize;
+
+    public override validate = 
+        (control: AbstractControl): ValidationErrors | null => this.validator(control);
 
     public override ngOnChanges(): void {
         this.update();
@@ -30,7 +39,7 @@ export class TuiInputFilesValidator extends TuiValidator implements OnInit, OnCh
     }
 
     private update(): void {
-        this.validate =
+        this.validator =
             Validators.compose([
                 tuiCreateFileFormatValidator(this.accept),
                 tuiCreateFileSizeValidator(this.maxFileSize),

--- a/projects/kit/components/files/test/files.utils.spec.ts
+++ b/projects/kit/components/files/test/files.utils.spec.ts
@@ -1,0 +1,52 @@
+import {FormControl} from '@angular/forms';
+import {
+    TUI_FORMAT_ERROR,
+    TUI_SIZE_ERROR,
+    tuiFilesAccepted,
+    tuiFilesRejected,
+} from '@taiga-ui/kit';
+
+const REJECTED = new File([], 'photo.png', {type: 'image/png'});
+const ACCEPTED = new File([], 'photo.jpg', {type: 'image/jpeg'});
+
+describe('tuiFilesRejected', () => {
+    it('returns an empty array for a missing control', () => {
+        expect(tuiFilesRejected(null)).toEqual([]);
+    });
+
+    it('reads both rejection reasons', () => {
+        const control = new FormControl([ACCEPTED, REJECTED]);
+
+        control.setErrors({
+            [TUI_FORMAT_ERROR]: {$implicit: [REJECTED]},
+            [TUI_SIZE_ERROR]: {$implicit: [ACCEPTED]},
+        });
+
+        expect(tuiFilesRejected(control)).toEqual([REJECTED, ACCEPTED]);
+    });
+
+    it('deduplicates a file rejected for both reasons', () => {
+        const control = new FormControl([REJECTED]);
+
+        control.setErrors({
+            [TUI_FORMAT_ERROR]: {$implicit: [REJECTED]},
+            [TUI_SIZE_ERROR]: {$implicit: [REJECTED]},
+        });
+
+        expect(tuiFilesRejected(control)).toEqual([REJECTED]);
+    });
+});
+
+describe('tuiFilesAccepted', () => {
+    it('returns an empty array for a missing control', () => {
+        expect(tuiFilesAccepted(null)).toEqual([]);
+    });
+
+    it('drops the rejected files', () => {
+        const control = new FormControl([ACCEPTED, REJECTED]);
+
+        control.setErrors({[TUI_FORMAT_ERROR]: {$implicit: [REJECTED]}});
+
+        expect(tuiFilesAccepted(control)).toEqual([ACCEPTED]);
+    });
+});

--- a/projects/kit/components/files/test/files.utils.spec.ts
+++ b/projects/kit/components/files/test/files.utils.spec.ts
@@ -9,44 +9,46 @@ import {
 const REJECTED = new File([], 'photo.png', {type: 'image/png'});
 const ACCEPTED = new File([], 'photo.jpg', {type: 'image/jpeg'});
 
-describe('tuiFilesRejected', () => {
-    it('returns an empty array for a missing control', () => {
-        expect(tuiFilesRejected(null)).toEqual([]);
-    });
-
-    it('reads both rejection reasons', () => {
-        const control = new FormControl([ACCEPTED, REJECTED]);
-
-        control.setErrors({
-            [TUI_FORMAT_ERROR]: {$implicit: [REJECTED]},
-            [TUI_SIZE_ERROR]: {$implicit: [ACCEPTED]},
+describe('File-related utils', () => {
+    describe('tuiFilesRejected', () => {
+        it('returns an empty array for a missing control', () => {
+            expect(tuiFilesRejected(null)).toEqual([]);
         });
 
-        expect(tuiFilesRejected(control)).toEqual([REJECTED, ACCEPTED]);
-    });
+        it('reads both rejection reasons', () => {
+            const control = new FormControl([ACCEPTED, REJECTED]);
 
-    it('deduplicates a file rejected for both reasons', () => {
-        const control = new FormControl([REJECTED]);
+            control.setErrors({
+                [TUI_FORMAT_ERROR]: {$implicit: [REJECTED]},
+                [TUI_SIZE_ERROR]: {$implicit: [ACCEPTED]},
+            });
 
-        control.setErrors({
-            [TUI_FORMAT_ERROR]: {$implicit: [REJECTED]},
-            [TUI_SIZE_ERROR]: {$implicit: [REJECTED]},
+            expect(tuiFilesRejected(control)).toEqual([REJECTED, ACCEPTED]);
         });
 
-        expect(tuiFilesRejected(control)).toEqual([REJECTED]);
+        it('deduplicates a file rejected for both reasons', () => {
+            const control = new FormControl([REJECTED]);
+
+            control.setErrors({
+                [TUI_FORMAT_ERROR]: {$implicit: [REJECTED]},
+                [TUI_SIZE_ERROR]: {$implicit: [REJECTED]},
+            });
+
+            expect(tuiFilesRejected(control)).toEqual([REJECTED]);
+        });
     });
-});
 
-describe('tuiFilesAccepted', () => {
-    it('returns an empty array for a missing control', () => {
-        expect(tuiFilesAccepted(null)).toEqual([]);
-    });
+    describe('tuiFilesAccepted', () => {
+        it('returns an empty array for a missing control', () => {
+            expect(tuiFilesAccepted(null)).toEqual([]);
+        });
 
-    it('drops the rejected files', () => {
-        const control = new FormControl([ACCEPTED, REJECTED]);
+        it('drops the rejected files', () => {
+            const control = new FormControl([ACCEPTED, REJECTED]);
 
-        control.setErrors({[TUI_FORMAT_ERROR]: {$implicit: [REJECTED]}});
+            control.setErrors({[TUI_FORMAT_ERROR]: {$implicit: [REJECTED]}});
 
-        expect(tuiFilesAccepted(control)).toEqual([ACCEPTED]);
+            expect(tuiFilesAccepted(control)).toEqual([ACCEPTED]);
+        });
     });
 });


### PR DESCRIPTION
### Problem 1

```html
<label tuiInputFiles>
  <input
    multiple
    tuiInputFiles
    [accept]="accept()"
    [formField]="f.files"
    [maxFileSize]="maxFileSize()"
    (reject)="onFieldReject($event)"
  />
</label>
```

throws

```
ERROR TypeError: control?.getError is not a function
    at tuiFilesRejected (files.utils.ts:11:37)
    at input-files.directive.ts:54:23
    at map.js:7:37
    at OperatorSubscriber2._this._next (OperatorSubscriber.js:15:21)
    at Subscriber2.next (Subscriber.js:34:18)
    at switchMap.js:14:159
    at OperatorSubscriber2._this._next (OperatorSubscriber.js:15:21)
    at Subscriber2.next (Subscriber.js:34:18)
    at distinctUntilChanged.js:15:28
    at OperatorSubscriber2._this._next (OperatorSubscriber.js:15:21)
```

### Problem 2
After fixing the 1st problem
```ts
it('a file of the wrong format is shown as rejected, not as accepted', () => {
    cy.get('@input').selectFile(NOT_AN_IMAGE, {force: true});

    cy.get('#rejected tui-file').should('have.length', 1);
    // [...]
});
```

```
AssertionError: Timed out retrying after 10000ms: 
Expected to find element: `#rejected tui-file`, but never found it.
```

___

```ts
it('a file over the size limit is shown as rejected, not as accepted', () => {
    cy.get('@input').selectFile(HUGE_IMAGE, {force: true});

    cy.get('#rejected tui-file').should('have.length', 1);
    // [...]
});
```

```
AssertionError: 
Timed out retrying after 10000ms:
Expected to find element: `#rejected tui-file`, but never found it.
```

Relates:
- https://github.com/taiga-family/taiga-ui/issues/14341