### PR TITLE
fix(schematics): migrate inline *tuiLet templates in v5 update

### DIFF
--- a/projects/cdk/schematics/ng-update/v5/steps/migrate-tui-let.ts
+++ b/projects/cdk/schematics/ng-update/v5/steps/migrate-tui-let.ts
@@ -22,9 +22,6 @@ const STRUCTURAL_ATTR = '*tuiLet';
 
 export function tuiLetMigration(tree: Tree, options: TuiSchema): void {
     const fileSystem = getFileSystem(tree);
-
-    removeModule('TuiLet', '@taiga-ui/cdk');
-
     const resources = getComponentTemplates(ALL_FILES);
 
     for (const resource of resources) {
@@ -32,6 +29,9 @@ export function tuiLetMigration(tree: Tree, options: TuiSchema): void {
     }
 
     fileSystem.commitEdits();
+
+    getFileSystem(tree);
+    removeModule('TuiLet', '@taiga-ui/cdk');
     saveActiveProject();
 }
 

--- a/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-tui-let.spec.ts.snap
+++ b/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-tui-let.spec.ts.snap
@@ -46,6 +46,37 @@ exports[`ng-update tuiLet keeps the alias when only an observable (foo$) shares 
 }
 `;
 
+exports[`ng-update tuiLet migrates *tuiLet inside an inline template and drops the import: test.ts 1`] = `
+{
+  "0. Before": "
+                import {Component} from '@angular/core';
+                import {TuiLet} from '@taiga-ui/cdk';
+
+                @Component({
+                    standalone: true,
+                    imports: [TuiLet],
+                    template: \`<test *tuiLet="value as val">{{ val }}</test>\`,
+                })
+                export class Test {
+                    readonly value = 'foo';
+                }
+            ",
+  "1. After": "
+                import {Component} from '@angular/core';
+
+                @Component({
+                    standalone: true,
+                    imports: [],
+                    template: \`@let val = value;
+ <test>{{ val }}</test>\`,
+                })
+                export class Test {
+                    readonly value = 'foo';
+                }
+            ",
+}
+`;
+
 exports[`ng-update tuiLet migrates nested anchors without crashing on reconstructed clones: test.html 1`] = `
 {
   "0. Before": "

--- a/projects/cdk/schematics/ng-update/v5/tests/schematic-migrate-tui-let.spec.ts
+++ b/projects/cdk/schematics/ng-update/v5/tests/schematic-migrate-tui-let.spec.ts
@@ -22,6 +22,10 @@ describe('ng-update tuiLet', () => {
         `,
     });
 
+    const inlineMigration = createMigration({
+        collection: join(__dirname, '../../../migration.json'),
+    });
+
     it(
         'migrates simple structural directive',
         migration({
@@ -115,6 +119,25 @@ describe('ng-update tuiLet', () => {
                         <a>{{ val }}</a>
                     </p>
                 </a>
+            `,
+        }),
+    );
+
+    it(
+        'migrates *tuiLet inside an inline template and drops the import',
+        inlineMigration({
+            component: /* TypeScript */ `
+                import {Component} from '@angular/core';
+                import {TuiLet} from '@taiga-ui/cdk';
+
+                @Component({
+                    standalone: true,
+                    imports: [TuiLet],
+                    template: \`<test *tuiLet="value as val">{{ val }}</test>\`,
+                })
+                export class Test {
+                    readonly value = 'foo';
+                }
             `,
         }),
     );


### PR DESCRIPTION
The `tuiLet` migration edits templates with a devkit `UpdateRecorder` but removes the `TuiLet` import with ng-morph. For an **inline** template both live in the same `.ts` file, and `removeModule` ran first — so committing the recorder's `@let` edit and then ng-morph's whole-file save overwrote it. Result: the import was dropped while `*tuiLet` was left behind, leaving inline usages referencing a directive that is no longer imported.

External templates (`.html`) were unaffected (separate file), which is why the existing tests — all external — never caught it. It hits the full `updateToV5` run, not just the standalone generator.

### Fix
Commit the template edits first, then re-parse from the updated tree so the import removal is applied on top of the inserted `@let`.

### Before (inline)
```ts
@Component({imports: [], template: `<test *tuiLet="value as val">{{ val }}</test>`})
```
`TuiLet` import removed, `*tuiLet` left intact → broken.

### After
```ts
@Component({imports: [], template: `@let val = value;
<test>{{ val }}</test>`})
```

Added an inline-template test case; full v5 suite stays green.