### PR TITLE
chore: ignore .claude directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,4 @@ blob-report
 .cursor/rules/nx-rules.mdc
 .github/instructions/nx.instructions.md
 terminalOutput
+.claude


### PR DESCRIPTION
Adds the local `.claude` directory to `.gitignore` so IDE/agent local config is not tracked.