### PR TITLE
fix(schematics): keep nested element migrations inside *tuiSidebar in v5

### DIFF
--- a/projects/cdk/schematics/ng-update/v5/steps/templates/migrate-sidebar.ts
+++ b/projects/cdk/schematics/ng-update/v5/steps/templates/migrate-sidebar.ts
@@ -61,8 +61,7 @@ export function migrateSidebar({
     );
 
     const replacements = elements
-        .map((element) => buildReplacement(template, element))
-        .filter((x): x is Replacement => Boolean(x))
+        .flatMap((element) => buildReplacements(element))
         .sort((a, b) => b.startOffset - a.startOffset);
 
     replacements.forEach(({startOffset, endOffset, replacement}) => {
@@ -71,18 +70,18 @@ export function migrateSidebar({
     });
 }
 
-function buildReplacement(template: string, element: Element): Replacement | null {
+function buildReplacements(element: Element): Replacement[] {
     const loc = element.sourceCodeLocation;
     const startTag = loc?.startTag;
 
     if (!startTag) {
-        return null;
+        return [];
     }
 
     const sidebarAttr = element.attrs.find((attr) => attr.name === SIDEBAR_ATTR);
 
     if (!sidebarAttr) {
-        return null;
+        return [];
     }
 
     const parsed = parseBinding(sidebarAttr.value);
@@ -111,20 +110,29 @@ function buildReplacement(template: string, element: Element): Replacement | nul
     const endTag = loc?.endTag;
 
     if (!endTag) {
-        return {
-            startOffset: startTag.startOffset,
-            endOffset: startTag.endOffset,
-            replacement: `${comments}<tui-drawer${attrsStr}></tui-drawer>`,
-        };
+        return [
+            {
+                startOffset: startTag.startOffset,
+                endOffset: startTag.endOffset,
+                replacement: `${comments}<tui-drawer${attrsStr}></tui-drawer>`,
+            },
+        ];
     }
 
-    const innerContent = template.slice(startTag.endOffset, endTag.startOffset);
-
-    return {
-        startOffset: startTag.startOffset,
-        endOffset: endTag.endOffset,
-        replacement: `${comments}<tui-drawer${attrsStr}>${innerContent}</tui-drawer>`,
-    };
+    // Rewrite only the opening and closing tags, leaving the inner content untouched so
+    // migrations already applied to nested elements by earlier passes are preserved.
+    return [
+        {
+            startOffset: startTag.startOffset,
+            endOffset: startTag.endOffset,
+            replacement: `${comments}<tui-drawer${attrsStr}>`,
+        },
+        {
+            startOffset: endTag.startOffset,
+            endOffset: endTag.endOffset,
+            replacement: '</tui-drawer>',
+        },
+    ];
 }
 
 function parseBinding(value: string): ParsedBinding {

--- a/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-sidebar.spec.ts.snap
+++ b/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-sidebar.spec.ts.snap
@@ -198,6 +198,52 @@ import { TuiDrawer } from "@taiga-ui/kit";
 }
 `;
 
+exports[`ng-update sidebar to drawer migrates elements nested inside *tuiSidebar (no clobber of inner migrations): test.html 1`] = `
+{
+  "0. Before": "<section *tuiSidebar="open; autoWidth: true">
+    <button tuiButtonClose></button>
+    <tui-avatar src="x"></tui-avatar>
+</section>",
+  "1. After": "<!-- TODO: (Taiga UI migration) tuiSidebarAutoWidth has no equivalent in TuiDrawer, adjust layout manually -->
+<tui-drawer *tuiPopup="open">
+    <button tuiButtonX></button>
+    <span tuiAvatar="x"></span>
+</tui-drawer>",
+}
+`;
+
+exports[`ng-update sidebar to drawer migrates elements nested inside *tuiSidebar (no clobber of inner migrations): test.ts 1`] = `
+{
+  "0. Before": "
+        import {Component} from '@angular/core';
+        import {TuiSidebar} from '@taiga-ui/addon-mobile';
+
+        @Component({
+            standalone: true,
+            imports: [TuiSidebar],
+            templateUrl: './test.html',
+        })
+        export class TestComponent {
+            protected open = false;
+        }
+    ",
+  "1. After": "import { TuiPopup } from "@taiga-ui/core";
+import { TuiDrawer } from "@taiga-ui/kit";
+
+        import {Component} from '@angular/core';
+
+        @Component({
+            standalone: true,
+            imports: [TuiDrawer, TuiPopup],
+            templateUrl: './test.html',
+        })
+        export class TestComponent {
+            protected open = false;
+        }
+    ",
+}
+`;
+
 exports[`ng-update sidebar to drawer migrates multiline content inside *tuiSidebar: test.html 1`] = `
 {
   "0. Before": "<div *tuiSidebar="open">

--- a/projects/cdk/schematics/ng-update/v5/tests/schematic-migrate-sidebar.spec.ts
+++ b/projects/cdk/schematics/ng-update/v5/tests/schematic-migrate-sidebar.spec.ts
@@ -104,5 +104,17 @@ describe('ng-update sidebar to drawer', () => {
         }),
     );
 
+    it(
+        'migrates elements nested inside *tuiSidebar (no clobber of inner migrations)',
+        migrate({
+            template: [
+                '<section *tuiSidebar="open; autoWidth: true">',
+                '    <button tuiButtonClose></button>',
+                '    <tui-avatar src="x"></tui-avatar>',
+                '</section>',
+            ].join('\n'),
+        }),
+    );
+
     afterEach(() => resetActiveProject());
 });


### PR DESCRIPTION
## What
Fix the `*tuiSidebar` → `<tui-drawer>` migration so it no longer reverts migrations applied to nested elements.

## Why
`migrateSidebar` removed the whole sidebar element range and re-inserted the *original* inner HTML verbatim (`template.slice(...)`). Since all template passes share one recorder and record against original offsets, any edit an earlier pass made inside the sidebar (e.g. `tuiButtonClose`→`tuiButtonX`, `<tui-avatar>`→`<span tuiAvatar>`) was silently wiped. Identical elements migrated fine outside a sidebar but not inside it. Reported on a real project (prm-ui): `tuiButtonClose` kept its old attribute and `<tui-avatar>` was not replaced when nested in a drawer.

## How
- `migrate-sidebar.ts`: rewrite only the opening and closing tags in place; leave the inner content untouched so nested migrations survive. Behaviour is unchanged for non-nested cases — all 19 existing sidebar snapshots pass unchanged.
- regression test with `tuiButtonClose` + `<tui-avatar>` nested inside `*tuiSidebar`.

Verified by running the full `updateToV5` collection via the schematics test harness — full `ng-update/v5` suite green (142 suites / 813 tests).