### PR TITLE
fix(schematics): prevent tuiLet migration crash on nested formatting elements

### DIFF
--- a/projects/cdk/schematics/ng-update/v5/steps/migrate-tui-let.ts
+++ b/projects/cdk/schematics/ng-update/v5/steps/migrate-tui-let.ts
@@ -64,6 +64,11 @@ function migrateStructuralLet(
         return;
     }
 
+    // adoption-agency clones of nested formatting elements keep *tuiLet but have no source location
+    if (!element.sourceCodeLocation) {
+        return;
+    }
+
     const {expr, key} = parseLetExpression(attr.value);
 
     if (!expr || !key) {

--- a/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-tui-let.spec.ts.snap
+++ b/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-tui-let.spec.ts.snap
@@ -46,6 +46,56 @@ exports[`ng-update tuiLet keeps the alias when only an observable (foo$) shares 
 }
 `;
 
+exports[`ng-update tuiLet migrates nested anchors without crashing on reconstructed clones: test.html 1`] = `
+{
+  "0. Before": "
+                <a *tuiLet="value as val">
+                    <p>
+                        <a>{{ val }}</a>
+                    </p>
+                </a>
+            ",
+  "1. After": "
+                @let val = value;
+                <a>
+                    <p>
+                        <a>{{ val }}</a>
+                    </p>
+                </a>
+            ",
+}
+`;
+
+exports[`ng-update tuiLet migrates nested anchors without crashing on reconstructed clones: test.ts 1`] = `
+{
+  "0. Before": "
+            import {Component} from '@angular/core';
+            import {TuiLet} from '@taiga-ui/cdk';
+
+            @Component({
+                standalone: true,
+                templateUrl: './test.html',
+                imports: [TuiLet],
+            })
+            export class Test {
+                readonly value = 'foo';
+            }
+        ",
+  "1. After": "
+            import {Component} from '@angular/core';
+
+            @Component({
+                standalone: true,
+                templateUrl: './test.html',
+                imports: [],
+            })
+            export class Test {
+                readonly value = 'foo';
+            }
+        ",
+}
+`;
+
 exports[`ng-update tuiLet migrates nested case with additional attributes: test.html 1`] = `
 {
   "0. Before": "

--- a/projects/cdk/schematics/ng-update/v5/tests/schematic-migrate-tui-let.spec.ts
+++ b/projects/cdk/schematics/ng-update/v5/tests/schematic-migrate-tui-let.spec.ts
@@ -106,5 +106,18 @@ describe('ng-update tuiLet', () => {
         }),
     );
 
+    it(
+        'migrates nested anchors without crashing on reconstructed clones',
+        migration({
+            template: /* HTML */ `
+                <a *tuiLet="value as val">
+                    <p>
+                        <a>{{ val }}</a>
+                    </p>
+                </a>
+            `,
+        }),
+    );
+
     afterEach(() => resetActiveProject());
 });


### PR DESCRIPTION
`ng update` / `nx migrate` (v4 → v5) crashes in the `tuiLetMigration` step with `TypeError: Cannot read properties of undefined (reading 'startOffset')`, which aborts the whole `updateToV5` run (no try/catch around steps).

parse5's adoption agency clones nested formatting elements — e.g. an `<a *tuiLet>` wrapping another `<a>`. The clone keeps the `*tuiLet` attribute but has no `sourceCodeLocation`, so `insertLetDeclaration` dereferences it and throws. The fix skips such clones; the authored element with a real location is still migrated.

Reproduced end-to-end on a real project template; added a failing test (crashes without the fix, green with it). Full v5 suite stays green (141 suites / 811 tests / 913 snapshots).
