### PR TITLE
fix(core): `InputPhoneInternational` & `InputNumber[step]` should ignore `:invalid` appearance until the control is `touched`

### DIFF
--- a/projects/core/components/input/input.directive.ts
+++ b/projects/core/components/input/input.directive.ts
@@ -32,6 +32,7 @@ import {type TuiInteractiveState} from '@taiga-ui/core/types';
         tuiInput: '',
         '[attr.role]': 'dropdown.content() && !el.matches("select") ? "combobox" : null',
         '[class._empty]': 'value() === ""',
+        '[class._untouched]': 'control?.untouched',
         '[readOnly]': 'readOnly()',
         '(focusin)': '0',
         '(focusout)': '0',

--- a/projects/demo-cypress/src/tests/input-number/signal-forms-required-validator.cy.ts
+++ b/projects/demo-cypress/src/tests/input-number/signal-forms-required-validator.cy.ts
@@ -1,0 +1,110 @@
+/*
+// TODO: Uncomment the whole file when the `@angular/forms/signals` entry point becomes available,
+// when Taiga UI drops support of Angular below 22 (stable API for signal forms appeared in Angular 22)
+import {ChangeDetectionStrategy, Component, signal, type Type} from '@angular/core';
+import {FormControl, ReactiveFormsModule, Validators} from '@angular/forms';
+import {form, FormField, required} from '@angular/forms/signals';
+import {TuiRoot} from '@taiga-ui/core';
+import {TuiInputNumber} from '@taiga-ui/kit';
+
+describe('tuiInputNumber[step] + required validator', () => {
+    @Component({
+        imports: [FormField, TuiInputNumber, TuiRoot],
+        template: `
+            <tui-root>
+                <tui-textfield>
+                    <input
+                        tuiInputNumber
+                        [formField]="f.amount"
+                        [step]="1"
+                    />
+                </tui-textfield>
+
+                <div style="margin-block-start: 1rem">
+                    <output id="touched">{{ f.amount().touched() }}</output>
+                </div>
+            </tui-root>
+        `,
+        changeDetection: ChangeDetectionStrategy.OnPush,
+    })
+    class SignalFormsSandbox {
+        public readonly model = signal<{amount: number | null}>({amount: null});
+
+        public readonly f = form(this.model, (path) => {
+            required(path.amount);
+        });
+    }
+
+    @Component({
+        imports: [ReactiveFormsModule, TuiInputNumber, TuiRoot],
+        template: `
+            <tui-root>
+                <tui-textfield>
+                    <input
+                        tuiInputNumber
+                        [formControl]="control"
+                        [step]="1"
+                    />
+                </tui-textfield>
+
+                <div style="margin-block-start: 1rem">
+                    <output id="touched">{{ control.touched }}</output>
+                </div>
+            </tui-root>
+        `,
+        changeDetection: ChangeDetectionStrategy.OnPush,
+    })
+    class ReactiveFormsSandbox {
+        public readonly control = new FormControl<number | null>(
+            null,
+            Validators.required,
+        );
+    }
+
+    const SANDBOXES: ReadonlyArray<{
+        readonly component: Type<unknown>;
+        readonly title: string;
+    }> = [
+        {component: SignalFormsSandbox, title: '[formField] (signal forms)'},
+        {component: ReactiveFormsSandbox, title: '[formControl] (reactive forms)'},
+    ];
+
+    function snapshot(description: string): void {
+        cy.get('tui-textfield').compareSnapshot({
+            name: `InputNumberStep-required-${description}`,
+            cypressScreenshotOptions: {padding: 8},
+        });
+    }
+
+    SANDBOXES.forEach(({component, title}) => {
+        describe(title, () => {
+            beforeEach(() => {
+                cy.viewport(300, 300);
+                cy.mount(component);
+                cy.get('input[tuiInputNumber]').as('input');
+            });
+
+            it('invalid but untouched => nothing is marked as invalid', () => {
+                cy.get('#touched').should('have.text', 'false');
+
+                cy.get('tui-textfield').should('not.have.class', 'tui-invalid');
+                cy.get('@input').should('have.attr', 'aria-invalid', 'false');
+                cy.get('@input').should('not.have.attr', 'data-mode', 'invalid');
+
+                snapshot(`untouched-invalid-${component.name}`);
+            });
+
+            it('blur => invalid decoration appears', () => {
+                cy.get('@input').focus().blur();
+
+                cy.get('#touched').should('have.text', 'true');
+                cy.get('tui-textfield').should('have.class', 'tui-invalid');
+                cy.get('@input').should('have.attr', 'aria-invalid', 'true');
+
+                snapshot(`touched-invalid-${component.name}`);
+            });
+        });
+    });
+});
+*/
+// eslint-disable-next-line unicorn/no-empty-file

--- a/projects/demo-cypress/src/tests/input-phone-international.cy.ts
+++ b/projects/demo-cypress/src/tests/input-phone-international.cy.ts
@@ -339,9 +339,7 @@ describe('InputPhoneInternational', () => {
         });
 
         it('paints an untouched control as well — the override does not wait for a touch', () => {
-            cy.mount(ManualInvalidSandbox, {
-                componentProperties: {control: ngControl},
-            });
+            cy.mount(ManualInvalidSandbox, {componentProperties: {control: ngControl}});
 
             initAliases();
 

--- a/projects/demo-cypress/src/tests/input-phone-international.cy.ts
+++ b/projects/demo-cypress/src/tests/input-phone-international.cy.ts
@@ -337,6 +337,21 @@ describe('InputPhoneInternational', () => {
                 });
             });
         });
+
+        it('paints an untouched control as well — the override does not wait for a touch', () => {
+            cy.mount(ManualInvalidSandbox, {
+                componentProperties: {control: ngControl},
+            });
+
+            initAliases();
+
+            cy.get('tui-textfield').should('have.attr', 'data-mode', 'invalid');
+
+            cy.get('tui-textfield').compareSnapshot({
+                name: 'phone-manual-invalid-untouched',
+                cypressScreenshotOptions: {padding: 8},
+            });
+        });
     });
 });
 

--- a/projects/demo-cypress/src/tests/input-phone-international/signal-forms-required-validator.cy.ts
+++ b/projects/demo-cypress/src/tests/input-phone-international/signal-forms-required-validator.cy.ts
@@ -1,0 +1,130 @@
+/*
+// TODO: Uncomment the whole file when the `@angular/forms/signals` entry point becomes available,
+// when Taiga UI drops support of Angular below 22 (stable API for signal forms appeared in Angular 22)
+import {ChangeDetectionStrategy, Component, signal, type Type} from '@angular/core';
+import {FormControl, ReactiveFormsModule, Validators} from '@angular/forms';
+import {form, FormField, required} from '@angular/forms/signals';
+import {TuiRoot} from '@taiga-ui/core';
+import {type TuiCountryIsoCode} from '@taiga-ui/i18n';
+import {
+    TuiInputPhoneInternational,
+    tuiInputPhoneInternationalOptionsProvider,
+} from '@taiga-ui/kit';
+import metadata from 'libphonenumber-js/min/metadata';
+import {of} from 'rxjs';
+
+describe('tuiInputPhoneInternational + signal forms: required() paints it before touch', () => {
+    const COUNTRIES: readonly TuiCountryIsoCode[] = ['CN', 'US'];
+
+    @Component({
+        imports: [FormField, TuiInputPhoneInternational, TuiRoot],
+        template: `
+            <tui-root>
+                <tui-textfield>
+                    <input
+                        tuiInputPhoneInternational
+                        [countries]="countries"
+                        [formField]="f.phone"
+                        [(countryIsoCode)]="iso"
+                    />
+                </tui-textfield>
+
+                <div style="margin-block-start: 1rem">
+                    <output id="touched">{{ f.phone().touched() }}</output>
+                </div>
+            </tui-root>
+        `,
+        providers: [
+            tuiInputPhoneInternationalOptionsProvider({metadata: of(metadata)}),
+        ],
+        changeDetection: ChangeDetectionStrategy.OnPush,
+    })
+    class SignalFormsSandbox {
+        public readonly countries = COUNTRIES;
+        public readonly iso = signal<TuiCountryIsoCode>('CN');
+        public readonly model = signal<{phone: string}>({phone: ''});
+
+        public readonly f = form(this.model, (path) => {
+            required(path.phone);
+        });
+    }
+
+    @Component({
+        imports: [ReactiveFormsModule, TuiInputPhoneInternational, TuiRoot],
+        template: `
+            <tui-root>
+                <tui-textfield>
+                    <input
+                        tuiInputPhoneInternational
+                        [countries]="countries"
+                        [formControl]="control"
+                        [(countryIsoCode)]="iso"
+                    />
+                </tui-textfield>
+
+                <div style="margin-block-start: 1rem">
+                    <output id="touched">{{ control.touched }}</output>
+                </div>
+            </tui-root>
+        `,
+        providers: [
+            tuiInputPhoneInternationalOptionsProvider({metadata: of(metadata)}),
+        ],
+        changeDetection: ChangeDetectionStrategy.OnPush,
+    })
+    class ReactiveFormsSandbox {
+        public readonly countries = COUNTRIES;
+        public readonly iso = signal<TuiCountryIsoCode>('CN');
+        public readonly control = new FormControl<string>('', {
+            nonNullable: true,
+            validators: Validators.required,
+        });
+    }
+
+    const SANDBOXES: ReadonlyArray<{
+        readonly component: Type<unknown>;
+        readonly title: string;
+    }> = [
+        {component: SignalFormsSandbox, title: '[formField] (signal forms)'},
+        {component: ReactiveFormsSandbox, title: '[formControl] (reactive forms)'},
+    ];
+
+    function snapshot(description: string): void {
+        cy.get('tui-textfield').compareSnapshot({
+            name: `InputPhonei18n-${description}`,
+            cypressScreenshotOptions: {padding: 8},
+        });
+    }
+
+    SANDBOXES.forEach(({component, title}) => {
+        describe(title, () => {
+            beforeEach(() => {
+                cy.viewport(300, 300);
+                cy.mount(component);
+                cy.get('input[tuiInputPhoneInternational]').as('input');
+            });
+
+            it('invalid but untouched => nothing is marked as invalid', () => {
+                cy.get('#touched').should('have.text', 'false');
+
+                cy.get('tui-textfield').should('not.have.class', 'tui-invalid');
+                cy.get('@input').should('have.attr', 'aria-invalid', 'false');
+                cy.get('@input').should('not.have.attr', 'data-mode', 'invalid');
+
+                snapshot(`untouched-invalid-${component.name}`);
+            });
+
+            it('blur => invalid decoration appears', () => {
+                cy.get('@input').focus().blur();
+
+                cy.get('#touched').should('have.text', 'true');
+                cy.get('tui-textfield').should('have.class', 'tui-invalid');
+                cy.get('@input').should('have.attr', 'aria-invalid', 'true');
+
+                snapshot(`touched-invalid-${component.name}`);
+            });
+        });
+    });
+});
+*/
+// eslint-disable-next-line unicorn/no-empty-file

--- a/projects/styles/mixins/appearance.less
+++ b/projects/styles/mixins/appearance.less
@@ -44,13 +44,12 @@
 }
 
 .appearance-invalid(@content) {
-    &:is([data-mode~='invalid'], .tui-invalid, :invalid):not(
+    &:is([data-mode~='invalid'], .tui-invalid, :invalid:not(._untouched)):not(
             [data-mode~='readonly'],
             [data-mode~='valid'],
             [data-state='disabled'],
             :disabled,
-            ._disabled,
-            ._untouched
+            ._disabled
         ) {
         @content();
     }

--- a/projects/styles/mixins/appearance.less
+++ b/projects/styles/mixins/appearance.less
@@ -49,7 +49,8 @@
             [data-mode~='valid'],
             [data-state='disabled'],
             :disabled,
-            ._disabled
+            ._disabled,
+            ._untouched
         ) {
         @content();
     }

--- a/projects/styles/mixins/appearance.scss
+++ b/projects/styles/mixins/appearance.scss
@@ -45,13 +45,12 @@
 }
 
 @mixin appearance-invalid {
-    &:is([data-mode~='invalid'], .tui-invalid, :invalid):not(
+    &:is([data-mode~='invalid'], .tui-invalid, :invalid:not(._untouched)):not(
             [data-mode~='readonly'],
             [data-mode~='valid'],
             [data-state='disabled'],
             :disabled,
-            ._disabled,
-            ._untouched
+            ._disabled
         ) {
         @content;
     }

--- a/projects/styles/mixins/appearance.scss
+++ b/projects/styles/mixins/appearance.scss
@@ -50,7 +50,8 @@
             [data-mode~='valid'],
             [data-state='disabled'],
             :disabled,
-            ._disabled
+            ._disabled,
+            ._untouched
         ) {
         @content;
     }


### PR DESCRIPTION
### Problem
`InputPhoneInternational` & `InputNumber[step]` has `TuiAppearanceProxy` as host directive:
https://github.com/taiga-family/taiga-ui/blob/2c1168410069e73dfc7ef85c741c476b0db31d8c/projects/kit/components/input-number/step/input-number-step.directive.ts#L19
https://github.com/taiga-family/taiga-ui/blob/2c1168410069e73dfc7ef85c741c476b0db31d8c/projects/kit/components/input-phone-international/input-phone-international.component.ts#L50


`TuiAppearanceProxy` re-hangs the appearance from `<tui-textfield>` onto the native `<input>`: it mounts its own `TuiAppearance`, and `TuiInputDirective` binds that one instead of the wrapper's:
```
tui-textield[tuiAppearance] => input[tuiAppearance]
```


Signal forms [mirror their constraints to the corresponding native attributes](https://angular.dev/guide/forms/signals/validation#native-html-validation), so signal-based `required()` validator becomes a real `<input required>` attribute: the empty control is `input:invalid` from initialization.

<img width="1483" height="436" alt="angular-documentation" src="https://github.com/user-attachments/assets/0bc18521-4c9b-4f9b-9d4f-345c236110b8" />


Appearance and `:invalid` are now on the same element, so `.appearance-invalid` fires and paints it.
https://github.com/taiga-family/taiga-ui/blob/2c1168410069e73dfc7ef85c741c476b0db31d8c/projects/styles/mixins/appearance.less#L46-L55

https://github.com/taiga-family/taiga-ui/blob/2c1168410069e73dfc7ef85c741c476b0db31d8c/projects/styles/theme/appearance/textfield.less#L41-L43



In JS (inside `TuiControl` / `tui-textfield`) everything is still valid — no `tui-invalid`, `aria-invalid="false"`, the field is untouched. Only CSS decided to paint, and nothing vetoed it.

Fixes #14341
- https://github.com/taiga-family/taiga-ui/issues/14341
