### PR TITLE
fix(schematics): migrate [tuiDropdownMobile] binding to [tuiDropdownSheet] in v5

### DIFF
--- a/projects/cdk/schematics/ng-update/v5/steps/constants/attrs-to-replace.ts
+++ b/projects/cdk/schematics/ng-update/v5/steps/constants/attrs-to-replace.ts
@@ -109,6 +109,10 @@ export const ATTRS_TO_REPLACE: readonly ReplacementAttribute[] = [
         to: {attrName: 'tuiDropdownSheet'},
     },
     {
+        from: {attrName: '[tuiDropdownMobile]', withTagNames: ['*']},
+        to: {attrName: '[tuiDropdownSheet]'},
+    },
+    {
         from: {attrName: '[tuiSheet]', withTagNames: ['*']},
         to: {attrName: '[tuiSheetDialog]'},
     },

--- a/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-dropdown-open.spec.ts.snap
+++ b/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-dropdown-open.spec.ts.snap
@@ -76,6 +76,13 @@ exports[`ng-update tuiDropdownOpen to tuiDropdownAuto should rename *tuiDataList
 }
 `;
 
+exports[`ng-update tuiDropdownOpen to tuiDropdownAuto should rename [tuiDropdownMobile] binding to [tuiDropdownSheet]: test.html 1`] = `
+{
+  "0. Before": "<tui-textfield [tuiDropdownMobile]="'label'"></tui-textfield>",
+  "1. After": "<tui-textfield [tuiDropdownSheet]="'label'"></tui-textfield>",
+}
+`;
+
 exports[`ng-update tuiDropdownOpen to tuiDropdownAuto should rename [tuiSheet] to [tuiSheetDialog]: test.html 1`] = `
 {
   "0. Before": "<button [tuiSheet]="content">Open</button>",

--- a/projects/cdk/schematics/ng-update/v5/tests/schematic-migrate-dropdown-open.spec.ts
+++ b/projects/cdk/schematics/ng-update/v5/tests/schematic-migrate-dropdown-open.spec.ts
@@ -25,6 +25,13 @@ describe('ng-update tuiDropdownOpen to tuiDropdownAuto', () => {
     );
 
     it(
+        'should rename [tuiDropdownMobile] binding to [tuiDropdownSheet]',
+        migrate({
+            template: `<tui-textfield [tuiDropdownMobile]="'label'"></tui-textfield>`,
+        }),
+    );
+
+    it(
         'should rename [tuiSheet] to [tuiSheetDialog]',
         migrate({template: '<button [tuiSheet]="content">Open</button>'}),
     );

--- a/projects/cdk/schematics/ng-update/v5/tests/schematic-migrate-dropdown-open.spec.ts
+++ b/projects/cdk/schematics/ng-update/v5/tests/schematic-migrate-dropdown-open.spec.ts
@@ -27,7 +27,7 @@ describe('ng-update tuiDropdownOpen to tuiDropdownAuto', () => {
     it(
         'should rename [tuiDropdownMobile] binding to [tuiDropdownSheet]',
         migrate({
-            template: `<tui-textfield [tuiDropdownMobile]="'label'"></tui-textfield>`,
+            template: '<tui-textfield [tuiDropdownMobile]="\'label\'"></tui-textfield>',
         }),
     );
 


### PR DESCRIPTION
## What
Add the property-binding form `[tuiDropdownMobile]` to the v5 attribute rename so it becomes `[tuiDropdownSheet]`.

## Why
Only the static `tuiDropdownMobile="…"` form was migrated; the bound form `[tuiDropdownMobile]="…"` was left untouched. In v5 the label input moved from `TuiDropdownMobile` (no longer has an input) to `TuiDropdownSheet`, so a bound `[tuiDropdownMobile]` silently stops working after migration. Reported on a real project (prm-ui).

`replaceAttrs` / `findElementsWithAttribute` match the attribute name literally (brackets included), so bracketed and unbracketed forms must be listed separately (as already done for `icon`/`[icon]`, `src`/`[src]`, `showLoader`/`[showLoader]`, …).

## How
- `attrs-to-replace.ts`: add `[tuiDropdownMobile]` → `[tuiDropdownSheet]`.
- snapshot test in `schematic-migrate-dropdown-open.spec.ts`.

Verified by running the full `updateToV5` collection via the schematics test harness — full `ng-update/v5` suite green (142 suites / 813 tests).