### PR TITLE
fix(core): `SelectLike` should reset form control value on Backspace/Delete

### DIFF
--- a/projects/core/components/textfield/select-like.directive.ts
+++ b/projects/core/components/textfield/select-like.directive.ts
@@ -1,7 +1,6 @@
 import {Directive, inject} from '@angular/core';
 import {WA_IS_ANDROID, WA_IS_MOBILE} from '@ng-web-apis/platform';
 import {tuiInjectElement} from '@taiga-ui/cdk/utils/dom';
-import {tuiClamp} from '@taiga-ui/cdk/utils/math';
 
 import {TUI_TEXTFIELD_OPTIONS} from './textfield.options';
 
@@ -16,16 +15,18 @@ import {TUI_TEXTFIELD_OPTIONS} from './textfield.options';
         '(beforeinput)':
             '(isMobile && $event.inputType.includes("insertText")) || options.cleaner() && $event.inputType.includes("delete") || $event.preventDefault()',
         '(input.capture)': '$event.inputType?.includes("delete") && clear()',
-        '(keydown.backspace)': 'options.cleaner() && dispatchInputEvent(-1)', // No (input) event if caret is at the beginning
-        '(keydown.delete)': 'options.cleaner() && dispatchInputEvent(1)', // No (input) event if caret is at the end
+        '(keydown.backspace.prevent)':
+            'options.cleaner() && el.value && dispatchInputEvent("deleteContentBackward")',
+        '(keydown.delete.prevent)':
+            'options.cleaner() && el.value && dispatchInputEvent("deleteContentForward")',
         // Hide Android text select handle (bubble marker below transparent caret)
         '(mousedown)': 'prevent($event)',
     },
 })
 export class TuiSelectLike {
-    private readonly el = tuiInjectElement<HTMLInputElement>();
     private readonly isAndroid = inject(WA_IS_ANDROID);
 
+    protected readonly el = tuiInjectElement<HTMLInputElement>();
     protected readonly isMobile = inject(WA_IS_MOBILE);
     protected readonly options = inject(TUI_TEXTFIELD_OPTIONS);
 
@@ -33,20 +34,13 @@ export class TuiSelectLike {
         this.el.value = '';
     }
 
-    protected dispatchInputEvent(direction: -1 | 1): void {
-        const caret = this.el.selectionStart ?? 0;
-
-        if (
-            this.el.value &&
-            tuiClamp(caret + direction, 0, this.el.value.length) === caret
-        ) {
-            this.el.dispatchEvent(
-                new InputEvent('input', {
-                    bubbles: true,
-                    inputType: `deleteContent${direction === 1 ? 'Forward' : 'Backward'}`,
-                }),
-            );
-        }
+    protected dispatchInputEvent(inputType: string): void {
+        this.el.dispatchEvent(
+            new InputEvent('input', {
+                inputType,
+                bubbles: true,
+            }),
+        );
     }
 
     protected prevent(event: MouseEvent): void {

--- a/projects/core/components/textfield/select-like.directive.ts
+++ b/projects/core/components/textfield/select-like.directive.ts
@@ -1,5 +1,6 @@
 import {Directive, inject} from '@angular/core';
 import {WA_IS_ANDROID, WA_IS_MOBILE} from '@ng-web-apis/platform';
+import {tuiClamp} from '@taiga-ui/cdk/utils/math';
 import {tuiInjectElement} from '@taiga-ui/cdk/utils/dom';
 
 import {TUI_TEXTFIELD_OPTIONS} from './textfield.options';
@@ -15,8 +16,8 @@ import {TUI_TEXTFIELD_OPTIONS} from './textfield.options';
         '(beforeinput)':
             '(isMobile && $event.inputType.includes("insertText")) || options.cleaner() && $event.inputType.includes("delete") || $event.preventDefault()',
         '(input.capture)': '$event.inputType?.includes("delete") && clear()',
-        '(keydown.backspace)': 'options.cleaner() && clear()', // No (input) event if caret is at the beginning
-        '(keydown.delete)': 'options.cleaner() && clear()', // No (input) event if caret is at the end
+        '(keydown.backspace)': 'options.cleaner() && dispatchInputEvent(-1)', // No (input) event if caret is at the beginning
+        '(keydown.delete)': 'options.cleaner() && dispatchInputEvent(1)', // No (input) event if caret is at the end
         // Hide Android text select handle (bubble marker below transparent caret)
         '(mousedown)': 'prevent($event)',
     },
@@ -30,6 +31,22 @@ export class TuiSelectLike {
 
     protected clear(): void {
         this.el.value = '';
+    }
+
+    protected dispatchInputEvent(direction: -1 | 1): void {
+        const caret = this.el.selectionStart ?? 0;
+
+        if (
+            this.el.value &&
+            tuiClamp(caret + direction, 0, this.el.value.length) === caret
+        ) {
+            this.el.dispatchEvent(
+                new InputEvent('input', {
+                    bubbles: true,
+                    inputType: `deleteContent${direction === 1 ? 'Forward' : 'Backward'}`,
+                }),
+            );
+        }
     }
 
     protected prevent(event: MouseEvent): void {

--- a/projects/core/components/textfield/select-like.directive.ts
+++ b/projects/core/components/textfield/select-like.directive.ts
@@ -1,7 +1,7 @@
 import {Directive, inject} from '@angular/core';
 import {WA_IS_ANDROID, WA_IS_MOBILE} from '@ng-web-apis/platform';
-import {tuiClamp} from '@taiga-ui/cdk/utils/math';
 import {tuiInjectElement} from '@taiga-ui/cdk/utils/dom';
+import {tuiClamp} from '@taiga-ui/cdk/utils/math';
 
 import {TUI_TEXTFIELD_OPTIONS} from './textfield.options';
 

--- a/projects/core/components/textfield/select-like.directive.ts
+++ b/projects/core/components/textfield/select-like.directive.ts
@@ -16,9 +16,9 @@ import {TUI_TEXTFIELD_OPTIONS} from './textfield.options';
             '(isMobile && $event.inputType.includes("insertText")) || options.cleaner() && $event.inputType.includes("delete") || $event.preventDefault()',
         '(input.capture)': '$event.inputType?.includes("delete") && clear()',
         '(keydown.backspace.prevent)':
-            'options.cleaner() && el.value && dispatchInputEvent("deleteContentBackward")',
+            'options.cleaner() && el.value && dispatchInputEvent()',
         '(keydown.delete.prevent)':
-            'options.cleaner() && el.value && dispatchInputEvent("deleteContentForward")',
+            'options.cleaner() && el.value && dispatchInputEvent()',
         // Hide Android text select handle (bubble marker below transparent caret)
         '(mousedown)': 'prevent($event)',
     },
@@ -34,10 +34,10 @@ export class TuiSelectLike {
         this.el.value = '';
     }
 
-    protected dispatchInputEvent(inputType: string): void {
+    protected dispatchInputEvent(): void {
         this.el.dispatchEvent(
             new InputEvent('input', {
-                inputType,
+                inputType: 'deleteContentBackward',
                 bubbles: true,
             }),
         );

--- a/projects/demo-playwright/tests/kit/input-month/input-month.pw.spec.ts
+++ b/projects/demo-playwright/tests/kit/input-month/input-month.pw.spec.ts
@@ -162,6 +162,75 @@ describe('InputMonth', () => {
                 });
             });
         });
+
+        describe('Keyboard clearing', () => {
+            const selectMonth = async (): Promise<void> => {
+                await inputMonth.textfield.click();
+                await new TuiCalendarMonthPO(inputMonth.calendar).month.nth(8).click();
+                await expect(inputMonth.textfield).toHaveValue('September 2020');
+            };
+
+            [true, false].forEach((cleanerEnabled) => {
+                describe(`tuiTextfieldCleaner=${cleanerEnabled}`, () => {
+                    beforeEach(async ({page}) => {
+                        await tuiGoto(
+                            page,
+                            `${DemoRoute.InputMonth}/API?tuiTextfieldCleaner=${cleanerEnabled}`,
+                        );
+                        await selectMonth();
+                        await inputMonth.textfield.click();
+
+                        await expect(inputMonth.calendar).toBeAttached();
+                    });
+
+                    test('Backspace', async ({page}) => {
+                        await page.keyboard.press('Backspace');
+                        await expect(inputMonth.textfield).toHaveValue(
+                            cleanerEnabled ? '' : 'September 2020',
+                        );
+                    });
+
+                    test('Delete', async ({page}) => {
+                        await page.keyboard.press('ControlOrMeta+A');
+                        await page.keyboard.press('Delete');
+                        await expect(inputMonth.textfield).toHaveValue(
+                            cleanerEnabled ? '' : 'September 2020',
+                        );
+                    });
+                });
+            });
+
+            describe('updates form control value', () => {
+                (['Home', 'End'] as const).forEach((caret) => {
+                    ['Backspace', 'Delete'].forEach((key) => {
+                        test(`caret at ${caret} + ${key} => form control value is null`, async ({
+                            page,
+                        }) => {
+                            await tuiGoto(
+                                page,
+                                `${DemoRoute.InputMonth}/API?sandboxExpanded=true&tuiTextfieldCleaner=true`,
+                            );
+
+                            const documentationPage = new TuiDocumentationPagePO(page);
+
+                            await selectMonth();
+                            await expect(documentationPage.value).toContainText(
+                                '2020-09',
+                            );
+
+                            await inputMonth.textfield.click();
+                            await page.keyboard.press(caret);
+                            await page.keyboard.press(key);
+
+                            await expect(inputMonth.textfield).toHaveValue('');
+                            await expect(documentationPage.value).toContainText(
+                                '"value": null',
+                            );
+                        });
+                    });
+                });
+            });
+        });
     });
 
     describe('Examples', () => {

--- a/projects/demo-playwright/tests/kit/select/select.pw.spec.ts
+++ b/projects/demo-playwright/tests/kit/select/select.pw.spec.ts
@@ -159,6 +159,31 @@ describe('Select', () => {
                 await expect(select.textfield).toHaveValue('');
             });
         });
+
+        describe('updates form control value', () => {
+            ['Backspace', 'Delete'].forEach((key) => {
+                test(`${key} => form control value is null`, async ({page}) => {
+                    await tuiGoto(
+                        page,
+                        `${DemoRoute.Select}/API?sandboxExpanded=true&tuiTextfieldCleaner=true`,
+                    );
+
+                    documentationPage = new TuiDocumentationPagePO(page);
+                    const select = new TuiSelectPO(
+                        documentationPage.demo.locator('tui-textfield:has([tuiSelect])'),
+                    );
+
+                    await expect(select.textfield).toHaveValue('USA');
+                    await expect(documentationPage.value).toContainText('"name": "USA"');
+
+                    await select.textfield.click();
+                    await page.keyboard.press(key);
+
+                    await expect(select.textfield).toHaveValue('');
+                    await expect(documentationPage.value).toContainText('"value": null');
+                });
+            });
+        });
     });
 
     describe('updateOn=submit', () => {

--- a/projects/kit/components/multi-select/multi-select-native/multi-select-native.component.ts
+++ b/projects/kit/components/multi-select/multi-select-native/multi-select-native.component.ts
@@ -7,7 +7,6 @@ import {tuiInjectElement} from '@taiga-ui/cdk/utils/dom';
 import {tuiIsFlat, tuiIsPresent} from '@taiga-ui/cdk/utils/miscellaneous';
 import {tuiAsOptionContent, TuiDataList} from '@taiga-ui/core/components/data-list';
 import {
-    TuiSelectLike,
     TuiTextfield,
     TuiTextfieldMultiComponent,
 } from '@taiga-ui/core/components/textfield';
@@ -26,9 +25,11 @@ import {TuiMultiSelectOption} from '../multi-select-option/multi-select-option.c
     templateUrl: './multi-select-native.template.html',
     changeDetection: ChangeDetectionStrategy.OnPush,
     providers: [tuiAsOptionContent(TuiMultiSelectOption)],
-    hostDirectives: [TuiInputChipDirective, TuiSelectLike],
+    hostDirectives: [TuiInputChipDirective],
     host: {
+        autocomplete: 'off',
         multiple: '',
+        tuiSelectLike: '', // selector for styles
         '[size]': 'mobile ? 1 : 2',
         '(click.stop.zoneless)': '0',
         '(input)': 'onInput()',


### PR DESCRIPTION
Fixes #14553
