### PR TITLE
chore(demo-playwright): drive mobile dropdown-hover e2e with touch

### DIFF
--- a/projects/demo-playwright/tests/kit/dropdown-hover/dropdown-hover.pw.spec.ts
+++ b/projects/demo-playwright/tests/kit/dropdown-hover/dropdown-hover.pw.spec.ts
@@ -53,7 +53,7 @@ test.describe('DropdownHover', () => {
             let example!: Locator;
             let po!: TuiDocumentationPagePO;
 
-            test.use(TUI_PLAYWRIGHT_MOBILE);
+            test.use({...TUI_PLAYWRIGHT_MOBILE, hasTouch: true});
 
             test.beforeEach(({page}) => {
                 po = new TuiDocumentationPagePO(page);
@@ -63,7 +63,7 @@ test.describe('DropdownHover', () => {
             test('Opens mobile version of dropdown on the 1st time click', async ({
                 page,
             }) => {
-                await example.locator('button').click();
+                await example.locator('button').tap();
                 await expect(page.locator('tui-dropdown')).not.toBeAttached();
                 await expect(page.locator('tui-sheet-dialog')).toBeVisible();
                 await po.hideContent();
@@ -73,9 +73,9 @@ test.describe('DropdownHover', () => {
             });
 
             test('Closes dropdown on click on overlay', async ({page}) => {
-                await example.locator('button').click();
+                await example.locator('button').tap();
                 await expect(page.locator('tui-sheet-dialog')).toBeVisible();
-                await page.locator('tui-sheet-dialog').click({position: {x: 32, y: 32}});
+                await page.locator('tui-sheet-dialog').tap({position: {x: 32, y: 32}});
                 await po.hideContent();
                 await expect(page.locator('tui-sheet-dialog')).not.toBeAttached();
             });


### PR DESCRIPTION
The mobile dropdown-hover e2e tests emulate a phone through userAgent only, but the webkit project runs Desktop Safari with hasTouch:false, so they drive a touch-only component (the sheet) with a mouse. Playwright's click() moves the pointer first, that mouseover opens the sheet via tuiDropdownHover, and the sheet backdrop then intercepts the actual click, so the test times out on webkit.

On real touch devices there is no hover, so the component itself works fine. This is the test's input model, not a product bug. The fix stays in the test: enable hasTouch for the mobile block and drive it with tap() instead of click().