### PR TITLE
chore(demo-playwright): fix flaky PW test from `InputNumber` spec

### DIFF
--- a/projects/demo-playwright/tests/kit/input-number/input-number.pw.spec.ts
+++ b/projects/demo-playwright/tests/kit/input-number/input-number.pw.spec.ts
@@ -492,6 +492,7 @@ describe('InputNumber', () => {
 
                 describe('Keeps caret position on step', () => {
                     beforeEach(async () => {
+                        await inputNumber.textfield.focus();
                         await inputNumber.textfield.fill('42');
 
                         await expect(inputNumber.textfield).toHaveValue('42kg');


### PR DESCRIPTION
Otherwise:

```
  1) [chromium] › projects/demo-playwright/tests/kit/input-number/input-number.pw.spec.ts:531:25 › InputNumber › API › [step] prop › caret position on step action › Keeps caret position on step › via keyboard arrow 

    Error: expect(locator).toHaveValue(expected) failed

    Locator:  locator('tui-doc-demo > .t-wrapper').locator('tui-textfield:has([tuiInputNumber])').getByRole('textbox')
    Expected: "42kg"
    Received: "kg"
    Timeout:  5000ms

    Call log:
      - Expect "toHaveValue" with timeout 5000ms
      - waiting for locator('tui-doc-demo > .t-wrapper').locator('tui-textfield:has([tuiInputNumber])').getByRole('textbox')
        14 × locator resolved to <input tuiinput="" placeholder="" maxlength="25" tuiappearance="" tuiinputnumber="" data-focus="true" id="tui_62kfimpaqo" inputmode="numeric" aria-invalid="false" data-tui-version="5.23.0" data-appearance="textfield" class="ng-untouched ng-pristine ng-invalid _with-buttons"/>
           - unexpected value "kg"


      495 |                         await inputNumber.textfield.fill('42');
      496 |
    > 497 |                         await expect(inputNumber.textfield).toHaveValue('42kg');
          |                                                             ^
      498 |                         await expect(inputNumber.textfield).toHaveJSProperty(
      499 |                             'selectionStart',
      500 |                             2,
        at /home/runner/work/taiga-ui/taiga-ui/projects/demo-playwright/tests/kit/input-number/input-number.pw.spec.ts:497:61

    Error Context: projects/demo-playwright/tests-results/tests-kit-input-number-inp-23d66--on-step-via-keyboard-arrow-chromium/error-context.md

    Retry #1 ───────────────────────────────────────────────────────────────────────────────────────

    Error: expect(locator).toHaveValue(expected) failed

    Locator:  locator('tui-doc-demo > .t-wrapper').locator('tui-textfield:has([tuiInputNumber])').getByRole('textbox')
    Expected: "42kg"
    Received: "kg"
    Timeout:  5000ms

    Call log:
      - Expect "toHaveValue" with timeout 5000ms
      - waiting for locator('tui-doc-demo > .t-wrapper').locator('tui-textfield:has([tuiInputNumber])').getByRole('textbox')
        14 × locator resolved to <input tuiinput="" placeholder="" maxlength="25" tuiappearance="" tuiinputnumber="" data-focus="true" id="tui_62kfimpaqo" inputmode="numeric" aria-invalid="false" data-tui-version="5.23.0" data-appearance="textfield" class="ng-untouched ng-pristine ng-invalid _with-buttons"/>
           - unexpected value "kg"


      495 |                         await inputNumber.textfield.fill('42');
      496 |
    > 497 |                         await expect(inputNumber.textfield).toHaveValue('42kg');
          |                                                             ^
      498 |                         await expect(inputNumber.textfield).toHaveJSProperty(
      499 |                             'selectionStart',
      500 |                             2,
        at /home/runner/work/taiga-ui/taiga-ui/projects/demo-playwright/tests/kit/input-number/input-number.pw.spec.ts:497:61

    Error Context: projects/demo-playwright/tests-results/tests-kit-input-number-inp-23d66--on-step-via-keyboard-arrow-chromium-retry1/error-context.md

    attachment #2: trace (application/zip) ─────────────────────────────────────────────────────────
    projects/demo-playwright/tests-results/tests-kit-input-number-inp-23d66--on-step-via-keyboard-arrow-chromium-retry1/trace.zip
    Usage:

        npx playwright show-trace projects/demo-playwright/tests-results/tests-kit-input-number-inp-23d66--on-step-via-keyboard-arrow-chromium-retry1/trace.zip

    ────────────────────────────────────────────────────────────────────────────────────────────────

    Retry #2 ───────────────────────────────────────────────────────────────────────────────────────

    Error: expect(locator).toHaveValue(expected) failed

    Locator:  locator('tui-doc-demo > .t-wrapper').locator('tui-textfield:has([tuiInputNumber])').getByRole('textbox')
    Expected: "42kg"
    Received: "kg"
    Timeout:  5000ms

    Call log:
      - Expect "toHaveValue" with timeout 5000ms
      - waiting for locator('tui-doc-demo > .t-wrapper').locator('tui-textfield:has([tuiInputNumber])').getByRole('textbox')
        14 × locator resolved to <input tuiinput="" placeholder="" maxlength="25" tuiappearance="" tuiinputnumber="" data-focus="true" id="tui_62kfimpaqo" inputmode="numeric" aria-invalid="false" data-tui-version="5.23.0" data-appearance="textfield" class="ng-untouched ng-pristine ng-invalid _with-buttons"/>
           - unexpected value "kg"


      495 |                         await inputNumber.textfield.fill('42');
      496 |
    > 497 |                         await expect(inputNumber.textfield).toHaveValue('42kg');
          |                                                             ^
      498 |                         await expect(inputNumber.textfield).toHaveJSProperty(
      499 |                             'selectionStart',
      500 |                             2,
        at /home/runner/work/taiga-ui/taiga-ui/projects/demo-playwright/tests/kit/input-number/input-number.pw.spec.ts:497:61

    Error Context: projects/demo-playwright/tests-results/tests-kit-input-number-inp-23d66--on-step-via-keyboard-arrow-chromium-retry2/error-context.md

  1 failed
    [chromium] › projects/demo-playwright/tests/kit/input-number/input-number.pw.spec.ts:531:25 › InputNumber › API › [step] prop › caret position on step action › Keeps caret position on step › via keyboard arrow 
```