### PR TITLE
fix(kit): `UnfinishedValidator` supports signal forms

### DIFF
--- a/projects/demo-cypress/src/tests/unfinished-validator/signal-forms.cy.ts
+++ b/projects/demo-cypress/src/tests/unfinished-validator/signal-forms.cy.ts
@@ -111,7 +111,7 @@ describe('tuiUnfinishedValidator + signal forms', () => {
                     cy.get('@input').type(HALF_TYPED);
                 });
 
-                it('before the field is even blured', () => {
+                it('before the field is even blurred', () => {
                     cy.get('#invalid').should('have.text', 'true');
                     cy.get('#submit').should('be.disabled');
                     cy.get('tui-error').should('not.be.visible');

--- a/projects/demo-cypress/src/tests/unfinished-validator/signal-forms.cy.ts
+++ b/projects/demo-cypress/src/tests/unfinished-validator/signal-forms.cy.ts
@@ -1,0 +1,338 @@
+/*
+// TODO: Uncomment the whole file when the `@angular/forms/signals` entry point becomes available,
+// when Taiga UI drops support of Angular below 22 (stable API for signal forms appeared in Angular 22)
+import {ChangeDetectionStrategy, Component, signal, type Type} from '@angular/core';
+import {takeUntilDestroyed} from '@angular/core/rxjs-interop';
+import {FormControl, ReactiveFormsModule} from '@angular/forms';
+import {form, FormField} from '@angular/forms/signals';
+import {TuiDay} from '@taiga-ui/cdk';
+import {TuiError, TuiRoot, tuiValidationErrorsProvider} from '@taiga-ui/core';
+import {TuiInputDate, TuiUnfinishedValidator} from '@taiga-ui/kit';
+
+describe('tuiUnfinishedValidator + signal forms', () => {
+    const UNFINISHED_MESSAGE = 'Fill in the date or leave the field empty';
+    const DATE = '12.12.2024';
+    const HALF_TYPED = '12.1';
+
+    @Component({
+        imports: [FormField, TuiError, TuiInputDate, TuiRoot, TuiUnfinishedValidator],
+        template: `
+            <tui-root>
+                <tui-textfield>
+                    <label tuiLabel>Optional date</label>
+                    <input
+                        tuiInputDate
+                        tuiUnfinishedValidator
+                        [formField]="f"
+                    />
+                </tui-textfield>
+
+                <tui-error [formField]="f" />
+
+                <output id="value">{{ f().value() ?? 'null' }}</output>
+                <output id="invalid">{{ f().invalid() }}</output>
+
+                <button
+                    id="submit"
+                    type="button"
+                    [disabled]="f().invalid()"
+                >
+                    Submit
+                </button>
+            </tui-root>
+        `,
+        changeDetection: ChangeDetectionStrategy.OnPush,
+        providers: [tuiValidationErrorsProvider({tuiUnfinished: UNFINISHED_MESSAGE})],
+    })
+    class SignalFormsSandbox {
+        private readonly date = signal<TuiDay | null>(null);
+
+        public readonly f = form(this.date);
+    }
+
+    @Component({
+        imports: [
+            ReactiveFormsModule,
+            TuiError,
+            TuiInputDate,
+            TuiRoot,
+            TuiUnfinishedValidator,
+        ],
+        template: `
+            <tui-root>
+                <tui-textfield>
+                    <label tuiLabel>Optional date</label>
+                    <input
+                        tuiInputDate
+                        tuiUnfinishedValidator
+                        [formControl]="control"
+                    />
+                </tui-textfield>
+
+                <tui-error [formControl]="control" />
+
+                <output id="value">{{ control.value ?? 'null' }}</output>
+                <output id="invalid">{{ control.invalid }}</output>
+
+                <button
+                    id="submit"
+                    type="button"
+                    [disabled]="control.invalid"
+                >
+                    Submit
+                </button>
+            </tui-root>
+        `,
+        changeDetection: ChangeDetectionStrategy.OnPush,
+        providers: [tuiValidationErrorsProvider({tuiUnfinished: UNFINISHED_MESSAGE})],
+    })
+    class ReactiveFormsSandbox {
+        public readonly control = new FormControl<TuiDay | null>(null);
+    }
+
+    const SANDBOXES: ReadonlyArray<{
+        readonly component: Type<unknown>;
+        readonly title: string;
+    }> = [
+        {component: SignalFormsSandbox, title: '[formField] (signal forms)'},
+        {component: ReactiveFormsSandbox, title: '[formControl] (reactive forms)'},
+    ];
+
+    SANDBOXES.forEach(({component, title}) => {
+        describe(title, () => {
+            beforeEach(() => {
+                cy.window().then((win) => cy.spy(win.console, 'error').as('console'));
+                cy.mount(component);
+                cy.get('input[tuiInputDate]').as('input');
+            });
+
+            describe('A half-typed date is flagged', () => {
+                beforeEach(() => {
+                    cy.get('@input').type(HALF_TYPED);
+                });
+
+                it('before the field is even blured', () => {
+                    cy.get('#invalid').should('have.text', 'true');
+                    cy.get('#submit').should('be.disabled');
+                    cy.get('tui-error').should('not.be.visible');
+                });
+
+                it('marks the field invalid', () => {
+                    cy.get('@input').blur();
+
+                    cy.get('#invalid').should('have.text', 'true');
+                    cy.get('@input').should('have.attr', 'aria-invalid', 'true');
+                    cy.get('tui-textfield').should('have.class', 'tui-invalid');
+                });
+
+                it('shows the message of the validator', () => {
+                    cy.get('@input').blur();
+
+                    cy.get('tui-error')
+                        .should('be.visible')
+                        .and('contain.text', UNFINISHED_MESSAGE);
+                });
+
+                it('blocks a submit button bound to the invalid state', () => {
+                    cy.get('@input').blur();
+
+                    cy.get('#value').should('have.text', 'null');
+                    cy.get('@input').should('have.value', HALF_TYPED);
+
+                    cy.get('#submit').should('be.disabled');
+                });
+            });
+
+            describe('A complete date is accepted', () => {
+                it('is valid and submittable', () => {
+                    cy.get('@input').type(DATE).blur();
+
+                    cy.get('#value').should('have.text', DATE);
+                    cy.get('#invalid').should('have.text', 'false');
+                    cy.get('#submit').should('be.enabled');
+                    cy.get('tui-error').should('not.be.visible');
+                });
+
+                it('deleting one character flags it again', () => {
+                    cy.get('@input').type(DATE).type('{backspace}').blur();
+
+                    cy.get('#invalid').should('have.text', 'true');
+                    cy.get('tui-error')
+                        .should('be.visible')
+                        .and('contain.text', UNFINISHED_MESSAGE);
+                });
+            });
+
+            describe('The error is cleared again', () => {
+                beforeEach(() => {
+                    cy.get('@input').type(DATE).type('{backspace}').blur();
+                    cy.get('#invalid').should('have.text', 'true');
+                });
+
+                it('emptying the optional field makes it valid', () => {
+                    cy.get('@input').clear().blur();
+
+                    cy.get('@input').should('have.value', '');
+                    cy.get('#value').should('have.text', 'null');
+                    cy.get('#invalid').should('have.text', 'false');
+                    cy.get('tui-error').should('not.be.visible');
+                });
+
+                it('emptying the optional field re-enables submit', () => {
+                    cy.get('@input').clear().blur();
+
+                    cy.get('#submit').should('be.enabled');
+                });
+
+                it('a complete date makes it valid', () => {
+                    cy.get('@input').clear().type(DATE).blur();
+
+                    cy.get('#value').should('have.text', DATE);
+                    cy.get('#invalid').should('have.text', 'false');
+                    cy.get('#submit').should('be.enabled');
+                });
+            });
+        });
+    });
+
+    describe('valueChanges count (reactive forms)', () => {
+        @Component({
+            imports: [ReactiveFormsModule, TuiInputDate, TuiRoot, TuiUnfinishedValidator],
+            template: `
+                <tui-root>
+                    <tui-textfield>
+                        <label tuiLabel>Optional date</label>
+                        <input
+                            tuiInputDate
+                            tuiUnfinishedValidator
+                            [formControl]="control"
+                        />
+                    </tui-textfield>
+
+                    <output id="value-changes">{{ valueChanges() }}</output>
+                    <output id="status-changes">{{ statusChanges() }}</output>
+
+                    <button
+                        id="reset-count"
+                        type="button"
+                        (click)="resetCount()"
+                    >
+                        Reset count
+                    </button>
+                </tui-root>
+            `,
+            changeDetection: ChangeDetectionStrategy.OnPush,
+        })
+        class CountingSandbox {
+            public readonly control = new FormControl<TuiDay | null>(null);
+
+            protected readonly valueChanges = signal(0);
+            protected readonly statusChanges = signal(0);
+
+            constructor() {
+                this.control.valueChanges
+                    .pipe(takeUntilDestroyed())
+                    .subscribe(() => this.valueChanges.update((count) => count + 1));
+
+                this.control.statusChanges
+                    .pipe(takeUntilDestroyed())
+                    .subscribe(() => this.statusChanges.update((count) => count + 1));
+            }
+
+            protected resetCount(): void {
+                this.valueChanges.set(0);
+                this.statusChanges.set(0);
+            }
+        }
+
+        @Component({
+            imports: [ReactiveFormsModule, TuiInputDate, TuiRoot],
+            template: `
+                <tui-root>
+                    <tui-textfield>
+                        <label tuiLabel>Optional date</label>
+                        <input
+                            tuiInputDate
+                            [formControl]="control"
+                        />
+                    </tui-textfield>
+
+                    <output id="value-changes">{{ valueChanges() }}</output>
+                </tui-root>
+            `,
+            changeDetection: ChangeDetectionStrategy.OnPush,
+        })
+        class BaselineSandbox {
+            public readonly control = new FormControl<TuiDay | null>(null);
+
+            protected readonly valueChanges = signal(0);
+
+            constructor() {
+                this.control.valueChanges
+                    .pipe(takeUntilDestroyed())
+                    .subscribe(() => this.valueChanges.update((count) => count + 1));
+            }
+        }
+
+        beforeEach(() => {
+            cy.mount(CountingSandbox);
+            cy.get('input[tuiInputDate]').as('input');
+        });
+
+        it('an untouched field is silent', () => {
+            cy.get('#value-changes').should('have.text', '0');
+            cy.get('#status-changes').should('have.text', '0');
+        });
+
+        // only the one carrying the parsed `TuiDay` — the ten keystrokes themselves are silent
+        it('typing a complete date fires once', () => {
+            cy.get('@input').type(DATE);
+
+            cy.get('#value-changes').should('have.text', '1');
+            cy.get('#status-changes').should('have.text', '1');
+        });
+
+        it('typing a half-typed date is silent', () => {
+            cy.get('@input').type(HALF_TYPED);
+
+            cy.get('#value-changes').should('have.text', '0');
+        });
+
+        it('blurring a half-typed date fires once', () => {
+            cy.get('@input').type(HALF_TYPED);
+            cy.get('#value-changes').should('have.text', '0');
+
+            cy.get('@input').blur();
+
+            cy.get('#value-changes').should('have.text', '1');
+        });
+
+        it('deleting one character from a complete date fires twice', () => {
+            cy.get('@input').type(DATE);
+            cy.get('#reset-count').click();
+
+            cy.get('@input').type('{backspace}');
+
+            cy.get('#value-changes').should('have.text', '2');
+        });
+
+        it('clearing a complete date fires twice', () => {
+            cy.get('@input').type(DATE);
+            cy.get('#reset-count').click();
+
+            cy.get('@input').clear();
+
+            cy.get('#value-changes').should('have.text', '2');
+        });
+
+        // the same count as with the directive: typing costs nothing extra any more
+        it('typing a complete date without the validator fires once', () => {
+            cy.mount(BaselineSandbox);
+            cy.get('input[tuiInputDate]').type(DATE);
+
+            cy.get('#value-changes').should('have.text', '1');
+        });
+    });
+});
+*/
+// eslint-disable-next-line unicorn/no-empty-file

--- a/projects/kit/directives/unfinished-validator/unfinished-validator-refresh.directive.ts
+++ b/projects/kit/directives/unfinished-validator/unfinished-validator-refresh.directive.ts
@@ -1,19 +1,30 @@
-import {Directive, inject} from '@angular/core';
-import {NgControl} from '@angular/forms';
+import {Directive, inject, INJECTOR, type OnInit} from '@angular/core';
+import {NG_VALIDATORS, NgControl} from '@angular/forms';
+import {TuiValidator} from '@taiga-ui/cdk/directives/validator';
+import {tuiProvide} from '@taiga-ui/cdk/utils/di';
 import {tuiInjectElement} from '@taiga-ui/cdk/utils/dom';
 
-@Directive({host: {'(blur)': 'updateValueAndValidity()', '(input)': 'onInput()'}})
-export class TuiUnfinishedValidatorRefresh {
+@Directive({
+    providers: [tuiProvide(NG_VALIDATORS, TuiUnfinishedValidatorRefresh, true)],
+    host: {'(blur)': 'onChange()', '(input)': 'onInput()'},
+})
+export class TuiUnfinishedValidatorRefresh extends TuiValidator implements OnInit {
+    private readonly injector = inject(INJECTOR);
     private readonly element = tuiInjectElement<HTMLInputElement>();
-    private readonly control = inject(NgControl, {self: true, optional: true});
+    private control: (NgControl & {field?: unknown}) | null = null;
 
-    protected onInput(): void {
-        if (this.control?.control?.value !== null || this.element.value === '') {
-            this.updateValueAndValidity();
-        }
+    public ngOnInit(): void {
+        this.control = this.injector.get(NgControl, null, {optional: true, self: true});
     }
 
-    protected updateValueAndValidity(): void {
-        this.control?.control?.updateValueAndValidity();
+    protected onInput(): void {
+        if (
+            this.control?.field || // Signal forms have nothing else to re-validate them, so they are always asked
+            // Reactive forms has silent `updateValueAndValidity({emitEvent: false})` (not compatible with signal forms) inside control components
+            this.control?.control?.value !== null ||
+            this.element.value === ''
+        ) {
+            this.onChange();
+        }
     }
 }


### PR DESCRIPTION
[Angular source code:](https://github.com/angular/angular/blob/9a58353b1b680f162a55969965ae6a90ae20316d/packages/forms/signals/src/controls/interop_ng_control.ts#L143-L146)

```ts
export class InteropNgControl implements CombinedControl {
  // [...]

  updateValueAndValidity() {
    // No-op since value and validity are always up to date in signal forms.
    // We offer this method so that reactive forms code attempting to call it doesn't error.
  }
}
```

Relates:
- https://github.com/taiga-family/taiga-ui/issues/14341

### Previous behavior
```
tuiUnfinishedValidator + signal forms
  [formField] (signal forms)
    A half-typed date is flagged
      1) before the field is even blured
      2) marks the field invalid
      3) shows the message of the validator
      4) blocks a submit button bound to the invalid state
    A complete date is accepted
      ✓ is valid and submittable (264ms)
      ✓ deleting one character flags it again (364ms)
    The error is cleared again
      5) emptying the optional field makes it valid
      6) emptying the optional field re-enables submit
      ✓ a complete date makes it valid (662ms)
  [formControl] (reactive forms)
    A half-typed date is flagged
      ✓ before the field is even blured (209ms)
      ✓ marks the field invalid (202ms)
      ✓ shows the message of the validator (217ms)
      ✓ blocks a submit button bound to the invalid state (200ms)
    A complete date is accepted
      ✓ is valid and submittable (276ms)
      ✓ deleting one character flags it again (358ms)
    The error is cleared again
      ✓ emptying the optional field makes it valid (492ms)
      ✓ emptying the optional field re-enables submit (481ms)
      ✓ a complete date makes it valid (664ms)
  valueChanges count (reactive forms)
    ✓ an untouched field is silent (22ms)
    ✓ typing a complete date fires once (264ms)
    ✓ typing a half-typed date is silent (194ms)
    ✓ blurring a half-typed date fires once (212ms)
    ✓ deleting one character from a complete date fires twice (467ms)
    ✓ clearing a complete date fires twice (485ms)
    ✓ typing a complete date without the validator fires once (286ms)


19 passing (1m)
6 failing
```

<details><summary>See detailed error logs</summary>
<p>

```
1) tuiUnfinishedValidator + signal forms
     [formField] (signal forms)
       A half-typed date is flagged
         before the field is even blured:

    Timed out retrying after 10000ms
    + expected - actual

    -'false'
    +'true'


2) tuiUnfinishedValidator + signal forms
     [formField] (signal forms)
       A half-typed date is flagged
         marks the field invalid:

    Timed out retrying after 10000ms
    + expected - actual

    -'false'
    +'true'
          

3) tuiUnfinishedValidator + signal forms
     [formField] (signal forms)
       A half-typed date is flagged
         shows the message of the validator:
   AssertionError: Timed out retrying after 10000ms: expected '<tui-error#tui_8mtrfsafe>' to be 'visible'

   This element `<tui-error#tui_8mtrfsafe>` is not visible because it has an effective width and height of: `468 x 0` pixels.
    

4) tuiUnfinishedValidator + signal forms
     [formField] (signal forms)
       A half-typed date is flagged
         blocks a submit button bound to the invalid state:
   AssertionError: Timed out retrying after 10000ms: expected '<button#submit>' to be 'disabled'


5) tuiUnfinishedValidator + signal forms
     [formField] (signal forms)
       The error is cleared again
         emptying the optional field makes it valid:

    Timed out retrying after 10000ms
    + expected - actual

    -'true'
    +'false'


6) tuiUnfinishedValidator + signal forms
     [formField] (signal forms)
       The error is cleared again
         emptying the optional field re-enables submit:
   AssertionError: Timed out retrying after 10000ms: expected '<button#submit>' to be 'enabled'
```

</p>
</details> 

### New behavior
```
  tuiUnfinishedValidator + signal forms
    [formField] (signal forms)
      A half-typed date is flagged
        ✓ before the field is even blured (312ms)
        ✓ marks the field invalid (196ms)
        ✓ shows the message of the validator (214ms)
        ✓ blocks a submit button bound to the invalid state (193ms)
      A complete date is accepted
        ✓ is valid and submittable (261ms)
        ✓ deleting one character flags it again (340ms)
      The error is cleared again
        ✓ emptying the optional field makes it valid (483ms)
        ✓ emptying the optional field re-enables submit (473ms)
        ✓ a complete date makes it valid (645ms)
    [formControl] (reactive forms)
      A half-typed date is flagged
        ✓ before the field is even blured (193ms)
        ✓ marks the field invalid (193ms)
        ✓ shows the message of the validator (212ms)
        ✓ blocks a submit button bound to the invalid state (208ms)
      A complete date is accepted
        ✓ is valid and submittable (275ms)
        ✓ deleting one character flags it again (357ms)
      The error is cleared again
        ✓ emptying the optional field makes it valid (481ms)
        ✓ emptying the optional field re-enables submit (471ms)
        ✓ a complete date makes it valid (656ms)
    valueChanges count (reactive forms)
      ✓ an untouched field is silent (27ms)
      ✓ typing a complete date fires once (265ms)
      ✓ typing a half-typed date is silent (188ms)
      ✓ blurring a half-typed date fires once (219ms)
      ✓ deleting one character from a complete date fires twice (464ms)
      ✓ clearing a complete date fires twice (474ms)
      ✓ typing a complete date without the validator fires once (286ms)


  25 passing (9s)
```

