### PR TITLE
fix(experimental): `SearchHistory` supports signal forms

### DIFF
--- a/projects/demo-cypress/src/tests/search-history/signal-forms.cy.ts
+++ b/projects/demo-cypress/src/tests/search-history/signal-forms.cy.ts
@@ -1,0 +1,116 @@
+/*
+// TODO: Uncomment the whole file when the `@angular/forms/signals` entry point becomes available,
+// when Taiga UI drops support of Angular below 22 (stable API for signal forms appeared in Angular 22)
+import {
+    ChangeDetectionStrategy,
+    Component,
+    Directive,
+    signal,
+    type Type,
+} from '@angular/core';
+import {FormControl, ReactiveFormsModule} from '@angular/forms';
+import {form, FormField} from '@angular/forms/signals';
+import {TuiRoot, TuiTextfield} from '@taiga-ui/core';
+import {TuiSearchResults} from '@taiga-ui/experimental';
+import {TuiInputSearch} from '@taiga-ui/layout';
+
+describe('tuiSearchHistory + signal forms', () => {
+    const POPULAR = ['Taiga UI', 'Maskito'];
+    const QUERY = 'angular';
+
+    @Directive()
+    abstract class SearchSandbox {
+        public readonly popular = POPULAR;
+    }
+
+    @Component({
+        imports: [FormField, TuiInputSearch, TuiRoot, TuiSearchResults, TuiTextfield],
+        template: `
+            <tui-root>
+                <tui-textfield (pointerdown.capture.stop)="(0)">
+                    <input
+                        [formField]="$any(f.query)"
+                        [tuiInputSearch]="dropdown"
+                    />
+                    <ng-template #dropdown>
+                        <tui-search-history [popular]="popular" />
+                    </ng-template>
+                </tui-textfield>
+            </tui-root>
+        `,
+        changeDetection: ChangeDetectionStrategy.OnPush,
+    })
+    class SignalFormsSandbox extends SearchSandbox {
+        public readonly model = signal({query: ''});
+        public readonly f = form(this.model);
+    }
+
+    @Component({
+        imports: [
+            ReactiveFormsModule,
+            TuiInputSearch,
+            TuiRoot,
+            TuiSearchResults,
+            TuiTextfield,
+        ],
+        template: `
+            <tui-root>
+                <tui-textfield (pointerdown.capture.stop)="(0)">
+                    <input
+                        [formControl]="control"
+                        [tuiInputSearch]="dropdown"
+                    />
+                    <ng-template #dropdown>
+                        <tui-search-history [popular]="popular" />
+                    </ng-template>
+                </tui-textfield>
+            </tui-root>
+        `,
+        changeDetection: ChangeDetectionStrategy.OnPush,
+    })
+    class ReactiveFormsSandbox extends SearchSandbox {
+        public readonly control = new FormControl('', {nonNullable: true});
+    }
+
+    const SANDBOXES: ReadonlyArray<{
+        readonly component: Type<SearchSandbox>;
+        readonly title: string;
+    }> = [
+        {component: SignalFormsSandbox, title: '[formField] (signal forms)'},
+        {component: ReactiveFormsSandbox, title: '[formControl] (reactive forms)'},
+    ];
+
+    SANDBOXES.forEach(({component, title}) => {
+        describe(title, () => {
+            beforeEach(() => {
+                cy.clearLocalStorage();
+                cy.viewport(600, 400);
+                cy.mount(component);
+                cy.get('input').as('input');
+            });
+
+            it('a query typed into the field is remembered in the search history', () => {
+                cy.get('@input').focus();
+                cy.get('@input').type(QUERY);
+                cy.get('@input').type('{esc}');
+                cy.get('@input').focus();
+
+                cy.get('tui-search-history button[tuiCell]')
+                    .contains(QUERY)
+                    .should('be.visible');
+            });
+
+            it('picking an item from the list puts it into the field', () => {
+                cy.get('@input').focus();
+
+                cy.get('tui-search-history button[tuiCell]')
+                    .contains(POPULAR[0]!)
+                    .click();
+
+                cy.get('@input').should('have.value', POPULAR[0]);
+            });
+        });
+    });
+});
+*/
+// eslint-disable-next-line unicorn/no-empty-file

--- a/projects/demo-cypress/src/tests/search-history/signal-forms.cy.ts
+++ b/projects/demo-cypress/src/tests/search-history/signal-forms.cy.ts
@@ -86,14 +86,13 @@ describe('tuiSearchHistory + signal forms', () => {
                 cy.clearLocalStorage();
                 cy.viewport(600, 400);
                 cy.mount(component);
-                cy.get('input').as('input');
             });
 
             it('a query typed into the field is remembered in the search history', () => {
-                cy.get('@input').focus();
-                cy.get('@input').type(QUERY);
-                cy.get('@input').type('{esc}');
-                cy.get('@input').focus();
+                cy.get('input').focus();
+                cy.get('input').type(QUERY);
+                cy.get('input').type('{esc}');
+                cy.get('input').focus();
 
                 cy.get('tui-search-history button[tuiCell]')
                     .contains(QUERY)
@@ -101,13 +100,13 @@ describe('tuiSearchHistory + signal forms', () => {
             });
 
             it('picking an item from the list puts it into the field', () => {
-                cy.get('@input').focus();
+                cy.get('input').focus();
 
                 cy.get('tui-search-history button[tuiCell]')
                     .contains(POPULAR[0]!)
                     .click();
 
-                cy.get('@input').should('have.value', POPULAR[0]);
+                cy.get('input').should('have.value', POPULAR[0]);
             });
         });
     });

--- a/projects/experimental/components/search-results/search-history.component.ts
+++ b/projects/experimental/components/search-results/search-history.component.ts
@@ -1,7 +1,8 @@
-import {ChangeDetectionStrategy, Component, inject, input} from '@angular/core';
+import {ChangeDetectionStrategy, Component, inject, INJECTOR, input} from '@angular/core';
 import {takeUntilDestroyed} from '@angular/core/rxjs-interop';
 import {NgControl} from '@angular/forms';
 import {WA_LOCAL_STORAGE} from '@ng-web-apis/common';
+import {tuiControlValue} from '@taiga-ui/cdk/observables';
 import {TuiButton} from '@taiga-ui/core/components/button';
 import {TuiCell} from '@taiga-ui/core/components/cell';
 import {TuiTextfieldComponent} from '@taiga-ui/core/components/textfield';
@@ -9,7 +10,7 @@ import {TuiTitle} from '@taiga-ui/core/components/title';
 import {TUI_CLOSE_WORD} from '@taiga-ui/core/tokens';
 import {TuiAvatar} from '@taiga-ui/kit/components/avatar';
 import {TUI_INPUT_SEARCH} from '@taiga-ui/layout/tokens';
-import {filter, map} from 'rxjs';
+import {filter, map, skip} from 'rxjs';
 
 import {TUI_SEARCH_RESULTS_OPTIONS} from './search-results.options';
 
@@ -34,8 +35,9 @@ export class TuiSearchHistory {
     protected readonly i18n = inject(TUI_INPUT_SEARCH);
     protected readonly options = inject(TUI_SEARCH_RESULTS_OPTIONS);
 
-    protected readonly $ = this.control.valueChanges
-        ?.pipe(
+    protected readonly $ = tuiControlValue<string>(this.control, inject(INJECTOR))
+        .pipe(
+            skip(1),
             map(String),
             filter((item) => !!item && !this.popular().includes(item)),
             takeUntilDestroyed(),
@@ -69,8 +71,7 @@ export class TuiSearchHistory {
     }
 
     protected select(item: string): void {
-        this.control.control?.setValue(item);
-        this.textfield.input()?.nativeElement.focus();
+        this.textfield.handleOption(item);
     }
 
     private get items(): readonly string[] {


### PR DESCRIPTION
Under `[formField]` the fake `NgControl` signal forms provide has neither `valueChanges` (nothing was ever recorded, silently) nor `setValue` (picking an item threw `TypeError: this.control.control?.setValue is not a function`).

Read the value with `tuiControlValue()` and write it back through `TuiTextfieldComponent.handleOption()` — the CVA, the one channel both form APIs share.

Relates:
- https://github.com/taiga-family/taiga-ui/issues/14341
