### PR TITLE
fix(schematics): add TODO for removed tui-group__auto-width-item class in v5

### DIFF
--- a/projects/cdk/schematics/ng-update/v5/steps/constants/html-comments.ts
+++ b/projects/cdk/schematics/ng-update/v5/steps/constants/html-comments.ts
@@ -172,4 +172,15 @@ export const HTML_COMMENTS: HtmlComment[] = [
         comment:
             'focusedChange was removed in v5 — legacy controls no longer emit a focus output. There is no drop-in: read the readonly `focused` signal on <tui-textfield>, or use native (focusin)/(focusout) on the <input>. See https://taiga-ui.dev/components/textfield',
     },
+    {
+        tag: '*',
+        withAttrs: ['class'],
+        filterFn: (element) => {
+            const value = findAttr(element.attrs, 'class')?.value;
+
+            return !!value && value.split(/\s+/).includes('tui-group__auto-width-item');
+        },
+        comment:
+            '`tui-group__auto-width-item` was removed in v5. Re-create it on the child element with CSS: `flex: 0 0 auto; min-inline-size: auto;`.',
+    },
 ];

--- a/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-removed-css-class.spec.ts.snap
+++ b/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-removed-css-class.spec.ts.snap
@@ -1,0 +1,9 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ng-update removed CSS classes adds a TODO for the removed tui-group__auto-width-item class: test.html 1`] = `
+{
+  "0. Before": "<div class="my-item tui-group__auto-width-item">x</div>",
+  "1. After": "<!-- TODO: (Taiga UI migration) \`tui-group__auto-width-item\` was removed in v5. Re-create it on the child element with CSS: \`flex: 0 0 auto; min-inline-size: auto;\`. -->
+<div class="my-item tui-group__auto-width-item">x</div>",
+}
+`;

--- a/projects/cdk/schematics/ng-update/v5/tests/schematic-migrate-removed-css-class.spec.ts
+++ b/projects/cdk/schematics/ng-update/v5/tests/schematic-migrate-removed-css-class.spec.ts
@@ -11,9 +11,7 @@ describe('ng-update removed CSS classes', () => {
 
     it(
         'adds a TODO for the removed tui-group__auto-width-item class',
-        migrate({
-            template: '<div class="my-item tui-group__auto-width-item">x</div>',
-        }),
+        migrate({template: '<div class="my-item tui-group__auto-width-item">x</div>'}),
     );
 
     it(

--- a/projects/cdk/schematics/ng-update/v5/tests/schematic-migrate-removed-css-class.spec.ts
+++ b/projects/cdk/schematics/ng-update/v5/tests/schematic-migrate-removed-css-class.spec.ts
@@ -1,0 +1,25 @@
+import {join} from 'node:path';
+
+import {resetActiveProject} from 'ng-morph';
+
+import {createMigration} from '../../../utils/run-migration';
+
+describe('ng-update removed CSS classes', () => {
+    const migrate = createMigration({
+        collection: join(__dirname, '../../../migration.json'),
+    });
+
+    it(
+        'adds a TODO for the removed tui-group__auto-width-item class',
+        migrate({
+            template: '<div class="my-item tui-group__auto-width-item">x</div>',
+        }),
+    );
+
+    it(
+        'does not touch a class that merely shares the prefix',
+        migrate({template: '<div class="tui-group__item">x</div>'}),
+    );
+
+    afterEach(() => resetActiveProject());
+});


### PR DESCRIPTION
## What
Insert a manual-migration TODO above any element whose `class` still contains the removed `tui-group__auto-width-item` class.

## Why
The `tui-group__auto-width-item` modifier class was removed in v5 (it was `&__auto-width-item { flex: 0 0 auto; min-inline-size: auto; }` under the group directive) and has no 1:1 class replacement — it can only be reproduced with manual CSS. Today the migration leaves the class untouched with no signal, so it silently stops working. Reported on a real project (prm-ui).

## How
- `html-comments.ts`: new entry keyed on the `class` attribute (`filterFn` does an exact token match via `split(/\s+/).includes(...)`, so `tui-group__item` / prefix-sharing classes are not flagged); comment points at the exact CSS replacement.
- new spec `schematic-migrate-removed-css-class.spec.ts` (positive + prefix-sharing negative).

Verified via the schematics test harness — full `ng-update/v5` suite green (143 suites / 814 tests).