### PR TITLE
fix(core): `Error` supports errors from validator directives with signal forms

### DIFF
--- a/projects/cdk/classes/form-value-control.ts
+++ b/projects/cdk/classes/form-value-control.ts
@@ -4,31 +4,7 @@ import {
     type ModelSignal,
     type OutputRef,
 } from '@angular/core';
-
-/**
- * @deprecated use import {ValidationError} from '@angular/forms/signals'
- * Just temporary copy-pasted types until Taiga UI supports Angular <22
- * https://github.com/angular/angular/blob/main/packages/forms/signals/src/api/rules/validation/validation_errors.ts#L368
- * TODO: replace all usages `TuiSignalValidationError` by built-in Angular alternative
- */
-export interface TuiSignalValidationError {
-    readonly kind: string;
-    readonly message?: string;
-}
-
-/**
- * @deprecated use import {CompatValidationError} from '@angular/forms/signals'
- * Just temporary copy-pasted types until Taiga UI supports Angular <22
- * https://github.com/angular/angular/blob/f44bf0fe221288d03107cc78acfbe333a9a9b7b5/packages/forms/signals/src/compat/validation_errors.ts#L19
- * TODO: replace all usages `TuiCompatValidationError` by built-in Angular alternative
- */
-export interface TuiCompatValidationError extends TuiSignalValidationError {
-    /**
-     * Signal forms wrap a reactive error into `CompatValidationError`
-     * https://github.com/angular/angular/blob/f44bf0fe221288d03107cc78acfbe333a9a9b7b5/packages/forms/signals/src/compat/validation_errors.ts#L55-L65
-     */
-    readonly context?: unknown;
-}
+import {type TuiSignalValidationError} from '@taiga-ui/cdk/types';
 
 // TODO: delete when all usages of `TuiFormValueControl` will be replaced by built-in Angular alternative
 interface FormUiControl {

--- a/projects/cdk/classes/form-value-control.ts
+++ b/projects/cdk/classes/form-value-control.ts
@@ -16,6 +16,20 @@ export interface TuiSignalValidationError {
     readonly message?: string;
 }
 
+/**
+ * @deprecated use import {CompatValidationError} from '@angular/forms/signals'
+ * Just temporary copy-pasted types until Taiga UI supports Angular <22
+ * https://github.com/angular/angular/blob/f44bf0fe221288d03107cc78acfbe333a9a9b7b5/packages/forms/signals/src/compat/validation_errors.ts#L19
+ * TODO: replace all usages `TuiCompatValidationError` by built-in Angular alternative
+ */
+export interface TuiCompatValidationError extends TuiSignalValidationError {
+    /**
+     * Signal forms wrap a reactive error into `CompatValidationError`
+     * https://github.com/angular/angular/blob/f44bf0fe221288d03107cc78acfbe333a9a9b7b5/packages/forms/signals/src/compat/validation_errors.ts#L55-L65
+     */
+    readonly context?: unknown;
+}
+
 // TODO: delete when all usages of `TuiFormValueControl` will be replaced by built-in Angular alternative
 interface FormUiControl {
     readonly errors?:

--- a/projects/cdk/types/index.ts
+++ b/projects/cdk/types/index.ts
@@ -3,3 +3,4 @@ export type * from './handler';
 export type * from './mapper';
 export type * from './matcher';
 export type * from './rounding';
+export type * from './signal-validation-error';

--- a/projects/cdk/types/signal-validation-error.ts
+++ b/projects/cdk/types/signal-validation-error.ts
@@ -1,0 +1,24 @@
+/**
+ * @deprecated use import {ValidationError} from '@angular/forms/signals'
+ * Just temporary copy-pasted types until Taiga UI supports Angular <22
+ * https://github.com/angular/angular/blob/main/packages/forms/signals/src/api/rules/validation/validation_errors.ts#L368
+ * TODO: replace all usages `TuiSignalValidationError` by built-in Angular alternative
+ */
+export interface TuiSignalValidationError {
+    readonly kind: string;
+    readonly message?: string;
+}
+
+/**
+ * @deprecated use import {CompatValidationError} from '@angular/forms/signals'
+ * Just temporary copy-pasted types until Taiga UI supports Angular <22
+ * https://github.com/angular/angular/blob/f44bf0fe221288d03107cc78acfbe333a9a9b7b5/packages/forms/signals/src/compat/validation_errors.ts#L19
+ * TODO: replace all usages `TuiCompatValidationError` by built-in Angular alternative
+ */
+export interface TuiCompatValidationError extends TuiSignalValidationError {
+    /**
+     * Signal forms wrap a reactive error into `CompatValidationError`
+     * https://github.com/angular/angular/blob/f44bf0fe221288d03107cc78acfbe333a9a9b7b5/packages/forms/signals/src/compat/validation_errors.ts#L55-L65
+     */
+    readonly context?: unknown;
+}

--- a/projects/cdk/utils/di/inject-form-field.ts
+++ b/projects/cdk/utils/di/inject-form-field.ts
@@ -1,6 +1,6 @@
 import {computed, inject, type InjectOptions, type Signal} from '@angular/core';
 import {NgControl} from '@angular/forms';
-import {type TuiCompatValidationError} from '@taiga-ui/cdk/classes';
+import {type TuiCompatValidationError} from '@taiga-ui/cdk/types';
 
 /**
  * @deprecated use inject(FORM_FIELD) from `@angular/forms/signals` if Angular >= 21

--- a/projects/cdk/utils/di/inject-form-field.ts
+++ b/projects/cdk/utils/di/inject-form-field.ts
@@ -1,10 +1,13 @@
 import {computed, inject, type InjectOptions, type Signal} from '@angular/core';
 import {NgControl} from '@angular/forms';
+import {type TuiCompatValidationError} from '@taiga-ui/cdk/classes';
 
 /**
  * @deprecated use inject(FORM_FIELD) from `@angular/forms/signals` if Angular >= 21
  */
-export function tuiInjectFormField(options: InjectOptions = {}): Signal<unknown> {
+export function tuiInjectFormField(
+    options: InjectOptions = {},
+): Signal<{errors: Signal<readonly TuiCompatValidationError[]>}> {
     const control = inject(NgControl, options);
 
     // @ts-expect-error

--- a/projects/core/components/error/error.directive.ts
+++ b/projects/core/components/error/error.directive.ts
@@ -17,11 +17,7 @@ import {
     type ValidationErrors,
     type Validator,
 } from '@angular/forms';
-import {
-    type TuiFormValueControl,
-    type TuiSignalValidationError,
-    TuiValidationError,
-} from '@taiga-ui/cdk/classes';
+import {type TuiFormValueControl, TuiValidationError} from '@taiga-ui/cdk/classes';
 import {TuiId} from '@taiga-ui/cdk/directives/id';
 import {type TuiNativeValidator} from '@taiga-ui/cdk/directives/native-validator';
 import {
@@ -159,12 +155,12 @@ export class TuiErrorField
     implements TuiFormValueControl<unknown>
 {
     private readonly field = tuiInjectFormField({self: true});
+    private readonly fieldErrors = computed(() => this.field()?.errors() ?? []);
 
-    public readonly errors = input<readonly TuiSignalValidationError[]>([]);
     public readonly touched = input(false);
     public readonly value = model<unknown>(null);
 
-    public readonly error = computed((errors = this.errors()) => {
+    public readonly error = computed((errors = this.fieldErrors()) => {
         if (!this.touched()) {
             return null;
         }
@@ -173,7 +169,10 @@ export class TuiErrorField
         const error = kind ? errors.find((x) => x.kind === kind) : errors[0];
 
         return error
-            ? this.getError(error, error.message ?? this.content[error.kind])
+            ? this.getError(
+                  error.context ?? error,
+                  error.message ?? this.content[error.kind],
+              )
             : null;
     });
 

--- a/projects/demo-cypress/src/tests/error/signal-forms.cy.ts
+++ b/projects/demo-cypress/src/tests/error/signal-forms.cy.ts
@@ -225,7 +225,7 @@ describe('tui-error + signal forms', () => {
         const UNFINISHED_MESSAGE = 'Finish the date';
 
         @Directive()
-        abstract class DisabledItemSandbox {
+        abstract class Sandbox {
             public readonly unfinishedMessage = UNFINISHED_MESSAGE;
 
             public readonly disabledItemHandler = (day: TuiDay): boolean =>
@@ -257,7 +257,7 @@ describe('tui-error + signal forms', () => {
             changeDetection: ChangeDetectionStrategy.OnPush,
             providers: [tuiValidationErrorsProvider({tuiDisabledItem: BANNED_MESSAGE})],
         })
-        class DisabledItemSignalFormsSandbox extends DisabledItemSandbox {
+        class DisabledItemSignalFormsSandbox extends Sandbox {
             private readonly value = signal<TuiDay | null>(null);
 
             public readonly f = form(this.value);
@@ -288,12 +288,12 @@ describe('tui-error + signal forms', () => {
             changeDetection: ChangeDetectionStrategy.OnPush,
             providers: [tuiValidationErrorsProvider({tuiDisabledItem: BANNED_MESSAGE})],
         })
-        class DisabledItemReactiveFormsSandbox extends DisabledItemSandbox {
+        class DisabledItemReactiveFormsSandbox extends Sandbox {
             public readonly control = new FormControl<TuiDay | null>(null);
         }
 
         const SANDBOXES: ReadonlyArray<{
-            readonly component: Type<DisabledItemSandbox>;
+            readonly component: Type<Sandbox>;
             readonly title: string;
         }> = [
             {

--- a/projects/demo-cypress/src/tests/error/signal-forms.cy.ts
+++ b/projects/demo-cypress/src/tests/error/signal-forms.cy.ts
@@ -1,7 +1,15 @@
 /*
 // TODO: Uncomment the whole file when the `@angular/forms/signals` entry point becomes available,
 // when Taiga UI drops support of Angular below 22 (stable API for signal forms appeared in Angular 22)
-import {ChangeDetectionStrategy, Component, input, signal} from '@angular/core';
+import {
+    ChangeDetectionStrategy,
+    Component,
+    Directive,
+    input,
+    signal,
+    type Type,
+} from '@angular/core';
+import {FormControl, ReactiveFormsModule} from '@angular/forms';
 import {
     disabled,
     form,
@@ -12,7 +20,9 @@ import {
     required,
     validate,
 } from '@angular/forms/signals';
+import {TuiDay} from '@taiga-ui/cdk';
 import {TuiError, TuiInput, TuiRoot, tuiValidationErrorsProvider} from '@taiga-ui/core';
+import {TuiInputDate, TuiUnfinishedValidator} from '@taiga-ui/kit';
 
 @Component({
     imports: [FormField, TuiError, TuiInput, TuiRoot],
@@ -201,6 +211,140 @@ describe('tui-error + signal forms', () => {
             cy.get('tui-textfield input').type('ab').blur();
 
             cy.get('tui-error').should('be.visible').and('contain.text', 'Digits only');
+        });
+    });
+
+    // Everything above validates through the signal forms schema. A validator can also come from
+    // a DIRECTIVE providing `NG_VALIDATORS` — here it is `TuiItemsHandlersValidator`, a host
+    // directive of `tuiInputDate` that rejects a date banned by `[disabledItemHandler]`;
+    describe('Errors from a validator directive', () => {
+        const BANNED_DAY = 13;
+        const BANNED_DATE = '13.12.2024';
+        const ALLOWED_DATE = '14.12.2024';
+        const BANNED_MESSAGE = 'This date is not available';
+        const UNFINISHED_MESSAGE = 'Finish the date';
+
+        @Directive()
+        abstract class DisabledItemSandbox {
+            public readonly unfinishedMessage = UNFINISHED_MESSAGE;
+
+            public readonly disabledItemHandler = (day: TuiDay): boolean =>
+                day.day === BANNED_DAY;
+        }
+
+        @Component({
+            imports: [
+                FormField,
+                TuiError,
+                TuiInputDate,
+                TuiRoot,
+                TuiUnfinishedValidator,
+            ],
+            template: `
+                <tui-root>
+                    <tui-textfield [disabledItemHandler]="disabledItemHandler">
+                        <label tuiLabel>Date</label>
+                        <input
+                            tuiInputDate
+                            [formField]="$any(f)"
+                            [tuiUnfinishedValidator]="unfinishedMessage"
+                        />
+                    </tui-textfield>
+
+                    <tui-error [formField]="$any(f)" />
+                </tui-root>
+            `,
+            changeDetection: ChangeDetectionStrategy.OnPush,
+            providers: [tuiValidationErrorsProvider({tuiDisabledItem: BANNED_MESSAGE})],
+        })
+        class DisabledItemSignalFormsSandbox extends DisabledItemSandbox {
+            private readonly value = signal<TuiDay | null>(null);
+
+            public readonly f = form(this.value);
+        }
+
+        @Component({
+            imports: [
+                ReactiveFormsModule,
+                TuiError,
+                TuiInputDate,
+                TuiRoot,
+                TuiUnfinishedValidator,
+            ],
+            template: `
+                <tui-root>
+                    <tui-textfield [disabledItemHandler]="disabledItemHandler">
+                        <label tuiLabel>Date</label>
+                        <input
+                            tuiInputDate
+                            [formControl]="control"
+                            [tuiUnfinishedValidator]="unfinishedMessage"
+                        />
+                    </tui-textfield>
+
+                    <tui-error [formControl]="control" />
+                </tui-root>
+            `,
+            changeDetection: ChangeDetectionStrategy.OnPush,
+            providers: [tuiValidationErrorsProvider({tuiDisabledItem: BANNED_MESSAGE})],
+        })
+        class DisabledItemReactiveFormsSandbox extends DisabledItemSandbox {
+            public readonly control = new FormControl<TuiDay | null>(null);
+        }
+
+        const SANDBOXES: ReadonlyArray<{
+            readonly component: Type<DisabledItemSandbox>;
+            readonly title: string;
+        }> = [
+            {
+                component: DisabledItemSignalFormsSandbox,
+                title: '[formField] (signal forms)',
+            },
+            {
+                component: DisabledItemReactiveFormsSandbox,
+                title: '[formControl] (reactive forms)',
+            },
+        ];
+
+        SANDBOXES.forEach(({component, title}) => {
+            describe(title, () => {
+                beforeEach(() => {
+                    cy.mount(component);
+                    cy.get('[tuiInputDate]').as('input');
+                });
+
+                it('a banned date marks the field invalid', () => {
+                    cy.get('@input').type(BANNED_DATE).blur();
+
+                    cy.get('@input').should('have.attr', 'aria-invalid', 'true');
+                    cy.get('tui-textfield').should('have.class', 'tui-invalid');
+                });
+
+                it('a banned date shows the message of the validator', () => {
+                    cy.get('@input').type(BANNED_DATE).blur();
+
+                    cy.get('tui-error')
+                        .should('be.visible')
+                        .and('contain.text', BANNED_MESSAGE);
+                });
+
+                it('an allowed date hides the message again', () => {
+                    cy.get('@input').type(BANNED_DATE).blur();
+                    cy.get('tui-error').should('be.visible');
+
+                    cy.get('@input').clear().type(ALLOWED_DATE).blur();
+
+                    cy.get('tui-error').should('not.be.visible');
+                });
+
+                it('a message carried by the validator itself is shown', () => {
+                    cy.get('@input').type(ALLOWED_DATE).type('{backspace}').blur();
+
+                    cy.get('tui-error')
+                        .should('be.visible')
+                        .and('contain.text', UNFINISHED_MESSAGE);
+                });
+            });
         });
     });
 });


### PR DESCRIPTION
Under `[formField]` an error from a validator directive never reached `tui-error`. Signal forms mark every error that comes from `NG_VALIDATORS` with the `FormField` that owns the value accessor. `FormField.errors` then keeps only its own errors, and that is what fills the `errors` input. The binding on `<tui-error>` is a second `FormField`, so it always got an empty list, even though the same field state did hold the error.

Now the errors are read from that shared field state, and the `errors` input is removed because it can never be right. A converted error keeps its original payload one level deeper, in `context`, so it is unwrapped before the message is resolved. That is what lets a `TuiValidationError` from the validator win over `TUI_VALIDATION_ERRORS`, like it already does for reactive forms.

Relates:
- https://github.com/taiga-family/taiga-ui/issues/14341

### Previous behavior
```
    Error visibility
      ✓ Invalid but untouched => nothing is shown (107ms)
      ✓ Blur of an empty field => shows the message of `required` (40ms)
      ✓ Too short value => message is built by a function with the error as context (188ms)
      ✓ Valid value => message hides (174ms)
      ✓ Already touched field => message returns without another blur (332ms)
      ✓ Error without a message anywhere => falls back to the default one (193ms)
      ✓ Disabled field => message hides even though the value is still invalid (108ms)
      ✓ Reset makes the field untouched => message hides (105ms)
    Message priority
      ✓ Message both in the schema and in `TUI_VALIDATION_ERRORS` => the schema wins (191ms)
      ✓ No message in the schema => `TUI_VALIDATION_ERRORS` is used (191ms)
    Error priority
      ✓ Without `order` the first error of the field wins (180ms)
      ✓ `order` moves `pattern` above `minLength` (180ms)
    Errors from a validator directive
      [formField] (signal forms)
        ✓ a banned date marks the field invalid (1248ms)
        1) a banned date shows the message of the validator
        2) an allowed date hides the message again
        3) a message carried by the validator itself is shown
      [formControl] (reactive forms)
        ✓ a banned date marks the field invalid (272ms)
        ✓ a banned date shows the message of the validator (274ms)
        ✓ an allowed date hides the message again (591ms)
        ✓ a message carried by the validator itself is shown (345ms)


  17 passing (1m)
  3 failing

  1) tui-error + signal forms
       Errors from a validator directive
         [formField] (signal forms)
           a banned date shows the message of the validator:
     AssertionError: Timed out retrying after 10000ms: expected '<tui-error#tui_41mtllpwah>' to be 'visible'

This element `<tui-error#tui_41mtllpwah>` is not visible because it has an effective width and height of: `468 x 0` pixels.
      at Context.<anonymous> (http://localhost:8080/spec-0.js:702:31)
      at _ZoneDelegate.invoke (http://localhost:8080/166.js:13697:158)
      at ProxyZoneSpec.onInvoke (http://localhost:8080/166.js:13170:33)
      at _ZoneDelegate.invoke (http://localhost:8080/166.js:13697:46)
      at ZoneImpl.run (http://localhost:8080/166.js:13441:35)
      at Context.<anonymous> (http://localhost:8080/166.js:11753:27)

  2) tui-error + signal forms
       Errors from a validator directive
         [formField] (signal forms)
           an allowed date hides the message again:
     AssertionError: Timed out retrying after 10000ms: expected '<tui-error#tui_44mtllq7f5>' to be 'visible'

This element `<tui-error#tui_44mtllq7f5>` is not visible because it has an effective width and height of: `468 x 0` pixels.
# [...]

  3) tui-error + signal forms
       Errors from a validator directive
         [formField] (signal forms)
           a message carried by the validator itself is shown:
     AssertionError: Timed out retrying after 10000ms: expected '<tui-error#tui_47mtllqfth>' to be 'visible'

This element `<tui-error#tui_47mtllqfth>` is not visible because it has an effective width and height of: `468 x 0` pixels.
   # [...]
```

### New behavior
```
  tui-error + signal forms
    Error visibility
      ✓ Invalid but untouched => nothing is shown (104ms)
      ✓ Blur of an empty field => shows the message of `required` (40ms)
      ✓ Too short value => message is built by a function with the error as context (190ms)
      ✓ Valid value => message hides (189ms)
      ✓ Already touched field => message returns without another blur (343ms)
      ✓ Error without a message anywhere => falls back to the default one (206ms)
      ✓ Disabled field => message hides even though the value is still invalid (118ms)
      ✓ Reset makes the field untouched => message hides (117ms)
    Message priority
      ✓ Message both in the schema and in `TUI_VALIDATION_ERRORS` => the schema wins (208ms)
      ✓ No message in the schema => `TUI_VALIDATION_ERRORS` is used (209ms)
    Error priority
      ✓ Without `order` the first error of the field wins (195ms)
      ✓ `order` moves `pattern` above `minLength` (1105ms)
    Errors from a validator directive
      [formField] (signal forms)
        ✓ a banned date marks the field invalid (16263ms)
        ✓ a banned date shows the message of the validator (288ms)
        ✓ an allowed date hides the message again (614ms)
        ✓ a message carried by the validator itself is shown (351ms)
      [formControl] (reactive forms)
        ✓ a banned date marks the field invalid (282ms)
        ✓ a banned date shows the message of the validator (289ms)
        ✓ an allowed date hides the message again (613ms)
        ✓ a message carried by the validator itself is shown (341ms)


  20 passing (23s)
```
