### PR TITLE
fix(schematics): migrate kit i18n token providers to signal (v5)

### DIFF
--- a/projects/cdk/schematics/ng-update/v5/index.ts
+++ b/projects/cdk/schematics/ng-update/v5/index.ts
@@ -45,6 +45,7 @@ import {migrateEditorProviders} from './steps/migrate-editor-providers';
 import {migrateFilterByInput} from './steps/migrate-filter-by-input';
 import {migrateHintDirectiveBinding} from './steps/migrate-hint-directive-binding';
 import {migrateI18nLanguageSignal} from './steps/migrate-i18n-language-signal';
+import {migrateI18nSignalTokens} from './steps/migrate-i18n-signal-tokens';
 import {migrateInputTagComponent} from './steps/migrate-input-tag-component';
 import {migratePackages} from './steps/migrate-packages';
 import {migratePortals} from './steps/migrate-portals';
@@ -150,6 +151,10 @@ function main(options: TuiSchema, timings: MigrationStepTiming[]): Rule {
                 {
                     name: 'migrateI18nLanguageSignal',
                     step: () => migrateI18nLanguageSignal(tree, options),
+                },
+                {
+                    name: 'migrateI18nSignalTokens',
+                    step: () => migrateI18nSignalTokens(tree, options),
                 },
                 {
                     name: 'migrateEditorProviders',

--- a/projects/cdk/schematics/ng-update/v5/steps/migrate-i18n-signal-tokens.ts
+++ b/projects/cdk/schematics/ng-update/v5/steps/migrate-i18n-signal-tokens.ts
@@ -1,0 +1,223 @@
+import {type Tree} from '@angular-devkit/schematics';
+import {
+    Node,
+    type ObjectLiteralExpression,
+    type PropertyAssignment,
+    saveActiveProject,
+} from 'ng-morph';
+
+import {type TuiSchema} from '../../../ng-add/schema';
+import {addUniqueImport} from '../../../utils/add-unique-import';
+import {infoLog} from '../../../utils/colored-log';
+import {getNamedImportReferences} from '../../../utils/get-named-import-references';
+import {insertTodo, TODO_MARK} from '../../../utils/insert-todo';
+
+const ANGULAR_CORE = '@angular/core';
+const RXJS_INTEROP = '@angular/core/rxjs-interop';
+const SIGNAL = 'signal';
+const TO_SIGNAL = 'toSignal';
+const RXJS_OF = 'of';
+const TAIGA_KIT = '@taiga-ui/kit';
+
+/**
+ * Kit i18n tokens built via `tuiExtractI18n`. Their type changed from
+ * `Observable<T>` to `Signal<T>` in v5 (the factory switched from
+ * `inject(TUI_LANGUAGE).pipe(map(...))` to `computed(...)`), so any
+ * `{provide, useValue: of(...)}` provider no longer type-checks.
+ */
+const KIT_I18N_TOKENS = [
+    'TUI_CONFIRM_WORDS',
+    'TUI_CANCEL_WORD',
+    'TUI_DONE_WORD',
+    'TUI_MORE_WORD',
+    'TUI_HIDE_TEXT',
+    'TUI_SHOW_ALL_TEXT',
+    'TUI_OTHER_DATE_TEXT',
+    'TUI_CHOOSE_DAY_OR_RANGE_TEXTS',
+    'TUI_FROM_TO_TEXTS',
+    'TUI_PLUS_MINUS_TEXTS',
+    'TUI_TIME_TEXTS',
+    'TUI_DATE_TEXTS',
+    'TUI_DIGITAL_INFORMATION_UNITS',
+    'TUI_COPY_TEXTS',
+    'TUI_PASSWORD_TEXTS',
+    'TUI_CALENDAR_MONTHS',
+    'TUI_FILE_TEXTS',
+    'TUI_PAGINATION_TEXTS',
+    'TUI_INPUT_FILE_TEXTS',
+    'TUI_MULTI_SELECT_TEXTS',
+    'TUI_COUNTRIES',
+    'TUI_PREVIEW_TEXTS',
+    'TUI_PREVIEW_ZOOM_TEXTS',
+    'TUI_INTERNATIONAL_SEARCH',
+    'TUI_DAY_RANGE_PERIODS',
+] as const;
+
+const TODO_MESSAGE =
+    'i18n token is a Signal in v5, not an Observable. Provide the value via signal(...), or convert an existing stream with toSignal(...).';
+
+export function migrateI18nSignalTokens(_tree: Tree, options: TuiSchema): void {
+    if (!options['skip-logs']) {
+        infoLog('Migrating kit i18n token providers to signal-based values...');
+    }
+
+    for (const tokenName of KIT_I18N_TOKENS) {
+        for (const ref of getNamedImportReferences(tokenName, TAIGA_KIT)) {
+            if (ref.wasForgotten()) {
+                continue;
+            }
+
+            const parent = ref.getParent();
+
+            if (
+                !parent ||
+                Node.isImportSpecifier(parent) ||
+                !Node.isPropertyAssignment(parent) ||
+                parent.getName() !== 'provide'
+            ) {
+                continue;
+            }
+
+            const objectLiteral = parent.getParent();
+
+            if (objectLiteral && Node.isObjectLiteralExpression(objectLiteral)) {
+                migrateProvider(objectLiteral, parent);
+            }
+        }
+    }
+
+    saveActiveProject();
+}
+
+function migrateProvider(
+    objectLiteral: ObjectLiteralExpression,
+    provideProp: PropertyAssignment,
+): void {
+    const useValueProp = objectLiteral.getProperty('useValue');
+
+    if (useValueProp && Node.isPropertyAssignment(useValueProp)) {
+        migrateUseValue(useValueProp, provideProp);
+
+        return;
+    }
+
+    const useFactoryProp = objectLiteral.getProperty('useFactory');
+
+    if (useFactoryProp && Node.isPropertyAssignment(useFactoryProp)) {
+        migrateUseFactory(useFactoryProp, provideProp);
+
+        return;
+    }
+
+    insertTodoOnce(provideProp);
+}
+
+function migrateUseValue(
+    useValueProp: PropertyAssignment,
+    provideProp: PropertyAssignment,
+): void {
+    const initializer = useValueProp.getInitializer();
+
+    if (!initializer) {
+        insertTodoOnce(provideProp);
+
+        return;
+    }
+
+    const initText = initializer.getText();
+
+    if (initText.startsWith(`${SIGNAL}(`) || initText.startsWith(`${TO_SIGNAL}(`)) {
+        return;
+    }
+
+    if (
+        Node.isCallExpression(initializer) &&
+        initializer.getExpression().getText() === RXJS_OF &&
+        initializer.getArguments().length === 1
+    ) {
+        wrapWithSignal(useValueProp, initializer.getArguments()[0]?.getText() ?? '');
+
+        return;
+    }
+
+    if (isPlainLiteral(initializer)) {
+        wrapWithSignal(useValueProp, initText);
+
+        return;
+    }
+
+    // Any other initializer is a real Observable. `toSignal()` needs an injection
+    // context, which a static `useValue` is not, so promote the provider to a
+    // `useFactory` where the factory body runs inside DI.
+    promoteToFactory(useValueProp, initText);
+}
+
+function migrateUseFactory(
+    useFactoryProp: PropertyAssignment,
+    provideProp: PropertyAssignment,
+): void {
+    const initializer = useFactoryProp.getInitializer();
+
+    if (!initializer || !Node.isArrowFunction(initializer)) {
+        insertTodoOnce(provideProp);
+
+        return;
+    }
+
+    const body = initializer.getBody();
+
+    if (Node.isBlock(body)) {
+        insertTodoOnce(provideProp);
+
+        return;
+    }
+
+    const bodyText = body.getText();
+
+    if (bodyText.startsWith(`${TO_SIGNAL}(`) || bodyText.startsWith(`${SIGNAL}(`)) {
+        return;
+    }
+
+    const params = initializer
+        .getParameters()
+        .map((parameter) => parameter.getText())
+        .join(', ');
+
+    useFactoryProp.setInitializer(`(${params}) => ${TO_SIGNAL}(${bodyText})`);
+    addUniqueImport(
+        useFactoryProp.getSourceFile().getFilePath(),
+        TO_SIGNAL,
+        RXJS_INTEROP,
+    );
+}
+
+function wrapWithSignal(useValueProp: PropertyAssignment, valueText: string): void {
+    useValueProp.setInitializer(`${SIGNAL}(${valueText})`);
+    addUniqueImport(useValueProp.getSourceFile().getFilePath(), SIGNAL, ANGULAR_CORE);
+}
+
+function promoteToFactory(useValueProp: PropertyAssignment, exprText: string): void {
+    const filePath = useValueProp.getSourceFile().getFilePath();
+
+    useValueProp.replaceWithText(`useFactory: () => ${TO_SIGNAL}(${exprText})`);
+    addUniqueImport(filePath, TO_SIGNAL, RXJS_INTEROP);
+}
+
+function isPlainLiteral(node: Node): boolean {
+    return (
+        Node.isStringLiteral(node) ||
+        Node.isNoSubstitutionTemplateLiteral(node) ||
+        Node.isArrayLiteralExpression(node) ||
+        Node.isObjectLiteralExpression(node)
+    );
+}
+
+function insertTodoOnce(node: Node): void {
+    const alreadyMarked = node
+        .getLeadingCommentRanges()
+        .some((range) => range.getText().includes(TODO_MARK));
+
+    if (!alreadyMarked) {
+        insertTodo(node, TODO_MESSAGE);
+    }
+}

--- a/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-i18n-signal-tokens.spec.ts.snap
+++ b/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-i18n-signal-tokens.spec.ts.snap
@@ -1,0 +1,357 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ng-update migrateI18nSignalTokens adds a TODO when useFactory has a block body: test.ts 1`] = `
+{
+  "0. Before": "
+                import {Component} from '@angular/core';
+                import {TUI_DIGITAL_INFORMATION_UNITS} from '@taiga-ui/kit';
+                import {of} from 'rxjs';
+
+                @Component({
+                    standalone: true,
+                    providers: [
+                        {
+                            provide: TUI_DIGITAL_INFORMATION_UNITS,
+                            useFactory: () => {
+                                return of(['Б']);
+                            },
+                        },
+                    ],
+                })
+                export class TestComponent {}
+            ",
+  "1. After": "
+                import {Component} from '@angular/core';
+                import {TUI_DIGITAL_INFORMATION_UNITS} from '@taiga-ui/kit';
+                import {of} from 'rxjs';
+
+                @Component({
+                    standalone: true,
+                    providers: [
+                        {
+// TODO: (Taiga UI migration) i18n token is a Signal in v5, not an Observable. Provide the value via signal(...), or convert an existing stream with toSignal(...).
+                            provide: TUI_DIGITAL_INFORMATION_UNITS,
+                            useFactory: () => {
+                                return of(['Б']);
+                            },
+                        },
+                    ],
+                })
+                export class TestComponent {}
+            ",
+}
+`;
+
+exports[`ng-update migrateI18nSignalTokens leaves an already signal-wrapped value untouched while migrating siblings: test.ts 1`] = `
+{
+  "0. Before": "
+                import {Component, signal} from '@angular/core';
+                import {
+                    TUI_DIGITAL_INFORMATION_UNITS,
+                    TUI_FILE_TEXTS,
+                } from '@taiga-ui/kit';
+                import {of} from 'rxjs';
+
+                @Component({
+                    standalone: true,
+                    providers: [
+                        {provide: TUI_DIGITAL_INFORMATION_UNITS, useValue: signal(['Б'])},
+                        {provide: TUI_FILE_TEXTS, useValue: of({loading: 'Загрузка'})},
+                    ],
+                })
+                export class TestComponent {}
+            ",
+  "1. After": "
+                import {Component, signal} from '@angular/core';
+                import {
+                    TUI_DIGITAL_INFORMATION_UNITS,
+                    TUI_FILE_TEXTS,
+                } from '@taiga-ui/kit';
+                import {of} from 'rxjs';
+
+                @Component({
+                    standalone: true,
+                    providers: [
+                        {provide: TUI_DIGITAL_INFORMATION_UNITS, useValue: signal(['Б'])},
+                        {provide: TUI_FILE_TEXTS, useValue: signal({loading: 'Загрузка'})},
+                    ],
+                })
+                export class TestComponent {}
+            ",
+}
+`;
+
+exports[`ng-update migrateI18nSignalTokens migrates a provider declared inside @NgModule: test.ts 1`] = `
+{
+  "0. Before": "
+                import {NgModule} from '@angular/core';
+                import {TUI_PAGINATION_TEXTS} from '@taiga-ui/kit';
+                import {of} from 'rxjs';
+
+                @NgModule({
+                    providers: [
+                        {
+                            provide: TUI_PAGINATION_TEXTS,
+                            useValue: of(['Назад', 'Вперёд']),
+                        },
+                    ],
+                })
+                export class TestModule {}
+            ",
+  "1. After": "
+                import { NgModule, signal } from '@angular/core';
+                import {TUI_PAGINATION_TEXTS} from '@taiga-ui/kit';
+                import {of} from 'rxjs';
+
+                @NgModule({
+                    providers: [
+                        {
+                            provide: TUI_PAGINATION_TEXTS,
+                            useValue: signal(['Назад', 'Вперёд']),
+                        },
+                    ],
+                })
+                export class TestModule {}
+            ",
+}
+`;
+
+exports[`ng-update migrateI18nSignalTokens promotes a stream useValue to a toSignal factory: test.ts 1`] = `
+{
+  "0. Before": "
+                import {Component, inject} from '@angular/core';
+                import {TUI_DIGITAL_INFORMATION_UNITS} from '@taiga-ui/kit';
+
+                @Component({
+                    standalone: true,
+                    providers: [
+                        {
+                            provide: TUI_DIGITAL_INFORMATION_UNITS,
+                            useValue: inject(SomeService).units$,
+                        },
+                    ],
+                })
+                export class TestComponent {}
+            ",
+  "1. After": "import { toSignal } from "@angular/core/rxjs-interop";
+
+                import {Component, inject} from '@angular/core';
+                import {TUI_DIGITAL_INFORMATION_UNITS} from '@taiga-ui/kit';
+
+                @Component({
+                    standalone: true,
+                    providers: [
+                        {
+                            provide: TUI_DIGITAL_INFORMATION_UNITS,
+                            useFactory: () => toSignal(inject(SomeService).units$),
+                        },
+                    ],
+                })
+                export class TestComponent {}
+            ",
+}
+`;
+
+exports[`ng-update migrateI18nSignalTokens reuses an existing signal import: test.ts 1`] = `
+{
+  "0. Before": "
+                import {Component, signal} from '@angular/core';
+                import {TUI_FILE_TEXTS} from '@taiga-ui/kit';
+                import {of} from 'rxjs';
+
+                @Component({
+                    standalone: true,
+                    providers: [
+                        {provide: TUI_FILE_TEXTS, useValue: of({loading: 'Загрузка'})},
+                    ],
+                })
+                export class TestComponent {}
+            ",
+  "1. After": "
+                import {Component, signal} from '@angular/core';
+                import {TUI_FILE_TEXTS} from '@taiga-ui/kit';
+                import {of} from 'rxjs';
+
+                @Component({
+                    standalone: true,
+                    providers: [
+                        {provide: TUI_FILE_TEXTS, useValue: signal({loading: 'Загрузка'})},
+                    ],
+                })
+                export class TestComponent {}
+            ",
+}
+`;
+
+exports[`ng-update migrateI18nSignalTokens unwraps of() into signal() for TUI_DIGITAL_INFORMATION_UNITS: test.ts 1`] = `
+{
+  "0. Before": "
+                import {Component} from '@angular/core';
+                import {TUI_DIGITAL_INFORMATION_UNITS} from '@taiga-ui/kit';
+                import {of} from 'rxjs';
+
+                @Component({
+                    standalone: true,
+                    providers: [
+                        {
+                            provide: TUI_DIGITAL_INFORMATION_UNITS,
+                            useValue: of(['Б', 'КБ', 'МБ']),
+                        },
+                    ],
+                })
+                export class TestComponent {}
+            ",
+  "1. After": "
+                import { Component, signal } from '@angular/core';
+                import {TUI_DIGITAL_INFORMATION_UNITS} from '@taiga-ui/kit';
+                import {of} from 'rxjs';
+
+                @Component({
+                    standalone: true,
+                    providers: [
+                        {
+                            provide: TUI_DIGITAL_INFORMATION_UNITS,
+                            useValue: signal(['Б', 'КБ', 'МБ']),
+                        },
+                    ],
+                })
+                export class TestComponent {}
+            ",
+}
+`;
+
+exports[`ng-update migrateI18nSignalTokens unwraps of() with a referenced value into signal(): test.ts 1`] = `
+{
+  "0. Before": "
+                import {Component} from '@angular/core';
+                import {TUI_DIGITAL_INFORMATION_UNITS} from '@taiga-ui/kit';
+                import {of} from 'rxjs';
+
+                const UNITS = ['Б', 'КБ', 'МБ'];
+
+                @Component({
+                    standalone: true,
+                    providers: [
+                        {provide: TUI_DIGITAL_INFORMATION_UNITS, useValue: of(UNITS)},
+                    ],
+                })
+                export class TestComponent {}
+            ",
+  "1. After": "
+                import { Component, signal } from '@angular/core';
+                import {TUI_DIGITAL_INFORMATION_UNITS} from '@taiga-ui/kit';
+                import {of} from 'rxjs';
+
+                const UNITS = ['Б', 'КБ', 'МБ'];
+
+                @Component({
+                    standalone: true,
+                    providers: [
+                        {provide: TUI_DIGITAL_INFORMATION_UNITS, useValue: signal(UNITS)},
+                    ],
+                })
+                export class TestComponent {}
+            ",
+}
+`;
+
+exports[`ng-update migrateI18nSignalTokens wraps a plain array literal useValue into signal(): test.ts 1`] = `
+{
+  "0. Before": "
+                import {Component} from '@angular/core';
+                import {TUI_COUNTRIES} from '@taiga-ui/kit';
+
+                @Component({
+                    standalone: true,
+                    providers: [{provide: TUI_COUNTRIES, useValue: {RU: 'Россия'}}],
+                })
+                export class TestComponent {}
+            ",
+  "1. After": "
+                import { Component, signal } from '@angular/core';
+                import {TUI_COUNTRIES} from '@taiga-ui/kit';
+
+                @Component({
+                    standalone: true,
+                    providers: [{provide: TUI_COUNTRIES, useValue: signal({RU: 'Россия'})}],
+                })
+                export class TestComponent {}
+            ",
+}
+`;
+
+exports[`ng-update migrateI18nSignalTokens wraps a useFactory stream with toSignal: test.ts 1`] = `
+{
+  "0. Before": "
+                import {Component} from '@angular/core';
+                import {TUI_DIGITAL_INFORMATION_UNITS} from '@taiga-ui/kit';
+                import {of} from 'rxjs';
+
+                @Component({
+                    standalone: true,
+                    providers: [
+                        {
+                            provide: TUI_DIGITAL_INFORMATION_UNITS,
+                            useFactory: () => of(['Б']),
+                        },
+                    ],
+                })
+                export class TestComponent {}
+            ",
+  "1. After": "import { toSignal } from "@angular/core/rxjs-interop";
+
+                import {Component} from '@angular/core';
+                import {TUI_DIGITAL_INFORMATION_UNITS} from '@taiga-ui/kit';
+                import {of} from 'rxjs';
+
+                @Component({
+                    standalone: true,
+                    providers: [
+                        {
+                            provide: TUI_DIGITAL_INFORMATION_UNITS,
+                            useFactory: () => toSignal(of(['Б'])),
+                        },
+                    ],
+                })
+                export class TestComponent {}
+            ",
+}
+`;
+
+exports[`ng-update migrateI18nSignalTokens wraps a useFactory with dependencies and keeps its parameters: test.ts 1`] = `
+{
+  "0. Before": "
+                import {Component} from '@angular/core';
+                import {TUI_FILE_TEXTS} from '@taiga-ui/kit';
+
+                @Component({
+                    standalone: true,
+                    providers: [
+                        {
+                            provide: TUI_FILE_TEXTS,
+                            useFactory: (service: SomeService) => service.fileTexts$,
+                            deps: [SomeService],
+                        },
+                    ],
+                })
+                export class TestComponent {}
+            ",
+  "1. After": "import { toSignal } from "@angular/core/rxjs-interop";
+
+                import {Component} from '@angular/core';
+                import {TUI_FILE_TEXTS} from '@taiga-ui/kit';
+
+                @Component({
+                    standalone: true,
+                    providers: [
+                        {
+                            provide: TUI_FILE_TEXTS,
+                            useFactory: (service: SomeService) => toSignal(service.fileTexts$),
+                            deps: [SomeService],
+                        },
+                    ],
+                })
+                export class TestComponent {}
+            ",
+}
+`;

--- a/projects/cdk/schematics/ng-update/v5/tests/schematic-migrate-i18n-signal-tokens.spec.ts
+++ b/projects/cdk/schematics/ng-update/v5/tests/schematic-migrate-i18n-signal-tokens.spec.ts
@@ -1,0 +1,224 @@
+import {join} from 'node:path';
+
+import {resetActiveProject} from 'ng-morph';
+
+import {createMigration} from '../../../utils/run-migration';
+
+describe('ng-update migrateI18nSignalTokens', () => {
+    const migrate = createMigration({
+        collection: join(__dirname, '../../../migration.json'),
+    });
+
+    it(
+        'unwraps of() into signal() for TUI_DIGITAL_INFORMATION_UNITS',
+        migrate({
+            component: /* TypeScript */ `
+                import {Component} from '@angular/core';
+                import {TUI_DIGITAL_INFORMATION_UNITS} from '@taiga-ui/kit';
+                import {of} from 'rxjs';
+
+                @Component({
+                    standalone: true,
+                    providers: [
+                        {
+                            provide: TUI_DIGITAL_INFORMATION_UNITS,
+                            useValue: of(['Б', 'КБ', 'МБ']),
+                        },
+                    ],
+                })
+                export class TestComponent {}
+            `,
+        }),
+    );
+
+    it(
+        'unwraps of() with a referenced value into signal()',
+        migrate({
+            component: /* TypeScript */ `
+                import {Component} from '@angular/core';
+                import {TUI_DIGITAL_INFORMATION_UNITS} from '@taiga-ui/kit';
+                import {of} from 'rxjs';
+
+                const UNITS = ['Б', 'КБ', 'МБ'];
+
+                @Component({
+                    standalone: true,
+                    providers: [
+                        {provide: TUI_DIGITAL_INFORMATION_UNITS, useValue: of(UNITS)},
+                    ],
+                })
+                export class TestComponent {}
+            `,
+        }),
+    );
+
+    it(
+        'wraps a plain array literal useValue into signal()',
+        migrate({
+            component: /* TypeScript */ `
+                import {Component} from '@angular/core';
+                import {TUI_COUNTRIES} from '@taiga-ui/kit';
+
+                @Component({
+                    standalone: true,
+                    providers: [{provide: TUI_COUNTRIES, useValue: {RU: 'Россия'}}],
+                })
+                export class TestComponent {}
+            `,
+        }),
+    );
+
+    it(
+        'reuses an existing signal import',
+        migrate({
+            component: /* TypeScript */ `
+                import {Component, signal} from '@angular/core';
+                import {TUI_FILE_TEXTS} from '@taiga-ui/kit';
+                import {of} from 'rxjs';
+
+                @Component({
+                    standalone: true,
+                    providers: [
+                        {provide: TUI_FILE_TEXTS, useValue: of({loading: 'Загрузка'})},
+                    ],
+                })
+                export class TestComponent {}
+            `,
+        }),
+    );
+
+    it(
+        'migrates a provider declared inside @NgModule',
+        migrate({
+            component: /* TypeScript */ `
+                import {NgModule} from '@angular/core';
+                import {TUI_PAGINATION_TEXTS} from '@taiga-ui/kit';
+                import {of} from 'rxjs';
+
+                @NgModule({
+                    providers: [
+                        {
+                            provide: TUI_PAGINATION_TEXTS,
+                            useValue: of(['Назад', 'Вперёд']),
+                        },
+                    ],
+                })
+                export class TestModule {}
+            `,
+        }),
+    );
+
+    it(
+        'promotes a stream useValue to a toSignal factory',
+        migrate({
+            component: /* TypeScript */ `
+                import {Component, inject} from '@angular/core';
+                import {TUI_DIGITAL_INFORMATION_UNITS} from '@taiga-ui/kit';
+
+                @Component({
+                    standalone: true,
+                    providers: [
+                        {
+                            provide: TUI_DIGITAL_INFORMATION_UNITS,
+                            useValue: inject(SomeService).units$,
+                        },
+                    ],
+                })
+                export class TestComponent {}
+            `,
+        }),
+    );
+
+    it(
+        'wraps a useFactory stream with toSignal',
+        migrate({
+            component: /* TypeScript */ `
+                import {Component} from '@angular/core';
+                import {TUI_DIGITAL_INFORMATION_UNITS} from '@taiga-ui/kit';
+                import {of} from 'rxjs';
+
+                @Component({
+                    standalone: true,
+                    providers: [
+                        {
+                            provide: TUI_DIGITAL_INFORMATION_UNITS,
+                            useFactory: () => of(['Б']),
+                        },
+                    ],
+                })
+                export class TestComponent {}
+            `,
+        }),
+    );
+
+    it(
+        'wraps a useFactory with dependencies and keeps its parameters',
+        migrate({
+            component: /* TypeScript */ `
+                import {Component} from '@angular/core';
+                import {TUI_FILE_TEXTS} from '@taiga-ui/kit';
+
+                @Component({
+                    standalone: true,
+                    providers: [
+                        {
+                            provide: TUI_FILE_TEXTS,
+                            useFactory: (service: SomeService) => service.fileTexts$,
+                            deps: [SomeService],
+                        },
+                    ],
+                })
+                export class TestComponent {}
+            `,
+        }),
+    );
+
+    it(
+        'adds a TODO when useFactory has a block body',
+        migrate({
+            component: /* TypeScript */ `
+                import {Component} from '@angular/core';
+                import {TUI_DIGITAL_INFORMATION_UNITS} from '@taiga-ui/kit';
+                import {of} from 'rxjs';
+
+                @Component({
+                    standalone: true,
+                    providers: [
+                        {
+                            provide: TUI_DIGITAL_INFORMATION_UNITS,
+                            useFactory: () => {
+                                return of(['Б']);
+                            },
+                        },
+                    ],
+                })
+                export class TestComponent {}
+            `,
+        }),
+    );
+
+    it(
+        'leaves an already signal-wrapped value untouched while migrating siblings',
+        migrate({
+            component: /* TypeScript */ `
+                import {Component, signal} from '@angular/core';
+                import {
+                    TUI_DIGITAL_INFORMATION_UNITS,
+                    TUI_FILE_TEXTS,
+                } from '@taiga-ui/kit';
+                import {of} from 'rxjs';
+
+                @Component({
+                    standalone: true,
+                    providers: [
+                        {provide: TUI_DIGITAL_INFORMATION_UNITS, useValue: signal(['Б'])},
+                        {provide: TUI_FILE_TEXTS, useValue: of({loading: 'Загрузка'})},
+                    ],
+                })
+                export class TestComponent {}
+            `,
+        }),
+    );
+
+    afterEach(() => resetActiveProject());
+});


### PR DESCRIPTION
Kit i18n tokens built via `tuiExtractI18n` changed from `Observable<T>` to `Signal<T>` in v5, so `{provide, useValue: of(...)}` providers stop working after `ng update`. Only `TUI_LANGUAGE` and the `TUI_DOC_*` family were covered before.

Adds a migration for the kit i18n token family:

- `useValue: of(x)` → `useValue: signal(x)`
- plain literal `useValue` → wrapped in `signal(...)`
- non-convertible values (streams, `useFactory`) → TODO

`signal` import is added and deduped; values already wrapped in `signal(...)` are left untouched, so re-runs are safe.