### PR TITLE
chore: use @taiga-ui/jest-config/angular preset

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -49,12 +49,15 @@
                 "express": "4.22.2",
                 "glob": "11.1.0",
                 "husky": "9.1.7",
+                "jest-environment-jsdom": "29.7.0",
+                "jest-preset-angular": "14.6.2",
                 "knip": "5.88.1",
                 "libphonenumber-js": "1.13.11",
                 "ng-morph": "5.0.1",
                 "ng-packagr": "19.2.2",
                 "ngx-highlightjs": "14.0.1",
                 "nx": "22.1.1",
+                "resize-observer-polyfill": "1.5.1",
                 "rxjs": "7.8.2",
                 "standard-version": "9.5.0",
                 "ts-mockito": "2.6.1",
@@ -16182,7 +16185,6 @@
             "integrity": "sha512-HqmEUIGRJ5fSXchkVgR5F7qn48bDBzv0kWj/Kfu5e6uci4UlEeng4331LnBkWffb++Ei3FOVLxo8JJWMFBDMeQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">= 10"
             }
@@ -16580,7 +16582,6 @@
             "integrity": "sha512-d0r18sZPmMQr1eG35u12FZfhIXNrnsPU/g5wvRKCUf/tOGilKKwYMYGqh33BNR6ba+2gkHw1EUiHoN3mn7E5IQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@types/node": "*",
                 "@types/tough-cookie": "*",
@@ -16845,8 +16846,7 @@
             "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
             "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/@types/unist": {
             "version": "3.0.3",
@@ -17823,8 +17823,7 @@
             "integrity": "sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA==",
             "deprecated": "Use your platform's native atob() and btoa() methods instead",
             "dev": true,
-            "license": "BSD-3-Clause",
-            "peer": true
+            "license": "BSD-3-Clause"
         },
         "node_modules/abbrev": {
             "version": "3.0.1",
@@ -17879,7 +17878,6 @@
             "integrity": "sha512-umOSDSDrfHbTNPuNpC2NSnnA3LUrqpevPb4T9jRx4MagXNS0rs+gwiTcAvqCRmsD6utzsrzNt+ebm00SNWiC3Q==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "acorn": "^8.1.0",
                 "acorn-walk": "^8.0.2"
@@ -19306,7 +19304,6 @@
             "integrity": "sha512-pd8DCoxmbgc7hyPKOvxtqNcjYoOsABPQdcCUjGp3d42VR2CX1ORhk2A87oqqu5R1kk+76nsxZupkmyd+MVtCog==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "fast-json-stable-stringify": "2.x"
             },
@@ -23134,8 +23131,7 @@
             "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.5.0.tgz",
             "integrity": "sha512-iKuQcq+NdHqlAcwUY0o/HL69XQrUaQdMjmStJ8JFmUaiiQErlhrmuigkg/CU4E2J0IyUKUrMAgl36TvN67MqTw==",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/cssstyle": {
             "version": "2.3.0",
@@ -23143,7 +23139,6 @@
             "integrity": "sha512-AZL67abkUzIuvcHqk7c09cezpGNcxUxU4Ioi/05xHk4DQeTkWmGYftIE6ctU6AEt+Gn4n1lDStOtj7FKycP71A==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "cssom": "~0.3.6"
             },
@@ -23156,8 +23151,7 @@
             "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.8.tgz",
             "integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg==",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/cypress": {
             "version": "15.17.0",
@@ -23577,7 +23571,6 @@
             "integrity": "sha512-Jy/tj3ldjZJo63sVAvg6LHt2mHvl4V6AgRAmNDtLdm7faqtsx+aJG42rsyCo9JCoRVKwPFzKlIPx3DIibwSIaQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "abab": "^2.0.6",
                 "whatwg-mimetype": "^3.0.0",
@@ -23742,8 +23735,7 @@
             "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
             "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/decode-named-character-reference": {
             "version": "1.3.0",
@@ -24286,7 +24278,6 @@
             "deprecated": "Use your platform's native DOMException instead",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "webidl-conversions": "^7.0.0"
             },
@@ -25046,7 +25037,6 @@
             "integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
             "dev": true,
             "license": "BSD-2-Clause",
-            "peer": true,
             "dependencies": {
                 "esprima": "^4.0.1",
                 "estraverse": "^5.2.0",
@@ -25070,7 +25060,6 @@
             "dev": true,
             "license": "BSD-3-Clause",
             "optional": true,
-            "peer": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -28893,7 +28882,6 @@
             "integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@tootallnate/once": "2",
                 "agent-base": "6",
@@ -28909,7 +28897,6 @@
             "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "debug": "4"
             },
@@ -29866,8 +29853,7 @@
             "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
             "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/is-promise": {
             "version": "4.0.0",
@@ -32442,7 +32428,6 @@
             "integrity": "sha512-k9iQbsf9OyOfdzWH8HDmrRT0gSIcX+FLNW7IQq94tFX0gynPwqDTW0Ho6iMVNjGz/nb+l/vW3dWM2bbLLpkbXA==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@jest/environment": "^29.7.0",
                 "@jest/fake-timers": "^29.7.0",
@@ -32471,7 +32456,6 @@
             "integrity": "sha512-aQIfHDq33ExsN4jP1NWGXhxgQ/wixs60gDiKO+XVMd8Mn0NWPWgc34ZQDTb2jKaUWQ7MuwoitXAsN2XVXNMpAw==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@jest/fake-timers": "^29.7.0",
                 "@jest/types": "^29.6.3",
@@ -32488,7 +32472,6 @@
             "integrity": "sha512-q4DH1Ha4TTFPdxLsqDXK1d3+ioSL7yL5oCMJZgDYm6i+6CygW5E5xVr/D1HdsGxjt1ZWSfUAs9OxSB/BNelWrQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@jest/types": "^29.6.3",
                 "@sinonjs/fake-timers": "^10.0.2",
@@ -32507,7 +32490,6 @@
             "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@sinclair/typebox": "^0.27.8"
             },
@@ -32521,7 +32503,6 @@
             "integrity": "sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@jest/schemas": "^29.6.3",
                 "@types/istanbul-lib-coverage": "^2.0.0",
@@ -32539,8 +32520,7 @@
             "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.10.tgz",
             "integrity": "sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/jest-environment-jsdom/node_modules/@sinonjs/fake-timers": {
             "version": "10.3.0",
@@ -32548,7 +32528,6 @@
             "integrity": "sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA==",
             "dev": true,
             "license": "BSD-3-Clause",
-            "peer": true,
             "dependencies": {
                 "@sinonjs/commons": "^3.0.0"
             }
@@ -32559,7 +32538,6 @@
             "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "ansi-styles": "^4.1.0",
                 "supports-color": "^7.1.0"
@@ -32583,7 +32561,6 @@
                 }
             ],
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=8"
             }
@@ -32594,7 +32571,6 @@
             "integrity": "sha512-GBEV4GRADeP+qtB2+6u61stea8mGcOT4mCtrYISZwfu9/ISHFJ/5zOMXYbpBE9RsS5+Gb63DW4FgmnKJ79Kf6w==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@babel/code-frame": "^7.12.13",
                 "@jest/types": "^29.6.3",
@@ -32616,7 +32592,6 @@
             "integrity": "sha512-ITOMZn+UkYS4ZFh83xYAOzWStloNzJFO2s8DWrE4lhtGD+AorgnbkiKERe4wQVBydIGPx059g6riW5Btp6Llnw==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@jest/types": "^29.6.3",
                 "@types/node": "*",
@@ -32632,7 +32607,6 @@
             "integrity": "sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@jest/types": "^29.6.3",
                 "@types/node": "*",
@@ -32651,7 +32625,6 @@
             "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=8.6"
             },
@@ -32948,7 +32921,6 @@
             "integrity": "sha512-QWnjfXrnYJX65D+iZXBrdQ0ABHSo6DGvcmL3dGYOdF+V2ZhDlqJwKTmt7nyiOcORPdCL+20P8y+Q1mmnjZTHKQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "bs-logger": "^0.2.6",
                 "esbuild-wasm": ">=0.15.13",
@@ -32983,7 +32955,6 @@
             "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@sinclair/typebox": "^0.27.8"
             },
@@ -32997,7 +32968,6 @@
             "integrity": "sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@jest/schemas": "^29.6.3",
                 "@types/istanbul-lib-coverage": "^2.0.0",
@@ -33015,8 +32985,7 @@
             "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.12.tgz",
             "integrity": "sha512-hhyNJ+nbR6ZR7pToHvllEFun9TL0sbL+tk/ON75lo+Xas054uez98qRbsuNt7MBCyZKK4+8Yli/OAGZhmfBZ/g==",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/jest-preset-angular/node_modules/chalk": {
             "version": "4.1.2",
@@ -33024,7 +32993,6 @@
             "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "ansi-styles": "^4.1.0",
                 "supports-color": "^7.1.0"
@@ -33048,7 +33016,6 @@
                 }
             ],
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=8"
             }
@@ -33059,7 +33026,6 @@
             "integrity": "sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@jest/types": "^29.6.3",
                 "@types/node": "*",
@@ -33078,7 +33044,6 @@
             "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=8.6"
             },
@@ -35089,7 +35054,6 @@
             "integrity": "sha512-SYhBvTh89tTfCD/CRdSOm13mOBa42iTaTyfyEWBdKcGdPxPtLFBXuHR8XHb33YNYaP+lLbmSvBTsnoesCNJEsQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "abab": "^2.0.6",
                 "acorn": "^8.8.1",
@@ -35136,7 +35100,6 @@
             "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "debug": "4"
             },
@@ -35150,7 +35113,6 @@
             "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "agent-base": "6",
                 "debug": "4"
@@ -39413,8 +39375,7 @@
             "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.24.tgz",
             "integrity": "sha512-7YRhZ3jS45LwmSCT4b2sVFHt/WuovaktDU07QrtOBY2PXskss5a9jfmR9jptyumwXST+rFjrmppMY1KT/yn35A==",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/nx": {
             "version": "22.1.1",
@@ -42128,7 +42089,6 @@
             "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@jest/schemas": "^29.6.3",
                 "ansi-styles": "^5.0.0",
@@ -42144,7 +42104,6 @@
             "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@sinclair/typebox": "^0.27.8"
             },
@@ -42157,8 +42116,7 @@
             "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.10.tgz",
             "integrity": "sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/pretty-format/node_modules/ansi-styles": {
             "version": "5.2.0",
@@ -42166,7 +42124,6 @@
             "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=10"
             },
@@ -42393,7 +42350,6 @@
             "integrity": "sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "punycode": "^2.3.1"
             },
@@ -42504,8 +42460,7 @@
             "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
             "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/queue-microtask": {
             "version": "1.2.3",
@@ -42644,8 +42599,7 @@
             "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
             "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/react-is-18": {
             "name": "react-is",
@@ -43698,8 +43652,7 @@
             "version": "1.5.1",
             "resolved": "https://registry.npmjs.org/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz",
             "integrity": "sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg==",
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/resolve": {
             "version": "1.22.10",
@@ -44645,7 +44598,6 @@
             "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
             "dev": true,
             "license": "ISC",
-            "peer": true,
             "dependencies": {
                 "xmlchars": "^2.2.0"
             },
@@ -47165,8 +47117,7 @@
             "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
             "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/sync-child-process": {
             "version": "1.0.2",
@@ -47764,7 +47715,6 @@
             "integrity": "sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==",
             "dev": true,
             "license": "BSD-3-Clause",
-            "peer": true,
             "dependencies": {
                 "psl": "^1.1.33",
                 "punycode": "^2.1.1",
@@ -47781,7 +47731,6 @@
             "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">= 4.0.0"
             }
@@ -47792,7 +47741,6 @@
             "integrity": "sha512-l7FvfAHlcmulp8kr+flpQZmVwtu7nfRV7NZujtN0OqES8EL4O4e0qqzL0DC5gAvx/ZC/9lk6rhcUwYvkBnBnYA==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "punycode": "^2.1.1"
             },
@@ -47983,7 +47931,6 @@
             "integrity": "sha512-Ov6ClY53Fflh6BGAnY2DlTq1hYDrTycz2PVTXBWFW2CU+9zrEqAp9fWdGXl42EXO5RLSFAcAZ2JFKbP+zBTFfw==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "bs-logger": "^0.2.6",
                 "fast-json-stable-stringify": "^2.1.0",
@@ -48037,7 +47984,6 @@
             "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
             "dev": true,
             "license": "ISC",
-            "peer": true,
             "bin": {
                 "semver": "bin/semver.js"
             },
@@ -48051,7 +47997,6 @@
             "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
             "dev": true,
             "license": "(MIT OR CC0-1.0)",
-            "peer": true,
             "engines": {
                 "node": ">=16"
             },
@@ -48886,7 +48831,6 @@
             "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "querystringify": "^2.1.1",
                 "requires-port": "^1.0.0"
@@ -49632,7 +49576,6 @@
             "integrity": "sha512-d+BFHzbiCx6zGfz0HyQ6Rg69w9k19nviJspaj4yNscGjrHu94sVP+aRm75yEbCh+r2/yR+7q6hux9LVtbuTGBw==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "xml-name-validator": "^4.0.0"
             },
@@ -49708,7 +49651,6 @@
             "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
             "dev": true,
             "license": "BSD-2-Clause",
-            "peer": true,
             "engines": {
                 "node": ">=12"
             }
@@ -50141,7 +50083,6 @@
             "integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=12"
             }
@@ -50152,7 +50093,6 @@
             "integrity": "sha512-RKT8HExMpoYx4igMiVMY83lN6UeITKJlBQ+vR/8ZJ8OCdSiN3RwCq+9gH0+Xzj0+5IrM6i4j/6LuvzbZIQgEcQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "tr46": "^3.0.0",
                 "webidl-conversions": "^7.0.0"
@@ -50523,7 +50463,6 @@
             "integrity": "sha512-ICP2e+jsHvAj2E2lIHxa5tjXRlKDJo4IdvPvCXbXQGdzSfmSpNVyIKMvoZHjDY9DP0zV17iI85o90vRFXNccRw==",
             "dev": true,
             "license": "Apache-2.0",
-            "peer": true,
             "engines": {
                 "node": ">=12"
             }
@@ -50543,8 +50482,7 @@
             "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
             "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/xtend": {
             "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
         }
     },
     "jest": {
-        "preset": "@taiga-ui/jest-config",
+        "preset": "@taiga-ui/jest-config/angular",
         "workerIdleMemoryLimit": "256MB"
     },
     "overrides": {
@@ -155,12 +155,15 @@
         "express": "4.22.2",
         "glob": "11.1.0",
         "husky": "9.1.7",
+        "jest-environment-jsdom": "29.7.0",
+        "jest-preset-angular": "14.6.2",
         "knip": "5.88.1",
         "libphonenumber-js": "1.13.11",
         "ng-morph": "5.0.1",
         "ng-packagr": "19.2.2",
         "ngx-highlightjs": "14.0.1",
         "nx": "22.1.1",
+        "resize-observer-polyfill": "1.5.1",
         "rxjs": "7.8.2",
         "standard-version": "9.5.0",
         "ts-mockito": "2.6.1",

--- a/projects/addon-doc/utils/test/flat-map-page.spec.ts
+++ b/projects/addon-doc/utils/test/flat-map-page.spec.ts
@@ -1,5 +1,5 @@
 import {tuiToFlatMapPages} from '@taiga-ui/addon-doc';
-import {tuiSwitchNgDevMode} from '@taiga-ui/jest-config';
+import {tuiSwitchNgDevMode} from '@taiga-ui/jest-config/angular';
 
 describe('tuiToFlatMapPages', () => {
     const testPage1 = {

--- a/projects/cdk/date-time/test/day.spec.ts
+++ b/projects/cdk/date-time/test/day.spec.ts
@@ -1,5 +1,5 @@
 import {TuiDay} from '@taiga-ui/cdk';
-import {tuiSwitchNgDevMode} from '@taiga-ui/jest-config';
+import {tuiSwitchNgDevMode} from '@taiga-ui/jest-config/angular';
 
 import {tuiMockDateInside} from './helpers';
 

--- a/projects/cdk/date-time/test/time.spec.ts
+++ b/projects/cdk/date-time/test/time.spec.ts
@@ -1,5 +1,5 @@
 import {TuiTime} from '@taiga-ui/cdk';
-import {tuiSwitchNgDevMode} from '@taiga-ui/jest-config';
+import {tuiSwitchNgDevMode} from '@taiga-ui/jest-config/angular';
 
 describe('TuiTime', () => {
     describe('static method', () => {

--- a/projects/cdk/schematics/ng-update/v5/steps/constants/identifiers-to-replace.ts
+++ b/projects/cdk/schematics/ng-update/v5/steps/constants/identifiers-to-replace.ts
@@ -171,7 +171,7 @@ export const IDENTIFIERS_TO_REPLACE: ReplacementIdentifierMulti[] = [
         },
         to: {
             name: 'tuiSwitchNgDevMode',
-            moduleSpecifier: '@taiga-ui/jest-config',
+            moduleSpecifier: '@taiga-ui/jest-config/angular',
         },
     },
     {

--- a/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-remaining-leftovers.spec.ts.snap
+++ b/projects/cdk/schematics/ng-update/v5/tests/__snapshots__/schematic-migrate-remaining-leftovers.spec.ts.snap
@@ -93,7 +93,7 @@ exports[`ng-update remaining v5 leftovers (#11917) renames leftover core/kit/tes
                     }
                 }
             ",
-  "1. After": "import { tuiSwitchNgDevMode } from "@taiga-ui/jest-config";
+  "1. After": "import { tuiSwitchNgDevMode } from "@taiga-ui/jest-config/angular";
 import { tuiAutoColor } from "@taiga-ui/kit";
 
                 import {Component} from '@angular/core';


### PR DESCRIPTION
## What

Switch to the new `@taiga-ui/jest-config/angular` subpath preset.

## Why

Companion to [taiga-family/toolkit#1993](https://github.com/taiga-family/toolkit/pull/1993): `@taiga-ui/jest-config` is split into `/node` and `/angular` presets and the bare alias is dropped. The old bare preset pulled `jest-preset-angular` → `@angular/*` as a **mandatory** peer, causing `ERESOLVE` failures in non-angular consumers of `@taiga-ui/configs`. After the split those angular peers become **optional**, so taiga-ui — which uses the angular preset — must declare them explicitly.

## Changes

- `jest` preset → `@taiga-ui/jest-config/angular`
- Import `tuiSwitchNgDevMode` from `/angular` in specs (`day`, `time`, `flat-map-page`)
- v5 `ng update` schematic: map `tuiSwitchNgDevMode` from bare `@taiga-ui/jest-config` → `/angular` (+ snapshot), so direct importers get auto-migrated
- Add explicit devDeps for the now-optional angular peers: `jest-preset-angular`, `jest-environment-jsdom`, `resize-observer-polyfill` (with in-sync `package-lock.json`)

## Impact / notes

- **Not a breaking change for component consumers.** This touches only taiga-ui's own dev tooling (its jest preset, test specs, devDependencies, lock) — no component API or runtime behavior changes.
- The only breaking edge is the dropped bare `@taiga-ui/jest-config` alias in toolkit#1993, which affects **direct importers of the preset** (dev/config tooling, not consumer runtime). v4→v5 upgraders are handled by the updated schematic above; users already past v5 would need a one-line manual change. For non-angular consumers of `@taiga-ui/configs` this is a fix (removes `ERESOLVE`).
- **Draft**: must wait for toolkit#1993 release + `@taiga-ui/configs` version bump before this lands together. CI typecheck/jest stays red on `/angular` until then (lock pins the real `jest-config@0.560.0`).
- Local verification via Verdaccio: `tsc --project tsconfig.spec.json` passes; jest runtime fails on node 26 with a **pre-existing** `exports is not defined` in the angular preset polyfill (unrelated to the split — identical to the pre-split bare preset; CI runs its own environment).