### PR TITLE
fix(schematics): report the file and step when a migration crashes

### DIFF
--- a/projects/cdk/schematics/ng-update/v5/steps/migrate-filter-by-input.ts
+++ b/projects/cdk/schematics/ng-update/v5/steps/migrate-filter-by-input.ts
@@ -5,6 +5,8 @@ import {ALL_TS_FILES} from '../../../constants';
 import {type TuiSchema} from '../../../ng-add/schema';
 import {addUniqueImport} from '../../../utils/add-unique-import';
 import {getComponentTemplates} from '../../../utils/templates/get-component-templates';
+import {getPathFromTemplateResource} from '../../../utils/templates/template-resource';
+import {withMigrationContext} from '../../../utils/with-migration-context';
 import {type TemplateResource} from '../../interfaces/template-resource';
 
 const FILTER_BY_INPUT_PIPE_RE = /\|\s*tuiFilterByInput:\s*(\w+)(\s*\(([^)]*)\))?/g;
@@ -21,7 +23,10 @@ interface FilterPropDescriptor {
 
 export function migrateFilterByInput(tree: Tree, _options: TuiSchema): void {
     for (const resource of getComponentTemplates(ALL_TS_FILES)) {
-        migrateResource(resource, tree);
+        withMigrationContext(
+            `Failed to migrate tuiFilterByInput in "${getPathFromTemplateResource(resource)}"`,
+            () => migrateResource(resource, tree),
+        );
     }
 }
 

--- a/projects/cdk/schematics/ng-update/v5/steps/migrate-templates.ts
+++ b/projects/cdk/schematics/ng-update/v5/steps/migrate-templates.ts
@@ -12,6 +12,7 @@ import {
 import {setupProgressLogger} from '../../../utils/progress';
 import {getComponentTemplates} from '../../../utils/templates/get-component-templates';
 import {getPathFromTemplateResource} from '../../../utils/templates/template-resource';
+import {withMigrationContext} from '../../../utils/with-migration-context';
 import {type TemplateResource} from '../../interfaces/template-resource';
 import {
     addHTMLCommentTags,
@@ -164,7 +165,10 @@ export function migrateTemplates(fileSystem: DevkitFileSystem, options: TuiSchem
             const isLastAction = actionIndex === actions.length - 1;
 
             !options['skip-logs'] && progressLog(action.name, isLastAction);
-            action({resource, fileSystem, recorder});
+            withMigrationContext(
+                `Failed to migrate "${path}" during "${action.name}"`,
+                () => action({resource, fileSystem, recorder}),
+            );
         });
     });
 

--- a/projects/cdk/schematics/ng-update/v5/steps/migrate-tui-let.ts
+++ b/projects/cdk/schematics/ng-update/v5/steps/migrate-tui-let.ts
@@ -13,6 +13,7 @@ import {
     getTemplateFromTemplateResource,
     getTemplateOffset,
 } from '../../../utils/templates/template-resource';
+import {withMigrationContext} from '../../../utils/with-migration-context';
 import {type TemplateResource} from '../../interfaces/template-resource';
 import {getFileSystem} from '../../utils/get-file-system';
 
@@ -41,14 +42,17 @@ function migrateTemplate(
     options: TuiSchema,
 ): void {
     const templatePath = fileSystem.resolve(getPathFromTemplateResource(resource));
-    const template = getTemplateFromTemplateResource(resource, fileSystem);
-    const recorder = fileSystem.edit(templatePath);
-    const offset = getTemplateOffset(resource);
-    const elements = findElementsWithAttribute(template, STRUCTURAL_ATTR);
 
-    for (const element of elements) {
-        migrateStructuralLet(element, template, recorder, offset, options);
-    }
+    withMigrationContext(`Failed to migrate *tuiLet in "${templatePath}"`, () => {
+        const template = getTemplateFromTemplateResource(resource, fileSystem);
+        const recorder = fileSystem.edit(templatePath);
+        const offset = getTemplateOffset(resource);
+        const elements = findElementsWithAttribute(template, STRUCTURAL_ATTR);
+
+        for (const element of elements) {
+            migrateStructuralLet(element, template, recorder, offset, options);
+        }
+    });
 }
 
 function migrateStructuralLet(

--- a/projects/cdk/schematics/ng-update/v5/steps/styles/index.ts
+++ b/projects/cdk/schematics/ng-update/v5/steps/styles/index.ts
@@ -1,6 +1,7 @@
 import {getSourceFiles, saveActiveProject} from 'ng-morph';
 
 import {ALL_STYLE_FILES, PROJECT_JSON_FILES} from '../../../../constants';
+import {withMigrationContext} from '../../../../utils/with-migration-context';
 import {addStyleComments} from './add-comments';
 import {migrateImports} from './migrate-imports';
 
@@ -13,11 +14,15 @@ const ACTIONS = [
 
 export function migrateStyles(): void {
     getSourceFiles([...ALL_STYLE_FILES, ...PROJECT_JSON_FILES]).forEach((sourceFile) => {
-        sourceFile.replaceWithText(
-            ACTIONS.reduce(
-                (content, action) => action(content),
-                sourceFile.getFullText(),
-            ),
+        withMigrationContext(
+            `Failed to migrate styles in "${sourceFile.getFilePath()}"`,
+            () =>
+                sourceFile.replaceWithText(
+                    ACTIONS.reduce(
+                        (content, action) => action(content),
+                        sourceFile.getFullText(),
+                    ),
+                ),
         );
     });
 

--- a/projects/cdk/schematics/utils/run-steps.ts
+++ b/projects/cdk/schematics/utils/run-steps.ts
@@ -1,6 +1,7 @@
 import {performance} from 'node:perf_hooks';
 
 import {type MigrationStepTiming} from './format-migration-stats';
+import {withMigrationContext} from './with-migration-context';
 
 export interface MigrationStep {
     readonly name: string;
@@ -14,7 +15,7 @@ export function runSteps(
     for (const {name, step} of steps) {
         const startedAt = performance.now();
 
-        step();
+        withMigrationContext(`Migration step "${name}" failed`, step);
 
         timings.push({name, durationMs: performance.now() - startedAt});
     }

--- a/projects/cdk/schematics/utils/tests/run-steps.spec.ts
+++ b/projects/cdk/schematics/utils/tests/run-steps.spec.ts
@@ -30,4 +30,25 @@ describe('runSteps', () => {
             {name: 'second', durationMs: 10},
         ]);
     });
+
+    it('names the failing step when a step throws', () => {
+        const timings: MigrationStepTiming[] = [];
+
+        expect(() =>
+            runSteps(
+                [
+                    {name: 'first', step: jest.fn()},
+                    {
+                        name: 'migrateTuiLet',
+                        step: () => {
+                            throw new TypeError(
+                                "Cannot read properties of undefined (reading 'startOffset')",
+                            );
+                        },
+                    },
+                ],
+                timings,
+            ),
+        ).toThrow('Migration step "migrateTuiLet" failed');
+    });
 });

--- a/projects/cdk/schematics/utils/tests/with-migration-context.spec.ts
+++ b/projects/cdk/schematics/utils/tests/with-migration-context.spec.ts
@@ -1,0 +1,35 @@
+import {withMigrationContext} from '../with-migration-context';
+
+describe('withMigrationContext', () => {
+    it('returns the task result when nothing throws', () => {
+        expect(withMigrationContext('ctx', () => 42)).toBe(42);
+    });
+
+    it('prefixes the context and keeps the original error instance and stack', () => {
+        const original = new TypeError(
+            "Cannot read properties of undefined (reading 'startOffset')",
+        );
+        const {stack} = original;
+
+        try {
+            withMigrationContext('Failed to migrate "src/app.html"', () => {
+                throw original;
+            });
+            throw new Error('should have rethrown');
+        } catch (error) {
+            expect(error).toBe(original);
+            expect((error as Error).message).toBe(
+                'Failed to migrate "src/app.html"\nCannot read properties of undefined (reading \'startOffset\')',
+            );
+            expect((error as Error).stack).toBe(stack);
+        }
+    });
+
+    it('wraps a non-Error throwable into an Error carrying the context', () => {
+        expect(() =>
+            withMigrationContext('step "x" failed', () => {
+                throw 'boom';
+            }),
+        ).toThrow('step "x" failed\nboom');
+    });
+});

--- a/projects/cdk/schematics/utils/tests/with-migration-context.spec.ts
+++ b/projects/cdk/schematics/utils/tests/with-migration-context.spec.ts
@@ -1,5 +1,15 @@
 import {withMigrationContext} from '../with-migration-context';
 
+function catchError(task: () => unknown): unknown {
+    try {
+        task();
+    } catch (error: unknown) {
+        return error;
+    }
+
+    return null;
+}
+
 describe('withMigrationContext', () => {
     it('returns the task result when nothing throws', () => {
         expect(withMigrationContext('ctx', () => 42)).toBe(42);
@@ -9,26 +19,28 @@ describe('withMigrationContext', () => {
         const original = new TypeError(
             "Cannot read properties of undefined (reading 'startOffset')",
         );
+
         const {stack} = original;
 
-        try {
+        const error = catchError(() =>
             withMigrationContext('Failed to migrate "src/app.html"', () => {
                 throw original;
-            });
-            throw new Error('should have rethrown');
-        } catch (error) {
-            expect(error).toBe(original);
-            expect((error as Error).message).toBe(
-                'Failed to migrate "src/app.html"\nCannot read properties of undefined (reading \'startOffset\')',
-            );
-            expect((error as Error).stack).toBe(stack);
-        }
+            }),
+        );
+
+        expect(error).toBe(original);
+        expect((error as Error).message).toBe(
+            'Failed to migrate "src/app.html"\nCannot read properties of undefined (reading \'startOffset\')',
+        );
+        expect((error as Error).stack).toBe(stack);
     });
 
     it('wraps a non-Error throwable into an Error carrying the context', () => {
+        const notAnError: unknown = 'boom';
+
         expect(() =>
             withMigrationContext('step "x" failed', () => {
-                throw 'boom';
+                throw notAnError;
             }),
         ).toThrow('step "x" failed\nboom');
     });

--- a/projects/cdk/schematics/utils/with-migration-context.ts
+++ b/projects/cdk/schematics/utils/with-migration-context.ts
@@ -1,0 +1,20 @@
+/**
+ * Runs `task` and, if it throws, prefixes the error message with `context` so a
+ * migration failure points at the file/step that produced it instead of showing
+ * only a stack trace into the compiled schematic.
+ */
+export function withMigrationContext<T>(context: string, task: () => T): T {
+    try {
+        return task();
+    } catch (error: unknown) {
+        if (error instanceof Error) {
+            // Mutate in place to keep the original stack frames (the real crash
+            // site); wrapping in a new Error would bury them behind `cause`.
+            error.message = `${context}\n${error.message}`;
+
+            throw error;
+        }
+
+        throw new Error(`${context}\n${String(error)}`);
+    }
+}


### PR DESCRIPTION
Migration steps run with no `try/catch`, so a crash surfaces only as a stack trace into the compiled schematic — with no hint which project file triggered it.

Each step, the template migration loop, and the `*tuiLet` step now run through a small `withMigrationContext` wrapper that prefixes the thrown error with the failing step and template path, while keeping the original stack frames.

### Before
```
TypeError: Cannot read properties of undefined (reading 'startOffset')
    at insertLetDeclaration (.../ng-update/v5/steps/migrate-tui-let.js:117:48)
    at migrateStructuralLet (.../ng-update/v5/steps/migrate-tui-let.js:54:5)
```

### After
```
Migration step "tuiLetMigration" failed
Failed to migrate *tuiLet in "src/app/foo/foo.component.html"
Cannot read properties of undefined (reading 'startOffset')
    at insertLetDeclaration (.../ng-update/v5/steps/migrate-tui-let.js:117:48)
    at migrateStructuralLet (.../ng-update/v5/steps/migrate-tui-let.js:54:5)
```

Full v5 suite stays green; added unit tests for the wrapper and the step runner.

### Why per-file context lives in each step

Step-level context is centralized in `runSteps` (`Migration step "<name>" failed`). Per-file context can't be: `runSteps` calls `step()` as a black box and never sees the file a step is iterating over — that path exists only inside each step's own loop. So the four file-heavy steps (`tuiLet`, `templates`, `filterByInput`, `styles`) wrap there.
