### PR TITLE
fix(addon-commerce): `InputCardGroup` should become `touched` only on blur

### DIFF
--- a/projects/addon-commerce/components/input-card-group/input-card-group.component.ts
+++ b/projects/addon-commerce/components/input-card-group/input-card-group.component.ts
@@ -104,7 +104,7 @@ export interface TuiCard {
         '[attr.data-size]': 'textfield.size()',
         '(pointerdown)': 'onPointerDown($event)',
         '(scroll.zoneless)': '$event.target.scrollLeft = 0',
-        '(tuiActiveZoneChange)': 'onTouched()',
+        '(tuiActiveZoneChange)': '!$event && onTouched()',
     },
 })
 export class TuiInputCardGroup

--- a/projects/addon-commerce/components/input-card-group/test/input-card-group.component.spec.ts
+++ b/projects/addon-commerce/components/input-card-group/test/input-card-group.component.spec.ts
@@ -144,6 +144,18 @@ describe('InputCardGroup', () => {
     });
 
     describe('Focus', () => {
+        it('marks control as touched only after focus leaves the group', () => {
+            expect(testComponent.control.touched).toBe(false);
+
+            inputCardPO.focus();
+
+            expect(testComponent.control.touched).toBe(false);
+
+            inputCardPO.blur();
+
+            expect(testComponent.control.touched).toBe(true);
+        });
+
         it('focus remains in card input when invalid card is entered', () => {
             inputCardPO.focus();
             inputCardPO.sendText('8888888888889999');


### PR DESCRIPTION
Fixes #14941 
