### PR TITLE
test: [DO NOT MERGE] flake fix variant B — animations disabled

### DIFF
--- a/projects/addon-mobile/directives/dropdown-sheet/dropdown-sheet.component.ts
+++ b/projects/addon-mobile/directives/dropdown-sheet/dropdown-sheet.component.ts
@@ -38,9 +38,9 @@ export class TuiDropdownSheetComponent {
     protected readonly sub = toObservable(this.content)
         .pipe(
             tuiIfMap((content) =>
-                this.dialogs.open(content, this.directive.tuiDropdownSheet()).pipe(
-                    finalize(() => this.dropdown.toggle(false)),
-                ),
+                this.dialogs
+                    .open(content, this.directive.tuiDropdownSheet())
+                    .pipe(finalize(() => this.dropdown.toggle(false))),
             ),
             takeUntilDestroyed(),
         )

--- a/projects/addon-mobile/directives/dropdown-sheet/dropdown-sheet.component.ts
+++ b/projects/addon-mobile/directives/dropdown-sheet/dropdown-sheet.component.ts
@@ -10,6 +10,7 @@ import {TuiSheetDialogService} from '@taiga-ui/addon-mobile/components/sheet-dia
 import {tuiIfMap} from '@taiga-ui/cdk/observables';
 import {TuiDropdownDirective} from '@taiga-ui/core/portals/dropdown';
 import {PolymorpheusOutlet} from '@taiga-ui/polymorpheus';
+import {finalize} from 'rxjs';
 
 import {TuiDropdownSheet} from './dropdown-sheet.directive';
 
@@ -37,9 +38,11 @@ export class TuiDropdownSheetComponent {
     protected readonly sub = toObservable(this.content)
         .pipe(
             tuiIfMap((content) =>
-                this.dialogs.open(content, this.directive.tuiDropdownSheet()),
+                this.dialogs.open(content, this.directive.tuiDropdownSheet()).pipe(
+                    finalize(() => this.dropdown.toggle(false)),
+                ),
             ),
             takeUntilDestroyed(),
         )
-        .subscribe({complete: () => this.dropdown.toggle(false)});
+        .subscribe();
 }

--- a/projects/addon-mobile/directives/dropdown-sheet/test/dropdown-sheet.component.spec.ts
+++ b/projects/addon-mobile/directives/dropdown-sheet/test/dropdown-sheet.component.spec.ts
@@ -1,0 +1,81 @@
+import {ChangeDetectionStrategy, Component} from '@angular/core';
+import {type ComponentFixture, fakeAsync, TestBed, tick} from '@angular/core/testing';
+import {By} from '@angular/platform-browser';
+import {WA_IS_MOBILE} from '@ng-web-apis/platform';
+import {TuiDropdownSheet} from '@taiga-ui/addon-mobile';
+import {
+    provideTaiga,
+    TuiDropdown,
+    TuiDropdownHover,
+    tuiDropdownHoverOptionsProvider,
+    TuiRoot,
+} from '@taiga-ui/core';
+
+describe('TuiDropdownSheet', () => {
+    @Component({
+        imports: [TuiDropdown, TuiDropdownHover, TuiDropdownSheet, TuiRoot],
+        template: `
+            <tui-root>
+                <button
+                    tuiDropdown="Content"
+                    tuiDropdownHover
+                    tuiDropdownSheet
+                    type="button"
+                >
+                    Open
+                </button>
+            </tui-root>
+        `,
+        changeDetection: ChangeDetectionStrategy.OnPush,
+    })
+    class Test {}
+
+    let fixture: ComponentFixture<Test>;
+
+    beforeEach(async () => {
+        TestBed.configureTestingModule({
+            imports: [Test],
+            providers: [
+                provideTaiga(),
+                {provide: WA_IS_MOBILE, useValue: true},
+                tuiDropdownHoverOptionsProvider({showDelay: 0, hideDelay: 0}),
+            ],
+        });
+        await TestBed.compileComponents();
+        fixture = TestBed.createComponent(Test);
+        fixture.detectChanges();
+    });
+
+    function button(): HTMLElement {
+        return fixture.debugElement.query(By.css('button')).nativeElement;
+    }
+
+    function sheet(): Element | null {
+        return fixture.nativeElement.querySelector('tui-sheet-dialog');
+    }
+
+    function hover(): void {
+        button().dispatchEvent(new MouseEvent('mouseover', {bubbles: true}));
+        tick();
+        fixture.detectChanges();
+        tick();
+    }
+
+    it('reopens on the next hover after the sheet is dismissed', fakeAsync(() => {
+        hover();
+        expect(sheet()).not.toBeNull();
+
+        // Dismiss via the backdrop (click.self on the sheet host) without a
+        // hover reset — the case that used to leave the dropdown stuck open.
+        sheet()!.dispatchEvent(new MouseEvent('click', {bubbles: true}));
+        tick();
+        fixture.detectChanges();
+        tick();
+        expect(sheet()).toBeNull();
+
+        hover();
+        expect(sheet()).not.toBeNull();
+
+        fixture.destroy();
+    }));
+});

--- a/projects/core/portals/dropdown/dropdown-hover.directive.ts
+++ b/projects/core/portals/dropdown/dropdown-hover.directive.ts
@@ -79,10 +79,7 @@ export class TuiDropdownHover extends TuiDriver {
             tuiTypedFromEvent(this.doc, 'mouseout').pipe(map((e) => e.relatedTarget)),
         ).pipe(
             map((element) => tuiIsElement(element) && this.isHovered(element)),
-            // On mobile the dropdown renders as a touch sheet dismissed via its own
-            // backdrop/swipe. Mouse hover may only OPEN it — stray mouseover/mouseout
-            // from layout shifts must not toggle it closed (closing is driven by the
-            // ref-removal branch above).
+            // Mobile sheet dismisses via its own backdrop — mouse hover may only open it, never close
             filter((hovered) => hovered || !this.isMobile),
         ),
     ).pipe(

--- a/projects/core/portals/dropdown/dropdown-hover.directive.ts
+++ b/projects/core/portals/dropdown/dropdown-hover.directive.ts
@@ -10,7 +10,6 @@ import {
     type WritableSignal,
 } from '@angular/core';
 import {toObservable} from '@angular/core/rxjs-interop';
-import {WA_IS_MOBILE} from '@ng-web-apis/platform';
 import {TuiActiveZone} from '@taiga-ui/cdk/directives/active-zone';
 import {tuiTypedFromEvent, tuiZoneOptimized} from '@taiga-ui/cdk/observables';
 import {
@@ -35,6 +34,7 @@ import {
     tap,
 } from 'rxjs';
 
+import {TuiDropdownComponent} from './dropdown.component';
 import {TuiDropdownDirective} from './dropdown.directive';
 import {TUI_DROPDOWN_HOVER_OPTIONS} from './dropdown-hover.options';
 import {TuiDropdownOpen} from './dropdown-open.directive';
@@ -51,7 +51,6 @@ export class TuiDropdownHover extends TuiDriver {
     });
 
     private readonly directive = inject(TuiDropdownDirective);
-    private readonly isMobile = inject(WA_IS_MOBILE);
     private readonly el = tuiInjectElement();
     private readonly doc = inject(DOCUMENT);
     private readonly options = inject(TUI_DROPDOWN_HOVER_OPTIONS);
@@ -79,8 +78,12 @@ export class TuiDropdownHover extends TuiDriver {
             tuiTypedFromEvent(this.doc, 'mouseout').pipe(map((e) => e.relatedTarget)),
         ).pipe(
             map((element) => tuiIsElement(element) && this.isHovered(element)),
-            // Mobile sheet dismisses via its own backdrop — mouse hover may only open it, never close
-            filter((hovered) => hovered || !this.isMobile),
+            // Sheet dropdown dismisses via its own backdrop — mouse hover may only open it, never close
+            filter(
+                (hovered) =>
+                    hovered ||
+                    this.directive.component.component === TuiDropdownComponent,
+            ),
         ),
     ).pipe(
         distinctUntilChanged(),

--- a/projects/core/portals/dropdown/dropdown-hover.directive.ts
+++ b/projects/core/portals/dropdown/dropdown-hover.directive.ts
@@ -10,6 +10,7 @@ import {
     type WritableSignal,
 } from '@angular/core';
 import {toObservable} from '@angular/core/rxjs-interop';
+import {WA_IS_MOBILE} from '@ng-web-apis/platform';
 import {TuiActiveZone} from '@taiga-ui/cdk/directives/active-zone';
 import {tuiTypedFromEvent, tuiZoneOptimized} from '@taiga-ui/cdk/observables';
 import {
@@ -50,6 +51,7 @@ export class TuiDropdownHover extends TuiDriver {
     });
 
     private readonly directive = inject(TuiDropdownDirective);
+    private readonly isMobile = inject(WA_IS_MOBILE);
     private readonly el = tuiInjectElement();
     private readonly doc = inject(DOCUMENT);
     private readonly options = inject(TUI_DROPDOWN_HOVER_OPTIONS);
@@ -70,11 +72,20 @@ export class TuiDropdownHover extends TuiDriver {
                     takeUntil(fromEvent(this.doc, 'mouseover')),
                 ),
             ),
+            map((element) => tuiIsElement(element) && this.isHovered(element)),
         ),
-        tuiTypedFromEvent(this.doc, 'mouseover').pipe(map(tuiGetActualTarget)),
-        tuiTypedFromEvent(this.doc, 'mouseout').pipe(map((e) => e.relatedTarget)),
+        merge(
+            tuiTypedFromEvent(this.doc, 'mouseover').pipe(map(tuiGetActualTarget)),
+            tuiTypedFromEvent(this.doc, 'mouseout').pipe(map((e) => e.relatedTarget)),
+        ).pipe(
+            map((element) => tuiIsElement(element) && this.isHovered(element)),
+            // On mobile the dropdown renders as a touch sheet dismissed via its own
+            // backdrop/swipe. Mouse hover may only OPEN it — stray mouseover/mouseout
+            // from layout shifts must not toggle it closed (closing is driven by the
+            // ref-removal branch above).
+            filter((hovered) => hovered || !this.isMobile),
+        ),
     ).pipe(
-        map((element) => tuiIsElement(element) && this.isHovered(element)),
         distinctUntilChanged(),
         switchMap((v) =>
             of(v).pipe(

--- a/projects/demo-playwright/tests/kit/dropdown-hover/dropdown-hover.pw.spec.ts
+++ b/projects/demo-playwright/tests/kit/dropdown-hover/dropdown-hover.pw.spec.ts
@@ -53,7 +53,7 @@ test.describe('DropdownHover', () => {
             let example!: Locator;
             let po!: TuiDocumentationPagePO;
 
-            test.use(TUI_PLAYWRIGHT_MOBILE);
+            test.use({...TUI_PLAYWRIGHT_MOBILE, hasTouch: true});
 
             test.beforeEach(({page}) => {
                 po = new TuiDocumentationPagePO(page);
@@ -63,7 +63,7 @@ test.describe('DropdownHover', () => {
             test('Opens mobile version of dropdown on the 1st time click', async ({
                 page,
             }) => {
-                await example.locator('button').click();
+                await example.locator('button').tap();
                 await expect(page.locator('tui-dropdown')).not.toBeAttached();
                 await expect(page.locator('tui-sheet-dialog')).toBeVisible();
                 await po.hideContent();
@@ -73,19 +73,19 @@ test.describe('DropdownHover', () => {
             });
 
             test('Closes dropdown on click on overlay', async ({page}) => {
-                await example.locator('button').click();
+                await example.locator('button').tap();
                 await expect(page.locator('tui-sheet-dialog')).toBeVisible();
-                await page.locator('tui-sheet-dialog').click({position: {x: 32, y: 32}});
+                await page.locator('tui-sheet-dialog').tap({position: {x: 32, y: 32}});
                 await po.hideContent();
                 await expect(page.locator('tui-sheet-dialog')).not.toBeAttached();
             });
 
-            test.skip('Opens mobile version of dropdown on the 2nd time click', async ({
+            test('Opens mobile version of dropdown on the 2nd time click', async ({
                 page,
             }) => {
-                await example.locator('button').click();
-                await page.locator('tui-sheet-dialog').click({position: {x: 32, y: 32}});
-                await example.locator('button').click();
+                await example.locator('button').tap();
+                await page.locator('tui-sheet-dialog').tap({position: {x: 32, y: 32}});
+                await example.locator('button').tap();
                 await expect(page.locator('tui-sheet-dialog')).toBeVisible();
                 await po.hideContent();
                 await expect

--- a/projects/demo-playwright/tests/kit/dropdown-hover/dropdown-hover.pw.spec.ts
+++ b/projects/demo-playwright/tests/kit/dropdown-hover/dropdown-hover.pw.spec.ts
@@ -67,9 +67,12 @@ test.describe('DropdownHover', () => {
                 await expect(page.locator('tui-dropdown')).not.toBeAttached();
                 await expect(page.locator('tui-sheet-dialog')).toBeVisible();
                 await po.hideContent();
+                await expect(page.locator('tui-sheet-dialog')).toBeVisible();
                 await expect
                     .soft(page)
-                    .toHaveScreenshot('mobile-dropdown-1st-time-time-click.png');
+                    .toHaveScreenshot('mobile-dropdown-1st-time-time-click.png', {
+                        animations: 'disabled',
+                    });
             });
 
             test('Closes dropdown on click on overlay', async ({page}) => {
@@ -88,9 +91,12 @@ test.describe('DropdownHover', () => {
                 await example.locator('button').tap();
                 await expect(page.locator('tui-sheet-dialog')).toBeVisible();
                 await po.hideContent();
+                await expect(page.locator('tui-sheet-dialog')).toBeVisible();
                 await expect
                     .soft(page)
-                    .toHaveScreenshot('mobile-dropdown-2nd-time-time-click.png');
+                    .toHaveScreenshot('mobile-dropdown-2nd-time-time-click.png', {
+                        animations: 'disabled',
+                    });
             });
         });
     });


### PR DESCRIPTION
**Variant B** of de-flaking the mobile dropdown-hover screenshot (see #14892).

Keeps `.soft().toHaveScreenshot(...)` after `hideContent()` but (1) waits for the sheet to settle and (2) captures with `{animations: 'disabled'}`, so the backdrop fade / sheet slide can't be caught mid-frame (root of the flaky diff between base and next renders). Baseline is regenerated by CI.

Local: 15×chromium + 15×webkit green vs own baseline, `retries=0`.

Draft / do-not-merge — opened only to compare CI against variant A (#14924) and the plain duplicate (#14923).