### PR TITLE
fix(schematics): restore standalone migrateTuiLet generator

### DIFF
--- a/projects/cdk/schematics/migrate-tui-let/index.ts
+++ b/projects/cdk/schematics/migrate-tui-let/index.ts
@@ -1,0 +1,16 @@
+import {type Rule, type Tree} from '@angular-devkit/schematics';
+
+import {type TuiSchema} from '../ng-add/schema';
+import {tuiLetMigration} from '../ng-update/v5/steps/migrate-tui-let';
+
+/**
+ * Standalone `*tuiLet` → `@let` migration, runnable on its own via
+ * `ng generate @taiga-ui/cdk:migrateTuiLet`. It wraps the same logic used by
+ * the v5 update so an Angular 18+ / Taiga UI 4 project can adopt the built-in
+ * control flow without upgrading to Taiga UI 5 at the same time.
+ */
+export default function migrateTuiLet(options: TuiSchema): Rule {
+    return (tree: Tree) => {
+        tuiLetMigration(tree, options);
+    };
+}

--- a/projects/cdk/schematics/migrate-tui-let/schema.json
+++ b/projects/cdk/schematics/migrate-tui-let/schema.json
@@ -1,0 +1,7 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema",
+    "$id": "taiga-ui-migrate-tui-let",
+    "title": "Taiga UI migrate tuiLet",
+    "type": "object",
+    "properties": {}
+}

--- a/projects/cdk/schematics/migrate-tui-let/tests/__snapshots__/schematic-migrate-tui-let-standalone.spec.ts.snap
+++ b/projects/cdk/schematics/migrate-tui-let/tests/__snapshots__/schematic-migrate-tui-let-standalone.spec.ts.snap
@@ -1,0 +1,23 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`migrateTuiLet [Standalone] drops the now-unused TuiLet import from the component 1`] = `
+"
+@Component({
+    standalone: true,
+    templateUrl: './test.template.html',
+    imports: [],
+})
+export class Test {
+    readonly value = 'foo';
+}
+"
+`;
+
+exports[`migrateTuiLet [Standalone] rewrites *tuiLet into @let in the template 1`] = `
+"
+@let val = value;
+<test>
+    {{ val }}
+</test>
+"
+`;

--- a/projects/cdk/schematics/migrate-tui-let/tests/schematic-migrate-tui-let-standalone.spec.ts
+++ b/projects/cdk/schematics/migrate-tui-let/tests/schematic-migrate-tui-let-standalone.spec.ts
@@ -1,0 +1,75 @@
+import {join} from 'node:path';
+
+import {HostTree} from '@angular-devkit/schematics';
+import {SchematicTestRunner, UnitTestTree} from '@angular-devkit/schematics/testing';
+import {
+    createProject,
+    createSourceFile,
+    resetActiveProject,
+    saveActiveProject,
+    setActiveProject,
+} from 'ng-morph';
+
+import {type TuiSchema} from '../../ng-add/schema';
+import {createAngularJson} from '../../utils/create-angular-json';
+
+const collectionPath = join(__dirname, '../../collection.json');
+
+const COMPONENT = `
+import {TuiLet} from '@taiga-ui/cdk';
+
+@Component({
+    standalone: true,
+    templateUrl: './test.template.html',
+    imports: [TuiLet],
+})
+export class Test {
+    readonly value = 'foo';
+}
+`;
+
+const TEMPLATE = `
+<test *tuiLet="value as val">
+    {{ val }}
+</test>
+`;
+
+const options: TuiSchema = {
+    addons: [],
+    project: '',
+    'skip-logs': process.env['TUI_CI'] === 'true',
+};
+
+describe('migrateTuiLet [Standalone]', () => {
+    let host: UnitTestTree;
+    let runner: SchematicTestRunner;
+
+    beforeEach(() => {
+        host = new UnitTestTree(new HostTree());
+        runner = new SchematicTestRunner('schematics', collectionPath);
+
+        setActiveProject(createProject(host));
+
+        createSourceFile('test/app/test.component.ts', COMPONENT);
+        createSourceFile('test/app/test.template.html', TEMPLATE);
+        createAngularJson();
+
+        saveActiveProject();
+    });
+
+    it('rewrites *tuiLet into @let in the template', async () => {
+        const tree = await runner.runSchematic('migrateTuiLet', options, host);
+
+        expect(tree.readContent('test/app/test.template.html')).toMatchSnapshot();
+    });
+
+    it('drops the now-unused TuiLet import from the component', async () => {
+        const tree = await runner.runSchematic('migrateTuiLet', options, host);
+
+        expect(tree.readContent('test/app/test.component.ts')).toMatchSnapshot();
+    });
+
+    afterEach(() => {
+        resetActiveProject();
+    });
+});


### PR DESCRIPTION
The `migrateTuiLet` entry in `collection.json` points at a factory (`./migrate-tui-let/index`) and schema (`./migrate-tui-let/schema.json`) that were removed in #12787 when the logic moved into the v5 update. So the advertised standalone generator is currently broken:

```
$ ng generate @taiga-ui/cdk:migrateTuiLet
Could not resolve schema "./migrate-tui-let/schema.json" from ".../@taiga-ui/cdk/schematics".
```

This re-adds the entry point as a thin wrapper over the **maintained** v5 `tuiLetMigration` (not the old pre-#12787 copy), so there is a single source of truth for the logic.

### Why keep it standalone
`ng generate @taiga-ui/cdk:migrateTuiLet` lets an Angular 18+ / Taiga UI 4 project adopt the built-in `@let` control flow without upgrading to Taiga UI 5 at the same time.

### Result
```html
<test *tuiLet="value as val">{{ val }}</test>
```
→
```html
@let val = value;
<test>{{ val }}</test>
```

Added a standalone test that runs the generator through `SchematicTestRunner` against `collection.json`.

> Supersedes #14893 (which deletes the entry instead) — that PR should be closed.