### PR TITLE
fix(schematics): install packages newly referenced by v5 import rewrites

### DIFF
--- a/projects/cdk/schematics/ng-update/v5/steps/update-packages.ts
+++ b/projects/cdk/schematics/ng-update/v5/steps/update-packages.ts
@@ -1,5 +1,14 @@
-import {type DevkitFileSystem} from 'ng-morph';
+import {type Tree} from '@angular-devkit/schematics';
+import {
+    addPackageJsonDependency,
+    type DevkitFileSystem,
+    getPackageJsonDependency,
+    getSourceFiles,
+    NodeDependencyType,
+} from 'ng-morph';
 
+import {ALL_TS_FILES} from '../../../constants';
+import {TAIGA_VERSION} from '../../../ng-add/constants/versions';
 import {replacePackageName} from '../../steps';
 
 export const TUI_POLYMORPHEUS_VERSION = '^5.0.0';
@@ -9,7 +18,43 @@ export const TUI_EDITOR_VERSION = '^5.4.0';
 export const NG_WEB_APIS = '^5.0.0';
 export const MASKITO_VERSION = '^5.0.0';
 
+interface IntroducedPackage {
+    name: string;
+    version: string;
+    type: NodeDependencyType;
+}
+
+// Opt-in packages the migration may rewrite imports to, but that a v4 app may not have installed.
+const MAYBE_INTRODUCED_PACKAGES: readonly IntroducedPackage[] = [
+    {
+        name: '@ng-web-apis/platform',
+        version: NG_WEB_APIS,
+        type: NodeDependencyType.Default,
+    },
+    {
+        name: '@taiga-ui/editor',
+        version: TUI_EDITOR_VERSION,
+        type: NodeDependencyType.Default,
+    },
+    {name: '@taiga-ui/legacy', version: TAIGA_VERSION, type: NodeDependencyType.Default},
+    {name: '@taiga-ui/layout', version: TAIGA_VERSION, type: NodeDependencyType.Default},
+    {
+        name: '@taiga-ui/addon-mobile',
+        version: TAIGA_VERSION,
+        type: NodeDependencyType.Default,
+    },
+    {name: '@maskito/kit', version: MASKITO_VERSION, type: NodeDependencyType.Default},
+    {
+        name: '@maskito/angular',
+        version: MASKITO_VERSION,
+        type: NodeDependencyType.Default,
+    },
+    {name: '@taiga-ui/jest-config', version: TAIGA_VERSION, type: NodeDependencyType.Dev},
+];
+
 export function updatePackages({tree}: DevkitFileSystem): void {
+    addIntroducedPackages(tree);
+
     const packages = (
         [
             [TUI_POLYMORPHEUS_VERSION, ['@taiga-ui/polymorpheus']],
@@ -24,6 +69,7 @@ export function updatePackages({tree}: DevkitFileSystem): void {
                     '@ng-web-apis/common',
                     '@ng-web-apis/intersection-observer',
                     '@ng-web-apis/universal',
+                    '@ng-web-apis/platform',
                 ],
             ],
             [TUI_DOMPURIFY_VERSION, ['@taiga-ui/dompurify']],
@@ -33,5 +79,26 @@ export function updatePackages({tree}: DevkitFileSystem): void {
 
     for (const {name, version} of packages) {
         replacePackageName(name, {name, version}, tree);
+    }
+}
+
+// Import rewrites never touch package.json, so add any now-imported package that is still missing.
+function addIntroducedPackages(tree: Tree): void {
+    const specifiers = getSourceFiles(ALL_TS_FILES).flatMap((sourceFile) =>
+        sourceFile
+            .getImportDeclarations()
+            .map((declaration) => declaration.getModuleSpecifierValue()),
+    );
+
+    for (const dependency of MAYBE_INTRODUCED_PACKAGES) {
+        const isImported = specifiers.some(
+            (specifier) =>
+                specifier === dependency.name ||
+                specifier.startsWith(`${dependency.name}/`),
+        );
+
+        if (isImported && !getPackageJsonDependency(tree, dependency.name)) {
+            addPackageJsonDependency(tree, dependency);
+        }
     }
 }

--- a/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-update-packages.spec.ts.snap
+++ b/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-update-packages.spec.ts.snap
@@ -1,5 +1,52 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`ng-update migrate packages adds introduced packages when their imports appear but they are missing: package.json 1`] = `
+{
+  "0. Before": "
+             {
+                 "dependencies": {
+                    "@angular/core": "~19.0.0",
+                    "@taiga-ui/cdk": "5.0.1",
+                    "@taiga-ui/core": "5.0.1"
+                 }
+             }
+            ",
+  "1. After": "
+             {
+                 "dependencies": {
+                    "@angular/core": "~19.0.0",
+                    "@ng-web-apis/platform": "^5.0.0",
+                    "@taiga-ui/cdk": "5.0.1",
+                    "@taiga-ui/core": "5.0.1",
+                    "@taiga-ui/editor": "^5.4.0"
+                 }
+             }
+            ",
+}
+`;
+
+exports[`ng-update migrate packages adds introduced packages when their imports appear but they are missing: test.ts 1`] = `
+{
+  "0. Before": "
+                import {tuiHexToRgb, TUI_IS_TOUCH} from '@taiga-ui/cdk';
+
+                export class Test {
+                    protected readonly rgb = tuiHexToRgb;
+                    protected readonly touch = TUI_IS_TOUCH;
+                }
+            ",
+  "1. After": "import { tuiHexToRgb } from "@taiga-ui/editor";
+// TODO: (Taiga UI migration) TUI_IS_TOUCH was renamed to WA_IS_TOUCH from @ng-web-apis/platform, which is a Signal<boolean> (the old token was a plain boolean), so read it with a call: inject(WA_IS_TOUCH)().
+import { WA_IS_TOUCH } from "@ng-web-apis/platform";
+
+                export class Test {
+                    protected readonly rgb = tuiHexToRgb;
+                    protected readonly touch = WA_IS_TOUCH;
+                }
+            ",
+}
+`;
+
 exports[`ng-update migrate packages update packages from v4: package.json 1`] = `
 {
   "0. Before": "

--- a/projects/cdk/schematics/ng-update/v5/tests/schematic-migrate-update-packages.spec.ts
+++ b/projects/cdk/schematics/ng-update/v5/tests/schematic-migrate-update-packages.spec.ts
@@ -94,5 +94,50 @@ describe('ng-update migrate packages', () => {
         }),
     );
 
+    it(
+        'adds introduced packages when their imports appear but they are missing',
+        migrate({
+            component: /* TypeScript */ `
+                import {tuiHexToRgb, TUI_IS_TOUCH} from '@taiga-ui/cdk';
+
+                export class Test {
+                    protected readonly rgb = tuiHexToRgb;
+                    protected readonly touch = TUI_IS_TOUCH;
+                }
+            `,
+            packageJson: `
+             {
+                 "dependencies": {
+                    "@angular/core": "~19.0.0",
+                    "@taiga-ui/cdk": "5.0.1",
+                    "@taiga-ui/core": "5.0.1"
+                 }
+             }
+            `,
+        }),
+    );
+
+    it(
+        'does not add introduced packages that are not imported',
+        migrate({
+            component: /* TypeScript */ `
+                import {TuiButton} from '@taiga-ui/core';
+
+                export class Test {
+                    protected readonly button = TuiButton;
+                }
+            `,
+            packageJson: `
+             {
+                 "dependencies": {
+                    "@angular/core": "~19.0.0",
+                    "@taiga-ui/cdk": "5.0.1",
+                    "@taiga-ui/core": "5.0.1"
+                 }
+             }
+            `,
+        }),
+    );
+
     afterEach(() => resetActiveProject());
 });


### PR DESCRIPTION
## What
When the v5 migration rewrites a TS import to an opt-in package the app may not have, add that package to `package.json` so the post-migration build resolves.

## Why
The migration rewrites import specifiers (`identifiers-to-replace` and dedicated steps) to packages like `@ng-web-apis/platform`, `@taiga-ui/editor`, `@taiga-ui/legacy`, `@taiga-ui/layout`, `@taiga-ui/addon-mobile`, `@maskito/kit|angular`, `@taiga-ui/jest-config`. Several of these symbols move **out of `@taiga-ui/cdk`** (always present in v4), so a plain v4 app gets its imports redirected to a package it never installed. The existing package handling (`replace-package-name.ts` `if (old) {…}`) only **bumps a version when the package is already present** — it never adds a newly-referenced one. Result today: `Cannot find module @ng-web-apis/platform` / `@taiga-ui/editor` after `ng update`. Reported on a real project (prm-ui).

Highest impact: `@ng-web-apis/platform` — receives 11 symbols moved from cdk (`TUI_IS_*`→`WA_IS_*`, `tuiIsApple`…), and was the one `@ng-web-apis/*` sibling missing from the bump list with no pinned version.

## How
- `update-packages.ts`: new `addIntroducedPackages(tree)` — scan all TS imports after rewrites; for each opt-in target that is now imported but missing from `package.json`, add it via `addPackageJsonDependency` at the pinned v5 version (`@taiga-ui/*` → `TAIGA_VERSION`, editor → `^5.4.0`, maskito → `MASKITO_VERSION`, platform → `^5.0.0`; `@taiga-ui/jest-config` as a devDependency). The existing `NodePackageInstallTask` then installs it. Add is **conditional** (only when the import actually appears), so apps that never triggered a given rename are untouched.
- Added `@ng-web-apis/platform` to the `NG_WEB_APIS` bump list so already-present installs are version-locked too.
- Always-present packages (core/kit/cdk/i18n/polymorpheus/resize-observer) are intentionally excluded.

## Tests
- `schematic-migrate-update-packages.spec.ts`: importing `tuiHexToRgb` + `TUI_IS_TOUCH` from cdk (→ editor / platform) with a package.json lacking both adds `@ng-web-apis/platform: ^5.0.0` and `@taiga-ui/editor: ^5.4.0`; a not-imported control adds nothing. Existing snapshots unchanged.

Verified via the schematics test harness — full `ng-update/v5` suite green (142 suites / 814 tests).