### PR TITLE
fix(layout): `List` remove outer padding on definition list (`dl`)

### DIFF
--- a/projects/layout/directives/list/list.style.less
+++ b/projects/layout/directives/list/list.style.less
@@ -119,10 +119,13 @@
 
     dt {
         color: var(--tui-text-secondary);
+    }
+
+    &[data-size] dt {
         padding-inline-start: 0;
     }
 
-    dd {
+    &[data-size] dd {
         padding-inline-end: 0;
     }
 


### PR DESCRIPTION
On `<dl tuiList>` the `<dt>` labels kept a left padding and `<dd>` values a right padding, so the outer edges weren't flush (in v5 they are).

The `padding-inline-start: 0` / `padding-inline-end: 0` resets were out-specified by the per-size `padding` shorthand: v4 uses `[tuiListV=…]:is(dl)` (no `:where()`), so `…[data-size='l'] dt` (0,2,2) beats the reset (0,1,2). In v5 these rules live inside `:where()`, stay specificity-flat, and the resets win by source order.

Scoping the resets under `&[data-size]` matches the size rule's specificity, so they win by source order — outer padding becomes `0` (as in v5), the inner column gap is unchanged.

<img width="1250" height="796" alt="image" src="https://github.com/user-attachments/assets/ad4da6f2-441d-48f4-9d92-b7c70b4f0fca" />

