### PR TITLE
fix(schematics): ng add fix collection error

### DIFF
--- a/projects/cdk/schematics/collection.json
+++ b/projects/cdk/schematics/collection.json
@@ -12,24 +12,6 @@
             "factory": "./ng-add/setup-project",
             "schema": "./ng-add/schema.json"
         },
-        "migrateIconsV4": {
-            "private": true,
-            "description": "Migrate Taiga UI icons to a new format",
-            "factory": "./ng-update/v4/migrate-icons/index#migrateIcons",
-            "schema": "./ng-update/v4/schema.json"
-        },
-        "migrateCssVarsV4": {
-            "private": true,
-            "description": "Migrate Taiga UI css variables",
-            "factory": "./ng-update/v4/migrate-css-vars/index#migrateCssVars",
-            "schema": "./ng-update/v4/schema.json"
-        },
-        "updateToV4": {
-            "private": true,
-            "description": "Manually run migration to update Taiga to v4.x.x",
-            "factory": "./ng-update/v4/index#updateToV4",
-            "schema": "./ng-update/v4/schema.json"
-        },
         "updateToV5": {
             "private": true,
             "description": "Manually run migration to update Taiga to v5.x.x",

--- a/projects/cdk/schematics/ng-add/index.ts
+++ b/projects/cdk/schematics/ng-add/index.ts
@@ -29,9 +29,8 @@ function addDependencies(tree: Tree, options: TuiSchema): void {
 
     removeTaigaSchematicsPackage(tree);
 
-    if (packages.includes('addon-table') || packages.includes('addon-mobile')) {
-        addAngularCdkDep(tree);
-    }
+    // Pin @angular/cdk (a @taiga-ui/cdk peer) to the app's major to avoid a version mismatch.
+    addAngularCdkDep(tree);
 }
 
 function addAngularCdkDep(tree: Tree): void {

--- a/projects/cdk/schematics/ng-add/tests/schematic-ng-add-standalone.spec.ts
+++ b/projects/cdk/schematics/ng-add/tests/schematic-ng-add-standalone.spec.ts
@@ -47,6 +47,7 @@ describe('ng-add [Standalone]', () => {
         expect(tree.readContent('package.json')).toBe(
             `{
   "dependencies": {
+    "@angular/cdk": "^13.0.0",
     "@angular/core": "~13.0.0",
     "@taiga-ui/cdk": "${TAIGA_VERSION}",
     "@taiga-ui/core": "${TAIGA_VERSION}",

--- a/projects/cdk/schematics/ng-add/tests/schematic-ng-add.spec.ts
+++ b/projects/cdk/schematics/ng-add/tests/schematic-ng-add.spec.ts
@@ -47,6 +47,7 @@ describe('ng-add', () => {
         expect(tree.readContent('package.json')).toBe(
             `{
   "dependencies": {
+    "@angular/cdk": "^13.0.0",
     "@angular/core": "~13.0.0",
     "@taiga-ui/cdk": "${TAIGA_VERSION}",
     "@taiga-ui/core": "${TAIGA_VERSION}",
@@ -271,6 +272,7 @@ export class AppModule {}
         expect(tree.readContent('package.json')).toBe(
             `{
   "dependencies": {
+    "@angular/cdk": "^13.0.0",
     "@angular/core": "~13.0.0",
     "@taiga-ui/cdk": "${TAIGA_VERSION}",
     "@taiga-ui/core": "${TAIGA_VERSION}",

--- a/projects/cdk/schematics/tests/collection-integrity.spec.ts
+++ b/projects/cdk/schematics/tests/collection-integrity.spec.ts
@@ -13,6 +13,7 @@ describe('@taiga-ui/cdk collection.json references only existing files', () => {
     const collection: {schematics: Record<string, SchematicEntry>} = JSON.parse(
         readFileSync(join(schematicsDir, 'collection.json'), 'utf8'),
     );
+
     const entries = Object.entries(collection.schematics);
 
     const moduleExists = (modulePath: string): boolean =>

--- a/projects/cdk/schematics/tests/collection-integrity.spec.ts
+++ b/projects/cdk/schematics/tests/collection-integrity.spec.ts
@@ -1,0 +1,36 @@
+import {existsSync, readFileSync} from 'node:fs';
+import {join} from 'node:path';
+
+interface SchematicEntry {
+    factory: string;
+    schema?: string;
+}
+
+// Dangling entries (factory/schema whose source was deleted) load lazily, so they
+// pass `ng add` and only fail when that schematic runs. Catch them up front.
+describe('@taiga-ui/cdk collection.json references only existing files', () => {
+    const schematicsDir = join(__dirname, '..');
+    const collection: {schematics: Record<string, SchematicEntry>} = JSON.parse(
+        readFileSync(join(schematicsDir, 'collection.json'), 'utf8'),
+    );
+    const entries = Object.entries(collection.schematics);
+
+    const moduleExists = (modulePath: string): boolean =>
+        ['.ts', '.js', '/index.ts', '/index.js'].some((suffix) =>
+            existsSync(join(schematicsDir, `${modulePath}${suffix}`)),
+        );
+
+    it.each(entries)('"%s" points at an existing factory module', (_name, desc) => {
+        expect(moduleExists(desc.factory.split('#')[0] ?? '')).toBe(true);
+    });
+
+    const schemaEntries = entries
+        .map(([name, {schema}]) => ({name, schema}))
+        .filter((entry): entry is {name: string; schema: string} =>
+            Boolean(entry.schema),
+        );
+
+    it.each(schemaEntries)('"$name" points at an existing schema file', ({schema}) => {
+        expect(existsSync(join(schematicsDir, schema))).toBe(true);
+    });
+});

--- a/projects/cdk/schematics/tests/meta-schematics-resolution.spec.ts
+++ b/projects/cdk/schematics/tests/meta-schematics-resolution.spec.ts
@@ -1,7 +1,8 @@
-import {NodeModulesEngineHost} from '@angular-devkit/schematics/tools';
 import {mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync} from 'node:fs';
 import {tmpdir} from 'node:os';
 import {join} from 'node:path';
+
+import {NodeModulesEngineHost} from '@angular-devkit/schematics/tools';
 
 // When npm nests @taiga-ui/cdk (mismatched @angular/cdk peer), the meta `schematics`
 // field must still resolve: a bare specifier does, a relative sibling path doesn't.
@@ -10,9 +11,9 @@ describe('taiga-ui meta package resolves its schematics collection when @taiga-u
         join(__dirname, '..', '..', '..', 'taiga-schematics', 'package.json'),
         'utf8',
     );
+
     const cdkManifest = readFileSync(join(__dirname, '..', '..', 'package.json'), 'utf8');
     const collection = readFileSync(join(__dirname, '..', 'collection.json'), 'utf8');
-
     let root = '';
 
     beforeEach(() => {

--- a/projects/cdk/schematics/tests/meta-schematics-resolution.spec.ts
+++ b/projects/cdk/schematics/tests/meta-schematics-resolution.spec.ts
@@ -1,0 +1,51 @@
+import {NodeModulesEngineHost} from '@angular-devkit/schematics/tools';
+import {mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync} from 'node:fs';
+import {tmpdir} from 'node:os';
+import {join} from 'node:path';
+
+// When npm nests @taiga-ui/cdk (mismatched @angular/cdk peer), the meta `schematics`
+// field must still resolve: a bare specifier does, a relative sibling path doesn't.
+describe('taiga-ui meta package resolves its schematics collection when @taiga-ui/cdk is nested', () => {
+    const metaManifest = readFileSync(
+        join(__dirname, '..', '..', '..', 'taiga-schematics', 'package.json'),
+        'utf8',
+    );
+    const cdkManifest = readFileSync(join(__dirname, '..', '..', 'package.json'), 'utf8');
+    const collection = readFileSync(join(__dirname, '..', 'collection.json'), 'utf8');
+
+    let root = '';
+
+    beforeEach(() => {
+        root = mkdtempSync(join(tmpdir(), 'tui-meta-schematics-'));
+
+        const metaDir = join(root, 'node_modules', 'taiga-ui');
+
+        mkdirSync(metaDir, {recursive: true});
+        writeFileSync(join(metaDir, 'package.json'), metaManifest);
+
+        // @taiga-ui/cdk NESTED under the meta package — the layout that broke ng add.
+        const cdkDir = join(metaDir, 'node_modules', '@taiga-ui', 'cdk');
+
+        mkdirSync(join(cdkDir, 'schematics'), {recursive: true});
+        writeFileSync(join(cdkDir, 'package.json'), cdkManifest);
+        writeFileSync(join(cdkDir, 'schematics', 'collection.json'), collection);
+    });
+
+    afterEach(() => {
+        if (root) {
+            rmSync(root, {recursive: true, force: true});
+        }
+    });
+
+    it('declares a layout-independent (non-relative) schematics specifier', () => {
+        const {schematics} = JSON.parse(metaManifest);
+
+        expect(schematics.startsWith('.')).toBe(false);
+    });
+
+    it('resolves the collection with @taiga-ui/cdk not hoisted', () => {
+        const host = new NodeModulesEngineHost([root]);
+
+        expect(() => host.createCollectionDescription('taiga-ui')).not.toThrow();
+    });
+});

--- a/projects/demo/src/pages/app/getting-started/index.html
+++ b/projects/demo/src/pages/app/getting-started/index.html
@@ -3,14 +3,6 @@
         <div>
             To install the Taiga UI use the command below. This command will automatically add the library to your
             project and configure it.
-
-            <p tuiNotification>
-                <strong>Note:</strong>
-                If you want to add Taiga UI to a project that is not using the latest major version of Angular, make
-                sure to install the appropriate version of
-                <code>&#64;angular/cdk</code>
-                first to prevent dependency conflicts.
-            </p>
         </div>
 
         <tui-doc-example

--- a/projects/taiga-schematics/package.json
+++ b/projects/taiga-schematics/package.json
@@ -37,5 +37,5 @@
     "peerDependencies": {
         "tslib": ">=2.8.1"
     },
-    "schematics": "../@taiga-ui/cdk/schematics/collection.json"
+    "schematics": "@taiga-ui/cdk/schematics/collection.json"
 }


### PR DESCRIPTION
## Problem

On a **fresh** Angular app, `ng add taiga-ui` crashes before touching any files:

```
✔ Installing package
Path ".../node_modules/@taiga-ui/cdk/schematics/collection.json" does not exist.
```

`@taiga-ui/cdk` has an unbounded `@angular/cdk` peer, so a fresh install pulls the **latest** `@angular/cdk`. When that major is newer than the app's Angular, npm can't hoist it and **nests** `@taiga-ui/cdk` under `node_modules/taiga-ui/`. The `taiga-ui` meta package then fails to locate its schematics collection, because it referenced it by a **relative sibling path** that only resolves when `@taiga-ui/cdk` is hoisted.

## Fix

- **`taiga-schematics/package.json`** — reference the collection by a bare specifier (`@taiga-ui/cdk/schematics/collection.json`) instead of the relative sibling path, so it resolves whether `@taiga-ui/cdk` is hoisted or nested. This is what removes the crash.
- **`ng-add`** — always pin `@angular/cdk` to the app's Angular major, so the post-schematic install resolves a matching `@angular/cdk` and prunes the duplicate Angular. (Previously pinned only for `addon-table`/`addon-mobile`, which left the common no-addon install unprotected.)
- Remove three dead v4 schematics from `collection.json` (sources deleted in #13917).
- Add two guards: the collection resolves when `@taiga-ui/cdk` is nested, and every collection factory/schema exists on disk.
- **Docs** — remove the getting-started note that told users on a non-latest Angular to pre-install `@angular/cdk` first; `ng add` now handles this automatically.

## Verification — real `ng add taiga-ui` on fresh Angular apps

| Angular | Before | After |
|:--:|:--|:--|
| 19 | ❌ crash — collection.json not found | ✅ clean install, single Angular |
| 20 | ❌ crash — collection.json not found | ✅ clean install, single Angular |
| 21 | ❌ crash — collection.json not found | ✅ clean install, single Angular |
| 22 | ✅ works (latest `@angular/cdk` already matches) | ✅ clean install, single Angular |

*"clean install" = exactly one `@angular/core`, `@angular/cdk` at the app's major, `@taiga-ui/cdk` installed, no nested duplicate Angular. Verified end-to-end on real `ng new` apps with `ng add taiga-ui` pulling the built packages from a local registry — with no manual `@angular/cdk` pre-install.*

> The peer is intentionally **not** capped: Taiga 5 supports Angular 19+ with no upper bound, and npm installs the max-in-range for an absent peer — so a cap would still mis-resolve. Pinning in `ng-add` fixes the install without constraining consumers.
