### PR TITLE
fix(kit): make controls with `min`/`max` & `{min,max}Length` input-props typing-compatible with signal forms

### DIFF
--- a/projects/kit/components/input-date-multi/input-date-multi.directive.ts
+++ b/projects/kit/components/input-date-multi/input-date-multi.directive.ts
@@ -94,12 +94,22 @@ export class TuiInputDateMultiDirective extends TuiInputChipDirective<TuiDay> {
         }
     });
 
+    /**
+     * TODO(v6): check https://github.com/angular/angular/issues/70600 status:
+     * Solved? Drop `readonly TuiDay[] | undefined` workaround from `transform`
+     */
     public readonly min = input(this.dateMultiOptions.min ?? TUI_FIRST_DAY, {
-        transform: (min: TuiDay | null): TuiDay => min ?? TUI_FIRST_DAY,
+        transform: (min: TuiDay | readonly TuiDay[] | null | undefined): TuiDay =>
+            min instanceof TuiDay ? min : (this.dateMultiOptions.min ?? TUI_FIRST_DAY),
     });
 
+    /**
+     * TODO(v6): check https://github.com/angular/angular/issues/70600 status:
+     * Solved? Drop `readonly TuiDay[] | undefined` workaround from `transform`
+     */
     public readonly max = input(this.dateMultiOptions.max ?? TUI_LAST_DAY, {
-        transform: (max: TuiDay | null): TuiDay => max ?? TUI_LAST_DAY,
+        transform: (max: TuiDay | readonly TuiDay[] | null | undefined): TuiDay =>
+            max instanceof TuiDay ? max : (this.dateMultiOptions.max ?? TUI_LAST_DAY),
     });
 
     protected processCalendar(calendar: AbstractTuiCalendar): void {

--- a/projects/kit/components/input-date-range/input-date-range.directive.ts
+++ b/projects/kit/components/input-date-range/input-date-range.directive.ts
@@ -37,12 +37,26 @@ import {TUI_INPUT_DATE_RANGE_OPTIONS} from './input-date-range.options';
     hostDirectives: [TuiWithInput, TuiDropdownAuto, MaskitoDirective],
 })
 export class TuiInputDateRangeDirective extends TuiInputDateBase<TuiDayRange> {
+    /**
+     * TODO(v6): check https://github.com/angular/angular/issues/70600 status:
+     * Solved? Drop `TuiDayRange | undefined` workaround from `transform`
+     */
     public override readonly max = input(this.options.max ?? TUI_LAST_DAY, {
-        transform: (max: TuiDay | null): TuiDay => max ?? TUI_LAST_DAY,
+        transform: (max: TuiDay | TuiDayRange | null | undefined): TuiDay =>
+            max && !(max instanceof TuiDayRange)
+                ? max
+                : (this.options.max ?? TUI_LAST_DAY),
     });
 
+    /**
+     * TODO(v6): check https://github.com/angular/angular/issues/70600 status:
+     * Solved? Drop `TuiDayRange | undefined` workaround from `transform`
+     */
     public override readonly min = input(this.options.min ?? TUI_FIRST_DAY, {
-        transform: (min: TuiDay | null): TuiDay => min ?? TUI_FIRST_DAY,
+        transform: (min: TuiDay | TuiDayRange | null | undefined): TuiDay =>
+            min && !(min instanceof TuiDayRange)
+                ? min
+                : (this.options.min ?? TUI_FIRST_DAY),
     });
 
     protected override readonly filler = tuiWithDateFiller(
@@ -62,8 +76,27 @@ export class TuiInputDateRangeDirective extends TuiInputDateBase<TuiDayRange> {
         ),
     );
 
-    public readonly minLength = input<TuiDayLike | null>(null);
-    public readonly maxLength = input<TuiDayLike | null>(null);
+    /**
+     * TODO(v6): check https://github.com/angular/angular/issues/70600 status:
+     * - Solved? Drop `number | undefined` workaround and `transform`
+     * - Not yet? Rename props to `margin`
+     * * (to be similar to `Range[margin]`: https://taiga-ui.dev/components/range/API?margin=2)
+     */
+    public readonly minLength = input<
+        TuiDayLike | null,
+        TuiDayLike | number | null | undefined
+    >(null, {transform: (x) => (typeof x === 'object' ? x : null)});
+
+    /**
+     * TODO(v6): check https://github.com/angular/angular/issues/70600 status:
+     * - Solved? Drop `number | undefined` workaround and `transform`
+     * - Not yet? Rename props to `limit`
+     * (to be similar to `Range[limit]`: https://taiga-ui.dev/components/range/API?limit=10)
+     */
+    public readonly maxLength = input<
+        TuiDayLike | null,
+        TuiDayLike | number | null | undefined
+    >(null, {transform: (x) => (typeof x === 'object' ? x : null)});
 
     protected override processCalendar(
         calendar: AbstractTuiCalendar | TuiCalendarRange,

--- a/projects/kit/components/input-range/input-range.component.ts
+++ b/projects/kit/components/input-range/input-range.component.ts
@@ -95,6 +95,7 @@ export class TuiInputRange extends TuiControl<readonly [number, number]> {
         100,
         {transform: (max) => (typeof max === 'number' ? max : 100)},
     );
+
     public readonly step = input(1);
     public readonly segments = input(1);
     public readonly keySteps = input<TuiKeySteps>();

--- a/projects/kit/components/input-range/input-range.component.ts
+++ b/projects/kit/components/input-range/input-range.component.ts
@@ -78,8 +78,23 @@ export class TuiInputRange extends TuiControl<readonly [number, number]> {
         this.contentStart() === this.content()[0] ? this.content()[1] : '',
     );
 
-    public readonly min = input(0);
-    public readonly max = input(100);
+    /**
+     * TODO(v6): check https://github.com/angular/angular/issues/70600 status:
+     * Solved? Drop `[number, number] | undefined` workaround and `transform`
+     */
+    public readonly min = input<number, number | readonly [number, number] | undefined>(
+        0,
+        {transform: (min) => (typeof min === 'number' ? min : 0)},
+    );
+
+    /**
+     * TODO(v6): check https://github.com/angular/angular/issues/70600 status:
+     * Solved? Drop `[number, number] | undefined` workaround and `transform`
+     */
+    public readonly max = input<number, number | readonly [number, number] | undefined>(
+        100,
+        {transform: (max) => (typeof max === 'number' ? max : 100)},
+    );
     public readonly step = input(1);
     public readonly segments = input(1);
     public readonly keySteps = input<TuiKeySteps>();

--- a/projects/kit/components/range/range.component.ts
+++ b/projects/kit/components/range/range.component.ts
@@ -52,8 +52,22 @@ export class TuiRange extends TuiControl<[number, number]> {
 
     protected lastActiveThumb: 'end' | 'start' = 'end';
 
-    public readonly min = input(0);
-    public readonly max = input(100);
+    /**
+     * TODO(v6): check https://github.com/angular/angular/issues/70600 status:
+     * Solved? Drop `[number, number] | undefined` workaround and `transform`
+     */
+    public readonly min = input<number, number | [number, number] | undefined>(0, {
+        transform: (min) => (typeof min === 'number' ? min : 0),
+    });
+
+    /**
+     * TODO(v6): check https://github.com/angular/angular/issues/70600 status:
+     * Solved? Drop `[number, number] | undefined` workaround and `transform`
+     */
+    public readonly max = input<number, number | [number, number] | undefined>(100, {
+        transform: (max) => (typeof max === 'number' ? max : 100),
+    });
+    
     public readonly step = input(1);
     public readonly segments = input(1);
     public readonly keySteps = input<TuiKeySteps>();

--- a/projects/kit/components/range/range.component.ts
+++ b/projects/kit/components/range/range.component.ts
@@ -67,7 +67,7 @@ export class TuiRange extends TuiControl<[number, number]> {
     public readonly max = input<number, number | [number, number] | undefined>(100, {
         transform: (max) => (typeof max === 'number' ? max : 100),
     });
-    
+
     public readonly step = input(1);
     public readonly segments = input(1);
     public readonly keySteps = input<TuiKeySteps>();

--- a/projects/kit/components/textarea/textarea.component.ts
+++ b/projects/kit/components/textarea/textarea.component.ts
@@ -35,8 +35,23 @@ export class TuiTextareaComponent implements OnInit {
 
     protected readonly isMobile = inject(WA_IS_MOBILE);
 
-    public readonly min = input(this.options.min);
-    public readonly max = input(this.options.max);
+    /**
+     * TODO(v6): check https://github.com/angular/angular/issues/70600 status:
+     * - Solved? Drop `string | undefined` workaround and `transform`
+     * - Not yet? Rename props to `minRows`
+     */
+    public readonly min = input<number, number | string | undefined>(this.options.min, {
+        transform: (min) => (typeof min === 'number' ? min : this.options.min),
+    });
+
+    /**
+     * TODO(v6): check https://github.com/angular/angular/issues/70600 status:
+     * - Solved? Drop `string | undefined` workaround and `transform`
+     * - Not yet? Rename props to `maxRows`
+     */
+    public readonly max = input<number, number | string | undefined>(this.options.max, {
+        transform: (max) => (typeof max === 'number' ? max : this.options.max),
+    });
     public readonly content = input(this.options.content);
     public readonly el = tuiInjectElement<HTMLTextAreaElement>();
 

--- a/projects/kit/components/textarea/textarea.component.ts
+++ b/projects/kit/components/textarea/textarea.component.ts
@@ -52,6 +52,7 @@ export class TuiTextareaComponent implements OnInit {
     public readonly max = input<number, number | string | undefined>(this.options.max, {
         transform: (max) => (typeof max === 'number' ? max : this.options.max),
     });
+
     public readonly content = input(this.options.content);
     public readonly el = tuiInjectElement<HTMLTextAreaElement>();
 


### PR DESCRIPTION
I hate every changed line of this PR! 
We cannot introduce breaking changes right now, so this is a temporary workaround until the Angular team fixes:
- https://github.com/angular/angular/issues/70600

### Problem
```html
<tui-textfield>
  <!-- TS2322: Type 'string | undefined' is not assignable to type 'number'.  ×2 -->
  <textarea tuiTextarea [formField]="f.comment"></textarea>
                         ~~~~~~~~~
</tui-textfield>

<tui-textfield>
  <!--
    TS2322: Type 'TuiDayRange | undefined' is not assignable to type 'TuiDay | null'.  ×2
    TS2322: Type 'number | undefined' is not assignable to type 'TuiDayLike | null'.   ×2
  -->
  <input tuiInputDateRange [formField]="f.period" />
                            ~~~~~~~~~
</tui-textfield>

<label tuiLabel>
  <!--
    TS2322: Type 'readonly [number, number] | undefined' is not assignable to type 'number'.  ×2
  -->
  <tui-input-range [formField]="f.span" [max]="100" [min]="0" />
                    ~~~~~~~~~
</label>

<!-- TS2322: Type '[number, number] | undefined' is not assignable to type 'number'.  ×2 -->
<tui-range [formField]="f.slider" [max]="100" [min]="0" />
            ~~~~~~~~~

<tui-textfield multi>
  <!--
    TS2322: Type 'readonly TuiDay[] | undefined' is not assignable to type 'TuiDay | null'.  ×2
    Same as the date range: the input is a calendar bound, the write is the whole value.
  -->
  <input tuiInputDateMulti [formField]="f.days" />
                            ~~~~~~~~~
</tui-textfield>
```

Relates:
- https://github.com/taiga-family/taiga-ui/issues/14341