### PR TITLE
test: disable CSS transitions in Cypress

### DIFF
--- a/projects/demo-cypress/src/tests/stepper.cy.ts
+++ b/projects/demo-cypress/src/tests/stepper.cy.ts
@@ -1,35 +1,38 @@
 import {ChangeDetectionStrategy, Component} from '@angular/core';
+import {TuiRoot} from '@taiga-ui/core';
 import {TuiStepper} from '@taiga-ui/kit';
 import {TuiCard} from '@taiga-ui/layout';
 
 @Component({
-    imports: [TuiCard, TuiStepper],
+    imports: [TuiCard, TuiRoot, TuiStepper],
     template: `
-        <div tuiCardLarge>
-            <tui-stepper
-                orientation="vertical"
-                [activeItemIndex]="1"
-            >
-                <button
-                    size="s"
-                    tuiStep
+        <tui-root>
+            <div tuiCardLarge>
+                <tui-stepper
+                    orientation="vertical"
+                    [activeItemIndex]="1"
                 >
-                    Small
-                </button>
-                <button
-                    size="m"
-                    tuiStep
-                >
-                    Medium
-                </button>
-                <button
-                    size="l"
-                    tuiStep
-                >
-                    Large
-                </button>
-            </tui-stepper>
-        </div>
+                    <button
+                        size="s"
+                        tuiStep
+                    >
+                        Small
+                    </button>
+                    <button
+                        size="m"
+                        tuiStep
+                    >
+                        Medium
+                    </button>
+                    <button
+                        size="l"
+                        tuiStep
+                    >
+                        Large
+                    </button>
+                </tui-stepper>
+            </div>
+        </tui-root>
     `,
     changeDetection: ChangeDetectionStrategy.OnPush,
 })


### PR DESCRIPTION
Disables Taiga UI CSS transitions in Cypress component tests by setting
`--tui-duration: 0ms` on `body`.

This keeps visual regression snapshots deterministic while preserving the
existing `TUI_ANIMATIONS_SPEED = 0` setup for DI-driven animations.

<img width="2048" height="303" alt="image" src="https://github.com/user-attachments/assets/393b08bd-8dd8-47f3-9fcf-a800cb6c0fb8" />
