### PR TITLE
fix(schematics): warn on opaque dynamic [tuiHeader] bindings in v5 migration

### DIFF
--- a/projects/cdk/schematics/ng-update/v5/steps/constants/html-comments.ts
+++ b/projects/cdk/schematics/ng-update/v5/steps/constants/html-comments.ts
@@ -11,11 +11,10 @@ const STRING_LITERAL_RE = /^'[^']*'$/;
 
 // tuiHeader: a value that is exactly one single-quoted literal is auto-migrated by
 // ATTR_WITH_VALUES_TO_REPLACE (single quotes only) or is already a v5 token — skip it.
+// Any other dynamic binding is opaque (a signal, variable or ternary): it cannot be
+// rewritten safely, so it gets a manual-migration TODO.
 const HEADER_SINGLE_LITERAL =
     /^'(?:xxl|xl|[lms]|xs|xxs|h1|h2|h3|h4|h5|h6|body-l|body-m|body-s)'$/;
-// tuiHeader: a v4 size token used as a quoted literal (single or double quotes) inside a
-// larger expression, e.g. `cond ? 'l' : 'm'` or `cond ? "l" : "m"`.
-const HEADER_OLD_TOKEN_LITERAL = /(['"])(?:xxl|xl|[lms]|xs|xxs)\1/;
 
 export const HTML_COMMENTS: HtmlComment[] = [
     {
@@ -145,14 +144,10 @@ export const HTML_COMMENTS: HtmlComment[] = [
         filterFn: (element) => {
             const value = findAttr(element.attrs, '[tuiHeader]')?.value?.trim();
 
-            return (
-                !!value &&
-                !HEADER_SINGLE_LITERAL.test(value) &&
-                HEADER_OLD_TOKEN_LITERAL.test(value)
-            );
+            return !!value && !HEADER_SINGLE_LITERAL.test(value);
         },
         comment:
-            '`tuiHeader` values changed in v5 from size tokens to typography tokens (xxl->h1, xl->h2, l->h3, m->h4, s->h5, xs->h6, xxs->body-l). This dynamic binding still contains old size tokens that cannot be migrated automatically — update them to the v5 tokens manually. See https://taiga-ui.dev/components/header',
+            '`tuiHeader` values changed in v5 from size tokens to typography tokens (xxl->h1, xl->h2, l->h3, m->h4, s->h5, xs->h6, xxs->body-l). This dynamic binding could not be migrated automatically — if it resolves to an old size token, update it to the v5 token manually. See https://taiga-ui.dev/components/header',
     },
     {
         tag: 'table',

--- a/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-attr-values.spec.ts.snap
+++ b/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-attr-values.spec.ts.snap
@@ -617,7 +617,8 @@ exports[`ng-update start/end instead of left/right replaces values for [tuiHeade
                 <h5 [tuiHeader]="'h5'"></h5>
                 <h6 [tuiHeader]="'h6'"></h6>
                 <p [tuiHeader]="'body-l'"></p>
-                <p [tuiHeader]="headerSize"></p>
+                <!-- TODO: (Taiga UI migration) \`tuiHeader\` values changed in v5 from size tokens to typography tokens (xxl->h1, xl->h2, l->h3, m->h4, s->h5, xs->h6, xxs->body-l). This dynamic binding could not be migrated automatically — if it resolves to an old size token, update it to the v5 token manually. See https://taiga-ui.dev/components/header -->
+<p [tuiHeader]="headerSize"></p>
             ",
 }
 `;

--- a/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-header.spec.ts.snap
+++ b/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-header.spec.ts.snap
@@ -3,7 +3,7 @@
 exports[`ng-update dynamic tuiHeader (#13869) adds a TODO for a dynamic [tuiHeader] carrying old size tokens: test.html 1`] = `
 {
   "0. Before": "<h1 [tuiHeader]="isMobile() ? 'l' : 'm'">Title</h1>",
-  "1. After": "<!-- TODO: (Taiga UI migration) \`tuiHeader\` values changed in v5 from size tokens to typography tokens (xxl->h1, xl->h2, l->h3, m->h4, s->h5, xs->h6, xxs->body-l). This dynamic binding still contains old size tokens that cannot be migrated automatically — update them to the v5 tokens manually. See https://taiga-ui.dev/components/header -->
+  "1. After": "<!-- TODO: (Taiga UI migration) \`tuiHeader\` values changed in v5 from size tokens to typography tokens (xxl->h1, xl->h2, l->h3, m->h4, s->h5, xs->h6, xxs->body-l). This dynamic binding could not be migrated automatically — if it resolves to an old size token, update it to the v5 token manually. See https://taiga-ui.dev/components/header -->
 <h1 [tuiHeader]="isMobile() ? 'l' : 'm'">Title</h1>",
 }
 `;
@@ -11,8 +11,16 @@ exports[`ng-update dynamic tuiHeader (#13869) adds a TODO for a dynamic [tuiHead
 exports[`ng-update dynamic tuiHeader (#13869) adds a TODO for a dynamic [tuiHeader] using double-quoted legacy tokens: test.html 1`] = `
 {
   "0. Before": "<h1 [tuiHeader]='isMobile() ? "l" : "m"'>Title</h1>",
-  "1. After": "<!-- TODO: (Taiga UI migration) \`tuiHeader\` values changed in v5 from size tokens to typography tokens (xxl->h1, xl->h2, l->h3, m->h4, s->h5, xs->h6, xxs->body-l). This dynamic binding still contains old size tokens that cannot be migrated automatically — update them to the v5 tokens manually. See https://taiga-ui.dev/components/header -->
+  "1. After": "<!-- TODO: (Taiga UI migration) \`tuiHeader\` values changed in v5 from size tokens to typography tokens (xxl->h1, xl->h2, l->h3, m->h4, s->h5, xs->h6, xxs->body-l). This dynamic binding could not be migrated automatically — if it resolves to an old size token, update it to the v5 token manually. See https://taiga-ui.dev/components/header -->
 <h1 [tuiHeader]='isMobile() ? "l" : "m"'>Title</h1>",
+}
+`;
+
+exports[`ng-update dynamic tuiHeader (#13869) adds a TODO for an opaque dynamic [tuiHeader] with no literal token (signal/input): test.html 1`] = `
+{
+  "0. Before": "<h1 [tuiHeader]="size()">Title</h1>",
+  "1. After": "<!-- TODO: (Taiga UI migration) \`tuiHeader\` values changed in v5 from size tokens to typography tokens (xxl->h1, xl->h2, l->h3, m->h4, s->h5, xs->h6, xxs->body-l). This dynamic binding could not be migrated automatically — if it resolves to an old size token, update it to the v5 token manually. See https://taiga-ui.dev/components/header -->
+<h1 [tuiHeader]="size()">Title</h1>",
 }
 `;
 

--- a/projects/cdk/schematics/ng-update/v5/tests/schematic-migrate-header.spec.ts
+++ b/projects/cdk/schematics/ng-update/v5/tests/schematic-migrate-header.spec.ts
@@ -33,6 +33,13 @@ describe('ng-update dynamic tuiHeader (#13869)', () => {
     );
 
     it(
+        'adds a TODO for an opaque dynamic [tuiHeader] with no literal token (signal/input)',
+        migrate({
+            template: /* HTML */ '<h1 [tuiHeader]="size()">Title</h1>',
+        }),
+    );
+
+    it(
         'migrates a single bound literal without adding a TODO',
         migrate({
             template: /* HTML */ `


### PR DESCRIPTION
## What
Insert a manual-migration TODO for any *opaque dynamic* `[tuiHeader]` binding (a signal getter, variable, or wrapper-input pass-through) during v5 migration.

## Why
`tuiHeader` changed from size tokens (`s`/`m`/`l`/…) to typography tokens (`h1`..`h6`, `body-l`) in v5. Static values and inline quoted tokens were already handled (rewrite, or a TODO when a legacy token was literally present, e.g. `? 'l' : 'm'`). But a binding whose value carries no literal token — e.g. `[tuiHeader]="size()"` where a wrapper component forwards the size — got neither a rewrite nor a warning, so the developer had no signal at all. Reported on a real project (prm-ui).

An opaque expression can't be inspected, so we can't tell whether it resolves to an old token; the accepted trade-off is to warn on all non-literal dynamic bindings. Single-token literals (`'l'`, `'h3'`, …) are still skipped/auto-migrated, so those don't get a false positive.

## How
- `html-comments.ts`: drop the `HEADER_OLD_TOKEN_LITERAL` gate — warn whenever the value isn't a recognized single literal; reworded the comment for the opaque case.
- tests in `schematic-migrate-header.spec.ts`; updated `schematic-migrate-attr-values.spec.ts` snapshot (its `[tuiHeader]="headerSize"` case now gets the TODO — the intended over-warn).

Verified by running the full `updateToV5` collection via the schematics test harness — full `ng-update/v5` suite green (142 suites / 813 tests).