### PR TITLE
chore(demo): keep example descriptions and headings in generated markdown

### DIFF
--- a/projects/demo/project.json
+++ b/projects/demo/project.json
@@ -207,7 +207,7 @@
             "options": {
                 "collectCoverage": false,
                 "jestConfig": "package.json",
-                "testMatch": ["<rootDir>/{projectRoot}/src/**/*.spec.ts"]
+                "testMatch": ["<rootDir>/{projectRoot}/**/*.spec.ts"]
             },
             "outputs": ["{workspaceRoot}/coverage/{projectName}"]
         }

--- a/projects/demo/scripts/llms/utils/file-system.ts
+++ b/projects/demo/scripts/llms/utils/file-system.ts
@@ -335,12 +335,19 @@ export async function getUsageExamples(
 
             examplesArray.forEach((example, index) => {
                 const exampleNumber = (index + 1).toString();
+                const existing = exampleDescriptions[exampleNumber];
 
-                if (!exampleDescriptions[exampleNumber]) {
+                if (!existing) {
                     exampleDescriptions[exampleNumber] = {
                         heading: example,
                         description: '',
                     };
+                } else if (
+                    !existing.heading ||
+                    existing.heading === `Example ${exampleNumber}`
+                ) {
+                    // Keep any description parsed from the template, fill the heading.
+                    existing.heading = example;
                 }
             });
         }
@@ -415,19 +422,25 @@ export async function getUsageExamples(
         return '';
     }
 
+    // Folders are read in filesystem order ("1", "10", "2"…); restore example order.
+    examples.sort((a, b) => {
+        const left = Number(a.name);
+        const right = Number(b.name);
+
+        return Number.isFinite(left) && Number.isFinite(right)
+            ? left - right
+            : a.name.localeCompare(b.name);
+    });
+
     let result = '\n### Usage Examples\n';
 
     for (const example of examples) {
         result += `\n#### ${example.heading}\n`;
 
         if (example.description) {
-            // Clean up the description HTML for better LLM consumption
-            const cleanDescription = example.description
-                .replaceAll(/<[^>]+>/g, '') // Remove HTML tags
-                .replaceAll(/\s+/g, ' ') // Replace multiple spaces with single space
-                .trim();
-
-            result += `\n${cleanDescription}\n`;
+            // Already cleaned by extractExampleDescriptions; re-stripping tags here
+            // would eat decoded markup such as `<tui-textfield />`.
+            result += `\n${example.description}\n`;
         }
 
         if (example.html) {
@@ -451,6 +464,121 @@ export async function getUsageExamples(
 
         result += '\n';
     }
+
+    return result;
+}
+
+function decodeHtmlEntities(text: string): string {
+    return text
+        .replaceAll(/&#(\d+);/g, (_, code: string) => String.fromCodePoint(Number(code)))
+        .replaceAll(/&#x([\da-f]+);/gi, (_, code: string) =>
+            String.fromCodePoint(Number.parseInt(code, 16)),
+        )
+        .replaceAll('&lt;', '<')
+        .replaceAll('&gt;', '>')
+        .replaceAll('&quot;', '"')
+        .replaceAll('&nbsp;', ' ')
+        .replaceAll('&amp;', '&');
+}
+
+// Turn a chunk of Angular template into plain prose: drop control-flow wrappers
+// (@if / @switch / @case …), strip HTML tags, decode entities, collapse whitespace.
+function cleanTemplateText(raw: string): string {
+    const withoutControlFlow = raw
+        .replaceAll(
+            /@(?:if|else|for|switch|case|default|empty|defer|placeholder|loading|error)\b[^{}]*\{/gi,
+            ' ',
+        )
+        .replaceAll(/[{}]/g, ' ');
+
+    return decodeHtmlEntities(withoutControlFlow.replaceAll(/<[^>]+>/g, ''))
+        .replaceAll(/\s+/g, ' ')
+        .trim();
+}
+
+// Return the text inside the braces starting at `openBraceIndex`, respecting nesting.
+function readBalancedBraces(source: string, openBraceIndex: number): string | null {
+    if (source[openBraceIndex] !== '{') {
+        return null;
+    }
+
+    let depth = 0;
+
+    for (let i = openBraceIndex; i < source.length; i++) {
+        const char = source[i];
+
+        if (char === '{') {
+            depth++;
+        } else if (char === '}') {
+            depth--;
+
+            if (depth === 0) {
+                return source.slice(openBraceIndex + 1, i);
+            }
+        }
+    }
+
+    return null;
+}
+
+// Descriptions rendered via `@switch ($index) { @case (N) { … } }` inside a
+// `@for` examples loop. Case N corresponds to example folder N + 1.
+function extractSwitchIndexDescriptions(content: string): Record<string, string> {
+    const result: Record<string, string> = {};
+    const switchMatch = /@switch\s*\(\s*\$index\s*\)\s*\{/i.exec(content);
+
+    if (!switchMatch) {
+        return result;
+    }
+
+    const switchBody = readBalancedBraces(
+        content,
+        switchMatch.index + switchMatch[0].length - 1,
+    );
+
+    if (switchBody === null) {
+        return result;
+    }
+
+    const caseRegex = /@case\s*\(\s*(\d+)\s*\)\s*\{/gi;
+    let caseMatch: RegExpExecArray | null;
+
+    while ((caseMatch = caseRegex.exec(switchBody)) !== null) {
+        const rawIndex = caseMatch[1];
+
+        if (!rawIndex) {
+            continue;
+        }
+
+        const braceIndex = caseMatch.index + caseMatch[0].length - 1;
+        const caseBody = readBalancedBraces(switchBody, braceIndex);
+
+        if (caseBody === null) {
+            continue;
+        }
+
+        result[(Number(rawIndex) + 1).toString()] = cleanTemplateText(caseBody);
+        // Skip past this case body so a nested @case is never matched as top-level.
+        caseRegex.lastIndex = braceIndex + caseBody.length + 2;
+    }
+
+    return result;
+}
+
+// Headings declared inline in the loop header, e.g. `@for (example of ['A', 'B']; …)`.
+function extractInlineForHeadings(content: string): Record<string, string> {
+    const result: Record<string, string> = {};
+    const forMatch = /@for\s*\(\s*\w+\s+of\s+(\[[\s\S]*?\])\s*;\s*track/i.exec(content);
+
+    if (!forMatch?.[1]) {
+        return result;
+    }
+
+    const items = forMatch[1].match(/(['"])(?:\\.|(?!\1).)*\1/g) ?? [];
+
+    items.forEach((quoted, index) => {
+        result[(index + 1).toString()] = quoted.slice(1, -1);
+    });
 
     return result;
 }
@@ -573,10 +701,7 @@ export function extractExampleDescriptions(
             );
 
             if (descriptionMatch?.[1]) {
-                description = descriptionMatch[1]
-                    .replaceAll(/<[^>]+>/g, '') // Remove HTML tags
-                    .replaceAll(/\s+/g, ' ') // Replace multiple spaces with single space
-                    .trim();
+                description = cleanTemplateText(descriptionMatch[1]);
             }
         }
 
@@ -584,6 +709,40 @@ export function extractExampleDescriptions(
             heading,
             description,
         };
+    }
+
+    // Modern pages render examples through a `@for` loop: headings come from an
+    // inline array (or the component's `examples` field) and descriptions from a
+    // `@switch ($index)` block. Neither is reachable by the tag scan above.
+    for (const [exampleNumber, heading] of Object.entries(
+        extractInlineForHeadings(content),
+    )) {
+        const existing = descriptions[exampleNumber];
+
+        if (!existing) {
+            descriptions[exampleNumber] = {heading, description: ''};
+        } else if (!existing.heading || existing.heading === `Example ${exampleNumber}`) {
+            existing.heading = heading;
+        }
+    }
+
+    for (const [exampleNumber, description] of Object.entries(
+        extractSwitchIndexDescriptions(content),
+    )) {
+        if (!description) {
+            continue;
+        }
+
+        const existing = descriptions[exampleNumber];
+
+        if (existing) {
+            existing.description = description;
+        } else {
+            descriptions[exampleNumber] = {
+                heading: `Example ${exampleNumber}`,
+                description,
+            };
+        }
     }
 
     // Also try to extract examples from TypeScript files for dynamic patterns

--- a/projects/demo/test/llms-example-descriptions.spec.ts
+++ b/projects/demo/test/llms-example-descriptions.spec.ts
@@ -1,0 +1,123 @@
+import {extractExampleDescriptions} from '../scripts/llms/utils/file-system';
+
+describe('extractExampleDescriptions', () => {
+    it('reads @switch ($index) descriptions from a @for examples loop', () => {
+        const content = `
+            <tui-doc-page header="ComboBox">
+                <ng-template pageTab>
+                    Intro text.
+                    @for (example of examples; track example) {
+                        <tui-doc-example
+                            [component]="$index + 1 | tuiComponent"
+                            [content]="$index + 1 | tuiExample"
+                            [description]="description"
+                            [heading]="example"
+                        />
+                        <ng-template #description>
+                            @switch ($index) {
+                                @case (0) {
+                                    First example description.
+                                }
+                                @case (1) {
+                                    Second one with <code>code</code> and
+                                    <a href="x">a link</a>.
+                                }
+                            }
+                        </ng-template>
+                    }
+                </ng-template>
+            </tui-doc-page>
+        `;
+
+        const result = extractExampleDescriptions(content);
+
+        // Case N maps to example folder N + 1.
+        expect(result['1']?.description).toBe('First example description.');
+        expect(result['2']?.description).toBe('Second one with code and a link.');
+    });
+
+    it('reads headings from an inline @for array', () => {
+        const content = `
+            <tui-doc-page header="Accordion">
+                <ng-template pageTab>
+                    @for (example of ['Basic', 'Custom']; track example) {
+                        <tui-doc-example
+                            [content]="$index + 1 | tuiExample"
+                            [description]="description"
+                            [heading]="example"
+                        />
+                        <ng-template #description>
+                            @switch ($index) {
+                                @case (0) {
+                                    Basic description.
+                                }
+                                @case (1) {
+                                    Custom description.
+                                }
+                            }
+                        </ng-template>
+                    }
+                </ng-template>
+            </tui-doc-page>
+        `;
+
+        const result = extractExampleDescriptions(content);
+
+        expect(result['1']?.heading).toBe('Basic');
+        expect(result['2']?.heading).toBe('Custom');
+        expect(result['1']?.description).toBe('Basic description.');
+        expect(result['2']?.description).toBe('Custom description.');
+    });
+
+    it('unescapes HTML entities in descriptions', () => {
+        const content = `
+            <tui-doc-page header="ComboBox">
+                <ng-template pageTab>
+                    @for (example of examples; track example) {
+                        <tui-doc-example
+                            [content]="$index + 1 | tuiExample"
+                            [description]="description"
+                            [heading]="example"
+                        />
+                        <ng-template #description>
+                            @switch ($index) {
+                                @case (0) {
+                                    Works with <code>&#64;angular/cdk/scrolling</code>
+                                    and <code>&lt;tui-textfield /&gt;</code>.
+                                }
+                            }
+                        </ng-template>
+                    }
+                </ng-template>
+            </tui-doc-page>
+        `;
+
+        const result = extractExampleDescriptions(content);
+
+        expect(result['1']?.description).toBe(
+            'Works with @angular/cdk/scrolling and <tui-textfield />.',
+        );
+    });
+
+    it('still reads static heading + inline description examples', () => {
+        const content = `
+            <tui-doc-page header="Button">
+                <ng-template pageTab>
+                    <tui-doc-example
+                        heading="Basics"
+                        [content]="1 | tuiExample"
+                    >
+                        <ng-template>
+                            A plain button.
+                        </ng-template>
+                    </tui-doc-example>
+                </ng-template>
+            </tui-doc-page>
+        `;
+
+        const result = extractExampleDescriptions(content);
+
+        expect(result['1']?.heading).toBe('Basics');
+        expect(result['1']?.description).toBe('A plain button.');
+    });
+});


### PR DESCRIPTION
The llms extractor never captured examples rendered through the modern `@for (example of …)` loop — descriptions live in a `@switch ($index)` block and headings in an inline array or the component `examples` field, none of which the old tag scan reached. So the generated markdown (`llms-full.txt` and the per-page files behind "Copy page") showed example headings with **no descriptions**, and only when the heading happened to come from a component field.

## What

- Parse `@switch ($index) { @case (N) { … } }` with balanced-brace scanning; case `N` maps to example folder `N + 1`.
- Read headings from an inline `@for (example of [A, B])` array when they are not declared on the component.
- Decode HTML entities so prose reads naturally (`@angular/cdk`, `<tui-textfield />`), and stop the second pass that re-stripped the decoded markup as if it were a tag.
- Emit examples in numeric order instead of filesystem order (`1, 10, 2 …`).

## Why it is a separate PR

The fix lives in the shared `extractExampleDescriptions` / `getUsageExamples` utilities, so it improves **both** `llms-full.txt` (already on `main`) and the per-page "Copy page" markdown (added in #14936). It is independent of #14936 and valuable on its own.

## Tests

Adds unit coverage for the extractor (the `@for`/`@switch` pattern, inline-array headings, entity decoding, and the existing static path as a regression guard). The `demo` project’s `testMatch` is widened to `**/*.spec.ts` — matching every other project — so these and the pre-existing (previously un-run) `test/` specs actually execute.

### Before / after (ComboBox)
```
#### Basic
**Template:** …            →   #### Basic
                                The main helper you’ll use with almost every ComboBox is the
                                tuiFilterByInput pipe. It enables item filtering as the user types.
                                **Template:** …
```