### PR TITLE
fix(addon-mobile): `DropdownSheet` reliably reopens after dismiss

### DIFF
--- a/projects/addon-mobile/directives/dropdown-sheet/dropdown-sheet.component.ts
+++ b/projects/addon-mobile/directives/dropdown-sheet/dropdown-sheet.component.ts
@@ -10,6 +10,7 @@ import {TuiSheetDialogService} from '@taiga-ui/addon-mobile/components/sheet-dia
 import {tuiIfMap} from '@taiga-ui/cdk/observables';
 import {TuiDropdownDirective} from '@taiga-ui/core/portals/dropdown';
 import {PolymorpheusOutlet} from '@taiga-ui/polymorpheus';
+import {finalize} from 'rxjs';
 
 import {TuiDropdownSheet} from './dropdown-sheet.directive';
 
@@ -37,9 +38,11 @@ export class TuiDropdownSheetComponent {
     protected readonly sub = toObservable(this.content)
         .pipe(
             tuiIfMap((content) =>
-                this.dialogs.open(content, this.directive.tuiDropdownSheet()),
+                this.dialogs
+                    .open(content, this.directive.tuiDropdownSheet())
+                    .pipe(finalize(() => this.dropdown.toggle(false))),
             ),
             takeUntilDestroyed(),
         )
-        .subscribe({complete: () => this.dropdown.toggle(false)});
+        .subscribe();
 }

--- a/projects/addon-mobile/directives/dropdown-sheet/test/dropdown-sheet.component.spec.ts
+++ b/projects/addon-mobile/directives/dropdown-sheet/test/dropdown-sheet.component.spec.ts
@@ -1,0 +1,81 @@
+import {ChangeDetectionStrategy, Component} from '@angular/core';
+import {type ComponentFixture, fakeAsync, TestBed, tick} from '@angular/core/testing';
+import {By} from '@angular/platform-browser';
+import {WA_IS_MOBILE} from '@ng-web-apis/platform';
+import {TuiDropdownSheet} from '@taiga-ui/addon-mobile';
+import {
+    provideTaiga,
+    TuiDropdown,
+    TuiDropdownHover,
+    tuiDropdownHoverOptionsProvider,
+    TuiRoot,
+} from '@taiga-ui/core';
+
+describe('TuiDropdownSheet', () => {
+    @Component({
+        imports: [TuiDropdown, TuiDropdownHover, TuiDropdownSheet, TuiRoot],
+        template: `
+            <tui-root>
+                <button
+                    tuiDropdown="Content"
+                    tuiDropdownHover
+                    tuiDropdownSheet
+                    type="button"
+                >
+                    Open
+                </button>
+            </tui-root>
+        `,
+        changeDetection: ChangeDetectionStrategy.OnPush,
+    })
+    class Test {}
+
+    let fixture: ComponentFixture<Test>;
+
+    beforeEach(async () => {
+        TestBed.configureTestingModule({
+            imports: [Test],
+            providers: [
+                provideTaiga(),
+                {provide: WA_IS_MOBILE, useValue: true},
+                tuiDropdownHoverOptionsProvider({showDelay: 0, hideDelay: 0}),
+            ],
+        });
+        await TestBed.compileComponents();
+        fixture = TestBed.createComponent(Test);
+        fixture.detectChanges();
+    });
+
+    function button(): HTMLElement {
+        return fixture.debugElement.query(By.css('button')).nativeElement;
+    }
+
+    function sheet(): Element | null {
+        return fixture.nativeElement.querySelector('tui-sheet-dialog');
+    }
+
+    function hover(): void {
+        button().dispatchEvent(new MouseEvent('mouseover', {bubbles: true}));
+        tick();
+        fixture.detectChanges();
+        tick();
+    }
+
+    it('reopens on the next hover after the sheet is dismissed', fakeAsync(() => {
+        hover();
+        expect(sheet()).not.toBeNull();
+
+        // Dismiss via the backdrop (click.self on the sheet host) without a
+        // hover reset — the case that used to leave the dropdown stuck open.
+        sheet()!.dispatchEvent(new MouseEvent('click', {bubbles: true}));
+        tick();
+        fixture.detectChanges();
+        tick();
+        expect(sheet()).toBeNull();
+
+        hover();
+        expect(sheet()).not.toBeNull();
+
+        fixture.destroy();
+    }));
+});


### PR DESCRIPTION
Closes #14964

### Problem

On mobile a dropdown rendered as a sheet (`tuiDropdownHover` + `tuiDropdownSheet`, without `tuiDropdownOpen`) does not reopen after it has been dismissed via the backdrop. Dismissing completes the `TuiSheetDialogService.open()` observable, but `tuiIfMap`'s inner `switchMap` swallows that completion, so `TuiDropdownDirective` is never toggled closed and its `ref` is not cleared. The dropdown stays logically "open", so the next tap has nothing to reopen — after a couple of open/dismiss cycles the sheet stops opening entirely.

### Fix

Close the dropdown when the sheet dialog completes via `finalize(() => this.dropdown.toggle(false))` on the inner observable, so `ref` clears and the hover state resets through the existing ref-removal branch, letting it reopen reliably on the next tap.