### PR TITLE
fix(schematics): remove dangling migrateTuiLet entry from collection

### DIFF
--- a/projects/cdk/schematics/collection.json
+++ b/projects/cdk/schematics/collection.json
@@ -30,11 +30,6 @@
             "factory": "./ng-update/v4/index#updateToV4",
             "schema": "./ng-update/v4/schema.json"
         },
-        "migrateTuiLet": {
-            "description": "Migrate TuiLet directive to @let control flow",
-            "factory": "./migrate-tui-let/index",
-            "schema": "./migrate-tui-let/schema.json"
-        },
         "updateToV5": {
             "private": true,
             "description": "Manually run migration to update Taiga to v5.x.x",


### PR DESCRIPTION
`migrateTuiLet` in the cdk schematics collection points to `./migrate-tui-let/index` and `./migrate-tui-let/schema.json`, which don't exist in the package. It's a non-private entry, so `ng g @taiga-ui/cdk:migrateTuiLet` fails with `Cannot find module .../migrate-tui-let/index`.

The TuiLet migration isn't a standalone schematic — it runs as a step inside `updateToV5` (via `migration.json`), so this entry is both broken and redundant. Removing it changes nothing at runtime: `ng update` and the TuiLet migration are unaffected, `ng-add` and the tuiLet specs stay green.
