### PR TITLE
refactor: `tuiPresent` remove redundant keyframe declaration

### DIFF
--- a/projects/core/components/root/animations.less
+++ b/projects/core/components/root/animations.less
@@ -1,7 +1,5 @@
 @keyframes tuiPresent {
-    to {
-        content: '';
-    }
+    /* Empty */
 }
 
 @keyframes tuiFade {


### PR DESCRIPTION
The animation is used solely to trigger the animationstart event for detecting element appearance, and the keyframe declaration is not required for the animation to run
