### PR TITLE
fix(kit): controls with `min` / `max` / `maxLength` input-properties support signal forms

### DIFF
--- a/projects/kit/components/counter/counter.component.ts
+++ b/projects/kit/components/counter/counter.component.ts
@@ -38,8 +38,14 @@ export class TuiCounter extends TuiControl<number> {
 
     public readonly step = input(this.options.step);
     public readonly size = input(this.options.size);
-    public readonly min = input(this.options.min);
-    public readonly max = input(this.options.max);
+    public readonly min = input(this.options.min, {
+        transform: (min: number | undefined) => min ?? this.options.min,
+    });
+
+    public readonly max = input(this.options.max, {
+        transform: (max: number | undefined) => max ?? this.options.max,
+    });
+
     public readonly appearance = input(this.options.appearance);
 
     protected onStep(step: number): void {

--- a/projects/kit/components/input-date-time/input-date-time.directive.ts
+++ b/projects/kit/components/input-date-time/input-date-time.directive.ts
@@ -124,14 +124,12 @@ export class TuiInputDateTimeDirective
     public readonly timeMode = input(this.options.timeMode);
 
     public readonly minInput = input<
-        TuiDay | readonly [TuiDay, TuiTime | null] | null,
         TuiDay | readonly [TuiDay, TuiTime | null] | null | undefined
-    >(this.options.min, {alias: 'min', transform: (min) => min ?? null});
+    >(this.options.min, {alias: 'min'});
 
     public readonly maxInput = input<
-        TuiDay | readonly [TuiDay, TuiTime | null] | null,
         TuiDay | readonly [TuiDay, TuiTime | null] | null | undefined
-    >(this.options.max, {alias: 'max', transform: (max) => max ?? null});
+    >(this.options.max, {alias: 'max'});
 
     public setValue(value: readonly [TuiDay, TuiTime | null] | null): void {
         this.onChange(value);

--- a/projects/kit/components/input-date-time/input-date-time.directive.ts
+++ b/projects/kit/components/input-date-time/input-date-time.directive.ts
@@ -123,15 +123,15 @@ export class TuiInputDateTimeDirective
 
     public readonly timeMode = input(this.options.timeMode);
 
-    public readonly minInput = input<TuiDay | readonly [TuiDay, TuiTime | null] | null>(
-        this.options.min,
-        {alias: 'min'},
-    );
+    public readonly minInput = input<
+        TuiDay | readonly [TuiDay, TuiTime | null] | null,
+        TuiDay | readonly [TuiDay, TuiTime | null] | null | undefined
+    >(this.options.min, {alias: 'min', transform: (min) => min ?? null});
 
-    public readonly maxInput = input<TuiDay | readonly [TuiDay, TuiTime | null] | null>(
-        this.options.max,
-        {alias: 'max'},
-    );
+    public readonly maxInput = input<
+        TuiDay | readonly [TuiDay, TuiTime | null] | null,
+        TuiDay | readonly [TuiDay, TuiTime | null] | null | undefined
+    >(this.options.max, {alias: 'max', transform: (max) => max ?? null});
 
     public setValue(value: readonly [TuiDay, TuiTime | null] | null): void {
         this.onChange(value);

--- a/projects/kit/components/input-date/input-date.directive.ts
+++ b/projects/kit/components/input-date/input-date.directive.ts
@@ -186,11 +186,11 @@ export abstract class TuiInputDateBase<
 })
 export class TuiInputDateDirective extends TuiInputDateBase<TuiDay> {
     public override readonly max = input(this.options.max ?? TUI_LAST_DAY, {
-        transform: (max: TuiDay | null): TuiDay => max ?? TUI_LAST_DAY,
+        transform: (max: TuiDay | null | undefined): TuiDay => max ?? TUI_LAST_DAY,
     });
 
     public override readonly min = input(this.options.min ?? TUI_FIRST_DAY, {
-        transform: (min: TuiDay | null): TuiDay => min ?? TUI_FIRST_DAY,
+        transform: (min: TuiDay | null | undefined): TuiDay => min ?? TUI_FIRST_DAY,
     });
 
     protected readonly mask = tuiMaskito(

--- a/projects/kit/components/input-month/input-month.component.ts
+++ b/projects/kit/components/input-month/input-month.component.ts
@@ -17,6 +17,6 @@ import {TuiInputMonthContent} from './input-month-content.component';
 })
 // TODO(v6): rename to TuiInputMonthNative
 export class TuiInputMonthComponent {
-    public readonly min = input<TuiMonth | null>(null);
-    public readonly max = input<TuiMonth | null>(null);
+    public readonly min = input<TuiMonth | null | undefined>(null);
+    public readonly max = input<TuiMonth | null | undefined>(null);
 }

--- a/projects/kit/components/input-number/number-mask.directive.ts
+++ b/projects/kit/components/input-number/number-mask.directive.ts
@@ -27,12 +27,12 @@ export class TuiNumberMask {
 
     public readonly min = input<
         TuiInputNumberOptions['min'],
-        TuiInputNumberOptions['min'] | null
+        TuiInputNumberOptions['min'] | null | undefined
     >(this.options.min, {transform: (x) => x ?? this.options.min});
 
     public readonly max = input<
         TuiInputNumberOptions['max'],
-        TuiInputNumberOptions['max'] | null
+        TuiInputNumberOptions['max'] | null | undefined
     >(this.options.max, {transform: (x) => x ?? this.options.max});
 
     public readonly params = computed(() => {

--- a/projects/kit/components/input-year/input-year.directive.ts
+++ b/projects/kit/components/input-year/input-year.directive.ts
@@ -86,8 +86,15 @@ export class TuiInputYearDirective extends TuiControl<number | null> {
         onCleanup(() => subscription?.unsubscribe());
     });
 
-    public readonly min = input((this.options.min ?? TUI_FIRST_DAY).year);
-    public readonly max = input((this.options.max ?? TUI_LAST_DAY).year);
+    public readonly min = input((this.options.min ?? TUI_FIRST_DAY).year, {
+        transform: (min: number | undefined) =>
+            min ?? (this.options.min ?? TUI_FIRST_DAY).year,
+    });
+
+    public readonly max = input((this.options.max ?? TUI_LAST_DAY).year, {
+        transform: (max: number | undefined) =>
+            max ?? (this.options.max ?? TUI_LAST_DAY).year,
+    });
 
     protected toggle(): void {
         if (this.interactive()) {

--- a/projects/kit/components/pincode/pincode.component.ts
+++ b/projects/kit/components/pincode/pincode.component.ts
@@ -60,7 +60,10 @@ export class TuiPincodeComponent extends TuiControl<string> {
         postprocessors: [(newState, initial) => (this.state() ? initial : newState)],
     });
 
-    public readonly maxLength = input(4);
+    public readonly maxLength = input(4, {
+        transform: (maxLength: number | undefined) => maxLength ?? 4,
+    });
+
     public readonly confirmed = output();
     public readonly finished = output();
 

--- a/projects/kit/components/rating/rating.component.ts
+++ b/projects/kit/components/rating/rating.component.ts
@@ -39,7 +39,9 @@ export class TuiRating extends TuiControl<number> {
     protected readonly array = computed(() => Array.from({length: this.max()}));
 
     public readonly icon = input(this.options.icon);
-    public readonly max = input(this.options.max);
+    public readonly max = input(this.options.max, {
+        transform: (max: number | undefined) => max ?? this.options.max,
+    });
 
     protected onKeyDown(event: KeyboardEvent): void {
         if (!this.interactive()) {


### PR DESCRIPTION
`[formField]` writes field state into any directive input with a matching name, and the template type checker types that write as `NonNullable<fieldValue> | undefined`. None of our inputs accepted `undefined`, so every control below failed to build under signal forms — even with an empty schema, without a single `min()` / `max()` validator in it.

```html

<!-- Type 'number | undefined' is not assignable to type 'number | bigint | null'.
  Type 'undefined' is not assignable to type 'number | bigint | null'. -->
<tui-textfield>
  <label tuiLabel>tuiInputNumber</label>
  <input tuiInputNumber [formField]="f.amount" />
                         ~~~~~~~~~
</tui-textfield>

<!-- Type 'TuiDay | undefined' is not assignable to type 'TuiDay | null'.
  Type 'undefined' is not assignable to type 'TuiDay | null'. -->
<tui-textfield>
  <label tuiLabel>tuiInputDate</label>
  <input tuiInputDate [formField]="f.date" />
                       ~~~~~~~~~
</tui-textfield>

<!-- Type 'readonly [TuiDay, TuiTime | null] | undefined' is not assignable to type 'TuiDay | readonly [TuiDay, TuiTime | null] | null'.
  Type 'undefined' is not assignable to type 'TuiDay | readonly [TuiDay, TuiTime | null] | null'. -->
<tui-textfield>
  <label tuiLabel>tuiInputDateTime</label>
  <input tuiInputDateTime [formField]="f.moment" />
                           ~~~~~~~~~
</tui-textfield>

<!-- Type 'number | undefined' is not assignable to type 'number'.
  Type 'undefined' is not assignable to type 'number'. -->
<tui-textfield>
  <label tuiLabel>tuiInputYear</label>
  <input tuiInputYear [formField]="f.year" />
                       ~~~~~~~~~
</tui-textfield>

<!-- Type 'number | undefined' is not assignable to type 'number'.
  Type 'undefined' is not assignable to type 'number'. -->
<tui-textfield>
  <label tuiLabel>tuiPincode</label>
  <input tuiPincode [formField]="f.pin" />
                     ~~~~~~~~~
</tui-textfield>

<!-- Type 'number | undefined' is not assignable to type 'number'.
  Type 'undefined' is not assignable to type 'number'. -->
<label tuiLabel>
  tui-counter
  <tui-counter [formField]="f.count" />
                ~~~~~~~~~
</label>

<!-- Type 'number | undefined' is not assignable to type 'number'.
  Type 'undefined' is not assignable to type 'number'. -->
<label tuiLabel>
  tui-rating
  <tui-rating [formField]="f.rate" />
               ~~~~~~~~~
</label>
```

> [!NOTE]
>  Controls where the input means something different from the validator — `Textarea` (`min` / `max` are the row count), `InputDateRange` (`minLength: TuiDayLike` vs `number`), `InputRange` / `Range` (`[number, number]` vs `number`), `InputDateMulti` (`TuiDay[]` vs `TuiDay`) — **need their own decision and are not touched here**.

Relates:
- https://github.com/taiga-family/taiga-ui/issues/14341
- https://github.com/angular/angular/issues/70600

